### PR TITLE
Fix key_values and a typo

### DIFF
--- a/build/lib/gradio/outputs.py
+++ b/build/lib/gradio/outputs.py
@@ -184,7 +184,7 @@ class Image(AbstractOutput):
 class KeyValues(AbstractOutput):
     '''
     Component displays a table representing values for multiple fields. 
-    Output type: List[Tuple[str, value]]
+    Output type: Dict[str, value]
     '''
 
     def __init__(self, label=None):

--- a/build/lib/gradio/outputs.py
+++ b/build/lib/gradio/outputs.py
@@ -184,7 +184,7 @@ class Image(AbstractOutput):
 class KeyValues(AbstractOutput):
     '''
     Component displays a table representing values for multiple fields. 
-    Output type: Dict[str, value]
+    Output type: List[Tuple[str, value]]
     '''
 
     def __init__(self, label=None):

--- a/gradio/outputs.py
+++ b/gradio/outputs.py
@@ -249,7 +249,7 @@ class HighlightedText(AbstractOutput):
         if isinstance(prediction, str) or isinstance(prediction, int) or isinstance(prediction, float):
             return str(prediction)
         else:
-            raise ValueError("The `Textbox` output interface expects an output that is one of: a string, or"
+            raise ValueError("The `HighlightedText` output interface expects an output that is one of: a string, or"
                              "an int/float that can be converted to a string.")
 
 

--- a/gradio/outputs.py
+++ b/gradio/outputs.py
@@ -195,7 +195,7 @@ class Image(AbstractOutput):
 class KeyValues(AbstractOutput):
     '''
     Component displays a table representing values for multiple fields. 
-    Output type: List[Tuple[str, value]]
+    Output type: Dict[str, value]
     '''
 
     def __init__(self, label=None):

--- a/gradio/static/js/interfaces/output/key_values.js
+++ b/gradio/static/js/interfaces/output/key_values.js
@@ -11,10 +11,10 @@ const key_values = {
   init: function(opts) {},
   output: function(data) {
     let html = ""
-    for (let row of data) {
+    for (const [key, value] of Object.entries(data)) {
       html += `<tr>
-        <td>${row[0]}</td>
-        <td>${row[1]}</td>
+        <td>${key}</td>
+        <td>${value}</td>
       </tr>`;
     }
     this.target.find("tbody").html(html);


### PR DESCRIPTION
Fixing KeyValues to match Python code (`dict` instead of `List[Tuple[str, value]]`).
Manually tested:
![image](https://user-images.githubusercontent.com/6879673/89094486-517ef600-d379-11ea-88bf-82cc31b78c96.png)
