### PR TITLE
Fix output lengths

### DIFF
--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -91,7 +91,9 @@ class Interface:
         def get_output_instance(iface):
             if isinstance(iface, str):
                 shortcut = OutputComponent.get_all_shortcut_implementations()[iface]
-                return shortcut[0](**shortcut[1])
+                shortcut = shortcut[0](**shortcut[1])
+                shortcut *= len(fn)
+                return shortcut
             elif isinstance(iface, OutputComponent):
                 return iface
             else:
@@ -111,7 +113,6 @@ class Interface:
         if not isinstance(fn, list):
             fn = [fn]
 
-        self.output_interfaces *= len(fn)
         self.predict = fn
         self.function_names = [func.__name__ for func in fn]
         self.verbose = verbose

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -113,6 +113,9 @@ class Interface:
         if not isinstance(fn, list):
             fn = [fn]
 
+        assert len(self.output_interfaces) == len(fn), \
+            "Number of prediction functions does not match the number of outputs"
+
         self.predict = fn
         self.function_names = [func.__name__ for func in fn]
         self.verbose = verbose


### PR DESCRIPTION
By default, the Gradio interface was multiplying the outputs by the number of prediction functions.
This isn't always the case however, since if a user passes their own outputs, then this operation is not necessary.