### PR TITLE
fixed single file handling, added keepfilename

### DIFF
--- a/gradio/inputs.py
+++ b/gradio/inputs.py
@@ -935,7 +935,8 @@ class File(InputComponent):
             else:
                 raise ValueError("Unknown type: " + str(self.type) + ". Please choose from: 'file', 'bytes'.")
         if self.file_count == "single":
-            return process_single_file(x)
+            if isinstance(x, list): return process_single_file(x[0])
+            else: return process_single_file(x)
         else:
             return [process_single_file(f) for f in x]
 

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -371,7 +371,7 @@ class Interface:
                 print("PASSED")
                 continue
 
-    def launch(self, inline=None, inbrowser=None, share=False, debug=False, auth=None, auth_message=None, private_endpoint=None):
+    def launch(self, inline=None, inbrowser=None, share=False, debug=False, auth=None, auth_message=None, private_endpoint=None, prevent_thread_lock=False):
         """
         Parameters:
         inline (bool): whether to display in the interface inline on python notebooks.
@@ -413,7 +413,7 @@ class Interface:
 
         # If running in a colab or not able to access localhost, automatically create a shareable link        
         is_colab = utils.colab_check()
-        if is_colab or not(networking.url_ok(path_to_local_server)):  
+        if is_colab or (share and not(networking.url_ok(path_to_local_server))):  
             share = True
             if is_colab:
                 if debug:
@@ -473,10 +473,12 @@ class Interface:
                 sys.stdout.flush()
                 time.sleep(0.1)
         is_in_interactive_mode = bool(getattr(sys, 'ps1', sys.flags.interactive))
-        if not is_in_interactive_mode:
+        print('is_in_interactive_mode=={}'.format(is_in_interactive_mode))
+        if not prevent_thread_lock and not is_in_interactive_mode:
+            print("going to lock thread and run in foreground  ...")
             self.run_until_interrupted(thread, path_to_local_server)
         
-        return app, path_to_local_server, share_url
+        return app, path_to_local_server, share_url, thread
 
 def show_tip(io):
     if not(io.show_tips):

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -80,14 +80,15 @@ def decode_base64_to_binary(encoding):
         data = encoding
     return base64.b64decode(data), extension
 
-def decode_base64_to_file(encoding, encryption_key=None):
+def decode_base64_to_file(encoding, encryption_key=None, filenameprefix=""):
     data, extension = decode_base64_to_binary(encoding)
     if extension is None:
-        file_obj = tempfile.NamedTemporaryFile(delete=False)
+        file_obj = tempfile.NamedTemporaryFile(delete=False, prefix=filenameprefix)
     else:
-        file_obj = tempfile.NamedTemporaryFile(delete=False, suffix="."+extension)
+        file_obj = tempfile.NamedTemporaryFile(delete=False, prefix=filenameprefix, suffix="."+extension)
     if encryption_key is not None:
         data = encryptor.encrypt(encryption_key, data)
+    #print("saving to ", file_obj.name)
     file_obj.write(data)
     file_obj.flush()
     return file_obj

--- a/gradio/templates/index.html
+++ b/gradio/templates/index.html
@@ -28,7 +28,7 @@
     <meta name="twitter:description" content="{{ config['description'] or '' }}">
     <meta name="twitter:image" content="{{ config['thumbnail'] or '' }}">
 
-    <title>Gradio</title>
+    <title>Hank.ai DocuVision UI</title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
     <!-- VENDOR -->
     <link type="text/css" href="{{ vendor_prefix }}/static/css/vendor/jquery-ui.css" rel="stylesheet">

--- a/gradio/templates/login.html
+++ b/gradio/templates/login.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <title>Gradio Login</title>
+  <title>Hank.ai Docuvision - Login</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/gradio.css') }}">
   <meta name="viewport" content="width=device-width">


### PR DESCRIPTION
Fixed line in input.py for File input object causing bug in single file handling

Added params to File input object to allow keepfilename=True or False to be passed
When True, will prefix the safe filename generated upon upload with the original filename and a trailing '_' character 
Thus accessing the file in gradio with f.name will now return 'originalfilenameabc_xxcyidfyudifd.png' or similar