### PR TITLE
Log "Created From" text to track Gradio usage in Comet 

### DIFF
--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -549,6 +549,7 @@ class Interface:
 
 
     def integrate(self, comet_ml=None):
+        comet_ml.log_other("Created from", "Gradio")
         if self.share_url is not None:
             comet_ml.log_text(self.share_url)
             comet_ml.end()


### PR DESCRIPTION
This PR:

Enables logging a message to the "Other" tab in a Comet Experiment that helps track whether an experiment was created from the Gradio integration.  

Example shown here:
https://www.comet.ml/team-comet-ml/gradio/ba385bd513df490d90c9f994147a5885?experiment-tab=other&viewId=LoEum7OL84ONyBkoUiX1BPsUX