### PR TITLE
Toggle on markdown support for fenced code blocks

### DIFF
--- a/demo/sepia_filter.py
+++ b/demo/sepia_filter.py
@@ -1,14 +1,27 @@
 import gradio as gr
 import numpy as np
 
-def sepia(img):
+def sepia(input_img):
   sepia_filter = np.array([[.393, .769, .189],
                            [.349, .686, .168],
                            [.272, .534, .131]])
-  sepia_img = img.dot(sepia_filter.T)
+  sepia_img = input_img.dot(sepia_filter.T)
   sepia_img /= sepia_img.max()                          
   return sepia_img
 
-iface = gr.Interface(sepia, gr.inputs.Image(shape=(200, 200)), "image")
+iface = gr.Interface(sepia, gr.inputs.Image(shape=(200, 200)), "image", 
+                     article=
+"""
+This simple image demo returns applies a sepia filter to the input image, as described below: 
+```python
+sepia_filter = np.array([[.393, .769, .189],
+                          [.349, .686, .168],
+                          [.272, .534, .131]])
+sepia_img = input_img.dot(sepia_filter.T)
+sepia_img /= sepia_img.max()                          
+```
+"""
+)
+
 if __name__ == "__main__":
     iface.launch()

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -140,7 +140,7 @@ class Interface:
         self.description = description
         if article is not None:
             article = utils.readme_to_html(article)
-            article = markdown2.markdown(article)
+            article = markdown2.markdown(article, extras=["fenced-code-blocks"])
         self.article = article
         self.thumbnail = thumbnail
         self.theme = theme if theme is not None else os.getenv("GRADIO_THEME", "default")


### PR DESCRIPTION
At the moment, quoting code between three backticks (i.e. [fenced code blocks](https://spec.commonmark.org/0.30/#fenced-code-blocks)) does not render correctly when passed to `article` in `gr.Interface`, which would come as a surprise to most users that are used to CommonMark and Github-flavoured Markdown. Apparently, `markdown2` does not support it by default, but requires toggling it on via an `extras` argument. 

This PR introduces a small change to enable rendering fenced code blocks in text passed to `article` correctly.