### PR TITLE
Fix comparison of "numpy" and "pil" types in Image

### DIFF
--- a/gradio/inputs.py
+++ b/gradio/inputs.py
@@ -760,7 +760,7 @@ class Image(InputComponent):
             return processing_utils.encode_url_or_file_to_base64(x)
         elif self.type == "file":
             return processing_utils.encode_url_or_file_to_base64(x.name)
-        elif self.type == "numpy" or "pil":
+        elif self.type in ("numpy", "pil"):
             if self.type == "numpy":
                 x = PIL.Image.fromarray(np.uint8(x)).convert('RGB')
             fmt = x.format

--- a/test/test_inputs.py
+++ b/test/test_inputs.py
@@ -315,6 +315,8 @@ class TestImage(unittest.TestCase):
         with self.assertRaises(ValueError):
             wrong_type = gr.inputs.Image(type="unknown")
             wrong_type.preprocess(img)
+         with self.assertRaises(ValueError):
+            wrong_type = gr.inputs.Image(type="unknown")
             wrong_type.serialize("test/test_files/bus.png", False)
         img_pil = PIL.Image.open('test/test_files/bus.png')
         image_input = gr.inputs.Image(type="numpy")


### PR DESCRIPTION
The line

```
elif self.type == "numpy" or "pil":
```

is interpreted as

```
elif (self.type == "numpy") or ("pil"):
```

where `("pil")` is always evaluated as True. See https://stackoverflow.com/a/20002504/50065 for more info.

The reason this wasn't caught by the tests is because they were written like:

```
  with self.assertRaises(ValueError):
      wrong_type = gr.inputs.Image(type="unknown")
      wrong_type.preprocess(img)
      wrong_type.serialize("test/test_files/bus.png", False)
```

The line `wrong_type.preprocess(img)` would trigger a ValueError and the test would be markes as succeeded, but it obscures that the line `wrong_type.serialize("test/test_files/bus.png", False)` would fail with:

```
Traceback (most recent call last):
  File "/home/biogeek/github/gradio/test/test_inputs.py", line 320, in test_as_component
    wrong_type.serialize("test/test_files/bus.png", False)
  File "/home/biogeek/github/gradio/gradio/inputs.py", line 768, in serialize
    "."+fmt.lower() if fmt is not None else ".png"))
AttributeError: 'builtin_function_or_method' object has no attribute 'lower'
```