### PR TITLE
format frontend code with prettier

### DIFF
--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -1,0 +1,2 @@
+packages/app/public/**
+pnpm-workspace.yaml

--- a/ui/.prettierrc.json
+++ b/ui/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+	"useTabs": true,
+	"singleQuote": false,
+	"trailingComma": "none",
+	"printWidth": 100
+}

--- a/ui/README.md
+++ b/ui/README.md
@@ -4,14 +4,13 @@ This folder contains all of the Gradio UI and component source code.
 
 ## set up
 
-This folder is managed as 'monorepo' a multi-package repository which make dependency management very simple. In order to do this we use `pnpm` as our package manager. 
+This folder is managed as 'monorepo' a multi-package repository which make dependency management very simple. In order to do this we use `pnpm` as our package manager.
 
-Make sure [`pnpm`](https://pnpm.io/) is installed by [following the installation instructions for your system](https://pnpm.io/installation). 
+Make sure [`pnpm`](https://pnpm.io/) is installed by [following the installation instructions for your system](https://pnpm.io/installation).
 
 You will also need `node` which you probably already have
 
 ## running the application
-
 
 Install all dependencies from the `ui` folder:
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,15 +1,19 @@
 {
-  "name": "gradio-ui",
-  "version": "0.0.1",
-  "description": "Gradio UI packages",
-  "scripts": {
-    "dev" : "pnpm dev --filter @gradio/app",
-    "build": "pnpm build --filter @gradio/app"
-  },
-  "author": "",
-  "license": "ISC",
-  "private": true,
-  "dependencies": {
-    "svelte": "^3.46.3"
-  }
+	"name": "gradio-ui",
+	"version": "0.0.1",
+	"description": "Gradio UI packages",
+	"scripts": {
+		"dev": "pnpm dev --filter @gradio/app",
+		"build": "pnpm build --filter @gradio/app",
+		"format:check": "prettier --check --plugin-search-dir=. .",
+		"format:write": "prettier --write --plugin-search-dir=. ."
+	},
+	"author": "",
+	"license": "ISC",
+	"private": true,
+	"dependencies": {
+		"prettier": "^2.5.1",
+		"prettier-plugin-svelte": "^2.6.0",
+		"svelte": "^3.46.3"
+	}
 }

--- a/ui/packages/app/README.md
+++ b/ui/packages/app/README.md
@@ -1,6 +1,6 @@
-*Psst — looking for a more complete solution? Check out [SvelteKit](https://kit.svelte.dev), the official framework for building web applications of all sizes, with a beautiful development experience and flexible filesystem-based routing.*
+_Psst — looking for a more complete solution? Check out [SvelteKit](https://kit.svelte.dev), the official framework for building web applications of all sizes, with a beautiful development experience and flexible filesystem-based routing._
 
-*Looking for a shareable component template instead? You can [use SvelteKit for that as well](https://kit.svelte.dev/docs#packaging) or the older [sveltejs/component-template](https://github.com/sveltejs/component-template)*
+_Looking for a shareable component template instead? You can [use SvelteKit for that as well](https://kit.svelte.dev/docs#packaging) or the older [sveltejs/component-template](https://github.com/sveltejs/component-template)_
 
 ---
 
@@ -15,8 +15,7 @@ npx degit sveltejs/template svelte-app
 cd svelte-app
 ```
 
-*Note that you will need to have [Node.js](https://nodejs.org) installed.*
-
+_Note that you will need to have [Node.js](https://nodejs.org) installed._
 
 ## Get started
 
@@ -49,12 +48,11 @@ npm run build
 
 You can run the newly built app with `npm run start`. This uses [sirv](https://github.com/lukeed/sirv), which is included in your package.json's `dependencies` so that the app will work when you deploy to platforms like [Heroku](https://heroku.com).
 
-
 ## Single-page app mode
 
 By default, sirv will only respond to requests that match files in `public`. This is to maximise compatibility with static fileservers, allowing you to deploy your app anywhere.
 
-If you're building a single-page app (SPA) with multiple routes, sirv needs to be able to respond to requests for *any* path. You can make it so by editing the `"start"` command in package.json:
+If you're building a single-page app (SPA) with multiple routes, sirv needs to be able to respond to requests for _any_ path. You can make it so by editing the `"start"` command in package.json:
 
 ```js
 "start": "sirv public --single"

--- a/ui/packages/app/package.json
+++ b/ui/packages/app/package.json
@@ -1,43 +1,43 @@
 {
-  "name": "@gradio/app",
-  "version": "1.0.0",
-  "private": true,
-  "scripts": {
-    "build": "rollup -c",
-    "dev": "rollup -c -w",
-    "start": "sirv public --no-clear --port 3000"
-  },
-  "devDependencies": {
-    "@rollup/plugin-commonjs": "^17.0.0",
-    "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^11.0.0",
-    "mime-types": "^2.1.34",
-    "postcss": "^8.4.5",
-    "postcss-nested": "^5.0.6",
-    "rollup": "^2.3.4",
-    "rollup-plugin-css-only": "^3.1.0",
-    "rollup-plugin-livereload": "^2.0.0",
-    "rollup-plugin-svelte": "^7.0.0",
-    "rollup-plugin-terser": "^7.0.0",
-    "svelte": "^3.46.3"
-  },
-  "dependencies": {
-    "@rollup/plugin-replace": "^3.0.1",
-    "autoprefixer": "^9.8.8",
-    "cropperjs": "^1.5.12",
-    "d3-dsv": "^3.0.1",
-    "d3-scale": "^4.0.2",
-    "d3-shape": "^3.1.0",
-    "lazy-brush": "^1.0.1",
-    "mime-types": "^2.1.34",
-    "node-sass": "^7.0.1",
-    "resize-observer-polyfill": "^1.5.1",
-    "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-postcss": "^4.0.2",
-    "sirv-cli": "^1.0.0",
-    "svelte-preprocess": "^4.10.1",
-    "svelte-range-slider-pips": "^2.0.1",
-    "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.2.17",
-    "tui-image-editor": "^3.15.2"
-  }
+	"name": "@gradio/app",
+	"version": "1.0.0",
+	"private": true,
+	"scripts": {
+		"build": "rollup -c",
+		"dev": "rollup -c -w",
+		"start": "sirv public --no-clear --port 3000"
+	},
+	"devDependencies": {
+		"@rollup/plugin-commonjs": "^17.0.0",
+		"@rollup/plugin-json": "^4.1.0",
+		"@rollup/plugin-node-resolve": "^11.0.0",
+		"mime-types": "^2.1.34",
+		"postcss": "^8.4.5",
+		"postcss-nested": "^5.0.6",
+		"rollup": "^2.3.4",
+		"rollup-plugin-css-only": "^3.1.0",
+		"rollup-plugin-livereload": "^2.0.0",
+		"rollup-plugin-svelte": "^7.0.0",
+		"rollup-plugin-terser": "^7.0.0",
+		"svelte": "^3.46.3"
+	},
+	"dependencies": {
+		"@rollup/plugin-replace": "^3.0.1",
+		"autoprefixer": "^9.8.8",
+		"cropperjs": "^1.5.12",
+		"d3-dsv": "^3.0.1",
+		"d3-scale": "^4.0.2",
+		"d3-shape": "^3.1.0",
+		"lazy-brush": "^1.0.1",
+		"mime-types": "^2.1.34",
+		"node-sass": "^7.0.1",
+		"resize-observer-polyfill": "^1.5.1",
+		"rollup-plugin-copy": "^3.4.0",
+		"rollup-plugin-postcss": "^4.0.2",
+		"sirv-cli": "^1.0.0",
+		"svelte-preprocess": "^4.10.1",
+		"svelte-range-slider-pips": "^2.0.1",
+		"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.2.17",
+		"tui-image-editor": "^3.15.2"
+	}
 }

--- a/ui/packages/app/rollup.config.js
+++ b/ui/packages/app/rollup.config.js
@@ -1,14 +1,14 @@
-import svelte from 'rollup-plugin-svelte';
+import svelte from "rollup-plugin-svelte";
 import sveltePreprocess from "svelte-preprocess";
-import commonjs from '@rollup/plugin-commonjs';
-import resolve from '@rollup/plugin-node-resolve';
-import livereload from 'rollup-plugin-livereload';
-import { terser } from 'rollup-plugin-terser';
-import css from 'rollup-plugin-css-only';
-import replace from '@rollup/plugin-replace';
+import commonjs from "@rollup/plugin-commonjs";
+import resolve from "@rollup/plugin-node-resolve";
+import livereload from "rollup-plugin-livereload";
+import { terser } from "rollup-plugin-terser";
+import css from "rollup-plugin-css-only";
+import replace from "@rollup/plugin-replace";
 import json from "@rollup/plugin-json";
-import copy from 'rollup-plugin-copy';
-import postcss from 'rollup-plugin-postcss';
+import copy from "rollup-plugin-copy";
+import postcss from "rollup-plugin-postcss";
 
 const production = !process.env.ROLLUP_WATCH;
 
@@ -22,37 +22,40 @@ function serve() {
 	return {
 		writeBundle() {
 			if (server) return;
-			server = require('child_process').spawn('npm', ['run', 'start', '--', '--dev'], {
-				stdio: ['ignore', 'inherit', 'inherit'],
+			server = require("child_process").spawn("npm", ["run", "start", "--", "--dev"], {
+				stdio: ["ignore", "inherit", "inherit"],
 				shell: true
 			});
 
-			process.on('SIGTERM', toExit);
-			process.on('exit', toExit);
+			process.on("SIGTERM", toExit);
+			process.on("exit", toExit);
 		}
 	};
 }
 
-const REPO_ROOT = '../../..';
+const REPO_ROOT = "../../..";
 
 export default {
-	input: 'src/main.js',
-	output: [{
-		sourcemap: true,
-		format: 'iife',
-		name: 'app',
-		file: 'public/build/bundle.js'
-	}, {
-		sourcemap: true,
-		format: 'iife',
-		name: 'app',
-		file: `${REPO_ROOT}/gradio/templates/frontend/build/bundle.js`
-	}],
+	input: "src/main.js",
+	output: [
+		{
+			sourcemap: true,
+			format: "iife",
+			name: "app",
+			file: "public/build/bundle.js"
+		},
+		{
+			sourcemap: true,
+			format: "iife",
+			name: "app",
+			file: `${REPO_ROOT}/gradio/templates/frontend/build/bundle.js`
+		}
+	],
 	plugins: [
 		copy({
 			targets: [
-				{ src: 'public/*', dest: `${REPO_ROOT}/gradio/templates/frontend` },
-				{ src: 'public/static', dest: `${REPO_ROOT}/gradio/templates/frontend` }
+				{ src: "public/*", dest: `${REPO_ROOT}/gradio/templates/frontend` },
+				{ src: "public/static", dest: `${REPO_ROOT}/gradio/templates/frontend` }
 			]
 		}),
 		json(),
@@ -61,23 +64,15 @@ export default {
 			BACKEND_URL: production ? "" : "http://localhost:7860/"
 		}),
 		postcss({
-			extract: 'themes.css',
-			plugins: [
-				require("tailwindcss"),
-				require("postcss-nested"),
-				require("autoprefixer"),
-			]
+			extract: "themes.css",
+			plugins: [require("tailwindcss"), require("postcss-nested"), require("autoprefixer")]
 		}),
 		svelte({
 			preprocess: sveltePreprocess({
 				// sourceMap: true,
 				postcss: {
-					plugins: [
-						require("tailwindcss"),
-						require("postcss-nested"),
-						require("autoprefixer"),
-					],
-				},
+					plugins: [require("tailwindcss"), require("postcss-nested"), require("autoprefixer")]
+				}
 			}),
 			compilerOptions: {
 				// enable run-time checks when not in production
@@ -87,7 +82,7 @@ export default {
 		// we'll extract any component CSS out into
 		// a separate file - better for performance
 		css({
-			output: 'bundle.css' 
+			output: "bundle.css"
 		}),
 
 		// If you have external dependencies installed from
@@ -97,7 +92,7 @@ export default {
 		// https://github.com/rollup/plugins/tree/master/packages/commonjs
 		resolve({
 			browser: true,
-			dedupe: ['svelte']
+			dedupe: ["svelte"]
 		}),
 		commonjs(),
 
@@ -107,7 +102,7 @@ export default {
 
 		// Watch the `public` directory and refresh the
 		// browser on changes when not in production
-		!production && livereload('public'),
+		!production && livereload("public"),
 
 		// If we're building for production (npm run build
 		// instead of npm run dev), minify

--- a/ui/packages/app/src/App.svelte
+++ b/ui/packages/app/src/App.svelte
@@ -1,52 +1,52 @@
 <script>
-  import Interface from "./Interface.svelte";
+	import Interface from "./Interface.svelte";
 
-  export let title;
-  export let description;
-  export let theme;
-  export let dark;
-  export let input_components;
-  export let output_components;
-  export let examples;
-  export let fn;
-  export let root;
-  export let allow_flagging;
-  export let allow_interpretation;
+	export let title;
+	export let description;
+	export let theme;
+	export let dark;
+	export let input_components;
+	export let output_components;
+	export let examples;
+	export let fn;
+	export let root;
+	export let allow_flagging;
+	export let allow_interpretation;
 </script>
 
 <div
-  class="gradio-bg flex flex-col dark:bg-gray-600 {window.gradio_mode === 'app'
-    ? 'h-full'
-    : 'h-auto'}"
-  {theme}
-  class:dark
+	class="gradio-bg flex flex-col dark:bg-gray-600 {window.gradio_mode === 'app'
+		? 'h-full'
+		: 'h-auto'}"
+	{theme}
+	class:dark
 >
-  <div
-    class="gradio-page container mx-auto flex flex-col box-border flex-grow text-gray-700 dark:text-gray-50"
-  >
-    <div class="content pt-4 px-4 mb-4">
-      {#if title}
-        <h1 class="title text-center p-4 text-4xl">{title}</h1>
-      {/if}
-      {#if description}
-        <p class="description pb-4">{description}</p>
-      {/if}
-      <Interface
-        {input_components}
-        {output_components}
-        {examples}
-        {theme}
-        {fn}
-        {root}
-        {allow_flagging}
-        {allow_interpretation}
-      />
-    </div>
-  </div>
+	<div
+		class="gradio-page container mx-auto flex flex-col box-border flex-grow text-gray-700 dark:text-gray-50"
+	>
+		<div class="content pt-4 px-4 mb-4">
+			{#if title}
+				<h1 class="title text-center p-4 text-4xl">{title}</h1>
+			{/if}
+			{#if description}
+				<p class="description pb-4">{description}</p>
+			{/if}
+			<Interface
+				{input_components}
+				{output_components}
+				{examples}
+				{theme}
+				{fn}
+				{root}
+				{allow_flagging}
+				{allow_interpretation}
+			/>
+		</div>
+	</div>
 </div>
 
 <style global lang="postcss">
-  @tailwind base;
-  @tailwind components;
-  @tailwind utilities;
+	@tailwind base;
+	@tailwind components;
+	@tailwind utilities;
 </style>

--- a/ui/packages/app/src/ExampleSet.svelte
+++ b/ui/packages/app/src/ExampleSet.svelte
@@ -1,101 +1,101 @@
 <script>
-  import { input_component_map } from "./components/directory.js";
+	import { input_component_map } from "./components/directory.js";
 
-  export let examples,
-    examples_dir,
-    example_id,
-    setExampleId,
-    examples_per_page,
-    input_components,
-    theme;
+	export let examples,
+		examples_dir,
+		example_id,
+		setExampleId,
+		examples_per_page,
+		input_components,
+		theme;
 
-  let selected_examples = examples;
-  let gallery = input_components.length === 1;
+	let selected_examples = examples;
+	let gallery = input_components.length === 1;
 </script>
 
 <div class="examples" {theme}>
-  <h4 class="text-lg font-semibold my-2">Examples</h4>
-  <div
-    class="examples-holder mt-4 inline-block max-w-full"
-    class:gallery
-    class:overflow-x-auto={!gallery}
-  >
-    {#if gallery}
-      <div class="examples-gallery flex gap-2 flex-wrap">
-        {#each selected_examples as example_row, i}
-          <button
-            class="example cursor-pointer p-2 rounded bg-gray-50 dark:bg-gray-700 transition"
-            on:click={() => setExampleId(i)}
-          >
-            <svelte:component
-              this={input_component_map[input_components[0].name].example}
-              {theme}
-              value={example_row[0]}
-              {examples_dir}
-            />
-          </button>
-        {/each}
-      </div>
-    {:else}
-      <table
-        class="examples-table table-auto p-2 bg-gray-50 dark:bg-gray-600 rounded max-w-full border-collapse"
-      >
-        <thead class="border-b-2 dark:border-gray-600">
-          <tr>
-            {#each input_components as input_component, i}
-              <th class="py-2 px-4" key={i}>
-                {input_component.label}
-              </th>
-            {/each}
-          </tr>
-        </thead>
-        <tbody>
-          {#each selected_examples as example_row, i}
-            <tr
-              class="cursor-pointer transition"
-              key={i}
-              class:selected={i === example_id}
-              on:click={() => setExampleId(i)}
-            >
-              {#each example_row as example_cell, j}
-                <td class="py-2 px-4">
-                  <svelte:component
-                    this={input_component_map[input_components[j].name].example}
-                    {theme}
-                    value={example_cell}
-                    {examples_dir}
-                  />
-                </td>
-              {/each}
-            </tr>
-          {/each}
-        </tbody>
-      </table>
-    {/if}
-  </div>
+	<h4 class="text-lg font-semibold my-2">Examples</h4>
+	<div
+		class="examples-holder mt-4 inline-block max-w-full"
+		class:gallery
+		class:overflow-x-auto={!gallery}
+	>
+		{#if gallery}
+			<div class="examples-gallery flex gap-2 flex-wrap">
+				{#each selected_examples as example_row, i}
+					<button
+						class="example cursor-pointer p-2 rounded bg-gray-50 dark:bg-gray-700 transition"
+						on:click={() => setExampleId(i)}
+					>
+						<svelte:component
+							this={input_component_map[input_components[0].name].example}
+							{theme}
+							value={example_row[0]}
+							{examples_dir}
+						/>
+					</button>
+				{/each}
+			</div>
+		{:else}
+			<table
+				class="examples-table table-auto p-2 bg-gray-50 dark:bg-gray-600 rounded max-w-full border-collapse"
+			>
+				<thead class="border-b-2 dark:border-gray-600">
+					<tr>
+						{#each input_components as input_component, i}
+							<th class="py-2 px-4" key={i}>
+								{input_component.label}
+							</th>
+						{/each}
+					</tr>
+				</thead>
+				<tbody>
+					{#each selected_examples as example_row, i}
+						<tr
+							class="cursor-pointer transition"
+							key={i}
+							class:selected={i === example_id}
+							on:click={() => setExampleId(i)}
+						>
+							{#each example_row as example_cell, j}
+								<td class="py-2 px-4">
+									<svelte:component
+										this={input_component_map[input_components[j].name].example}
+										{theme}
+										value={example_cell}
+										{examples_dir}
+									/>
+								</td>
+							{/each}
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		{/if}
+	</div>
 </div>
 
 <style lang="postcss" global>
-  .examples[theme="default"] {
-    .examples-holder:not(.gallery) {
-      @apply shadow;
-      .examples-table {
-        @apply rounded dark:bg-gray-700;
-        thead {
-          @apply border-gray-300 dark:border-gray-600;
-        }
-        tbody tr:hover {
-          @apply bg-yellow-500 dark:bg-red-700 text-white;
-        }
-      }
-    }
-    .examples-holder .examples-gallery {
-      .example {
-        @apply shadow;
-      }
-      .example:hover {
-        @apply bg-yellow-500 text-white;
-      }
-    }
-  }
+	.examples[theme="default"] {
+		.examples-holder:not(.gallery) {
+			@apply shadow;
+			.examples-table {
+				@apply rounded dark:bg-gray-700;
+				thead {
+					@apply border-gray-300 dark:border-gray-600;
+				}
+				tbody tr:hover {
+					@apply bg-yellow-500 dark:bg-red-700 text-white;
+				}
+			}
+		}
+		.examples-holder .examples-gallery {
+			.example {
+				@apply shadow;
+			}
+			.example:hover {
+				@apply bg-yellow-500 text-white;
+			}
+		}
+	}
 </style>

--- a/ui/packages/app/src/Interface.svelte
+++ b/ui/packages/app/src/Interface.svelte
@@ -1,319 +1,285 @@
 <script>
-  import {
-    input_component_map,
-    output_component_map,
-  } from "./components/directory.js";
-  import { deepCopy } from "./components/utils/helpers.js";
-  import ExampleSet from "./ExampleSet.svelte";
+	import { input_component_map, output_component_map } from "./components/directory.js";
+	import { deepCopy } from "./components/utils/helpers.js";
+	import ExampleSet from "./ExampleSet.svelte";
 
-  export let input_components;
-  export let output_components;
-  export let theme;
-  export let fn;
-  export let examples;
-  export let root;
-  export let allow_flagging;
-  export let allow_interpretation;
-  export let avg_durations;
+	export let input_components;
+	export let output_components;
+	export let theme;
+	export let fn;
+	export let examples;
+	export let root;
+	export let allow_flagging;
+	export let allow_interpretation;
+	export let avg_durations;
 
-  let examples_dir = root + "file/";
-  let interpret_mode = false;
-  let submission_count = 0;
-  let state = "START";
-  let last_duration = null;
+	let examples_dir = root + "file/";
+	let interpret_mode = false;
+	let submission_count = 0;
+	let state = "START";
+	let last_duration = null;
 
-  const default_inputs = input_components.map((component) =>
-    "default" in component ? component.default : null
-  );
-  const default_outputs = new Array(output_components.length).fill(null);
+	const default_inputs = input_components.map((component) =>
+		"default" in component ? component.default : null
+	);
+	const default_outputs = new Array(output_components.length).fill(null);
 
-  let input_values = deepCopy(default_inputs);
-  let output_values = deepCopy(default_outputs);
-  let interpretation_values = [];
-  let timer = null;
-  let timer_start = 0;
-  let timer_diff = 0;
-  let avg_duration = Array.isArray(avg_durations)
-    ? this.props.avg_durations[0]
-    : null;
+	let input_values = deepCopy(default_inputs);
+	let output_values = deepCopy(default_outputs);
+	let interpretation_values = [];
+	let timer = null;
+	let timer_start = 0;
+	let timer_diff = 0;
+	let avg_duration = Array.isArray(avg_durations) ? this.props.avg_durations[0] : null;
 
-  const setValues = (index, value) => {
-    input_values[index] = value;
-  };
-  const setExampleId = async (example_id) => {
-    input_components.forEach(async (input_component, i) => {
-      const process_example =
-        input_component_map[input_component.name].process_example;
-      if (process_example !== undefined) {
-        input_values[i] = await process_example(
-          examples[example_id][i],
-          examples_dir
-        );
-      } else {
-        input_values[i] = examples[example_id][i];
-      }
-    });
-  };
-  const startTimer = () => {
-    timer_start = Date.now();
-    timer_diff = 0;
-    timer = setInterval(() => {
-      timer_diff = (Date.now() - timer_start) / 1000;
-    }, 100);
-  };
-  const stopTimer = () => {
-    clearInterval(timer);
-  };
-  const submit = () => {
-    if (state === "PENDING") {
-      return;
-    }
-    state = "PENDING";
-    submission_count += 1;
-    let submission_count_at_click = submission_count;
-    startTimer();
-    fn("predict", { data: input_values })
-      .then((output) => {
-        if (
-          state !== "PENDING" ||
-          submission_count_at_click !== submission_count
-        ) {
-          return;
-        }
-        stopTimer();
-        output_values = output["data"];
-        if ("durations" in output) {
-          last_duration = output["durations"][0];
-        }
-        if ("avg_duration" in output) {
-          avg_duration = output["avg_durations"][0];
-        }
-        state = "COMPLETE";
-      })
-      .catch((e) => {
-        if (
-          state !== "PENDING" ||
-          submission_count_at_click !== submission_count
-        ) {
-          return;
-        }
-        stopTimer();
-        console.error(e);
-        state = "ERROR";
-        output_values = deepCopy(default_outputs);
-      });
-  };
-  const clear = () => {
-    input_values = deepCopy(default_inputs);
-    output_values = deepCopy(default_outputs);
-    interpret_mode = false;
-    state = "START";
-    stopTimer();
-  };
-  const flag = () => {
-    fn("flag", {
-      data: {
-        input_data: input_values,
-        output_data: output_values,
-      },
-    });
-  };
-  const interpret = () => {
-    if (interpret_mode) {
-      interpret_mode = false;
-    } else {
-      fn("interpret", {
-        data: input_values,
-      }).then((output) => {
-        interpret_mode = true;
-        interpretation_values = output.interpretation_scores;
-      });
-    }
-  };
+	const setValues = (index, value) => {
+		input_values[index] = value;
+	};
+	const setExampleId = async (example_id) => {
+		input_components.forEach(async (input_component, i) => {
+			const process_example = input_component_map[input_component.name].process_example;
+			if (process_example !== undefined) {
+				input_values[i] = await process_example(examples[example_id][i], examples_dir);
+			} else {
+				input_values[i] = examples[example_id][i];
+			}
+		});
+	};
+	const startTimer = () => {
+		timer_start = Date.now();
+		timer_diff = 0;
+		timer = setInterval(() => {
+			timer_diff = (Date.now() - timer_start) / 1000;
+		}, 100);
+	};
+	const stopTimer = () => {
+		clearInterval(timer);
+	};
+	const submit = () => {
+		if (state === "PENDING") {
+			return;
+		}
+		state = "PENDING";
+		submission_count += 1;
+		let submission_count_at_click = submission_count;
+		startTimer();
+		fn("predict", { data: input_values })
+			.then((output) => {
+				if (state !== "PENDING" || submission_count_at_click !== submission_count) {
+					return;
+				}
+				stopTimer();
+				output_values = output["data"];
+				if ("durations" in output) {
+					last_duration = output["durations"][0];
+				}
+				if ("avg_duration" in output) {
+					avg_duration = output["avg_durations"][0];
+				}
+				state = "COMPLETE";
+			})
+			.catch((e) => {
+				if (state !== "PENDING" || submission_count_at_click !== submission_count) {
+					return;
+				}
+				stopTimer();
+				console.error(e);
+				state = "ERROR";
+				output_values = deepCopy(default_outputs);
+			});
+	};
+	const clear = () => {
+		input_values = deepCopy(default_inputs);
+		output_values = deepCopy(default_outputs);
+		interpret_mode = false;
+		state = "START";
+		stopTimer();
+	};
+	const flag = () => {
+		fn("flag", {
+			data: {
+				input_data: input_values,
+				output_data: output_values
+			}
+		});
+	};
+	const interpret = () => {
+		if (interpret_mode) {
+			interpret_mode = false;
+		} else {
+			fn("interpret", {
+				data: input_values
+			}).then((output) => {
+				interpret_mode = true;
+				interpretation_values = output.interpretation_scores;
+			});
+		}
+	};
 </script>
 
 <div class="gradio-interface" {theme}>
-  <div class="panels flex flex-wrap justify-center gap-4">
-    <div class="panel flex-1">
-      <div
-        class="component-set p-2 rounded flex flex-col flex-1 gap-2"
-        style="min-height: 36px"
-      >
-        {#each input_components as input_component, i}
-          <div class="component" key={i}>
-            <div class="panel-header mb-1.5">{input_component.label}</div>
-            <svelte:component
-              this={input_component_map[input_component.name][
-                interpret_mode ? "interpretation" : "component"
-              ]}
-              {...input_component}
-              {theme}
-              value={input_values[i]}
-              interpretation={interpret_mode ? interpretation_values[i] : null}
-              setValue={setValues.bind(this, i)}
-            />
-          </div>
-        {/each}
-      </div>
-      <div class="panel-buttons flex gap-4 my-4">
-        <button
-          class="panel-button bg-gray-50 dark:bg-gray-700 flex-1 p-3 rounded transition font-semibold focus:outline-none"
-          on:click={clear}
-        >
-          Clear
-        </button>
-        <button
-          class="panel-button submit bg-gray-50 dark:bg-gray-700 flex-1 p-3 rounded transition font-semibold focus:outline-none"
-          on:click={submit}
-        >
-          Submit
-        </button>
-      </div>
-    </div>
-    <div class="panel flex-1">
-      <div
-        class="component-set p-2 rounded flex flex-col flex-1 gap-2 relative"
-        style="min-height: 36px"
-        class:opacity-50={state === "PENDING"}
-      >
-        {#if state !== "START"}
-          <div class="state absolute right-2 flex items-center gap-2 text-xs">
-            {#if state === "PENDING"}
-              <div class="timer font-mono">{timer_diff.toFixed(1)}s</div>
-              <img
-                src="./static/img/logo.svg"
-                alt="Pending"
-                class="pending h-5 ml-2 inline-block"
-              />
-            {:else if state === "ERROR"}
-              <img
-                src="./static/img/logo_error.svg"
-                alt="Error"
-                class="error h-5 ml-2 inline-block"
-              />
-            {:else if state === "COMPLETE" && last_duration !== null}
-              <div class="duration font-mono">{last_duration.toFixed(1)}s</div>
-            {/if}
-          </div>
-        {/if}
-        {#each output_components as output_component, i}
-          {#if output_values[i] !== null}
-            <div class="component" key={i}>
-              <div class="panel-header mb-1.5">{output_component.label}</div>
-              <svelte:component
-                this={output_component_map[output_component.name].component}
-                {...output_component}
-                {theme}
-                value={output_values[i]}
-              />
-            </div>
-          {/if}
-        {/each}
-      </div>
-      <div class="panel-buttons flex gap-4 my-4">
-        {#if allow_interpretation !== false}
-          <button
-            class="panel-button flag bg-gray-50 dark:bg-gray-700 flex-1 p-3 rounded transition font-semibold focus:outline-none"
-            on:click={interpret}
-          >
-            {#if interpret_mode}
-              Hide
-            {:else}
-              Interpret
-            {/if}
-          </button>
-        {/if}
-        {#if allow_flagging !== "never"}
-          <button
-            class="panel-button flag bg-gray-50 dark:bg-gray-700 flex-1 p-3 rounded transition font-semibold focus:outline-none"
-            on:click={flag}
-          >
-            Flag
-          </button>
-        {/if}
-      </div>
-    </div>
-  </div>
-  {#if examples}
-    <ExampleSet
-      {examples}
-      {input_components}
-      {theme}
-      {examples_dir}
-      {setExampleId}
-    />
-  {/if}
+	<div class="panels flex flex-wrap justify-center gap-4">
+		<div class="panel flex-1">
+			<div class="component-set p-2 rounded flex flex-col flex-1 gap-2" style="min-height: 36px">
+				{#each input_components as input_component, i}
+					<div class="component" key={i}>
+						<div class="panel-header mb-1.5">{input_component.label}</div>
+						<svelte:component
+							this={input_component_map[input_component.name][
+								interpret_mode ? "interpretation" : "component"
+							]}
+							{...input_component}
+							{theme}
+							value={input_values[i]}
+							interpretation={interpret_mode ? interpretation_values[i] : null}
+							setValue={setValues.bind(this, i)}
+						/>
+					</div>
+				{/each}
+			</div>
+			<div class="panel-buttons flex gap-4 my-4">
+				<button
+					class="panel-button bg-gray-50 dark:bg-gray-700 flex-1 p-3 rounded transition font-semibold focus:outline-none"
+					on:click={clear}
+				>
+					Clear
+				</button>
+				<button
+					class="panel-button submit bg-gray-50 dark:bg-gray-700 flex-1 p-3 rounded transition font-semibold focus:outline-none"
+					on:click={submit}
+				>
+					Submit
+				</button>
+			</div>
+		</div>
+		<div class="panel flex-1">
+			<div
+				class="component-set p-2 rounded flex flex-col flex-1 gap-2 relative"
+				style="min-height: 36px"
+				class:opacity-50={state === "PENDING"}
+			>
+				{#if state !== "START"}
+					<div class="state absolute right-2 flex items-center gap-2 text-xs">
+						{#if state === "PENDING"}
+							<div class="timer font-mono">{timer_diff.toFixed(1)}s</div>
+							<img
+								src="./static/img/logo.svg"
+								alt="Pending"
+								class="pending h-5 ml-2 inline-block"
+							/>
+						{:else if state === "ERROR"}
+							<img
+								src="./static/img/logo_error.svg"
+								alt="Error"
+								class="error h-5 ml-2 inline-block"
+							/>
+						{:else if state === "COMPLETE" && last_duration !== null}
+							<div class="duration font-mono">{last_duration.toFixed(1)}s</div>
+						{/if}
+					</div>
+				{/if}
+				{#each output_components as output_component, i}
+					{#if output_values[i] !== null}
+						<div class="component" key={i}>
+							<div class="panel-header mb-1.5">{output_component.label}</div>
+							<svelte:component
+								this={output_component_map[output_component.name].component}
+								{...output_component}
+								{theme}
+								value={output_values[i]}
+							/>
+						</div>
+					{/if}
+				{/each}
+			</div>
+			<div class="panel-buttons flex gap-4 my-4">
+				{#if allow_interpretation !== false}
+					<button
+						class="panel-button flag bg-gray-50 dark:bg-gray-700 flex-1 p-3 rounded transition font-semibold focus:outline-none"
+						on:click={interpret}
+					>
+						{#if interpret_mode}
+							Hide
+						{:else}
+							Interpret
+						{/if}
+					</button>
+				{/if}
+				{#if allow_flagging !== "never"}
+					<button
+						class="panel-button flag bg-gray-50 dark:bg-gray-700 flex-1 p-3 rounded transition font-semibold focus:outline-none"
+						on:click={flag}
+					>
+						Flag
+					</button>
+				{/if}
+			</div>
+		</div>
+	</div>
+	{#if examples}
+		<ExampleSet {examples} {input_components} {theme} {examples_dir} {setExampleId} />
+	{/if}
 </div>
 
 <style lang="postcss" global>
-  .pending {
-    @keyframes ld-breath {
-      0% {
-        animation-timing-function: cubic-bezier(
-          0.9647,
-          0.2413,
-          -0.0705,
-          0.7911
-        );
-        transform: scale(0.9);
-      }
-      51% {
-        animation-timing-function: cubic-bezier(
-          0.9226,
-          0.2631,
-          -0.0308,
-          0.7628
-        );
-        transform: scale(1.2);
-      }
-      100% {
-        transform: scale(0.9);
-      }
-    }
-    animation: ld-breath 0.75s infinite linear;
-  }
-  .gradio-interface[theme="default"] {
-    .component-set {
-      @apply bg-gray-50 dark:bg-gray-700 dark:drop-shadow-xl shadow;
-    }
-    .component {
-      @apply mb-2;
-    }
-    .panel-header {
-      @apply uppercase text-xs;
-    }
-    .panel-button {
-      @apply hover:bg-gray-100 dark:hover:bg-gray-600 shadow;
-    }
-    .panel-button.disabled {
-      @apply text-gray-400 cursor-not-allowed;
-    }
-    .panel-button.submit {
-      @apply bg-yellow-500 hover:bg-yellow-400 dark:bg-red-700 dark:hover:bg-red-600 text-white;
-    }
-    .examples {
-      .examples-table-holder:not(.gallery) {
-        @apply shadow;
-        .examples-table {
-          @apply rounded dark:bg-gray-700;
-          thead {
-            @apply border-gray-300 dark:border-gray-600;
-          }
-          tbody tr:hover {
-            @apply bg-yellow-500 dark:bg-red-700 text-white;
-          }
-        }
-      }
-      .examples-table-holder.gallery .examples-table {
-        tbody td {
-          @apply shadow;
-        }
-        tbody td:hover {
-          @apply bg-yellow-500 text-white;
-        }
-      }
-    }
-  }
-  .gradio-interface[theme="huggingface"] {
-  }
+	.pending {
+		@keyframes ld-breath {
+			0% {
+				animation-timing-function: cubic-bezier(0.9647, 0.2413, -0.0705, 0.7911);
+				transform: scale(0.9);
+			}
+			51% {
+				animation-timing-function: cubic-bezier(0.9226, 0.2631, -0.0308, 0.7628);
+				transform: scale(1.2);
+			}
+			100% {
+				transform: scale(0.9);
+			}
+		}
+		animation: ld-breath 0.75s infinite linear;
+	}
+	.gradio-interface[theme="default"] {
+		.component-set {
+			@apply bg-gray-50 dark:bg-gray-700 dark:drop-shadow-xl shadow;
+		}
+		.component {
+			@apply mb-2;
+		}
+		.panel-header {
+			@apply uppercase text-xs;
+		}
+		.panel-button {
+			@apply hover:bg-gray-100 dark:hover:bg-gray-600 shadow;
+		}
+		.panel-button.disabled {
+			@apply text-gray-400 cursor-not-allowed;
+		}
+		.panel-button.submit {
+			@apply bg-yellow-500 hover:bg-yellow-400 dark:bg-red-700 dark:hover:bg-red-600 text-white;
+		}
+		.examples {
+			.examples-table-holder:not(.gallery) {
+				@apply shadow;
+				.examples-table {
+					@apply rounded dark:bg-gray-700;
+					thead {
+						@apply border-gray-300 dark:border-gray-600;
+					}
+					tbody tr:hover {
+						@apply bg-yellow-500 dark:bg-red-700 text-white;
+					}
+				}
+			}
+			.examples-table-holder.gallery .examples-table {
+				tbody td {
+					@apply shadow;
+				}
+				tbody td:hover {
+					@apply bg-yellow-500 text-white;
+				}
+			}
+		}
+	}
+	.gradio-interface[theme="huggingface"] {
+	}
 </style>

--- a/ui/packages/app/src/Login.svelte
+++ b/ui/packages/app/src/Login.svelte
@@ -1,23 +1,23 @@
 <script>
-  export let root;
+	export let root;
 </script>
 
 <div class="login container mt-8">
-  <form
-    class="mx-auto p-4 bg-gray-50 shadow-md w-1/2"
-    id="login"
-    method="POST"
-    action={root + "login"}
-  >
-    <h2 class="text-2xl font-semibold my-2">login</h2>
+	<form
+		class="mx-auto p-4 bg-gray-50 shadow-md w-1/2"
+		id="login"
+		method="POST"
+		action={root + "login"}
+	>
+		<h2 class="text-2xl font-semibold my-2">login</h2>
 
-    <label class="block uppercase mt-4" for="username">username</label>
-    <input class="p-2 block" type="text" name="username" />
-    <label class="block uppercase mt-4" for="password">password</label>
-    <input class="p-2 block" type="password" name="password" />
-    <input
-      type="submit"
-      class="block bg-yellow-500 hover:bg-yellow-400 dark:hover:bg-yellow-600 transition px-4 py-2 rounded text-white font-semibold cursor-pointer mt-4"
-    />
-  </form>
+		<label class="block uppercase mt-4" for="username">username</label>
+		<input class="p-2 block" type="text" name="username" />
+		<label class="block uppercase mt-4" for="password">password</label>
+		<input class="p-2 block" type="password" name="password" />
+		<input
+			type="submit"
+			class="block bg-yellow-500 hover:bg-yellow-400 dark:hover:bg-yellow-600 transition px-4 py-2 rounded text-white font-semibold cursor-pointer mt-4"
+		/>
+	</form>
 </div>

--- a/ui/packages/app/src/api.js
+++ b/ui/packages/app/src/api.js
@@ -1,54 +1,51 @@
 function delay(n) {
-  return new Promise(function (resolve) {
-    setTimeout(resolve, n * 1000);
-  });
+	return new Promise(function (resolve) {
+		setTimeout(resolve, n * 1000);
+	});
 }
 
 let postData = async (url, body) => {
-  const output = await fetch(url, {
-    method: "POST",
-    body: JSON.stringify(body),
-    headers: { "Content-Type": "application/json" }
-  });
-  return output;
+	const output = await fetch(url, {
+		method: "POST",
+		body: JSON.stringify(body),
+		headers: { "Content-Type": "application/json" }
+	});
+	return output;
 };
 
 export const fn = async (api_endpoint, action, data, queue, queue_callback) => {
-  if (queue && ["predict", "interpret"].includes(action)) {
-    data["action"] = action;
-    const output = await postData(api_endpoint + "queue/push/", data);
-    const output_json = await output.json();
-    let [hash, queue_position] = [
-      output_json["hash"],
-      output_json["queue_position"]
-    ];
-    queue_callback(queue_position, /*is_initial=*/ true);
-    let status = "UNKNOWN";
-    while (status != "COMPLETE" && status != "FAILED") {
-      if (status != "UNKNOWN") {
-        await delay(1);
-      }
-      const status_response = await postData(api_endpoint + "queue/status/", {
-        hash: hash
-      });
-      var status_obj = await status_response.json();
-      status = status_obj["status"];
-      if (status === "QUEUED") {
-        queue_callback(status_obj["data"]);
-      } else if (status === "PENDING") {
-        queue_callback(null);
-      }
-    }
-    if (status == "FAILED") {
-      throw new Error(status);
-    } else {
-      return status_obj["data"];
-    }
-  } else {
-    const output = await postData(api_endpoint + action + "/", data);
-    if (output.status !== 200) {
-      throw new Error(output.statusText);
-    }
-    return await output.json();
-  }
+	if (queue && ["predict", "interpret"].includes(action)) {
+		data["action"] = action;
+		const output = await postData(api_endpoint + "queue/push/", data);
+		const output_json = await output.json();
+		let [hash, queue_position] = [output_json["hash"], output_json["queue_position"]];
+		queue_callback(queue_position, /*is_initial=*/ true);
+		let status = "UNKNOWN";
+		while (status != "COMPLETE" && status != "FAILED") {
+			if (status != "UNKNOWN") {
+				await delay(1);
+			}
+			const status_response = await postData(api_endpoint + "queue/status/", {
+				hash: hash
+			});
+			var status_obj = await status_response.json();
+			status = status_obj["status"];
+			if (status === "QUEUED") {
+				queue_callback(status_obj["data"]);
+			} else if (status === "PENDING") {
+				queue_callback(null);
+			}
+		}
+		if (status == "FAILED") {
+			throw new Error(status);
+		} else {
+			return status_obj["data"];
+		}
+	} else {
+		const output = await postData(api_endpoint + action + "/", data);
+		if (output.status !== 200) {
+			throw new Error(output.statusText);
+		}
+		return await output.json();
+	}
 };

--- a/ui/packages/app/src/components/Dummy.svelte
+++ b/ui/packages/app/src/components/Dummy.svelte
@@ -1,6 +1,6 @@
 <script>
-    export let value, setValue, theme;
-    export let choices;
+	export let value, setValue, theme;
+	export let choices;
 </script>
 
 <div class="dummy" {theme}>DUMMY</div>

--- a/ui/packages/app/src/components/directory.js
+++ b/ui/packages/app/src/components/directory.js
@@ -10,7 +10,7 @@ import InputSlider from "./input/Slider/config.js";
 import InputTextbox from "./input/Textbox/config.js";
 import InputVideo from "./input/Video/config.js";
 import InputDataFrame from "./input/DataFrame/config.js";
-import InputTimeSeries from './input/TimeSeries/config.js';
+import InputTimeSeries from "./input/TimeSeries/config.js";
 
 import OutputAudio from "./output/Audio/config.js";
 import OutputCarousel from "./output/Carousel/config.js";
@@ -23,37 +23,37 @@ import OutputJson from "./output/Json/config.js";
 import OutputLabel from "./output/Label/config.js";
 import OutputTextbox from "./output/Textbox/config.js";
 import OutputVideo from "./output/Video/config.js";
-import OutputTimeSeries from './output/TimeSeries/config.js'
+import OutputTimeSeries from "./output/TimeSeries/config.js";
 
-import Dummy from "./Dummy.svelte"
+import Dummy from "./Dummy.svelte";
 
 export const input_component_map = {
-    "audio": InputAudio,
-    "checkbox": InputCheckbox,
-    "checkboxgroup": InputCheckboxGroup,
-    "dataframe": InputDataFrame,
-    "dropdown": InputDropdown,
-    "file": InputFile,
-    "image": InputImage,
-    "number": InputNumber,
-    "radio": InputRadio,
-    "slider": InputSlider,
-    "textbox": InputTextbox,
-    "timeseries": InputTimeSeries,
-    "video": InputVideo,
-}
+	audio: InputAudio,
+	checkbox: InputCheckbox,
+	checkboxgroup: InputCheckboxGroup,
+	dataframe: InputDataFrame,
+	dropdown: InputDropdown,
+	file: InputFile,
+	image: InputImage,
+	number: InputNumber,
+	radio: InputRadio,
+	slider: InputSlider,
+	textbox: InputTextbox,
+	timeseries: InputTimeSeries,
+	video: InputVideo
+};
 
 export const output_component_map = {
-    "audio": OutputAudio,
-    "carousel": OutputCarousel,
-    "dataframe": OutputDataframe,
-    "file": OutputFile,
-    "highlightedtext": OutputHighlightedText,
-    "html": OutputHtml,
-    "image": OutputImage,
-    "json": OutputJson,
-    "label": OutputLabel,
-    "textbox": OutputTextbox,
-    "timeseries": OutputTimeSeries,
-    "video": OutputVideo,
-}
+	audio: OutputAudio,
+	carousel: OutputCarousel,
+	dataframe: OutputDataframe,
+	file: OutputFile,
+	highlightedtext: OutputHighlightedText,
+	html: OutputHtml,
+	image: OutputImage,
+	json: OutputJson,
+	label: OutputLabel,
+	textbox: OutputTextbox,
+	timeseries: OutputTimeSeries,
+	video: OutputVideo
+};

--- a/ui/packages/app/src/components/input/Audio/Component.svelte
+++ b/ui/packages/app/src/components/input/Audio/Component.svelte
@@ -1,160 +1,155 @@
 <script>
-  import { onDestroy } from "svelte";
-  import Upload from "../../utils/Upload.svelte";
-  import ModifyUpload from "../../utils/ModifyUpload.svelte";
-  import Range from "svelte-range-slider-pips";
+	import { onDestroy } from "svelte";
+	import Upload from "../../utils/Upload.svelte";
+	import ModifyUpload from "../../utils/ModifyUpload.svelte";
+	import Range from "svelte-range-slider-pips";
 
-  export let value,
-    setValue,
-    theme,
-    name,
-    is_example = false;
-  export let source;
+	export let value,
+		setValue,
+		theme,
+		name,
+		is_example = false;
+	export let source;
 
-  let recording = false;
-  let recorder;
-  let mode = "";
-  let audio_chunks = [];
-  let audio_blob;
-  let player;
-  let inited = false;
-  let crop_values = [0, 100];
+	let recording = false;
+	let recorder;
+	let mode = "";
+	let audio_chunks = [];
+	let audio_blob;
+	let player;
+	let inited = false;
+	let crop_values = [0, 100];
 
-  function blob_to_data_url(blob) {
-    return new Promise((fulfill, reject) => {
-      let reader = new FileReader();
-      reader.onerror = reject;
-      reader.onload = (e) => fulfill(reader.result);
-      reader.readAsDataURL(blob);
-    });
-  }
+	function blob_to_data_url(blob) {
+		return new Promise((fulfill, reject) => {
+			let reader = new FileReader();
+			reader.onerror = reject;
+			reader.onload = (e) => fulfill(reader.result);
+			reader.readAsDataURL(blob);
+		});
+	}
 
-  async function prepare_audio() {
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    recorder = new MediaRecorder(stream);
+	async function prepare_audio() {
+		const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+		recorder = new MediaRecorder(stream);
 
-    recorder.addEventListener("dataavailable", (event) => {
-      audio_chunks.push(event.data);
-    });
+		recorder.addEventListener("dataavailable", (event) => {
+			audio_chunks.push(event.data);
+		});
 
-    recorder.addEventListener("stop", async () => {
-      recording = false;
-      audio_blob = new Blob(audio_chunks, { type: "audio/wav" });
+		recorder.addEventListener("stop", async () => {
+			recording = false;
+			audio_blob = new Blob(audio_chunks, { type: "audio/wav" });
 
-      setValue({
-        data: await blob_to_data_url(audio_blob),
-        name,
-        is_example,
-      });
-    });
-  }
+			setValue({
+				data: await blob_to_data_url(audio_blob),
+				name,
+				is_example
+			});
+		});
+	}
 
-  async function record() {
-    recording = true;
-    audio_chunks = [];
+	async function record() {
+		recording = true;
+		audio_chunks = [];
 
-    if (!inited) await prepare_audio();
+		if (!inited) await prepare_audio();
 
-    recorder.start();
-  }
+		recorder.start();
+	}
 
-  onDestroy(() => {
-    if (recorder) {
-      recorder.stop();
-    }
-  });
+	onDestroy(() => {
+		if (recorder) {
+			recorder.stop();
+		}
+	});
 
-  const stop = () => {
-    recorder.stop();
-  };
+	const stop = () => {
+		recorder.stop();
+	};
 
-  function clear() {
-    setValue(null);
-    mode = "";
-  }
+	function clear() {
+		setValue(null);
+		mode = "";
+	}
 
-  function loaded(node) {
-    function clamp_playback() {
-      const start_time = (crop_values[0] / 100) * node.duration;
-      const end_time = (crop_values[1] / 100) * node.duration;
-      if (node.currentTime < start_time) {
-        node.currentTime = start_time;
-      }
+	function loaded(node) {
+		function clamp_playback() {
+			const start_time = (crop_values[0] / 100) * node.duration;
+			const end_time = (crop_values[1] / 100) * node.duration;
+			if (node.currentTime < start_time) {
+				node.currentTime = start_time;
+			}
 
-      if (node.currentTime > end_time) {
-        node.currentTime = start_time;
-        node.pause();
-      }
-    }
+			if (node.currentTime > end_time) {
+				node.currentTime = start_time;
+				node.pause();
+			}
+		}
 
-    node.addEventListener("timeupdate", clamp_playback);
+		node.addEventListener("timeupdate", clamp_playback);
 
-    return {
-      destroy: () => node.removeEventListener("timeupdate", clamp_playback),
-    };
-  }
+		return {
+			destroy: () => node.removeEventListener("timeupdate", clamp_playback)
+		};
+	}
 </script>
 
 <div class="input-audio">
-  {#if value === null}
-    {#if source === "microphone"}
-      {#if recording}
-        <button
-          class="p-2 rounded font-semibold bg-red-200 text-red-500 dark:bg-red-600 dark:text-red-100 shadow transition hover:shadow-md"
-          on:click={stop}
-        >
-          Stop Recording
-        </button>
-      {:else}
-        <button
-          class="p-2 rounded font-semibold bg-white dark:bg-gray-600 shadow transition hover:shadow-md bg-white dark:bg-gray-800"
-          on:click={record}
-        >
-          Record
-        </button>
-      {/if}
-    {:else if source === "upload"}
-      <Upload filetype="audio/*" load={setValue} {theme}>
-        Drop Audio Here
-        <br />- or -<br />
-        Click to Upload
-      </Upload>
-    {/if}
-  {:else}
-    <ModifyUpload
-      {clear}
-      edit={() => (mode = "edit")}
-      absolute={false}
-      {theme}
-    />
+	{#if value === null}
+		{#if source === "microphone"}
+			{#if recording}
+				<button
+					class="p-2 rounded font-semibold bg-red-200 text-red-500 dark:bg-red-600 dark:text-red-100 shadow transition hover:shadow-md"
+					on:click={stop}
+				>
+					Stop Recording
+				</button>
+			{:else}
+				<button
+					class="p-2 rounded font-semibold bg-white dark:bg-gray-600 shadow transition hover:shadow-md bg-white dark:bg-gray-800"
+					on:click={record}
+				>
+					Record
+				</button>
+			{/if}
+		{:else if source === "upload"}
+			<Upload filetype="audio/*" load={setValue} {theme}>
+				Drop Audio Here
+				<br />- or -<br />
+				Click to Upload
+			</Upload>
+		{/if}
+	{:else}
+		<ModifyUpload {clear} edit={() => (mode = "edit")} absolute={false} {theme} />
 
-    <audio
-      use:loaded
-      class="w-full"
-      controls
-      bind:this={player}
-      preload="metadata"
-      src={value.data}
-    />
+		<audio
+			use:loaded
+			class="w-full"
+			controls
+			bind:this={player}
+			preload="metadata"
+			src={value.data}
+		/>
 
-    {#if mode === "edit" && player?.duration}
-      <Range
-        bind:values={crop_values}
-        range
-        min={0}
-        max={100}
-        step={1}
-        on:change={({ detail: { values } }) =>
-          setValue({
-            data: value.data,
-            name,
-            is_example,
-            crop_min: values[0],
-            crop_max: values[1],
-          })}
-      />
-    {/if}
-  {/if}
+		{#if mode === "edit" && player?.duration}
+			<Range
+				bind:values={crop_values}
+				range
+				min={0}
+				max={100}
+				step={1}
+				on:change={({ detail: { values } }) =>
+					setValue({
+						data: value.data,
+						name,
+						is_example,
+						crop_min: values[0],
+						crop_max: values[1]
+					})}
+			/>
+		{/if}
+	{/if}
 </div>
 
 <style lang="postcss">

--- a/ui/packages/app/src/components/input/Audio/Example.svelte
+++ b/ui/packages/app/src/components/input/Audio/Example.svelte
@@ -1,5 +1,5 @@
 <script>
-    export let value;
-  </script>
-  
-  <div class="input-audio-example">{value}</div>  
+	export let value;
+</script>
+
+<div class="input-audio-example">{value}</div>

--- a/ui/packages/app/src/components/input/Audio/Interpretation.svelte
+++ b/ui/packages/app/src/components/input/Audio/Interpretation.svelte
@@ -1,17 +1,17 @@
 <script>
-  import { getSaliencyColor } from "../../utils/helpers";
-  export let value, interpretation, theme;
+	import { getSaliencyColor } from "../../utils/helpers";
+	export let value, interpretation, theme;
 </script>
 
 <div class="input-audio" {theme}>
-  <audio class="w-full" controls>
-    <source src={value.data} />
-  </audio>
-  <div class="interpret_range flex">
-    {#each interpretation as interpret_value}
-      <div class="flex-1 h-4" style={"background-color: " + getSaliencyColor(interpret_value)} />
-    {/each}
-  </div>
+	<audio class="w-full" controls>
+		<source src={value.data} />
+	</audio>
+	<div class="interpret_range flex">
+		{#each interpretation as interpret_value}
+			<div class="flex-1 h-4" style={"background-color: " + getSaliencyColor(interpret_value)} />
+		{/each}
+	</div>
 </div>
 
 <style lang="postcss">

--- a/ui/packages/app/src/components/input/Audio/config.js
+++ b/ui/packages/app/src/components/input/Audio/config.js
@@ -4,8 +4,8 @@ import Interpretation from "./Interpretation.svelte";
 import { loadAsFile } from "../../utils/example_processors";
 
 export default {
-    "component": Component,
-    "example": ExampleComponent,
-    "interpretation": Interpretation,
-    "process_example": loadAsFile
-}
+	component: Component,
+	example: ExampleComponent,
+	interpretation: Interpretation,
+	process_example: loadAsFile
+};

--- a/ui/packages/app/src/components/input/Checkbox/Component.svelte
+++ b/ui/packages/app/src/components/input/Checkbox/Component.svelte
@@ -1,54 +1,50 @@
 <script>
-  export let value, setValue, theme;
+	export let value, setValue, theme;
 </script>
 
-<div
-  class="input-checkbox inline-block"
-  {theme}
-  on:click={() => setValue(!value)}
->
-  <button class="checkbox-item py-2 px-3 rounded cursor-pointer" class:selected={value}>
-    <div class="checkbox w-4 h-4 bg-white flex items-center justify-center">
-      <svg class="check opacity-0 h-3 w-4" viewBox="-10 -10 20 20">
-        <line
-          x1="-7.5"
-          y1="0"
-          x2="-2.5"
-          y2="5"
-          stroke="white"
-          stroke-width="4"
-          stroke-linecap="round"
-        />
-        <line
-          x1="-2.5"
-          y1="5"
-          x2="7.5"
-          y2="-7.5"
-          stroke="white"
-          stroke-width="4"
-          stroke-linecap="round"
-        />
-      </svg>
-    </div>
-  </button>
+<div class="input-checkbox inline-block" {theme} on:click={() => setValue(!value)}>
+	<button class="checkbox-item py-2 px-3 rounded cursor-pointer" class:selected={value}>
+		<div class="checkbox w-4 h-4 bg-white flex items-center justify-center">
+			<svg class="check opacity-0 h-3 w-4" viewBox="-10 -10 20 20">
+				<line
+					x1="-7.5"
+					y1="0"
+					x2="-2.5"
+					y2="5"
+					stroke="white"
+					stroke-width="4"
+					stroke-linecap="round"
+				/>
+				<line
+					x1="-2.5"
+					y1="5"
+					x2="7.5"
+					y2="-7.5"
+					stroke="white"
+					stroke-width="4"
+					stroke-linecap="round"
+				/>
+			</svg>
+		</div>
+	</button>
 </div>
 
 <style lang="postcss">
-  .selected .check {
-    @apply opacity-100;
-  }
-  .input-checkbox[theme="default"] {
-    .checkbox-item {
-      @apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
-    }
-    .checkbox {
-      @apply bg-gray-100 dark:bg-gray-400 transition;
-    }
-    .checkbox-item.selected {
-      @apply bg-yellow-500 dark:bg-red-600 text-white;
-    }
-    .selected .checkbox {
-      @apply bg-yellow-600 dark:bg-red-700;
-    }
-  }
+	.selected .check {
+		@apply opacity-100;
+	}
+	.input-checkbox[theme="default"] {
+		.checkbox-item {
+			@apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
+		}
+		.checkbox {
+			@apply bg-gray-100 dark:bg-gray-400 transition;
+		}
+		.checkbox-item.selected {
+			@apply bg-yellow-500 dark:bg-red-600 text-white;
+		}
+		.selected .checkbox {
+			@apply bg-yellow-600 dark:bg-red-700;
+		}
+	}
 </style>

--- a/ui/packages/app/src/components/input/Checkbox/Example.svelte
+++ b/ui/packages/app/src/components/input/Checkbox/Example.svelte
@@ -1,5 +1,5 @@
 <script>
-    export let value;
-  </script>
-  
-  <div class="input-checkbox-example">{value.toLocaleString()}</div>  
+	export let value;
+</script>
+
+<div class="input-checkbox-example">{value.toLocaleString()}</div>

--- a/ui/packages/app/src/components/input/Checkbox/Interpretation.svelte
+++ b/ui/packages/app/src/components/input/Checkbox/Interpretation.svelte
@@ -1,56 +1,53 @@
 <script>
-  import { getSaliencyColor } from "../../utils/helpers";
+	import { getSaliencyColor } from "../../utils/helpers";
 
-  export let value, interpretation, theme;
+	export let value, interpretation, theme;
 </script>
 
 <div class="input-checkbox inline-block" {theme}>
-  <button
-    class="checkbox-item py-2 px-3 rounded cursor-pointer flex gap-1"
-    class:selected={value}
-  >
-    <div
-      class="checkbox w-4 h-4 bg-white flex items-center justify-center border border-gray-400 box-border"
-      style={"background-color: " + getSaliencyColor(interpretation[0])}
-    />
-    <div
-      class="checkbox w-4 h-4 bg-white flex items-center justify-center border border-gray-400 box-border"
-      style={"background-color: " + getSaliencyColor(interpretation[1])}
-    >
-      <svg class="check h-3 w-4" viewBox="-10 -10 20 20">
-        <line
-          x1="-7.5"
-          y1="0"
-          x2="-2.5"
-          y2="5"
-          stroke="black"
-          stroke-width="4"
-          stroke-linecap="round"
-        />
-        <line
-          x1="-2.5"
-          y1="5"
-          x2="7.5"
-          y2="-7.5"
-          stroke="black"
-          stroke-width="4"
-          stroke-linecap="round"
-        />
-      </svg>
-    </div>
-  </button>
+	<button class="checkbox-item py-2 px-3 rounded cursor-pointer flex gap-1" class:selected={value}>
+		<div
+			class="checkbox w-4 h-4 bg-white flex items-center justify-center border border-gray-400 box-border"
+			style={"background-color: " + getSaliencyColor(interpretation[0])}
+		/>
+		<div
+			class="checkbox w-4 h-4 bg-white flex items-center justify-center border border-gray-400 box-border"
+			style={"background-color: " + getSaliencyColor(interpretation[1])}
+		>
+			<svg class="check h-3 w-4" viewBox="-10 -10 20 20">
+				<line
+					x1="-7.5"
+					y1="0"
+					x2="-2.5"
+					y2="5"
+					stroke="black"
+					stroke-width="4"
+					stroke-linecap="round"
+				/>
+				<line
+					x1="-2.5"
+					y1="5"
+					x2="7.5"
+					y2="-7.5"
+					stroke="black"
+					stroke-width="4"
+					stroke-linecap="round"
+				/>
+			</svg>
+		</div>
+	</button>
 </div>
 
 <style lang="postcss">
-  .selected .check {
-    @apply opacity-100;
-  }
-  .input-checkbox[theme="default"] {
-    .checkbox-item {
-      @apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
-    }
-    .checkbox-item.selected {
-      @apply bg-yellow-500 dark:bg-red-600 text-white;
-    }
-  }
+	.selected .check {
+		@apply opacity-100;
+	}
+	.input-checkbox[theme="default"] {
+		.checkbox-item {
+			@apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
+		}
+		.checkbox-item.selected {
+			@apply bg-yellow-500 dark:bg-red-600 text-white;
+		}
+	}
 </style>

--- a/ui/packages/app/src/components/input/Checkbox/config.js
+++ b/ui/packages/app/src/components/input/Checkbox/config.js
@@ -3,7 +3,7 @@ import ExampleComponent from "./Example.svelte";
 import Interpretation from "./Interpretation.svelte";
 
 export default {
-    "component": Component, 
-    "example": ExampleComponent, 
-    "interpretation": Interpretation, 
-}
+	component: Component,
+	example: ExampleComponent,
+	interpretation: Interpretation
+};

--- a/ui/packages/app/src/components/input/CheckboxGroup/Component.svelte
+++ b/ui/packages/app/src/components/input/CheckboxGroup/Component.svelte
@@ -1,68 +1,68 @@
 <script>
-  export let value, setValue, theme;
-  export let choices;
+	export let value, setValue, theme;
+	export let choices;
 
-  const toggleChoice = (choice) => {
-    if (value.includes(choice)) {
-      value.splice(value.indexOf(choice), 1);
-    } else {
-      value.push(choice);
-    }
-    setValue(value);
-  };
+	const toggleChoice = (choice) => {
+		if (value.includes(choice)) {
+			value.splice(value.indexOf(choice), 1);
+		} else {
+			value.push(choice);
+		}
+		setValue(value);
+	};
 </script>
 
 <div class="input-checkbox-group flex flex-wrap gap-2" {theme}>
-  {#each choices as choice, i}
-    <button
-      class="checkbox-item py-2 px-3 font-semibold rounded cursor-pointer flex items-center gap-2"
-      class:selected={value.includes(choice)}
-      key={i}
-      on:click={() => toggleChoice(choice)}
-    >
-      <div class="checkbox w-4 h-4 bg-white flex items-center justify-center">
-        <svg class="check opacity-0 h-3 w-4" viewBox="-10 -10 20 20">
-          <line
-            x1="-7.5"
-            y1="0"
-            x2="-2.5"
-            y2="5"
-            stroke="white"
-            stroke-width="4"
-            stroke-linecap="round"
-          />
-          <line
-            x1="-2.5"
-            y1="5"
-            x2="7.5"
-            y2="-7.5"
-            stroke="white"
-            stroke-width="4"
-            stroke-linecap="round"
-          />
-        </svg>
-      </div>
-      {choice}
-    </button>
-  {/each}
+	{#each choices as choice, i}
+		<button
+			class="checkbox-item py-2 px-3 font-semibold rounded cursor-pointer flex items-center gap-2"
+			class:selected={value.includes(choice)}
+			key={i}
+			on:click={() => toggleChoice(choice)}
+		>
+			<div class="checkbox w-4 h-4 bg-white flex items-center justify-center">
+				<svg class="check opacity-0 h-3 w-4" viewBox="-10 -10 20 20">
+					<line
+						x1="-7.5"
+						y1="0"
+						x2="-2.5"
+						y2="5"
+						stroke="white"
+						stroke-width="4"
+						stroke-linecap="round"
+					/>
+					<line
+						x1="-2.5"
+						y1="5"
+						x2="7.5"
+						y2="-7.5"
+						stroke="white"
+						stroke-width="4"
+						stroke-linecap="round"
+					/>
+				</svg>
+			</div>
+			{choice}
+		</button>
+	{/each}
 </div>
 
 <style lang="postcss">
-  .selected .check {
-    @apply opacity-100;
-  }
-  .input-checkbox-group[theme="default"] {
-    .checkbox-item {
-      @apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
-    }
-    .checkbox {
-      @apply bg-gray-100 dark:bg-gray-400 transition;
-    }
-    .checkbox-item.selected {
-      @apply bg-yellow-500 dark:bg-red-600 text-white;
-    }
-    .selected .checkbox {
-      @apply bg-yellow-600 dark:bg-red-700;
-    }
-  }
+	.selected .check {
+		@apply opacity-100;
+	}
+	.input-checkbox-group[theme="default"] {
+		.checkbox-item {
+			@apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
+		}
+		.checkbox {
+			@apply bg-gray-100 dark:bg-gray-400 transition;
+		}
+		.checkbox-item.selected {
+			@apply bg-yellow-500 dark:bg-red-600 text-white;
+		}
+		.selected .checkbox {
+			@apply bg-yellow-600 dark:bg-red-700;
+		}
+	}
 </style>

--- a/ui/packages/app/src/components/input/CheckboxGroup/Example.svelte
+++ b/ui/packages/app/src/components/input/CheckboxGroup/Example.svelte
@@ -1,5 +1,5 @@
 <script>
-    export let value;
-  </script>
-  
-  <div class="input-checkboxgroup-example">{value.join(", ")}</div>  
+	export let value;
+</script>
+
+<div class="input-checkboxgroup-example">{value.join(", ")}</div>

--- a/ui/packages/app/src/components/input/CheckboxGroup/Interpretation.svelte
+++ b/ui/packages/app/src/components/input/CheckboxGroup/Interpretation.svelte
@@ -1,67 +1,67 @@
 <script>
-  import { getSaliencyColor } from "../../utils/helpers";
+	import { getSaliencyColor } from "../../utils/helpers";
 
-  export let value, interpretation, theme;
-  export let choices;
+	export let value, interpretation, theme;
+	export let choices;
 </script>
 
 <div class="input-checkbox-group flex flex-wrap gap-2" {theme}>
-  {#each choices as choice, i}
-    <button
-      class="checkbox-item py-2 px-3 font-semibold rounded cursor-pointer flex items-center gap-1"
-      class:selected={value.includes(choice)}
-      key={i}
-    >
-      <div
-        class="checkbox w-4 h-4 bg-white flex items-center justify-center border border-gray-400 box-border"
-        style={"background-color: " + getSaliencyColor(interpretation[i][0])}
-      />
-      <div
-        class="checkbox w-4 h-4 bg-white flex items-center justify-center border border-gray-400 box-border"
-        style={"background-color: " + getSaliencyColor(interpretation[i][1])}
-      >
-        <svg class="check h-3 w-4" viewBox="-10 -10 20 20">
-          <line
-            x1="-7.5"
-            y1="0"
-            x2="-2.5"
-            y2="5"
-            stroke="black"
-            stroke-width="4"
-            stroke-linecap="round"
-          />
-          <line
-            x1="-2.5"
-            y1="5"
-            x2="7.5"
-            y2="-7.5"
-            stroke="black"
-            stroke-width="4"
-            stroke-linecap="round"
-          />
-        </svg>
-      </div>
-      {choice}
-    </button>
-  {/each}
+	{#each choices as choice, i}
+		<button
+			class="checkbox-item py-2 px-3 font-semibold rounded cursor-pointer flex items-center gap-1"
+			class:selected={value.includes(choice)}
+			key={i}
+		>
+			<div
+				class="checkbox w-4 h-4 bg-white flex items-center justify-center border border-gray-400 box-border"
+				style={"background-color: " + getSaliencyColor(interpretation[i][0])}
+			/>
+			<div
+				class="checkbox w-4 h-4 bg-white flex items-center justify-center border border-gray-400 box-border"
+				style={"background-color: " + getSaliencyColor(interpretation[i][1])}
+			>
+				<svg class="check h-3 w-4" viewBox="-10 -10 20 20">
+					<line
+						x1="-7.5"
+						y1="0"
+						x2="-2.5"
+						y2="5"
+						stroke="black"
+						stroke-width="4"
+						stroke-linecap="round"
+					/>
+					<line
+						x1="-2.5"
+						y1="5"
+						x2="7.5"
+						y2="-7.5"
+						stroke="black"
+						stroke-width="4"
+						stroke-linecap="round"
+					/>
+				</svg>
+			</div>
+			{choice}
+		</button>
+	{/each}
 </div>
 
 <style lang="postcss">
-  .selected .check {
-    @apply opacity-100;
-  }
-  .input-checkbox-group[theme="default"] {
-    .checkbox-item {
-      @apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
-    }
-    .checkbox {
-      @apply bg-gray-100 dark:bg-gray-400 transition;
-    }
-    .checkbox-item.selected {
-      @apply bg-yellow-500 dark:bg-red-600 text-white;
-    }
-    .selected .checkbox {
-      @apply bg-yellow-600 dark:bg-red-700;
-    }
-  }
+	.selected .check {
+		@apply opacity-100;
+	}
+	.input-checkbox-group[theme="default"] {
+		.checkbox-item {
+			@apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
+		}
+		.checkbox {
+			@apply bg-gray-100 dark:bg-gray-400 transition;
+		}
+		.checkbox-item.selected {
+			@apply bg-yellow-500 dark:bg-red-600 text-white;
+		}
+		.selected .checkbox {
+			@apply bg-yellow-600 dark:bg-red-700;
+		}
+	}
 </style>

--- a/ui/packages/app/src/components/input/CheckboxGroup/config.js
+++ b/ui/packages/app/src/components/input/CheckboxGroup/config.js
@@ -3,7 +3,7 @@ import ExampleComponent from "./Example.svelte";
 import Interpretation from "./Interpretation.svelte";
 
 export default {
-    "component": Component, 
-    "example": ExampleComponent, 
-    "interpretation": Interpretation, 
-}
+	component: Component,
+	example: ExampleComponent,
+	interpretation: Interpretation
+};

--- a/ui/packages/app/src/components/input/DataFrame/Component.svelte
+++ b/ui/packages/app/src/components/input/DataFrame/Component.svelte
@@ -1,362 +1,354 @@
 <script>
-  import { tick } from "svelte";
+	import { tick } from "svelte";
 
-  export let theme = "";
-  export let label = "Title";
-  export let headers = [];
-  export let values = [
-    ["Frank", 32, "Male"],
-    ["Beatrice", 99, "Female"],
-    ["Simone", 999, "Male"],
-  ];
-  export let setValue;
-  export let editable = true;
+	export let theme = "";
+	export let label = "Title";
+	export let headers = [];
+	export let values = [
+		["Frank", 32, "Male"],
+		["Beatrice", 99, "Female"],
+		["Simone", 999, "Male"]
+	];
+	export let setValue;
+	export let editable = true;
 
-  let id = 0;
-  let editing = false;
-  let selected = false;
-  let els = {};
+	let id = 0;
+	let editing = false;
+	let selected = false;
+	let els = {};
 
-  function make_headers(_h) {
-    if (_h.length === 0) {
-      return values[0].map((_, i) => {
-        const _id = ++id;
-        els[_id] = { cell: null, input: null };
-        return { id: _id, value: i + 1 };
-      });
-    } else {
-      return _h.map((h) => {
-        const _id = ++id;
-        els[_id] = { cell: null, input: null };
-        return { id: _id, value: h };
-      });
-    }
-  }
+	function make_headers(_h) {
+		if (_h.length === 0) {
+			return values[0].map((_, i) => {
+				const _id = ++id;
+				els[_id] = { cell: null, input: null };
+				return { id: _id, value: i + 1 };
+			});
+		} else {
+			return _h.map((h) => {
+				const _id = ++id;
+				els[_id] = { cell: null, input: null };
+				return { id: _id, value: h };
+			});
+		}
+	}
 
-  let _headers = make_headers(headers);
+	let _headers = make_headers(headers);
 
-  let data = values.map((x) =>
-    x.map((n) => {
-      const _id = ++id;
-      els[id] = { input: null, cell: null };
-      return { value: n, id: _id };
-    })
-  ) || [
-    Array(headers.length)
-      .fill(0)
+	let data = values.map((x) =>
+		x.map((n) => {
+			const _id = ++id;
+			els[id] = { input: null, cell: null };
+			return { value: n, id: _id };
+		})
+	) || [
+		Array(headers.length)
+			.fill(0)
 
-      .map((_) => {
-        const _id = ++id;
-        els[id] = { input: null, cell: null };
+			.map((_) => {
+				const _id = ++id;
+				els[id] = { input: null, cell: null };
 
-        return { value: "", id: _id };
-      }),
-  ];
+				return { value: "", id: _id };
+			})
+	];
 
-  $: setValue(data.map((r) => r.map(({ value }) => value)));
+	$: setValue(data.map((r) => r.map(({ value }) => value)));
 
-  function get_sort_status(name, sort) {
-    if (!sort) return "none";
-    if (sort[0] === name) {
-      return sort[1];
-    }
-  }
+	function get_sort_status(name, sort) {
+		if (!sort) return "none";
+		if (sort[0] === name) {
+			return sort[1];
+		}
+	}
 
-  async function start_edit(id) {
-    if (!editable) return;
-    editing = id;
-    await tick();
-    const { input } = els[id];
-    input.focus();
-  }
+	async function start_edit(id) {
+		if (!editable) return;
+		editing = id;
+		await tick();
+		const { input } = els[id];
+		input.focus();
+	}
 
-  function handle_keydown(event, i, j, id) {
-    let is_data;
-    switch (event.key) {
-      case "ArrowRight":
-        if (editing) break;
-        event.preventDefault();
-        is_data = data[i][j + 1];
-        selected = is_data ? is_data.id : selected;
-        break;
-      case "ArrowLeft":
-        if (editing) break;
-        event.preventDefault();
-        is_data = data[i][j - 1];
-        selected = is_data ? is_data.id : selected;
-        break;
-      case "ArrowDown":
-        if (editing) break;
-        event.preventDefault();
-        is_data = data[i + 1];
-        selected = is_data ? is_data[j].id : selected;
-        break;
-      case "ArrowUp":
-        if (editing) break;
-        event.preventDefault();
-        is_data = data[i - 1];
-        selected = is_data ? is_data[j].id : selected;
-        break;
-      case "Escape":
-        if (!editable) break;
-        event.preventDefault();
-        editing = false;
-        break;
-      case "Enter":
-        if (!editable) break;
-        event.preventDefault();
-        if (editing === id) {
-          editing = false;
-        } else {
-          editing = id;
-        }
-        break;
-      default:
-        break;
-    }
-  }
+	function handle_keydown(event, i, j, id) {
+		let is_data;
+		switch (event.key) {
+			case "ArrowRight":
+				if (editing) break;
+				event.preventDefault();
+				is_data = data[i][j + 1];
+				selected = is_data ? is_data.id : selected;
+				break;
+			case "ArrowLeft":
+				if (editing) break;
+				event.preventDefault();
+				is_data = data[i][j - 1];
+				selected = is_data ? is_data.id : selected;
+				break;
+			case "ArrowDown":
+				if (editing) break;
+				event.preventDefault();
+				is_data = data[i + 1];
+				selected = is_data ? is_data[j].id : selected;
+				break;
+			case "ArrowUp":
+				if (editing) break;
+				event.preventDefault();
+				is_data = data[i - 1];
+				selected = is_data ? is_data[j].id : selected;
+				break;
+			case "Escape":
+				if (!editable) break;
+				event.preventDefault();
+				editing = false;
+				break;
+			case "Enter":
+				if (!editable) break;
+				event.preventDefault();
+				if (editing === id) {
+					editing = false;
+				} else {
+					editing = id;
+				}
+				break;
+			default:
+				break;
+		}
+	}
 
-  async function handle_cell_click(id) {
-    editing = false;
-    selected = id;
-  }
+	async function handle_cell_click(id) {
+		editing = false;
+		selected = id;
+	}
 
-  async function set_focus(id, type) {
-    if (type === "edit" && typeof id == "number") {
-      await tick();
-      els[id].input.focus();
-    }
+	async function set_focus(id, type) {
+		if (type === "edit" && typeof id == "number") {
+			await tick();
+			els[id].input.focus();
+		}
 
-    if (type === "edit" && typeof id == "boolean") {
-      let cell = els[selected]?.cell;
-      await tick();
-      cell?.focus();
-    }
+		if (type === "edit" && typeof id == "boolean") {
+			let cell = els[selected]?.cell;
+			await tick();
+			cell?.focus();
+		}
 
-    if (type === "select" && typeof id == "number") {
-      const { cell } = els[id];
-      cell.setAttribute("tabindex", 0);
-      await tick();
-      els[id].cell.focus();
-    }
-  }
+		if (type === "select" && typeof id == "number") {
+			const { cell } = els[id];
+			cell.setAttribute("tabindex", 0);
+			await tick();
+			els[id].cell.focus();
+		}
+	}
 
-  $: set_focus(editing, "edit");
-  $: set_focus(selected, "select");
+	$: set_focus(editing, "edit");
+	$: set_focus(selected, "select");
 
-  let sort_direction;
-  let sort_by;
+	let sort_direction;
+	let sort_by;
 
-  function sort(col, dir) {
-    if (dir === "asc") {
-      data = data.sort((a, b) => (a[col].value < b[col].value ? -1 : 1));
-    } else if (dir === "des") {
-      data = data.sort((a, b) => (a[col].value > b[col].value ? -1 : 1));
-    }
-  }
+	function sort(col, dir) {
+		if (dir === "asc") {
+			data = data.sort((a, b) => (a[col].value < b[col].value ? -1 : 1));
+		} else if (dir === "des") {
+			data = data.sort((a, b) => (a[col].value > b[col].value ? -1 : 1));
+		}
+	}
 
-  function handle_sort(col) {
-    if (typeof sort_by !== "number" || sort_by !== col) {
-      sort_direction = "asc";
-      sort_by = col;
-    } else {
-      if (sort_direction === "asc") {
-        sort_direction = "des";
-      } else if (sort_direction === "des") {
-        sort_direction = "asc";
-      }
-    }
+	function handle_sort(col) {
+		if (typeof sort_by !== "number" || sort_by !== col) {
+			sort_direction = "asc";
+			sort_by = col;
+		} else {
+			if (sort_direction === "asc") {
+				sort_direction = "des";
+			} else if (sort_direction === "des") {
+				sort_direction = "asc";
+			}
+		}
 
-    sort(col, sort_direction);
-  }
+		sort(col, sort_direction);
+	}
 
-  let header_edit;
+	let header_edit;
 
-  async function edit_header(_id, select) {
-    if (!editable) return;
-    header_edit = _id;
-    await tick();
-    els[_id].input.focus();
+	async function edit_header(_id, select) {
+		if (!editable) return;
+		header_edit = _id;
+		await tick();
+		els[_id].input.focus();
 
-    if (select) els[_id].input.select();
-  }
+		if (select) els[_id].input.select();
+	}
 
-  function end_header_edit(event) {
-    if (!editable) return;
+	function end_header_edit(event) {
+		if (!editable) return;
 
-    switch (event.key) {
-      case "Escape":
-        event.preventDefault();
-        header_edit = false;
-        break;
-      case "Enter":
-        event.preventDefault();
-        header_edit = false;
-    }
-  }
+		switch (event.key) {
+			case "Escape":
+				event.preventDefault();
+				header_edit = false;
+				break;
+			case "Enter":
+				event.preventDefault();
+				header_edit = false;
+		}
+	}
 
-  function add_row() {
-    data.push(
-      headers.map(() => {
-        const _id = ++id;
-        els[_id] = { cell: null, input: null };
-        return { id: _id, value: "" };
-      })
-    );
-    data = data;
-  }
+	function add_row() {
+		data.push(
+			headers.map(() => {
+				const _id = ++id;
+				els[_id] = { cell: null, input: null };
+				return { id: _id, value: "" };
+			})
+		);
+		data = data;
+	}
 
-  async function add_col() {
-    for (let i = 0; i < data.length; i++) {
-      const _id = ++id;
-      els[_id] = { cell: null, input: null };
-      data[i].push({ id: _id, value: "" });
-    }
+	async function add_col() {
+		for (let i = 0; i < data.length; i++) {
+			const _id = ++id;
+			els[_id] = { cell: null, input: null };
+			data[i].push({ id: _id, value: "" });
+		}
 
-    const _id = ++id;
-    els[_id] = { cell: null, input: null };
-    _headers.push({ id: _id, value: `Header ${_headers.length + 1}` });
+		const _id = ++id;
+		els[_id] = { cell: null, input: null };
+		_headers.push({ id: _id, value: `Header ${_headers.length + 1}` });
 
-    data = data;
-    _headers = _headers;
+		data = data;
+		_headers = _headers;
 
-    await tick();
+		await tick();
 
-    edit_header(_id, true);
-  }
+		edit_header(_id, true);
+	}
 
-  const double_click = (node, { click, dblclick }) => {
-    let timer;
+	const double_click = (node, { click, dblclick }) => {
+		let timer;
 
-    function handler(event) {
-      if (timer) {
-        clearTimeout(timer);
-        timer = undefined;
-        dblclick(event);
-      } else {
-        timer = setTimeout(() => {
-          click(event);
-          timer = undefined;
-        }, 250);
-      }
-    }
+		function handler(event) {
+			if (timer) {
+				clearTimeout(timer);
+				timer = undefined;
+				dblclick(event);
+			} else {
+				timer = setTimeout(() => {
+					click(event);
+					timer = undefined;
+				}, 250);
+			}
+		}
 
-    node.addEventListener("click", handler);
+		node.addEventListener("click", handler);
 
-    return {
-      destroy: () => node.removeEventListener("click", handler),
-    };
-  };
+		return {
+			destroy: () => node.removeEventListener("click", handler)
+		};
+	};
 </script>
 
 <h4 id="title">{label}</h4>
 
 <div class="shadow overflow-hidden border-gray-200 rounded-sm relative">
-  <table
-    id="grid"
-    role="grid"
-    aria-labelledby="title"
-    class="min-w-full divide-y divide-gray-200 "
-  >
-    <thead class="bg-gray-50">
-      <tr>
-        {#each _headers as { value, id }, i (id)}
-          <th
-            use:double_click={{
-              click: () => handle_sort(i),
-              dblclick: () => edit_header(id),
-            }}
-            aria-sort={get_sort_status(value, sort_by)}
-            class="relative after:absolute after:opacity-0 after:content-['▲'] after:ml-2 after:inset-y-0 after:h-[1.05rem] after:m-auto relative px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-            class:sorted={sort_by === i}
-            class:des={sort_by === i && sort_direction === "des"}
-          >
-            {#if header_edit === id}
-              <input
-                class="bg-transparent inset-y-0 left-6 w-full outline-none absolute p-0 w-3/4 text-xs font-medium text-gray-500 uppercase tracking-wider"
-                tabindex="-1"
-                bind:value
-                bind:this={els[id].input}
-                on:keydown={end_header_edit}
-                on:blur={({ currentTarget }) =>
-                  currentTarget.setAttribute("tabindex", -1)}
-              />
-            {/if}
-            <span
-              tabindex="-1"
-              role="button"
-              class="min-h-full"
-              class:opacity-0={header_edit === id}>{value}</span
-            >
-          </th>
-        {/each}
-      </tr></thead
-    ><tbody class="bg-white divide-y divide-gray-200">
-      {#each data as row, i (row)}
-        <tr>
-          {#each row as { value, id }, j (id)}
-            <td
-              tabindex="-1"
-              class="p-0 whitespace-nowrap display-block outline-none relative "
-              on:dblclick={() => start_edit(id)}
-              on:click={() => handle_cell_click(id)}
-              on:keydown={(e) => handle_keydown(e, i, j, id)}
-              bind:this={els[id].cell}
-              on:blur={({ currentTarget }) =>
-                currentTarget.setAttribute("tabindex", -1)}
-            >
-              <div
-                class:border-gray-600={selected === id}
-                class:border-transparent={selected !== id}
-                class="min-h-[3.3rem] px-5 py-3  border-[0.125rem]"
-              >
-                {#if editing === id}
-                  <input
-                    class="w-full outline-none absolute p-0 w-3/4"
-                    tabindex="-1"
-                    bind:value
-                    bind:this={els[id].input}
-                    on:blur={({ currentTarget }) =>
-                      currentTarget.setAttribute("tabindex", -1)}
-                  />
-                {/if}
-                <span
-                  class=" cursor-default w-full"
-                  class:opacity-0={editing === id}
-                  tabindex="-1"
-                  role="button"
-                >
-                  {value}
-                </span>
-              </div>
-            </td>
-          {/each}
-        </tr>
-      {/each}
-    </tbody>
-  </table>
+	<table id="grid" role="grid" aria-labelledby="title" class="min-w-full divide-y divide-gray-200 ">
+		<thead class="bg-gray-50">
+			<tr>
+				{#each _headers as { value, id }, i (id)}
+					<th
+						use:double_click={{
+							click: () => handle_sort(i),
+							dblclick: () => edit_header(id)
+						}}
+						aria-sort={get_sort_status(value, sort_by)}
+						class="relative after:absolute after:opacity-0 after:content-['▲'] after:ml-2 after:inset-y-0 after:h-[1.05rem] after:m-auto relative px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+						class:sorted={sort_by === i}
+						class:des={sort_by === i && sort_direction === "des"}
+					>
+						{#if header_edit === id}
+							<input
+								class="bg-transparent inset-y-0 left-6 w-full outline-none absolute p-0 w-3/4 text-xs font-medium text-gray-500 uppercase tracking-wider"
+								tabindex="-1"
+								bind:value
+								bind:this={els[id].input}
+								on:keydown={end_header_edit}
+								on:blur={({ currentTarget }) => currentTarget.setAttribute("tabindex", -1)}
+							/>
+						{/if}
+						<span
+							tabindex="-1"
+							role="button"
+							class="min-h-full"
+							class:opacity-0={header_edit === id}>{value}</span
+						>
+					</th>
+				{/each}
+			</tr></thead
+		><tbody class="bg-white divide-y divide-gray-200">
+			{#each data as row, i (row)}
+				<tr>
+					{#each row as { value, id }, j (id)}
+						<td
+							tabindex="-1"
+							class="p-0 whitespace-nowrap display-block outline-none relative "
+							on:dblclick={() => start_edit(id)}
+							on:click={() => handle_cell_click(id)}
+							on:keydown={(e) => handle_keydown(e, i, j, id)}
+							bind:this={els[id].cell}
+							on:blur={({ currentTarget }) => currentTarget.setAttribute("tabindex", -1)}
+						>
+							<div
+								class:border-gray-600={selected === id}
+								class:border-transparent={selected !== id}
+								class="min-h-[3.3rem] px-5 py-3  border-[0.125rem]"
+							>
+								{#if editing === id}
+									<input
+										class="w-full outline-none absolute p-0 w-3/4"
+										tabindex="-1"
+										bind:value
+										bind:this={els[id].input}
+										on:blur={({ currentTarget }) => currentTarget.setAttribute("tabindex", -1)}
+									/>
+								{/if}
+								<span
+									class=" cursor-default w-full"
+									class:opacity-0={editing === id}
+									tabindex="-1"
+									role="button"
+								>
+									{value}
+								</span>
+							</div>
+						</td>
+					{/each}
+				</tr>
+			{/each}
+		</tbody>
+	</table>
 </div>
 {#if editable}
-  <div class="flex justify-end ">
-    <button
-      on:click={add_col}
-      class="hover:bg-gray-100 dark:hover:bg-gray-600 shadow  py-1 px-3 rounded transition  focus:outline-none m-2 mr-0"
-      >New Column</button
-    >
-    <button
-      on:click={add_row}
-      class="bg-yellow-500 hover:bg-yellow-400 dark:bg-red-700 dark:hover:bg-red-600 text-white shadow py-1 px-3 rounded transition focus:outline-none m-2 mr-0"
-      >New Row</button
-    >
-  </div>
+	<div class="flex justify-end ">
+		<button
+			on:click={add_col}
+			class="hover:bg-gray-100 dark:hover:bg-gray-600 shadow  py-1 px-3 rounded transition  focus:outline-none m-2 mr-0"
+			>New Column</button
+		>
+		<button
+			on:click={add_row}
+			class="bg-yellow-500 hover:bg-yellow-400 dark:bg-red-700 dark:hover:bg-red-600 text-white shadow py-1 px-3 rounded transition focus:outline-none m-2 mr-0"
+			>New Row</button
+		>
+	</div>
 {/if}
 
 <style>
-  .sorted::after {
-    opacity: 1;
-  }
+	.sorted::after {
+		opacity: 1;
+	}
 
-  .des::after {
-    transform: rotate(180deg) translateY(1.5px);
-  }
+	.des::after {
+		transform: rotate(180deg) translateY(1.5px);
+	}
 </style>

--- a/ui/packages/app/src/components/input/DataFrame/config.js
+++ b/ui/packages/app/src/components/input/DataFrame/config.js
@@ -1,5 +1,5 @@
 import Component from "./Component.svelte";
 
 export default {
-    "component": Component,
-}
+	component: Component
+};

--- a/ui/packages/app/src/components/input/Dropdown/Component.svelte
+++ b/ui/packages/app/src/components/input/Dropdown/Component.svelte
@@ -1,46 +1,40 @@
 <script>
-  export let value, setValue, theme;
-  export let choices;
+	export let value, setValue, theme;
+	export let choices;
 </script>
 
 <div class="input-dropdown group inline-block relative" {theme}>
-  <button
-    class="selector py-2 px-3 font-semibold rounded inline-flex items-center"
-  >
-    {value}
-    <svg class="caret ml-2 fill-current h-4 w-4" viewBox="0 0 20 20">
-      <path
-        d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"
-      />
-    </svg>
-  </button>
-  <div
-    class="dropdown-menu-holder absolute hidden group-hover:block pt-1 z-10 bg-none"
-  >
-    <ul class="dropdown-menu max-h-80 overflow-y-auto">
-      {#each choices as choice, i}
-        <li
-          class="dropdown-item first:rounded-t transition last:rounded-b py-2 px-3 block whitespace-nowrap cursor-pointer"
-          on:click={() => setValue(choice)}
-          key={i}
-        >
-          {choice}
-        </li>
-      {/each}
-    </ul>
-  </div>
+	<button class="selector py-2 px-3 font-semibold rounded inline-flex items-center">
+		{value}
+		<svg class="caret ml-2 fill-current h-4 w-4" viewBox="0 0 20 20">
+			<path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" />
+		</svg>
+	</button>
+	<div class="dropdown-menu-holder absolute hidden group-hover:block pt-1 z-10 bg-none">
+		<ul class="dropdown-menu max-h-80 overflow-y-auto">
+			{#each choices as choice, i}
+				<li
+					class="dropdown-item first:rounded-t transition last:rounded-b py-2 px-3 block whitespace-nowrap cursor-pointer"
+					on:click={() => setValue(choice)}
+					key={i}
+				>
+					{choice}
+				</li>
+			{/each}
+		</ul>
+	</div>
 </div>
 
 <style lang="postcss" global>
-  .input-dropdown[theme="default"] {
-    .selector {
-      @apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
-    }
-    .dropdown-menu {
-      @apply shadow;
-    }
-    .dropdown-item {
-      @apply bg-white dark:bg-gray-800 hover:bg-yellow-500 dark:hover:bg-red-600 hover:text-gray-50 hover:font-semibold;
-    }
-  }
+	.input-dropdown[theme="default"] {
+		.selector {
+			@apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
+		}
+		.dropdown-menu {
+			@apply shadow;
+		}
+		.dropdown-item {
+			@apply bg-white dark:bg-gray-800 hover:bg-yellow-500 dark:hover:bg-red-600 hover:text-gray-50 hover:font-semibold;
+		}
+	}
 </style>

--- a/ui/packages/app/src/components/input/Dropdown/Example.svelte
+++ b/ui/packages/app/src/components/input/Dropdown/Example.svelte
@@ -1,5 +1,5 @@
 <script>
-    export let value;
-  </script>
-  
-  <div class="input-dropdown-example">{value}</div>  
+	export let value;
+</script>
+
+<div class="input-dropdown-example">{value}</div>

--- a/ui/packages/app/src/components/input/Dropdown/Interpretation.svelte
+++ b/ui/packages/app/src/components/input/Dropdown/Interpretation.svelte
@@ -1,34 +1,34 @@
 <script>
-  import { getSaliencyColor } from "../../utils/helpers";
+	import { getSaliencyColor } from "../../utils/helpers";
 
-  export let value, interpretation, theme;
-  export let choices;
+	export let value, interpretation, theme;
+	export let choices;
 </script>
 
 <div class="input-dropdown" {theme}>
-  <ul class="dropdown-menu">
-    {#each choices as choice, i}
-      <li
-        class="dropdown-item first:rounded-t transition last:rounded-b py-2 px-3 block whitespace-nowrap cursor-pointer"
-        style={"background-color: " + getSaliencyColor(interpretation[i])}
-        key={i}
-      >
-        {choice}
-      </li>
-    {/each}
-  </ul>
+	<ul class="dropdown-menu">
+		{#each choices as choice, i}
+			<li
+				class="dropdown-item first:rounded-t transition last:rounded-b py-2 px-3 block whitespace-nowrap cursor-pointer"
+				style={"background-color: " + getSaliencyColor(interpretation[i])}
+				key={i}
+			>
+				{choice}
+			</li>
+		{/each}
+	</ul>
 </div>
 
 <style lang="postcss" global>
-  .input-dropdown[theme="default"] {
-    .selector {
-      @apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
-    }
-    .dropdown-menu {
-      @apply shadow;
-    }
-    .dropdown-item {
-      @apply bg-white dark:bg-gray-800 hover:font-semibold;
-    }
-  }
+	.input-dropdown[theme="default"] {
+		.selector {
+			@apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
+		}
+		.dropdown-menu {
+			@apply shadow;
+		}
+		.dropdown-item {
+			@apply bg-white dark:bg-gray-800 hover:font-semibold;
+		}
+	}
 </style>

--- a/ui/packages/app/src/components/input/Dropdown/config.js
+++ b/ui/packages/app/src/components/input/Dropdown/config.js
@@ -3,7 +3,7 @@ import ExampleComponent from "./Example.svelte";
 import Interpretation from "./Interpretation.svelte";
 
 export default {
-    "component": Component, 
-    "example": ExampleComponent, 
-    "interpretation": Interpretation, 
-}
+	component: Component,
+	example: ExampleComponent,
+	interpretation: Interpretation
+};

--- a/ui/packages/app/src/components/input/File/Component.svelte
+++ b/ui/packages/app/src/components/input/File/Component.svelte
@@ -1,34 +1,45 @@
 <script>
-  import Upload from "../../utils/Upload.svelte";
-  import ModifyUpload from "../../utils/ModifyUpload.svelte";
-  import { prettyBytes } from "../../utils/helpers";
+	import Upload from "../../utils/Upload.svelte";
+	import ModifyUpload from "../../utils/ModifyUpload.svelte";
+	import { prettyBytes } from "../../utils/helpers";
 
-  export let value, setValue, theme;
+	export let value, setValue, theme;
 </script>
 
 <div class="input-file" {theme}>
-  {#if value === null}
-    <Upload load={setValue} {theme}>
-      Drop File Here
-      <br />- or -<br />
-      Click to Upload
-    </Upload>
-  {:else}
-  <div class="file-preview w-full flex flex-row flex-wrap justify-center items-center relative">
-    <ModifyUpload clear={() => setValue(null)} {theme} />
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-1/5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-      </svg>
-    <div class="file-name w-3/5 text-4xl p-6 break-all">{value.name}</div>
-    <div class="file-size text-2xl p-2">
-      {prettyBytes(value.size)}
-    </div>
-  </div>
-  {/if}
+	{#if value === null}
+		<Upload load={setValue} {theme}>
+			Drop File Here
+			<br />- or -<br />
+			Click to Upload
+		</Upload>
+	{:else}
+		<div class="file-preview w-full flex flex-row flex-wrap justify-center items-center relative">
+			<ModifyUpload clear={() => setValue(null)} {theme} />
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				class="h-10 w-1/5"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+				/>
+			</svg>
+			<div class="file-name w-3/5 text-4xl p-6 break-all">{value.name}</div>
+			<div class="file-size text-2xl p-2">
+				{prettyBytes(value.size)}
+			</div>
+		</div>
+	{/if}
 </div>
 
 <style lang="postcss">
-  .input-file[theme="default"] .file-preview {
-    @apply h-60;
-  }
+	.input-file[theme="default"] .file-preview {
+		@apply h-60;
+	}
 </style>

--- a/ui/packages/app/src/components/input/File/Example.svelte
+++ b/ui/packages/app/src/components/input/File/Example.svelte
@@ -1,5 +1,5 @@
 <script>
-    export let value;
-  </script>
-  
-  <div class="input-file-example">{value}</div>  
+	export let value;
+</script>
+
+<div class="input-file-example">{value}</div>

--- a/ui/packages/app/src/components/input/File/config.js
+++ b/ui/packages/app/src/components/input/File/config.js
@@ -3,7 +3,7 @@ import ExampleComponent from "./Example.svelte";
 import { loadAsFile } from "../../utils/example_processors";
 
 export default {
-    "component": Component, 
-    "example": ExampleComponent, 
-    "process_example": loadAsFile
-}
+	component: Component,
+	example: ExampleComponent,
+	process_example: loadAsFile
+};

--- a/ui/packages/app/src/components/input/Image/Component.svelte
+++ b/ui/packages/app/src/components/input/Image/Component.svelte
@@ -1,86 +1,75 @@
 <script>
-  import Cropper from "../../utils/Cropper.svelte";
+	import Cropper from "../../utils/Cropper.svelte";
 
-  import Upload from "../../utils/Upload.svelte";
-  import ModifyUpload from "../../utils/ModifyUpload.svelte";
-  import ModifySketch from "../../utils/ModifySketch.svelte";
-  import ImageEditor from "../../utils/ImageEditor.svelte";
-  import Sketch from "../../utils/Sketch.svelte";
-  import Webcam from "../../utils/Webcam.svelte";
-  export let value, setValue, theme;
-  export let source = "upload";
-  export let tool = "editor";
+	import Upload from "../../utils/Upload.svelte";
+	import ModifyUpload from "../../utils/ModifyUpload.svelte";
+	import ModifySketch from "../../utils/ModifySketch.svelte";
+	import ImageEditor from "../../utils/ImageEditor.svelte";
+	import Sketch from "../../utils/Sketch.svelte";
+	import Webcam from "../../utils/Webcam.svelte";
+	export let value, setValue, theme;
+	export let source = "upload";
+	export let tool = "editor";
 
-  let mode;
-  let sketch;
+	let mode;
+	let sketch;
 
-  function handle_save({ detail }) {
-    setValue(detail);
-    mode = "view";
-  }
+	function handle_save({ detail }) {
+		setValue(detail);
+		mode = "view";
+	}
 </script>
 
 <div class="input-image">
-  <div
-    class="image-preview w-full h-80 flex justify-center items-center dark:bg-gray-600 relative"
-    class:bg-gray-200={value}
-    class:h-80={source !== "webcam"}
-  >
-    {#if source === "canvas"}
-      <ModifySketch
-        on:undo={() => sketch.undo()}
-        on:clear={() => sketch.clear()}
-      />
-      <Sketch bind:this={sketch} on:change={({ detail }) => setValue(detail)} />
-    {:else if value === null}
-      {#if source === "upload"}
-        <Upload
-          filetype="image/x-png,image/gif,image/jpeg"
-          load={setValue}
-          include_file_metadata={false}
-          {theme}
-        >
-          Drop Image Here
-          <br />- or -<br />
-          Click to Upload
-        </Upload>
-      {:else if source === "webcam"}
-        <Webcam on:capture={({ detail }) => setValue(detail)} />
-      {/if}
-    {:else if tool === "select"}
-      <Cropper image={value} on:crop={({ detail }) => setValue(detail)} />
-    {:else if tool === "editor"}
-      {#if mode === "edit"}
-        <ImageEditor
-          {value}
-          on:cancel={() => (mode = "view")}
-          on:save={handle_save}
-        />
-      {/if}
-      <ModifyUpload
-        edit={() => (mode = "edit")}
-        clear={() => setValue(null)}
-        {theme}
-      />
+	<div
+		class="image-preview w-full h-80 flex justify-center items-center dark:bg-gray-600 relative"
+		class:bg-gray-200={value}
+		class:h-80={source !== "webcam"}
+	>
+		{#if source === "canvas"}
+			<ModifySketch on:undo={() => sketch.undo()} on:clear={() => sketch.clear()} />
+			<Sketch bind:this={sketch} on:change={({ detail }) => setValue(detail)} />
+		{:else if value === null}
+			{#if source === "upload"}
+				<Upload
+					filetype="image/x-png,image/gif,image/jpeg"
+					load={setValue}
+					include_file_metadata={false}
+					{theme}
+				>
+					Drop Image Here
+					<br />- or -<br />
+					Click to Upload
+				</Upload>
+			{:else if source === "webcam"}
+				<Webcam on:capture={({ detail }) => setValue(detail)} />
+			{/if}
+		{:else if tool === "select"}
+			<Cropper image={value} on:crop={({ detail }) => setValue(detail)} />
+		{:else if tool === "editor"}
+			{#if mode === "edit"}
+				<ImageEditor {value} on:cancel={() => (mode = "view")} on:save={handle_save} />
+			{/if}
+			<ModifyUpload edit={() => (mode = "edit")} clear={() => setValue(null)} {theme} />
 
-      <img class="w-full h-full object-contain" src={value} alt="" />
-    {/if}
-  </div>
+			<img class="w-full h-full object-contain" src={value} alt="" />
+		{/if}
+	</div>
 </div>
 
 <style lang="postcss">
-  :global(.image_editor_buttons) {
-    width: 800px;
-    @apply flex justify-end gap-1;
-  }
-  :global(.image_editor_buttons button) {
-    @apply px-2 py-1 text-xl bg-black text-white font-semibold rounded-t;
-  }
-  :global(.tui-image-editor-header-buttons) {
-    @apply hidden;
-  }
-  :global(.tui-colorpicker-palette-button) {
-    width: 12px;
-    height: 12px;
-  }
+	:global(.image_editor_buttons) {
+		width: 800px;
+		@apply flex justify-end gap-1;
+	}
+	:global(.image_editor_buttons button) {
+		@apply px-2 py-1 text-xl bg-black text-white font-semibold rounded-t;
+	}
+	:global(.tui-image-editor-header-buttons) {
+		@apply hidden;
+	}
+	:global(.tui-colorpicker-palette-button) {
+		width: 12px;
+		height: 12px;
+	}
 </style>

--- a/ui/packages/app/src/components/input/Image/Example.svelte
+++ b/ui/packages/app/src/components/input/Image/Example.svelte
@@ -1,5 +1,5 @@
 <script>
-  export let value, examples_dir;
+	export let value, examples_dir;
 </script>
 
 <!-- svelte-ignore a11y-missing-attribute -->

--- a/ui/packages/app/src/components/input/Image/Interpretation.svelte
+++ b/ui/packages/app/src/components/input/Image/Interpretation.svelte
@@ -1,71 +1,60 @@
 <script>
-  import ModifyUpload from "../../utils/ModifyUpload.svelte";
-  import { getObjectFitSize, getSaliencyColor } from "../../utils/helpers";
-  import { afterUpdate } from "svelte";
+	import ModifyUpload from "../../utils/ModifyUpload.svelte";
+	import { getObjectFitSize, getSaliencyColor } from "../../utils/helpers";
+	import { afterUpdate } from "svelte";
 
-  export let value, setValue, interpretation, shape, theme;
+	export let value, setValue, interpretation, shape, theme;
 
-  let saliency_layer;
-  let image;
+	let saliency_layer;
+	let image;
 
-  const paintSaliency = (data, ctx, width, height) => {
-    var cell_width = width / data[0].length;
-    var cell_height = height / data.length;
-    var r = 0;
-    data.forEach(function (row) {
-      var c = 0;
-      row.forEach(function (cell) {
-        ctx.fillStyle = getSaliencyColor(cell);
-        ctx.fillRect(c * cell_width, r * cell_height, cell_width, cell_height);
-        c++;
-      });
-      r++;
-    });
-  };
+	const paintSaliency = (data, ctx, width, height) => {
+		var cell_width = width / data[0].length;
+		var cell_height = height / data.length;
+		var r = 0;
+		data.forEach(function (row) {
+			var c = 0;
+			row.forEach(function (cell) {
+				ctx.fillStyle = getSaliencyColor(cell);
+				ctx.fillRect(c * cell_width, r * cell_height, cell_width, cell_height);
+				c++;
+			});
+			r++;
+		});
+	};
 
-  afterUpdate(() => {
-    let size = getObjectFitSize(
-      true,
-      image.width,
-      image.height,
-      image.naturalWidth,
-      image.naturalHeight
-    );
-    if (shape) {
-      size = getObjectFitSize(
-        true,
-        size.width,
-        size.height,
-        shape[0],
-        shape[1]
-      );
-    }
-    let width = size.width;
-    let height = size.height;
-    saliency_layer.setAttribute("height", height);
-    saliency_layer.setAttribute("width", width);
-    paintSaliency(
-      interpretation,
-      saliency_layer.getContext("2d"),
-      width,
-      height
-    );
-  });
+	afterUpdate(() => {
+		let size = getObjectFitSize(
+			true,
+			image.width,
+			image.height,
+			image.naturalWidth,
+			image.naturalHeight
+		);
+		if (shape) {
+			size = getObjectFitSize(true, size.width, size.height, shape[0], shape[1]);
+		}
+		let width = size.width;
+		let height = size.height;
+		saliency_layer.setAttribute("height", height);
+		saliency_layer.setAttribute("width", width);
+		paintSaliency(interpretation, saliency_layer.getContext("2d"), width, height);
+	});
 </script>
 
 <div class="input-image">
-  <div
-    class="image-preview w-full h-60 flex justify-center items-center bg-gray-200 dark:bg-gray-600 relative"
-  >
-    <!-- svelte-ignore a11y-missing-attribute -->
-    <div
-      class="interpretation w-full h-full absolute top-0 left-0 flex justify-center items-center opacity-90 hover:opacity-20 transition"
-    >
-      <canvas bind:this={saliency_layer} />
-    </div>
-    <!-- svelte-ignore a11y-missing-attribute -->
-    <img class="w-full h-full object-contain" bind:this={image} src={value} />
-  </div>
+	<div
+		class="image-preview w-full h-60 flex justify-center items-center bg-gray-200 dark:bg-gray-600 relative"
+	>
+		<!-- svelte-ignore a11y-missing-attribute -->
+		<div
+			class="interpretation w-full h-full absolute top-0 left-0 flex justify-center items-center opacity-90 hover:opacity-20 transition"
+		>
+			<canvas bind:this={saliency_layer} />
+		</div>
+		<!-- svelte-ignore a11y-missing-attribute -->
+		<img class="w-full h-full object-contain" bind:this={image} src={value} />
+	</div>
 </div>
 
 <style lang="postcss">

--- a/ui/packages/app/src/components/input/Image/config.js
+++ b/ui/packages/app/src/components/input/Image/config.js
@@ -4,8 +4,8 @@ import Interpretation from "./Interpretation.svelte";
 import { loadAsData } from "../../utils/example_processors";
 
 export default {
-    "component": Component,
-    "example": ExampleComponent,
-    "interpretation": Interpretation,
-    "process_example": loadAsData
-}
+	component: Component,
+	example: ExampleComponent,
+	interpretation: Interpretation,
+	process_example: loadAsData
+};

--- a/ui/packages/app/src/components/input/Number/Component.svelte
+++ b/ui/packages/app/src/components/input/Number/Component.svelte
@@ -1,25 +1,25 @@
 <script>
-  export let value, setValue, theme;
+	export let value, setValue, theme;
 </script>
 
 <input
-  type="number"
-  class="input-number w-full rounded box-border p-2 focus:outline-none appearance-none"
-  {value}
-  on:change={(e) => setValue(parseFloat(e.target.value))}
-  {theme}
+	type="number"
+	class="input-number w-full rounded box-border p-2 focus:outline-none appearance-none"
+	{value}
+	on:change={(e) => setValue(parseFloat(e.target.value))}
+	{theme}
 />
 
 <style lang="postcss" global>
-  input::-webkit-outer-spin-button,
-  input::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-  input[type="number"] {
-    -moz-appearance: textfield;
-  }
-  .input-number[theme="default"] {
-    @apply shadow transition hover:shadow-md dark:bg-gray-800;
-  }
+	input::-webkit-outer-spin-button,
+	input::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
+	}
+	input[type="number"] {
+		-moz-appearance: textfield;
+	}
+	.input-number[theme="default"] {
+		@apply shadow transition hover:shadow-md dark:bg-gray-800;
+	}
 </style>

--- a/ui/packages/app/src/components/input/Number/Example.svelte
+++ b/ui/packages/app/src/components/input/Number/Example.svelte
@@ -1,5 +1,5 @@
 <script>
-    export let value;
-  </script>
-  
-  <div class="input-number-example">{value}</div>  
+	export let value;
+</script>
+
+<div class="input-number-example">{value}</div>

--- a/ui/packages/app/src/components/input/Number/Interpretation.svelte
+++ b/ui/packages/app/src/components/input/Number/Interpretation.svelte
@@ -1,32 +1,29 @@
 <script>
-  import { getSaliencyColor } from "../../utils/helpers";
+	import { getSaliencyColor } from "../../utils/helpers";
 
-  export let value, interpretation, theme;
+	export let value, interpretation, theme;
 </script>
 
 <div class="input-number">
-  <div class="interpret_range flex">
-    {#each interpretation as interpret_value}
-      <div
-        class="flex-1"
-        style={"background-color: " + getSaliencyColor(interpret_value[1])}
-      >
-        {interpret_value[0]}
-      </div>
-    {/each}
-  </div>
+	<div class="interpret_range flex">
+		{#each interpretation as interpret_value}
+			<div class="flex-1" style={"background-color: " + getSaliencyColor(interpret_value[1])}>
+				{interpret_value[0]}
+			</div>
+		{/each}
+	</div>
 </div>
 
 <style lang="postcss" global>
-  input::-webkit-outer-spin-button,
-  input::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-  input[type="number"] {
-    -moz-appearance: textfield;
-  }
-  .input-number[theme="default"] {
-    @apply shadow transition hover:shadow-md dark:bg-gray-800;
-  }
+	input::-webkit-outer-spin-button,
+	input::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
+	}
+	input[type="number"] {
+		-moz-appearance: textfield;
+	}
+	.input-number[theme="default"] {
+		@apply shadow transition hover:shadow-md dark:bg-gray-800;
+	}
 </style>

--- a/ui/packages/app/src/components/input/Number/config.js
+++ b/ui/packages/app/src/components/input/Number/config.js
@@ -3,7 +3,7 @@ import ExampleComponent from "./Example.svelte";
 import Interpretation from "./Interpretation.svelte";
 
 export default {
-    "component": Component, 
-    "example": ExampleComponent, 
-    "interpretation": Interpretation, 
-}
+	component: Component,
+	example: ExampleComponent,
+	interpretation: Interpretation
+};

--- a/ui/packages/app/src/components/input/Radio/Component.svelte
+++ b/ui/packages/app/src/components/input/Radio/Component.svelte
@@ -1,38 +1,38 @@
 <script>
-  export let value, setValue, theme;
-  export let choices;
+	export let value, setValue, theme;
+	export let choices;
 </script>
 
 <div class="input-radio flex flex-wrap gap-2" {theme}>
-  {#each choices as choice, i}
-    <button
-      class="radio-item py-2 px-3 font-semibold rounded cursor-pointer flex items-center gap-2"
-      class:selected={value === choice}
-      key={i}
-      on:click={() => setValue(choice)}
-    >
-      <div class="radio-circle w-4 h-4 rounded-full box-border" />
-      {choice}
-    </button>
-  {/each}
+	{#each choices as choice, i}
+		<button
+			class="radio-item py-2 px-3 font-semibold rounded cursor-pointer flex items-center gap-2"
+			class:selected={value === choice}
+			key={i}
+			on:click={() => setValue(choice)}
+		>
+			<div class="radio-circle w-4 h-4 rounded-full box-border" />
+			{choice}
+		</button>
+	{/each}
 </div>
 
 <style lang="postcss">
-  .input-radio[theme="default"] {
-    .radio-item {
-      @apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
-    }
-    .radio-circle {
-      @apply bg-gray-50 dark:bg-gray-400 border-4 border-gray-200 dark:border-gray-600;
-    }
-    .radio-item.selected {
-      @apply bg-yellow-500 dark:bg-red-600 text-white shadow;
-    }
-    .radio-circle {
-      @apply w-4 h-4 bg-white transition rounded-full box-border;
-    }
-    .selected .radio-circle {
-      @apply border-yellow-600 dark:border-red-700;
-    }
-  }
+	.input-radio[theme="default"] {
+		.radio-item {
+			@apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
+		}
+		.radio-circle {
+			@apply bg-gray-50 dark:bg-gray-400 border-4 border-gray-200 dark:border-gray-600;
+		}
+		.radio-item.selected {
+			@apply bg-yellow-500 dark:bg-red-600 text-white shadow;
+		}
+		.radio-circle {
+			@apply w-4 h-4 bg-white transition rounded-full box-border;
+		}
+		.selected .radio-circle {
+			@apply border-yellow-600 dark:border-red-700;
+		}
+	}
 </style>

--- a/ui/packages/app/src/components/input/Radio/Example.svelte
+++ b/ui/packages/app/src/components/input/Radio/Example.svelte
@@ -1,5 +1,5 @@
 <script>
-    export let value;
-  </script>
-  
-  <div class="input-radio-example">{value}</div>  
+	export let value;
+</script>
+
+<div class="input-radio-example">{value}</div>

--- a/ui/packages/app/src/components/input/Radio/Interpretation.svelte
+++ b/ui/packages/app/src/components/input/Radio/Interpretation.svelte
@@ -1,35 +1,36 @@
 <script>
-  import { getSaliencyColor } from "../../utils/helpers";
+	import { getSaliencyColor } from "../../utils/helpers";
 
-  export let value, interpretation, theme;
-  export let choices;
+	export let value, interpretation, theme;
+	export let choices;
 </script>
 
 <div class="input-radio flex flex-wrap gap-2" {theme}>
-  {#each choices as choice, i}
-    <button
-      class="radio-item py-2 px-3 font-semibold rounded cursor-pointer flex items-center gap-2"
-      class:selected={value === choice}
-      key={i}
-    >
-      <div class="radio-circle w-4 h-4 rounded-full box-border" 
-      style={"background-color: " + getSaliencyColor(interpretation[i])}
-      />
-      {choice}
-    </button>
-  {/each}
+	{#each choices as choice, i}
+		<button
+			class="radio-item py-2 px-3 font-semibold rounded cursor-pointer flex items-center gap-2"
+			class:selected={value === choice}
+			key={i}
+		>
+			<div
+				class="radio-circle w-4 h-4 rounded-full box-border"
+				style={"background-color: " + getSaliencyColor(interpretation[i])}
+			/>
+			{choice}
+		</button>
+	{/each}
 </div>
 
 <style lang="postcss">
-  .input-radio[theme="default"] {
-    .radio-item {
-      @apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
-    }
-    .radio-circle {
-      @apply w-4 h-4  rounded-full box-border;
-    }
-    .radio-item.selected {
-      @apply bg-yellow-500 dark:bg-red-600 text-white shadow;
-    }
-  }
+	.input-radio[theme="default"] {
+		.radio-item {
+			@apply bg-white dark:bg-gray-800 shadow transition hover:shadow-md;
+		}
+		.radio-circle {
+			@apply w-4 h-4  rounded-full box-border;
+		}
+		.radio-item.selected {
+			@apply bg-yellow-500 dark:bg-red-600 text-white shadow;
+		}
+	}
 </style>

--- a/ui/packages/app/src/components/input/Radio/config.js
+++ b/ui/packages/app/src/components/input/Radio/config.js
@@ -3,7 +3,7 @@ import ExampleComponent from "./Example.svelte";
 import Interpretation from "./Interpretation.svelte";
 
 export default {
-    "component": Component, 
-    "example": ExampleComponent, 
-    "interpretation": Interpretation, 
-}
+	component: Component,
+	example: ExampleComponent,
+	interpretation: Interpretation
+};

--- a/ui/packages/app/src/components/input/Slider/Component.svelte
+++ b/ui/packages/app/src/components/input/Slider/Component.svelte
@@ -1,42 +1,42 @@
 <script>
-  export let value, setValue, theme;
-  export let minimum, maximum, step;
+	export let value, setValue, theme;
+	export let minimum, maximum, step;
 </script>
 
 <div class="input-slider text-center" {theme}>
-  <input
-    type="range"
-    class="range w-full appearance-none transition rounded h-4"
-    on:input={(e) => setValue(parseFloat(e.target.value))}
-    {value}
-    min={minimum}
-    max={maximum}
-    {step}
-  />
-  <div class="value inline-block mx-auto mt-1 px-2 py-0.5 rounded">{value}</div>
+	<input
+		type="range"
+		class="range w-full appearance-none transition rounded h-4"
+		on:input={(e) => setValue(parseFloat(e.target.value))}
+		{value}
+		min={minimum}
+		max={maximum}
+		{step}
+	/>
+	<div class="value inline-block mx-auto mt-1 px-2 py-0.5 rounded">{value}</div>
 </div>
 
 <style lang="postcss">
-  .range::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    @apply appearance-none w-5 h-5 rounded cursor-pointer;
-  }
-  .range::-moz-range-thumb {
-    @apply appearance-none w-5 h-5 rounded cursor-pointer;
-  }
+	.range::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		@apply appearance-none w-5 h-5 rounded cursor-pointer;
+	}
+	.range::-moz-range-thumb {
+		@apply appearance-none w-5 h-5 rounded cursor-pointer;
+	}
 
-  .input-slider[theme="default"] {
-    .range {
-      @apply bg-white dark:bg-gray-800 shadow h-3 transition hover:shadow-md;
-    }
-    .range::-webkit-slider-thumb {
-      @apply bg-gradient-to-b from-yellow-400 to-yellow-500 dark:from-red-500 dark:to-red-600 shadow;
-    }
-    .range::-moz-range-thumb {
-      @apply bg-gradient-to-b from-yellow-400 to-yellow-500 shadow;
-    }
-    .value {
-      @apply bg-gray-100 dark:bg-gray-600 font-semibold;
-    }
-  }
+	.input-slider[theme="default"] {
+		.range {
+			@apply bg-white dark:bg-gray-800 shadow h-3 transition hover:shadow-md;
+		}
+		.range::-webkit-slider-thumb {
+			@apply bg-gradient-to-b from-yellow-400 to-yellow-500 dark:from-red-500 dark:to-red-600 shadow;
+		}
+		.range::-moz-range-thumb {
+			@apply bg-gradient-to-b from-yellow-400 to-yellow-500 shadow;
+		}
+		.value {
+			@apply bg-gray-100 dark:bg-gray-600 font-semibold;
+		}
+	}
 </style>

--- a/ui/packages/app/src/components/input/Slider/Example.svelte
+++ b/ui/packages/app/src/components/input/Slider/Example.svelte
@@ -1,5 +1,5 @@
 <script>
-    export let value;
-  </script>
-  
-  <div class="input-slider-example">{value}</div>  
+	export let value;
+</script>
+
+<div class="input-slider-example">{value}</div>

--- a/ui/packages/app/src/components/input/Slider/Interpretation.svelte
+++ b/ui/packages/app/src/components/input/Slider/Interpretation.svelte
@@ -1,49 +1,49 @@
 <script>
-  import { getSaliencyColor } from "../../utils/helpers";
+	import { getSaliencyColor } from "../../utils/helpers";
 
-  export let value, interpretation, theme;
-  export let minimum, maximum, step;
+	export let value, interpretation, theme;
+	export let minimum, maximum, step;
 </script>
 
 <div class="input-slider text-center" {theme}>
-  <input
-    type="range"
-    class="range w-full appearance-none transition rounded h-4"
-    disabled
-    {value}
-    min={minimum}
-    max={maximum}
-    {step}
-  />
-  <div class="interpret_range flex">
-    {#each interpretation as interpret_value}
-      <div class="flex-1 h-4" style={"background-color: " + getSaliencyColor(interpret_value)} />
-    {/each}
-  </div>
-  <div class="value inline-block mx-auto mt-1 px-2 py-0.5 rounded">{value}</div>
+	<input
+		type="range"
+		class="range w-full appearance-none transition rounded h-4"
+		disabled
+		{value}
+		min={minimum}
+		max={maximum}
+		{step}
+	/>
+	<div class="interpret_range flex">
+		{#each interpretation as interpret_value}
+			<div class="flex-1 h-4" style={"background-color: " + getSaliencyColor(interpret_value)} />
+		{/each}
+	</div>
+	<div class="value inline-block mx-auto mt-1 px-2 py-0.5 rounded">{value}</div>
 </div>
 
 <style lang="postcss">
-  .range::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    @apply appearance-none w-5 h-5 rounded cursor-pointer;
-  }
-  .range::-moz-range-thumb {
-    @apply appearance-none w-5 h-5 rounded cursor-pointer;
-  }
+	.range::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		@apply appearance-none w-5 h-5 rounded cursor-pointer;
+	}
+	.range::-moz-range-thumb {
+		@apply appearance-none w-5 h-5 rounded cursor-pointer;
+	}
 
-  .input-slider[theme="default"] {
-    .range {
-      @apply bg-white dark:bg-gray-800 shadow h-3 transition hover:shadow-md;
-    }
-    .range::-webkit-slider-thumb {
-      @apply bg-gradient-to-b from-yellow-400 to-yellow-500 dark:from-red-500 dark:to-red-600 shadow;
-    }
-    .range::-moz-range-thumb {
-      @apply bg-gradient-to-b from-yellow-400 to-yellow-500 shadow;
-    }
-    .value {
-      @apply bg-gray-100 dark:bg-gray-600 font-semibold;
-    }
-  }
+	.input-slider[theme="default"] {
+		.range {
+			@apply bg-white dark:bg-gray-800 shadow h-3 transition hover:shadow-md;
+		}
+		.range::-webkit-slider-thumb {
+			@apply bg-gradient-to-b from-yellow-400 to-yellow-500 dark:from-red-500 dark:to-red-600 shadow;
+		}
+		.range::-moz-range-thumb {
+			@apply bg-gradient-to-b from-yellow-400 to-yellow-500 shadow;
+		}
+		.value {
+			@apply bg-gray-100 dark:bg-gray-600 font-semibold;
+		}
+	}
 </style>

--- a/ui/packages/app/src/components/input/Slider/config.js
+++ b/ui/packages/app/src/components/input/Slider/config.js
@@ -3,7 +3,7 @@ import ExampleComponent from "./Example.svelte";
 import Interpretation from "./Interpretation.svelte";
 
 export default {
-    "component": Component, 
-    "example": ExampleComponent, 
-    "interpretation": Interpretation, 
-}
+	component: Component,
+	example: ExampleComponent,
+	interpretation: Interpretation
+};

--- a/ui/packages/app/src/components/input/Textbox/Component.svelte
+++ b/ui/packages/app/src/components/input/Textbox/Component.svelte
@@ -1,29 +1,29 @@
 <script>
-  export let value, setValue, theme;
-  export let lines, placeholder;
+	export let value, setValue, theme;
+	export let lines, placeholder;
 </script>
 
 {#if lines > 1}
-  <textarea
-    class="input-text w-full rounded box-border p-2 focus:outline-none appearance-none"
-    {value}
-    {placeholder}
-    on:change={(e) => setValue(e.target.value)}
-    {theme}
-  />
+	<textarea
+		class="input-text w-full rounded box-border p-2 focus:outline-none appearance-none"
+		{value}
+		{placeholder}
+		on:change={(e) => setValue(e.target.value)}
+		{theme}
+	/>
 {:else}
-  <input
-    type="text"
-    class="input-text w-full rounded box-border p-2 focus:outline-none appearance-none"
-    {value}
-    {placeholder}
-    on:change={(e) => setValue(e.target.value)}
-    {theme}
-  />
+	<input
+		type="text"
+		class="input-text w-full rounded box-border p-2 focus:outline-none appearance-none"
+		{value}
+		{placeholder}
+		on:change={(e) => setValue(e.target.value)}
+		{theme}
+	/>
 {/if}
 
 <style lang="postcss" global>
-  .input-text[theme="default"] {
-    @apply shadow transition hover:shadow-md dark:bg-gray-800;
-  }
+	.input-text[theme="default"] {
+		@apply shadow transition hover:shadow-md dark:bg-gray-800;
+	}
 </style>

--- a/ui/packages/app/src/components/input/Textbox/Example.svelte
+++ b/ui/packages/app/src/components/input/Textbox/Example.svelte
@@ -1,5 +1,5 @@
 <script>
-    export let value;
-  </script>
-  
-  <div class="input-text-example">{value}</div>  
+	export let value;
+</script>
+
+<div class="input-text-example">{value}</div>

--- a/ui/packages/app/src/components/input/Textbox/config.js
+++ b/ui/packages/app/src/components/input/Textbox/config.js
@@ -2,6 +2,6 @@ import Component from "./Component.svelte";
 import ExampleComponent from "./Example.svelte";
 
 export default {
-    "component": Component, 
-    "example": ExampleComponent, 
-}
+	component: Component,
+	example: ExampleComponent
+};

--- a/ui/packages/app/src/components/input/TimeSeries/Component.svelte
+++ b/ui/packages/app/src/components/input/TimeSeries/Component.svelte
@@ -1,76 +1,71 @@
 <script>
-  import Upload from "../../utils/Upload.svelte";
-  import Chart from "../../utils/Chart.svelte";
+	import Upload from "../../utils/Upload.svelte";
+	import Chart from "../../utils/Chart.svelte";
 
-  export let value, setValue, theme, y, x;
-  let _value;
+	export let value, setValue, theme, y, x;
+	let _value;
 
-  function data_uri_to_blob(data_uri) {
-    var byte_str = atob(data_uri.split(",")[1]);
-    var mime_str = data_uri.split(",")[0].split(":")[1].split(";")[0];
+	function data_uri_to_blob(data_uri) {
+		var byte_str = atob(data_uri.split(",")[1]);
+		var mime_str = data_uri.split(",")[0].split(":")[1].split(";")[0];
 
-    var ab = new ArrayBuffer(byte_str.length);
-    var ia = new Uint8Array(ab);
+		var ab = new ArrayBuffer(byte_str.length);
+		var ia = new Uint8Array(ab);
 
-    for (var i = 0; i < byte_str.length; i++) {
-      ia[i] = byte_str.charCodeAt(i);
-    }
+		for (var i = 0; i < byte_str.length; i++) {
+			ia[i] = byte_str.charCodeAt(i);
+		}
 
-    return new Blob([ab], { type: mime_str });
-  }
+		return new Blob([ab], { type: mime_str });
+	}
 
-  function blob_to_string(blb) {
-    const reader = new FileReader();
+	function blob_to_string(blb) {
+		const reader = new FileReader();
 
-    reader.addEventListener("loadend", (e) => {
-      _value = e.srcElement.result;
-    });
+		reader.addEventListener("loadend", (e) => {
+			_value = e.srcElement.result;
+		});
 
-    reader.readAsText(blb);
-  }
+		reader.readAsText(blb);
+	}
 
-  $: {
-    if (value && value.data && typeof value.data === "string") {
-      if (!value) _value = null;
-      else blob_to_string(data_uri_to_blob(value.data));
-    }
-  }
+	$: {
+		if (value && value.data && typeof value.data === "string") {
+			if (!value) _value = null;
+			else blob_to_string(data_uri_to_blob(value.data));
+		}
+	}
 
-  function make_dict(x, y) {
-    const headers = [];
-    const data = [];
+	function make_dict(x, y) {
+		const headers = [];
+		const data = [];
 
-    headers.push(x.name);
-    y.forEach(({ name }) => headers.push(name));
+		headers.push(x.name);
+		y.forEach(({ name }) => headers.push(name));
 
-    for (let i = 0; i < x.values.length; i++) {
-      let _data = [];
-      _data.push(x.values[i]);
-      y.forEach(({ values }) => _data.push(values[i].y));
+		for (let i = 0; i < x.values.length; i++) {
+			let _data = [];
+			_data.push(x.values[i]);
+			y.forEach(({ values }) => _data.push(values[i].y));
 
-      data.push(_data);
-    }
-    return { headers, data };
-  }
+			data.push(_data);
+		}
+		return { headers, data };
+	}
 </script>
 
 {#if _value}
-  <Chart
-    value={_value}
-    {y}
-    {x}
-    on:process={({ detail: { x, y } }) => setValue(make_dict(x, y))}
-  />
+	<Chart value={_value} {y} {x} on:process={({ detail: { x, y } }) => setValue(make_dict(x, y))} />
 {/if}
 {#if !value}
-  <Upload
-    filetype="text/csv"
-    load={(v) => setValue({ data: v })}
-    include_file_metadata={false}
-    {theme}
-  >
-    Drop CSV Here
-    <br />- or -<br />
-    Click to Upload
-  </Upload>
+	<Upload
+		filetype="text/csv"
+		load={(v) => setValue({ data: v })}
+		include_file_metadata={false}
+		{theme}
+	>
+		Drop CSV Here
+		<br />- or -<br />
+		Click to Upload
+	</Upload>
 {/if}

--- a/ui/packages/app/src/components/input/TimeSeries/config.js
+++ b/ui/packages/app/src/components/input/TimeSeries/config.js
@@ -1,5 +1,5 @@
 import Component from "./Component.svelte";
 
 export default {
-    "component": Component, 
-}
+	component: Component
+};

--- a/ui/packages/app/src/components/input/Video/Component.svelte
+++ b/ui/packages/app/src/components/input/Video/Component.svelte
@@ -1,42 +1,42 @@
 <script>
-  import Upload from "../../utils/Upload.svelte";
-  import ModifyUpload from "../../utils/ModifyUpload.svelte";
-  import { prettyBytes, playable } from "../../utils/helpers";
+	import Upload from "../../utils/Upload.svelte";
+	import ModifyUpload from "../../utils/ModifyUpload.svelte";
+	import { prettyBytes, playable } from "../../utils/helpers";
 
-  export let value, setValue, theme;
-  export let source;
+	export let value, setValue, theme;
+	export let source;
 </script>
 
 <div
-  class="video-preview w-full h-80 object-contain flex justify-center items-center  dark:bg-gray-600 relative"
-  class:bg-gray-200={value}
+	class="video-preview w-full h-80 object-contain flex justify-center items-center  dark:bg-gray-600 relative"
+	class:bg-gray-200={value}
 >
-  {#if value === null}
-    {#if source === "upload"}
-      <Upload filetype="video/mp4,video/x-m4v,video/*" load={setValue} {theme}>
-        Drop Video Here
-        <br />- or -<br />
-        Click to Upload
-      </Upload>
-    {/if}
-  {:else}
-    <ModifyUpload clear={() => setValue(null)} {theme} />
-    {#if playable(value.name)}
-      <!-- svelte-ignore a11y-media-has-caption -->
-      <video
-        class="w-full h-full object-contain bg-black"
-        controls
-        playsInline
-        preload
-        src={value.data}
-      />
-    {:else}
-      <div class="file-name text-4xl p-6 break-all">{value.name}</div>
-      <div class="file-size text-2xl p-2">
-        {prettyBytes(value.size)}
-      </div>
-    {/if}
-  {/if}
+	{#if value === null}
+		{#if source === "upload"}
+			<Upload filetype="video/mp4,video/x-m4v,video/*" load={setValue} {theme}>
+				Drop Video Here
+				<br />- or -<br />
+				Click to Upload
+			</Upload>
+		{/if}
+	{:else}
+		<ModifyUpload clear={() => setValue(null)} {theme} />
+		{#if playable(value.name)}
+			<!-- svelte-ignore a11y-media-has-caption -->
+			<video
+				class="w-full h-full object-contain bg-black"
+				controls
+				playsInline
+				preload
+				src={value.data}
+			/>
+		{:else}
+			<div class="file-name text-4xl p-6 break-all">{value.name}</div>
+			<div class="file-size text-2xl p-2">
+				{prettyBytes(value.size)}
+			</div>
+		{/if}
+	{/if}
 </div>
 
 <style lang="postcss">

--- a/ui/packages/app/src/components/input/Video/Example.svelte
+++ b/ui/packages/app/src/components/input/Video/Example.svelte
@@ -1,20 +1,20 @@
 <script>
-  import { playable } from "../../utils/helpers";
+	import { playable } from "../../utils/helpers";
 
-  export let value, examples_dir;
-  let video;
+	export let value, examples_dir;
+	let video;
 </script>
 
 <!-- svelte-ignore a11y-media-has-caption -->
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if playable(value)}
-  <video
-    bind:this={video}
-    on:mouseover={video.play}
-    on:mouseout={video.pause}
-    class="input-video-example h-24 max-w-none"
-    src={examples_dir + value}
-  />
+	<video
+		bind:this={video}
+		on:mouseover={video.play}
+		on:mouseout={video.pause}
+		class="input-video-example h-24 max-w-none"
+		src={examples_dir + value}
+	/>
 {:else}
-  <div class="input-video-example">{value}</div>
+	<div class="input-video-example">{value}</div>
 {/if}

--- a/ui/packages/app/src/components/input/Video/config.js
+++ b/ui/packages/app/src/components/input/Video/config.js
@@ -3,7 +3,7 @@ import ExampleComponent from "./Example.svelte";
 import { loadAsFile } from "../../utils/example_processors";
 
 export default {
-    "component": Component, 
-    "example": ExampleComponent, 
-    "process_example": loadAsFile
-}
+	component: Component,
+	example: ExampleComponent,
+	process_example: loadAsFile
+};

--- a/ui/packages/app/src/components/output/Audio/Component.svelte
+++ b/ui/packages/app/src/components/output/Audio/Component.svelte
@@ -1,9 +1,9 @@
 <script>
-  export let value, theme;
+	export let value, theme;
 </script>
 
 <audio {theme} controls>
-  <source src={value} />
+	<source src={value} />
 </audio>
 
 <style lang="postcss">

--- a/ui/packages/app/src/components/output/Audio/config.js
+++ b/ui/packages/app/src/components/output/Audio/config.js
@@ -1,5 +1,5 @@
 import Component from "./Component.svelte";
 
 export default {
-    "component": Component, 
-}
+	component: Component
+};

--- a/ui/packages/app/src/components/output/Carousel/Component.svelte
+++ b/ui/packages/app/src/components/output/Carousel/Component.svelte
@@ -1,55 +1,55 @@
 <script>
-    import { output_component_map } from "../../directory";
+	import { output_component_map } from "../../directory";
 
-    export let value, theme;
-    export let components;
+	export let value, theme;
+	export let components;
 
-    let carousel_index = 0;
-    const next = () => {
-        carousel_index = (carousel_index + 1) % value.length;
-    };
-    const prev = () => {
-        carousel_index = (carousel_index - 1 + value.length) % value.length;
-    };
+	let carousel_index = 0;
+	const next = () => {
+		carousel_index = (carousel_index + 1) % value.length;
+	};
+	const prev = () => {
+		carousel_index = (carousel_index - 1 + value.length) % value.length;
+	};
 </script>
 
 <div class="output-carousel flex flex-col gap-2" {theme}>
-    {#each components as component, i}
-        <div class="component" key={i}>
-            {#if component.label}
-                <div class="panel-header">{component.label}</div>
-            {/if}
-            <svelte:component
-                this={output_component_map[component.name].component}
-                {...component}
-                {theme}
-                value={value[carousel_index][i]}
-            />
-        </div>
-    {/each}
-    <div class="carousel-control flex gap-4 justify-center items-center my-1">
-        <button on:click={prev}>
-            <svg class="caret h-3 mt-0.5 fill-current" viewBox="0 0 9.1457395 15.999842">
-                <path
-                    d="M 0.32506616,7.2360106 7.1796187,0.33129769 c 0.4360247,-0.439451 1.1455702,-0.442056 1.5845974,-0.0058 0.4390612,0.435849 0.441666,1.14535901 0.00582,1.58438501 l -6.064985,6.1096644 6.10968,6.0646309 c 0.4390618,0.436026 0.4416664,1.145465 0.00582,1.584526 -0.4358485,0.439239 -1.1453586,0.441843 -1.5845975,0.0058 L 0.33088256,8.8203249 C 0.11135166,8.6022941 0.00105996,8.3161928 7.554975e-6,8.0295489 -0.00104244,7.7427633 0.10735446,7.4556467 0.32524356,7.2361162"
-                />
-            </svg>
-        </button>
-        <div class="carousel_index text-xl text-center font-semibold" style="min-width: 60px">
-            {carousel_index + 1} / {value.length}
-        </div>
-        <button on:click={next}>
-            <svg
-                class="caret h-3 mt-0.5 fill-current"
-                viewBox="0 0 9.1457395 15.999842"
-                transform="scale(-1, 1)"
-            >
-                <path
-                    d="M 0.32506616,7.2360106 7.1796187,0.33129769 c 0.4360247,-0.439451 1.1455702,-0.442056 1.5845974,-0.0058 0.4390612,0.435849 0.441666,1.14535901 0.00582,1.58438501 l -6.064985,6.1096644 6.10968,6.0646309 c 0.4390618,0.436026 0.4416664,1.145465 0.00582,1.584526 -0.4358485,0.439239 -1.1453586,0.441843 -1.5845975,0.0058 L 0.33088256,8.8203249 C 0.11135166,8.6022941 0.00105996,8.3161928 7.554975e-6,8.0295489 -0.00104244,7.7427633 0.10735446,7.4556467 0.32524356,7.2361162"
-                />
-            </svg>
-        </button>
-    </div>
+	{#each components as component, i}
+		<div class="component" key={i}>
+			{#if component.label}
+				<div class="panel-header">{component.label}</div>
+			{/if}
+			<svelte:component
+				this={output_component_map[component.name].component}
+				{...component}
+				{theme}
+				value={value[carousel_index][i]}
+			/>
+		</div>
+	{/each}
+	<div class="carousel-control flex gap-4 justify-center items-center my-1">
+		<button on:click={prev}>
+			<svg class="caret h-3 mt-0.5 fill-current" viewBox="0 0 9.1457395 15.999842">
+				<path
+					d="M 0.32506616,7.2360106 7.1796187,0.33129769 c 0.4360247,-0.439451 1.1455702,-0.442056 1.5845974,-0.0058 0.4390612,0.435849 0.441666,1.14535901 0.00582,1.58438501 l -6.064985,6.1096644 6.10968,6.0646309 c 0.4390618,0.436026 0.4416664,1.145465 0.00582,1.584526 -0.4358485,0.439239 -1.1453586,0.441843 -1.5845975,0.0058 L 0.33088256,8.8203249 C 0.11135166,8.6022941 0.00105996,8.3161928 7.554975e-6,8.0295489 -0.00104244,7.7427633 0.10735446,7.4556467 0.32524356,7.2361162"
+				/>
+			</svg>
+		</button>
+		<div class="carousel_index text-xl text-center font-semibold" style="min-width: 60px">
+			{carousel_index + 1} / {value.length}
+		</div>
+		<button on:click={next}>
+			<svg
+				class="caret h-3 mt-0.5 fill-current"
+				viewBox="0 0 9.1457395 15.999842"
+				transform="scale(-1, 1)"
+			>
+				<path
+					d="M 0.32506616,7.2360106 7.1796187,0.33129769 c 0.4360247,-0.439451 1.1455702,-0.442056 1.5845974,-0.0058 0.4390612,0.435849 0.441666,1.14535901 0.00582,1.58438501 l -6.064985,6.1096644 6.10968,6.0646309 c 0.4390618,0.436026 0.4416664,1.145465 0.00582,1.584526 -0.4358485,0.439239 -1.1453586,0.441843 -1.5845975,0.0058 L 0.33088256,8.8203249 C 0.11135166,8.6022941 0.00105996,8.3161928 7.554975e-6,8.0295489 -0.00104244,7.7427633 0.10735446,7.4556467 0.32524356,7.2361162"
+				/>
+			</svg>
+		</button>
+	</div>
 </div>
 
 <style lang="postcss">

--- a/ui/packages/app/src/components/output/Carousel/config.js
+++ b/ui/packages/app/src/components/output/Carousel/config.js
@@ -1,5 +1,5 @@
 import Component from "./Component.svelte";
 
 export default {
-    "component": Component, 
-}
+	component: Component
+};

--- a/ui/packages/app/src/components/output/Dataframe/Component.svelte
+++ b/ui/packages/app/src/components/output/Dataframe/Component.svelte
@@ -1,16 +1,16 @@
 <script>
-  import DataFrame from "../../input/DataFrame/Component.svelte";
+	import DataFrame from "../../input/DataFrame/Component.svelte";
 
-  export let headers,
-    value,
-    theme,
-    setValue = () => {};
+	export let headers,
+		value,
+		theme,
+		setValue = () => {};
 </script>
 
 <DataFrame
-  headers={headers || value.headers}
-  values={value.data}
-  {setValue}
-  editable={false}
-  {theme}
+	headers={headers || value.headers}
+	values={value.data}
+	{setValue}
+	editable={false}
+	{theme}
 />

--- a/ui/packages/app/src/components/output/Dataframe/config.js
+++ b/ui/packages/app/src/components/output/Dataframe/config.js
@@ -1,5 +1,5 @@
 import Component from "./Component.svelte";
 
 export default {
-    "component": Component, 
-}
+	component: Component
+};

--- a/ui/packages/app/src/components/output/File/Component.svelte
+++ b/ui/packages/app/src/components/output/File/Component.svelte
@@ -1,26 +1,37 @@
 <script>
-  import { prettyBytes } from "../../utils/helpers";
+	import { prettyBytes } from "../../utils/helpers";
 
-  export let value, theme;
+	export let value, theme;
 </script>
 
 <a
-  class="output-file w-full h-full flex flex-row flex-wrap justify-center items-center relative"
-  href={value.data}
-  download={value.name}
-  {theme}
+	class="output-file w-full h-full flex flex-row flex-wrap justify-center items-center relative"
+	href={value.data}
+	download={value.name}
+	{theme}
 >
-  <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-1/5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-  </svg>
-  <div class="file-name w-3/5 text-4xl p-6 break-all">{value.name}</div>
-  <div class="text-2xl p-2">
-    {isNaN(value.size) ? "" : prettyBytes(value.size)}
-  </div>
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		class="h-10 w-1/5"
+		fill="none"
+		viewBox="0 0 24 24"
+		stroke="currentColor"
+	>
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width="2"
+			d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+		/>
+	</svg>
+	<div class="file-name w-3/5 text-4xl p-6 break-all">{value.name}</div>
+	<div class="text-2xl p-2">
+		{isNaN(value.size) ? "" : prettyBytes(value.size)}
+	</div>
 </a>
 
 <style lang="postcss">
-  .output-file[theme="default"] {
-    @apply h-60 hover:text-gray-500;
-  }
+	.output-file[theme="default"] {
+		@apply h-60 hover:text-gray-500;
+	}
 </style>

--- a/ui/packages/app/src/components/output/File/config.js
+++ b/ui/packages/app/src/components/output/File/config.js
@@ -1,5 +1,5 @@
 import Component from "./Component.svelte";
 
 export default {
-    "component": Component, 
-}
+	component: Component
+};

--- a/ui/packages/app/src/components/output/HighlightedText/Component.svelte
+++ b/ui/packages/app/src/components/output/HighlightedText/Component.svelte
@@ -1,104 +1,103 @@
 <script>
-  import { getNextColor } from "../../utils/helpers";
+	import { getNextColor } from "../../utils/helpers";
 
-  export let value, theme;
-  export let show_legend, color_map;
-  color_map = color_map || {};
-  let mode;
+	export let value, theme;
+	export let show_legend, color_map;
+	color_map = color_map || {};
+	let mode;
 
-  if (value.length > 0) {
-    for (let [_, label] of value) {
-      if (label !== null) {
-        if (typeof label === "string") {
-          mode = "categories";
-          if (!(label in color_map)) {
-            let color = getNextColor(Object.keys(color_map).length);
-            color_map[label] = color;
-          }
-        } else {
-          mode = "scores";
-        }
-      }
-    }
-  }
+	if (value.length > 0) {
+		for (let [_, label] of value) {
+			if (label !== null) {
+				if (typeof label === "string") {
+					mode = "categories";
+					if (!(label in color_map)) {
+						let color = getNextColor(Object.keys(color_map).length);
+						color_map[label] = color;
+					}
+				} else {
+					mode = "scores";
+				}
+			}
+		}
+	}
 </script>
 
 <div class="output-highlightedtext" {theme}>
-  {#if mode === "categories"}
-    {#if show_legend}
-      <div class="category-legend flex flex-wrap gap-1 mb-2">
-        {#each color_map.entries() as [category, color], i}
-          <div
-            class="category-label px-2 py-1 rounded text-white font-semibold"
-            style={"background-color" + color}
-            key={i}
-          >
-            {category}
-          </div>
-        {/each}
-      </div>
-    {/if}
-    <div
-      class="textfield p-2 bg-white dark:bg-gray-800 rounded box-border max-w-full leading-8 break-word"
-    >
-      {#each value as [text, category], i}
-        <span
-          class="textspan p-1 mr-0.5 bg-opacity-20 dark:bg-opacity-80 rounded-sm"
-          title={category}
-          style={category === null
-            ? ""
-            : `color: ${color_map[category]}; background-color: ${color_map[
-                category
-              ].replace("1)", "var(--tw-bg-opacity))")}`}
-          key={i}
-        >
-          <span class="text dark:text-white">{text}</span>
-          {#if !show_legend && category !== null}
-            <span
-              class="inline-category text-xs text-white ml-0.5 px-0.5 rounded-sm"
-              style={category === null
-                ? ""
-                : `background-color: ${color_map[category]}`}
-            >
-              {category}
-            </span>
-          {/if}
-        </span>
-      {/each}
-    </div>
-  {:else}
-    {#if show_legend}
-      <div
-        class="color_legend flex px-2 py-1 justify-between rounded mb-3 font-semibold"
-        style="background: -webkit-linear-gradient(to right,#8d83d6,(255,255,255,0),#eb4d4b); background: linear-gradient(to right,#8d83d6,rgba(255,255,255,0),#eb4d4b);"
-      >
-        <span>-1</span>
-        <span>0</span>
-        <span>+1</span>
-      </div>
-    {/if}
-    <div
-      class="textfield p-2 bg-white dark:bg-gray-800 rounded box-border max-w-full leading-8 break-word"
-    >
-      {#each value as [text, score], i}
-        <span
-          class="textspan p-1 mr-0.5 bg-opacity-20 dark:bg-opacity-80 rounded-sm"
-          title={value}
-          style={"background-color: rgba(" +
-            (score < 0 ? "141, 131, 214," + -score : "235, 77, 75," + score) +
-            ")"}
-        >
-          <span class="text dark:text-white">{text}</span>
-        </span>
-      {/each}
-    </div>
-  {/if}
+	{#if mode === "categories"}
+		{#if show_legend}
+			<div class="category-legend flex flex-wrap gap-1 mb-2">
+				{#each color_map.entries() as [category, color], i}
+					<div
+						class="category-label px-2 py-1 rounded text-white font-semibold"
+						style={"background-color" + color}
+						key={i}
+					>
+						{category}
+					</div>
+				{/each}
+			</div>
+		{/if}
+		<div
+			class="textfield p-2 bg-white dark:bg-gray-800 rounded box-border max-w-full leading-8 break-word"
+		>
+			{#each value as [text, category], i}
+				<span
+					class="textspan p-1 mr-0.5 bg-opacity-20 dark:bg-opacity-80 rounded-sm"
+					title={category}
+					style={category === null
+						? ""
+						: `color: ${color_map[category]}; background-color: ${color_map[category].replace(
+								"1)",
+								"var(--tw-bg-opacity))"
+						  )}`}
+					key={i}
+				>
+					<span class="text dark:text-white">{text}</span>
+					{#if !show_legend && category !== null}
+						<span
+							class="inline-category text-xs text-white ml-0.5 px-0.5 rounded-sm"
+							style={category === null ? "" : `background-color: ${color_map[category]}`}
+						>
+							{category}
+						</span>
+					{/if}
+				</span>
+			{/each}
+		</div>
+	{:else}
+		{#if show_legend}
+			<div
+				class="color_legend flex px-2 py-1 justify-between rounded mb-3 font-semibold"
+				style="background: -webkit-linear-gradient(to right,#8d83d6,(255,255,255,0),#eb4d4b); background: linear-gradient(to right,#8d83d6,rgba(255,255,255,0),#eb4d4b);"
+			>
+				<span>-1</span>
+				<span>0</span>
+				<span>+1</span>
+			</div>
+		{/if}
+		<div
+			class="textfield p-2 bg-white dark:bg-gray-800 rounded box-border max-w-full leading-8 break-word"
+		>
+			{#each value as [text, score], i}
+				<span
+					class="textspan p-1 mr-0.5 bg-opacity-20 dark:bg-opacity-80 rounded-sm"
+					title={value}
+					style={"background-color: rgba(" +
+						(score < 0 ? "141, 131, 214," + -score : "235, 77, 75," + score) +
+						")"}
+				>
+					<span class="text dark:text-white">{text}</span>
+				</span>
+			{/each}
+		</div>
+	{/if}
 </div>
 
 <style lang="postcss">
-  .output-highlightedtext[theme="default"] {
-    .textfield {
-      @apply shadow;
-    }
-  }
+	.output-highlightedtext[theme="default"] {
+		.textfield {
+			@apply shadow;
+		}
+	}
 </style>

--- a/ui/packages/app/src/components/output/HighlightedText/config.js
+++ b/ui/packages/app/src/components/output/HighlightedText/config.js
@@ -1,5 +1,5 @@
 import Component from "./Component.svelte";
 
 export default {
-    "component": Component, 
-}
+	component: Component
+};

--- a/ui/packages/app/src/components/output/Html/Component.svelte
+++ b/ui/packages/app/src/components/output/Html/Component.svelte
@@ -1,10 +1,7 @@
 <script>
-  export let value, theme;
+	export let value, theme;
 </script>
 
-<div
-  class="output-html"
-  {theme}
->
-  {@html value}
+<div class="output-html" {theme}>
+	{@html value}
 </div>

--- a/ui/packages/app/src/components/output/Html/config.js
+++ b/ui/packages/app/src/components/output/Html/config.js
@@ -1,5 +1,5 @@
 import Component from "./Component.svelte";
 
 export default {
-    "component": Component, 
-}
+	component: Component
+};

--- a/ui/packages/app/src/components/output/Image/Component.svelte
+++ b/ui/packages/app/src/components/output/Image/Component.svelte
@@ -1,10 +1,13 @@
 <script>
-  export let value, theme;
+	export let value, theme;
 </script>
 
-<div class="output-image w-full h-60 flex justify-center items-center bg-gray-200 dark:bg-gray-600 relative" {theme}>
-  <!-- svelte-ignore a11y-missing-attribute -->
-  <img class="w-full h-full object-contain" src={value} />
+<div
+	class="output-image w-full h-60 flex justify-center items-center bg-gray-200 dark:bg-gray-600 relative"
+	{theme}
+>
+	<!-- svelte-ignore a11y-missing-attribute -->
+	<img class="w-full h-full object-contain" src={value} />
 </div>
 
 <style lang="postcss">

--- a/ui/packages/app/src/components/output/Image/config.js
+++ b/ui/packages/app/src/components/output/Image/config.js
@@ -1,5 +1,5 @@
 import Component from "./Component.svelte";
 
 export default {
-    "component": Component, 
-}
+	component: Component
+};

--- a/ui/packages/app/src/components/output/Json/Component.svelte
+++ b/ui/packages/app/src/components/output/Json/Component.svelte
@@ -1,15 +1,15 @@
 <script>
-  import JsonNode from "./JsonNode.svelte";
+	import JsonNode from "./JsonNode.svelte";
 
-  export let value, theme;
+	export let value, theme;
 </script>
 
 <div class="output-json font-mono leading-relaxed" {theme}>
-  <JsonNode {value} depth={0} {theme} />
+	<JsonNode {value} depth={0} {theme} />
 </div>
 
 <style lang="postcss" global>
-  .output-text[theme="default"] {
-    @apply shadow transition hover:shadow-md dark:bg-gray-800;
-  }
+	.output-text[theme="default"] {
+		@apply shadow transition hover:shadow-md dark:bg-gray-800;
+	}
 </style>

--- a/ui/packages/app/src/components/output/Json/JsonNode.svelte
+++ b/ui/packages/app/src/components/output/Json/JsonNode.svelte
@@ -1,90 +1,85 @@
 <script>
-  export let value, theme;
-  export let depth;
-  export let collapsed = depth > 4;
+	export let value, theme;
+	export let depth;
+	export let collapsed = depth > 4;
 </script>
 
 <div class="json-node inline" {theme}>
-  {#if value instanceof Array}
-    {#if collapsed}
-      <button
-        on:click={() => {
-          collapsed = false;
-        }}
-      >
-        [+{value.length} children]
-      </button>
-    {:else}
-      [
-      <div class="json-children pl-4">
-        {#each value as node, i}
-          <div class="json-item">
-            {i}: <svelte:self
-              value={node}
-              depth={depth + 1}
-              key={i}
-              {theme}
-            /><!--
+	{#if value instanceof Array}
+		{#if collapsed}
+			<button
+				on:click={() => {
+					collapsed = false;
+				}}
+			>
+				[+{value.length} children]
+			</button>
+		{:else}
+			[
+			<div class="json-children pl-4">
+				{#each value as node, i}
+					<div class="json-item">
+						{i}: <svelte:self
+							value={node}
+							depth={depth + 1}
+							key={i}
+							{theme}
+						/><!--
             -->{#if i !== value.length - 1}<!--
             -->,
-            {/if}
-          </div>
-        {/each}
-      </div>
-      ]
-    {/if}
-  {:else if value instanceof Object}
-    {#if collapsed}
-      <button
-        on:click={() => {
-          collapsed = false;
-        }}
-      >
-        &#123;+{Object.keys(value).length} items&#125;
-      </button>
-    {:else}
-      &#123;
-      <div class="json-children pl-4">
-        {#each Object.entries(value) as node, i}
-          <div class="json-item">
-            {node[0]}: <svelte:self
-              value={node[1]}
-              depth={depth + 1}
-              key={i}
-              {theme}
-            /><!--
+						{/if}
+					</div>
+				{/each}
+			</div>
+			]
+		{/if}
+	{:else if value instanceof Object}
+		{#if collapsed}
+			<button
+				on:click={() => {
+					collapsed = false;
+				}}
+			>
+				&#123;+{Object.keys(value).length} items&#125;
+			</button>
+		{:else}
+			&#123;
+			<div class="json-children pl-4">
+				{#each Object.entries(value) as node, i}
+					<div class="json-item">
+						{node[0]}: <svelte:self
+							value={node[1]}
+							depth={depth + 1}
+							key={i}
+							{theme}
+						/><!--
             -->{#if i !== Object.keys(value).length - 1}<!--
             -->,
-            {/if}
-          </div>
-        {/each}
-      </div>
-      &#125;
-    {/if}
-  {:else if value === null}
-    <div
-      class="json-item inline text-gray-500 dark:text-gray-400"
-      item-type="null"
-    >
-      null
-    </div>
-  {:else if typeof value === "string"}
-    <div class="json-item inline text-green-500" item-type="string">
-      "{value}"
-    </div>
-  {:else if typeof value === "boolean"}
-    <div class="json-item inline text-red-500" item-type="boolean">
-      {value.toLocaleString()}
-    </div>
-  {:else if typeof value === "number"}
-    <div class="json-item inline text-blue-500" item-type="number">
-      {value}
-    </div>
-  {:else}
-    <div class="json-item inline" item-type="other">
-      {value}
-    </div>
-  {/if}
+						{/if}
+					</div>
+				{/each}
+			</div>
+			&#125;
+		{/if}
+	{:else if value === null}
+		<div class="json-item inline text-gray-500 dark:text-gray-400" item-type="null">null</div>
+	{:else if typeof value === "string"}
+		<div class="json-item inline text-green-500" item-type="string">
+			"{value}"
+		</div>
+	{:else if typeof value === "boolean"}
+		<div class="json-item inline text-red-500" item-type="boolean">
+			{value.toLocaleString()}
+		</div>
+	{:else if typeof value === "number"}
+		<div class="json-item inline text-blue-500" item-type="number">
+			{value}
+		</div>
+	{:else}
+		<div class="json-item inline" item-type="other">
+			{value}
+		</div>
+	{/if}
 </div>
 
 <style lang="postcss">

--- a/ui/packages/app/src/components/output/Json/config.js
+++ b/ui/packages/app/src/components/output/Json/config.js
@@ -1,5 +1,5 @@
 import Component from "./Component.svelte";
 
 export default {
-    "component": Component, 
-}
+	component: Component
+};

--- a/ui/packages/app/src/components/output/Label/Component.svelte
+++ b/ui/packages/app/src/components/output/Label/Component.svelte
@@ -1,54 +1,52 @@
 <script>
-  export let value, theme;
+	export let value, theme;
 </script>
 
 <div class="output-label" {theme}>
-  <div
-    class="output-class font-bold text-2xl py-6 px-4 flex-grow flex items-center justify-center"
-    class:no-confidence={!("confidences" in value)}
-  >
-    {value.label}
-  </div>
-  {#if "confidences" in value}
-    <div class="confidence-intervals flex text-xl">
-      <div class="labels mr-2" style={{ maxWidth: "120px" }}>
-        {#each value.confidences as confidence_set, i}
-          <div
-            class="label overflow-hidden whitespace-nowrap h-7 mb-2 overflow-ellipsis text-right"
-            title={confidence_set.label}
-            key={i}
-          >
-            {confidence_set.label}
-          </div>
-        {/each}
-      </div>
-      <div class="confidences flex flex-grow flex-col items-baseline">
-        {#each value.confidences as confidence_set, i}
-          <div
-          class="confidence flex justify-end items-center overflow-hidden whitespace-nowrap h-7 mb-2 px-1"
-          style={"min-width: calc(" +
-              Math.round(confidence_set.confidence * 100) +
-              "% - 12px)"}
-            key={i}
-          >
-            {Math.round(confidence_set.confidence * 100) + "%"}
-          </div>
-        {/each}
-      </div>
-    </div>
-  {/if}
+	<div
+		class="output-class font-bold text-2xl py-6 px-4 flex-grow flex items-center justify-center"
+		class:no-confidence={!("confidences" in value)}
+	>
+		{value.label}
+	</div>
+	{#if "confidences" in value}
+		<div class="confidence-intervals flex text-xl">
+			<div class="labels mr-2" style={{ maxWidth: "120px" }}>
+				{#each value.confidences as confidence_set, i}
+					<div
+						class="label overflow-hidden whitespace-nowrap h-7 mb-2 overflow-ellipsis text-right"
+						title={confidence_set.label}
+						key={i}
+					>
+						{confidence_set.label}
+					</div>
+				{/each}
+			</div>
+			<div class="confidences flex flex-grow flex-col items-baseline">
+				{#each value.confidences as confidence_set, i}
+					<div
+						class="confidence flex justify-end items-center overflow-hidden whitespace-nowrap h-7 mb-2 px-1"
+						style={"min-width: calc(" + Math.round(confidence_set.confidence * 100) + "% - 12px)"}
+						key={i}
+					>
+						{Math.round(confidence_set.confidence * 100) + "%"}
+					</div>
+				{/each}
+			</div>
+		</div>
+	{/if}
 </div>
 
 <style lang="postcss">
-  .output-label[theme="default"] {
-    .label {
-      @apply text-base h-7;
-    }
-    .confidence {
-      @apply font-mono box-border border-b-2 border-gray-300 bg-gray-200 dark:bg-gray-500 dark:border-gray-600 text-sm h-7 font-semibold rounded;
-    }
-    .confidence:first-child {
-      @apply border-yellow-600 bg-yellow-500 dark:bg-red-600 border-red-700 text-white;
-    }
-  }
+	.output-label[theme="default"] {
+		.label {
+			@apply text-base h-7;
+		}
+		.confidence {
+			@apply font-mono box-border border-b-2 border-gray-300 bg-gray-200 dark:bg-gray-500 dark:border-gray-600 text-sm h-7 font-semibold rounded;
+		}
+		.confidence:first-child {
+			@apply border-yellow-600 bg-yellow-500 dark:bg-red-600 border-red-700 text-white;
+		}
+	}
 </style>

--- a/ui/packages/app/src/components/output/Label/config.js
+++ b/ui/packages/app/src/components/output/Label/config.js
@@ -1,5 +1,5 @@
 import Component from "./Component.svelte";
 
 export default {
-    "component": Component, 
-}
+	component: Component
+};

--- a/ui/packages/app/src/components/output/Textbox/Component.svelte
+++ b/ui/packages/app/src/components/output/Textbox/Component.svelte
@@ -1,16 +1,16 @@
 <script>
-  export let value, theme;
+	export let value, theme;
 </script>
 
 <div
-  class="output-text w-full bg-white dark:bg-gray-800 rounded box-border p-2 whitespace-pre-wrap"
-  {theme}
+	class="output-text w-full bg-white dark:bg-gray-800 rounded box-border p-2 whitespace-pre-wrap"
+	{theme}
 >
-  {value}
+	{value}
 </div>
 
 <style lang="postcss" global>
-  .output-text[theme="default"] {
-    @apply shadow transition hover:shadow-md dark:bg-gray-800;
-  }
+	.output-text[theme="default"] {
+		@apply shadow transition hover:shadow-md dark:bg-gray-800;
+	}
 </style>

--- a/ui/packages/app/src/components/output/Textbox/config.js
+++ b/ui/packages/app/src/components/output/Textbox/config.js
@@ -1,5 +1,5 @@
 import Component from "./Component.svelte";
 
 export default {
-    "component": Component, 
-}
+	component: Component
+};

--- a/ui/packages/app/src/components/output/TimeSeries/Component.svelte
+++ b/ui/packages/app/src/components/output/TimeSeries/Component.svelte
@@ -1,11 +1,11 @@
 <script>
-  import Upload from "../../utils/Upload.svelte";
-  import Chart from "../../utils/Chart.svelte";
+	import Upload from "../../utils/Upload.svelte";
+	import Chart from "../../utils/Chart.svelte";
 
-  export let value;
-  $: formatted_value = value.data.map((r) =>
-    r.reduce((acc, next, i) => ({ ...acc, [value.headers[i]]: next }), {})
-  );
+	export let value;
+	$: formatted_value = value.data.map((r) =>
+		r.reduce((acc, next, i) => ({ ...acc, [value.headers[i]]: next }), {})
+	);
 </script>
 
 <Chart value={formatted_value} type="data" />

--- a/ui/packages/app/src/components/output/TimeSeries/config.js
+++ b/ui/packages/app/src/components/output/TimeSeries/config.js
@@ -1,5 +1,5 @@
 import Component from "./Component.svelte";
 
 export default {
-    "component": Component, 
-}
+	component: Component
+};

--- a/ui/packages/app/src/components/output/Video/Component.svelte
+++ b/ui/packages/app/src/components/output/Video/Component.svelte
@@ -1,30 +1,30 @@
 <script>
-  import { prettyBytes, playable } from "../../utils/helpers";
+	import { prettyBytes, playable } from "../../utils/helpers";
 
-  export let value, theme;
+	export let value, theme;
 </script>
 
 <div
-  class="output-video w-full h-60 flex justify-center items-center bg-gray-200 dark:bg-gray-600 relative"
+	class="output-video w-full h-60 flex justify-center items-center bg-gray-200 dark:bg-gray-600 relative"
 >
-  {#if playable(value.name)}
-    <!-- svelte-ignore a11y-media-has-caption -->
-    <video
-      class="video_preview w-full h-full object-contain"
-      controls
-      playsInline
-      preload
-      src={value.data}
-    />
-  {:else}
-    <a
-      href={value.data}
-      download={value.name}
-      class="file-preview h-60 w-full flex flex-col justify-center items-center relative"
-    >
-      <div class="file-name text-4xl p-6 break-all">{value.name}</div>
-    </a>
-  {/if}
+	{#if playable(value.name)}
+		<!-- svelte-ignore a11y-media-has-caption -->
+		<video
+			class="video_preview w-full h-full object-contain"
+			controls
+			playsInline
+			preload
+			src={value.data}
+		/>
+	{:else}
+		<a
+			href={value.data}
+			download={value.name}
+			class="file-preview h-60 w-full flex flex-col justify-center items-center relative"
+		>
+			<div class="file-name text-4xl p-6 break-all">{value.name}</div>
+		</a>
+	{/if}
 </div>
 
 <style lang="postcss">

--- a/ui/packages/app/src/components/output/Video/config.js
+++ b/ui/packages/app/src/components/output/Video/config.js
@@ -1,5 +1,5 @@
 import Component from "./Component.svelte";
 
 export default {
-    "component": Component, 
-}
+	component: Component
+};

--- a/ui/packages/app/src/components/utils/Chart.svelte
+++ b/ui/packages/app/src/components/utils/Chart.svelte
@@ -1,164 +1,150 @@
 <script>
-  import { csvParse } from "d3-dsv";
-  import { scaleLinear } from "d3-scale";
-  import { line as _line, curveLinear } from "d3-shape";
-  import { createEventDispatcher, onMount } from "svelte";
+	import { csvParse } from "d3-dsv";
+	import { scaleLinear } from "d3-scale";
+	import { line as _line, curveLinear } from "d3-shape";
+	import { createEventDispatcher, onMount } from "svelte";
 
-  import { get_domains, transform_values, get_color } from "./utils.js";
-  import { tooltip } from "./tooltip.js";
+	import { get_domains, transform_values, get_color } from "./utils.js";
+	import { tooltip } from "./tooltip.js";
 
-  export let value;
-  export let theme;
-  export let x;
-  export let y;
-  export let type = "csv";
+	export let value;
+	export let theme;
+	export let x;
+	export let y;
+	export let type = "csv";
 
-  const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-  $: ({ x, y } =
-    type === "csv"
-      ? transform_values(csvParse(value), x, y)
-      : transform_values(value, x, y));
+	$: ({ x, y } =
+		type === "csv" ? transform_values(csvParse(value), x, y) : transform_values(value, x, y));
 
-  $: x_domain = get_domains(x);
-  $: y_domain = get_domains(y);
+	$: x_domain = get_domains(x);
+	$: y_domain = get_domains(y);
 
-  $: scale_x = scaleLinear(x_domain, [0, 600]).nice();
-  $: scale_y = scaleLinear(y_domain, [350, 0]).nice();
-  $: x_ticks = scale_x.ticks(8);
-  $: y_ticks = scale_y.ticks(y_domain[1] < 10 ? y_domain[1] : 8);
+	$: scale_x = scaleLinear(x_domain, [0, 600]).nice();
+	$: scale_y = scaleLinear(y_domain, [350, 0]).nice();
+	$: x_ticks = scale_x.ticks(8);
+	$: y_ticks = scale_y.ticks(y_domain[1] < 10 ? y_domain[1] : 8);
 
-  $: colors = y.reduce(
-    (acc, next) => ({ ...acc, [next.name]: get_color() }),
-    {}
-  );
+	$: colors = y.reduce((acc, next) => ({ ...acc, [next.name]: get_color() }), {});
 
-  onMount(() => {
-    dispatch("process", { x, y });
-  });
+	onMount(() => {
+		dispatch("process", { x, y });
+	});
 </script>
 
 <div>
-  <div class="flex justify-center align-items-center text-sm">
-    {#each y as { name }}
-      <div class="mx-2">
-        <span
-          class="inline-block w-[10px] h-[10px]"
-          style="background-color: {colors[name]}"
-        />
-        {name}
-      </div>
-    {/each}
-  </div>
-  <svg class="w-full" viewbox="-70 -20 700 420">
-    <g>
-      {#each x_ticks as tick}
-        <line
-          stroke-width="0.5"
-          x1={scale_x(tick)}
-          x2={scale_x(tick)}
-          y1={scale_y(y_ticks[0] < y_domain[0] ? y_ticks[0] : y_domain[0]) + 10}
-          y2={scale_y(
-            y_domain[1] > y_ticks[y_ticks.length - 1]
-              ? y_domain[1]
-              : y_ticks[y_ticks.length - 1]
-          )}
-          stroke="#aaa"
-        />
-        <text
-          class="font-mono text-xs"
-          text-anchor="middle"
-          x={scale_x(tick)}
-          y={scale_y(y_ticks[0]) + 30}
-        >
-          {tick}
-        </text>
-      {/each}
+	<div class="flex justify-center align-items-center text-sm">
+		{#each y as { name }}
+			<div class="mx-2">
+				<span class="inline-block w-[10px] h-[10px]" style="background-color: {colors[name]}" />
+				{name}
+			</div>
+		{/each}
+	</div>
+	<svg class="w-full" viewbox="-70 -20 700 420">
+		<g>
+			{#each x_ticks as tick}
+				<line
+					stroke-width="0.5"
+					x1={scale_x(tick)}
+					x2={scale_x(tick)}
+					y1={scale_y(y_ticks[0] < y_domain[0] ? y_ticks[0] : y_domain[0]) + 10}
+					y2={scale_y(
+						y_domain[1] > y_ticks[y_ticks.length - 1] ? y_domain[1] : y_ticks[y_ticks.length - 1]
+					)}
+					stroke="#aaa"
+				/>
+				<text
+					class="font-mono text-xs"
+					text-anchor="middle"
+					x={scale_x(tick)}
+					y={scale_y(y_ticks[0]) + 30}
+				>
+					{tick}
+				</text>
+			{/each}
 
-      {#each y_ticks as tick}
-        <line
-          stroke-width="0.5"
-          y1={scale_y(tick)}
-          y2={scale_y(tick)}
-          x1={scale_x(x_ticks[0] < x_domain[0] ? x_ticks[0] : x_domain[0]) - 10}
-          x2={scale_x(
-            x_domain[1] > x_ticks[x_ticks.length - 1]
-              ? x_domain[1]
-              : x_ticks[x_ticks.length - 1]
-          )}
-          stroke="#aaa"
-        />
+			{#each y_ticks as tick}
+				<line
+					stroke-width="0.5"
+					y1={scale_y(tick)}
+					y2={scale_y(tick)}
+					x1={scale_x(x_ticks[0] < x_domain[0] ? x_ticks[0] : x_domain[0]) - 10}
+					x2={scale_x(
+						x_domain[1] > x_ticks[x_ticks.length - 1] ? x_domain[1] : x_ticks[x_ticks.length - 1]
+					)}
+					stroke="#aaa"
+				/>
 
-        <text
-          class="font-mono text-xs"
-          text-anchor="end"
-          y={scale_y(tick) + 4}
-          x={scale_x(x_ticks[0]) - 20}
-        >
-          {tick}
-        </text>
-      {/each}
+				<text
+					class="font-mono text-xs"
+					text-anchor="end"
+					y={scale_y(tick) + 4}
+					x={scale_x(x_ticks[0]) - 20}
+				>
+					{tick}
+				</text>
+			{/each}
 
-      {#if y_domain[1] > y_ticks[y_ticks.length - 1]}
-        <line
-          stroke-width="0.5"
-          y1={scale_y(y_domain[1])}
-          y2={scale_y(y_domain[1])}
-          x1={scale_x(x_ticks[0])}
-          x2={scale_x(x_domain[1])}
-          stroke="#aaa"
-        />
-        <text
-          class="font-mono text-xs"
-          text-anchor="end"
-          y={scale_y(y_domain[1]) + 4}
-          x={scale_x(x_ticks[0]) - 20}
-        >
-          {y_domain[1]}
-        </text>
-      {/if}
-    </g>
+			{#if y_domain[1] > y_ticks[y_ticks.length - 1]}
+				<line
+					stroke-width="0.5"
+					y1={scale_y(y_domain[1])}
+					y2={scale_y(y_domain[1])}
+					x1={scale_x(x_ticks[0])}
+					x2={scale_x(x_domain[1])}
+					stroke="#aaa"
+				/>
+				<text
+					class="font-mono text-xs"
+					text-anchor="end"
+					y={scale_y(y_domain[1]) + 4}
+					x={scale_x(x_ticks[0]) - 20}
+				>
+					{y_domain[1]}
+				</text>
+			{/if}
+		</g>
 
-    {#each y as { name, values }}
-      {@const color = colors[name]}
-      {#each values as { x, y }}
-        <circle
-          r="3.5"
-          cx={scale_x(x)}
-          cy={scale_y(y)}
-          stroke-width="1.5"
-          stroke={color}
-          fill="none"
-        />
-      {/each}
-      <path
-        d={_line().curve(curveLinear)(
-          values.map(({ x, y }) => [scale_x(x), scale_y(y)])
-        )}
-        fill="none"
-        stroke={color}
-        stroke-width="3"
-        line-cap="round"
-      />
-    {/each}
+		{#each y as { name, values }}
+			{@const color = colors[name]}
+			{#each values as { x, y }}
+				<circle
+					r="3.5"
+					cx={scale_x(x)}
+					cy={scale_y(y)}
+					stroke-width="1.5"
+					stroke={color}
+					fill="none"
+				/>
+			{/each}
+			<path
+				d={_line().curve(curveLinear)(values.map(({ x, y }) => [scale_x(x), scale_y(y)]))}
+				fill="none"
+				stroke={color}
+				stroke-width="3"
+				line-cap="round"
+			/>
+		{/each}
 
-    {#each y as { name, values }}
-      {@const color = colors[name]}
-      {#each values as { x, y }}
-        <circle
-          use:tooltip={{ color, text: `(${x}, ${y})` }}
-          r="7"
-          cx={scale_x(x)}
-          cy={scale_y(y)}
-          stroke="black"
-          fill="black"
-          style="cursor: pointer; opacity: 0"
-        />
-      {/each}
-    {/each}
-  </svg>
+		{#each y as { name, values }}
+			{@const color = colors[name]}
+			{#each values as { x, y }}
+				<circle
+					use:tooltip={{ color, text: `(${x}, ${y})` }}
+					r="7"
+					cx={scale_x(x)}
+					cy={scale_y(y)}
+					stroke="black"
+					fill="black"
+					style="cursor: pointer; opacity: 0"
+				/>
+			{/each}
+		{/each}
+	</svg>
 
-  <div class="flex justify-center align-items-center text-sm">
-    {x.name}
-  </div>
+	<div class="flex justify-center align-items-center text-sm">
+		{x.name}
+	</div>
 </div>

--- a/ui/packages/app/src/components/utils/Cropper.svelte
+++ b/ui/packages/app/src/components/utils/Cropper.svelte
@@ -1,23 +1,23 @@
 <script>
-  import Cropper from "cropperjs";
-  import { onMount, createEventDispatcher } from "svelte";
+	import Cropper from "cropperjs";
+	import { onMount, createEventDispatcher } from "svelte";
 
-  export let image;
-  let el;
+	export let image;
+	let el;
 
-  const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-  onMount(() => {
-    const cropper = new Cropper(el, {
-      autoCropArea: 1,
-      cropend() {
-        const image_data = cropper.getCroppedCanvas().toDataURL();
-        dispatch("crop", image_data);
-      },
-    });
+	onMount(() => {
+		const cropper = new Cropper(el, {
+			autoCropArea: 1,
+			cropend() {
+				const image_data = cropper.getCroppedCanvas().toDataURL();
+				dispatch("crop", image_data);
+			}
+		});
 
-    dispatch("crop", image);
-  });
+		dispatch("crop", image);
+	});
 </script>
 
 <img src={image} bind:this={el} alt="" />

--- a/ui/packages/app/src/components/utils/ImageEditor.svelte
+++ b/ui/packages/app/src/components/utils/ImageEditor.svelte
@@ -1,46 +1,46 @@
 <script>
-  import ImageEditor from "tui-image-editor";
+	import ImageEditor from "tui-image-editor";
 
-  import { createEventDispatcher, onMount } from "svelte";
+	import { createEventDispatcher, onMount } from "svelte";
 
-  export let value;
-  let el;
-  let editor;
+	export let value;
+	let el;
+	let editor;
 
-  const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-  function create_editor() {
-    editor = new ImageEditor(el, {
-      usageStatistics: false,
-      includeUI: {
-        loadImage: {
-          path: value,
-          name: "Edit Image",
-        },
-        menuBarPosition: "left",
-        uiSize: {
-          width: "800px",
-          height: "600px",
-        },
-      },
-      cssMaxWidth: 700,
-      cssMaxHeight: 500,
-      selectionStyle: {
-        cornerSize: 20,
-        rotatingPointOffset: 70,
-      },
-    });
-  }
+	function create_editor() {
+		editor = new ImageEditor(el, {
+			usageStatistics: false,
+			includeUI: {
+				loadImage: {
+					path: value,
+					name: "Edit Image"
+				},
+				menuBarPosition: "left",
+				uiSize: {
+					width: "800px",
+					height: "600px"
+				}
+			},
+			cssMaxWidth: 700,
+			cssMaxHeight: 500,
+			selectionStyle: {
+				cornerSize: 20,
+				rotatingPointOffset: 70
+			}
+		});
+	}
 
-  onMount(create_editor);
+	onMount(create_editor);
 </script>
 
 <div
-  class="fixed w-screen h-screen top-0 left-0 bg-black bg-opacity-50 z-40 flex flex-col justify-center items-center"
+	class="fixed w-screen h-screen top-0 left-0 bg-black bg-opacity-50 z-40 flex flex-col justify-center items-center"
 >
-  <div class="image_editor_buttons">
-    <button on:click={() => dispatch("save", editor.toDataURL())}>Save</button>
-    <button on:click={() => dispatch("cancel")}>Cancel</button>
-  </div>
-  <div bind:this={el} />
+	<div class="image_editor_buttons">
+		<button on:click={() => dispatch("save", editor.toDataURL())}>Save</button>
+		<button on:click={() => dispatch("cancel")}>Cancel</button>
+	</div>
+	<div bind:this={el} />
 </div>

--- a/ui/packages/app/src/components/utils/ModifySketch.svelte
+++ b/ui/packages/app/src/components/utils/ModifySketch.svelte
@@ -1,20 +1,20 @@
 <script>
-  import { createEventDispatcher } from "svelte";
+	import { createEventDispatcher } from "svelte";
 
-  const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 </script>
 
 <div class="z-50 top-0 right-0 flex justify-end m-1 flex gap-1 absolute">
-  <button
-    class="bg-opacity-30 hover:bg-opacity-100 transition p-1 bg-yellow-500 dark:bg-red-600 rounded shadow"
-    on:click={() => dispatch("undo")}
-  >
-    undo
-  </button>
-  <button
-    class="clear bg-opacity-30 hover:bg-opacity-100 transition p-1 bg-gray-50 dark:bg-gray-500 rounded shadow"
-    on:click={() => dispatch("clear")}
-  >
-    clear
-  </button>
+	<button
+		class="bg-opacity-30 hover:bg-opacity-100 transition p-1 bg-yellow-500 dark:bg-red-600 rounded shadow"
+		on:click={() => dispatch("undo")}
+	>
+		undo
+	</button>
+	<button
+		class="clear bg-opacity-30 hover:bg-opacity-100 transition p-1 bg-gray-50 dark:bg-gray-500 rounded shadow"
+		on:click={() => dispatch("clear")}
+	>
+		clear
+	</button>
 </div>

--- a/ui/packages/app/src/components/utils/ModifyUpload.svelte
+++ b/ui/packages/app/src/components/utils/ModifyUpload.svelte
@@ -1,45 +1,27 @@
 <script>
-  export let edit, clear, theme;
-  export let absolute = true;
+	export let edit, clear, theme;
+	export let absolute = true;
 </script>
 
-<div
-  class="modify-upload z-10 top-0 right-0 flex justify-end"
-  class:absolute
-  {theme}
->
-  {#if edit}
-    <button
-      class="edit bg-opacity-30 hover:bg-opacity-100 transition p-1"
-      on:click={edit}
-    >
-      <img
-        class="h-4 filter dark:invert"
-        src="static/img/edit.svg"
-        alt="Edit"
-      />
-    </button>
-  {/if}
-  <button
-    class="clear bg-opacity-30 hover:bg-opacity-100 transition p-1"
-    on:click={clear}
-  >
-    <img
-      class="h-4 filter dark:invert"
-      src="static/img/clear.svg"
-      alt="Clear"
-    />
-  </button>
+<div class="modify-upload z-10 top-0 right-0 flex justify-end" class:absolute {theme}>
+	{#if edit}
+		<button class="edit bg-opacity-30 hover:bg-opacity-100 transition p-1" on:click={edit}>
+			<img class="h-4 filter dark:invert" src="static/img/edit.svg" alt="Edit" />
+		</button>
+	{/if}
+	<button class="clear bg-opacity-30 hover:bg-opacity-100 transition p-1" on:click={clear}>
+		<img class="h-4 filter dark:invert" src="static/img/clear.svg" alt="Clear" />
+	</button>
 </div>
 
 <style lang="postcss" global>
-  .modify-upload[theme="default"] {
-    @apply m-1 flex gap-1;
-    .edit {
-      @apply bg-yellow-500 dark:bg-red-600 rounded shadow;
-    }
-    .clear {
-      @apply bg-gray-50 dark:bg-gray-500 rounded shadow;
-    }
-  }
+	.modify-upload[theme="default"] {
+		@apply m-1 flex gap-1;
+		.edit {
+			@apply bg-yellow-500 dark:bg-red-600 rounded shadow;
+		}
+		.clear {
+			@apply bg-gray-50 dark:bg-gray-500 rounded shadow;
+		}
+	}
 </style>

--- a/ui/packages/app/src/components/utils/Sketch.svelte
+++ b/ui/packages/app/src/components/utils/Sketch.svelte
@@ -1,356 +1,356 @@
 <script>
-  import { onMount, onDestroy, createEventDispatcher } from "svelte";
-  import { LazyBrush } from "lazy-brush";
-  import ResizeObserver from "resize-observer-polyfill";
+	import { onMount, onDestroy, createEventDispatcher } from "svelte";
+	import { LazyBrush } from "lazy-brush";
+	import ResizeObserver from "resize-observer-polyfill";
 
-  const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-  let brush_radius = 30;
-  let brush_color = "#444";
-  let catenary_color = "#aaa";
-  let background_color = "#FFF";
+	let brush_radius = 30;
+	let brush_color = "#444";
+	let catenary_color = "#aaa";
+	let background_color = "#FFF";
 
-  let canvas_width = 400;
-  let canvas_height = 400;
+	let canvas_width = 400;
+	let canvas_height = 400;
 
-  function mid_point(p1, p2) {
-    return {
-      x: p1.x + (p2.x - p1.x) / 2,
-      y: p1.y + (p2.y - p1.y) / 2,
-    };
-  }
+	function mid_point(p1, p2) {
+		return {
+			x: p1.x + (p2.x - p1.x) / 2,
+			y: p1.y + (p2.y - p1.y) / 2
+		};
+	}
 
-  const canvas_types = [
-    {
-      name: "interface",
-      zIndex: 15,
-    },
-    {
-      name: "drawing",
-      zIndex: 11,
-    },
-    {
-      name: "temp",
-      zIndex: 12,
-    },
-  ];
+	const canvas_types = [
+		{
+			name: "interface",
+			zIndex: 15
+		},
+		{
+			name: "drawing",
+			zIndex: 11
+		},
+		{
+			name: "temp",
+			zIndex: 12
+		}
+	];
 
-  let canvas = {};
-  let ctx = {};
-  let points = [];
-  let lines = [];
-  let mouse_has_moved = true;
-  let values_changed = true;
-  let is_drawing = false;
-  let is_pressing = false;
-  let lazy = null;
-  let chain_length = null;
-  let canvas_container = null;
-  let canvas_observer = null;
-  let save_data = "";
+	let canvas = {};
+	let ctx = {};
+	let points = [];
+	let lines = [];
+	let mouse_has_moved = true;
+	let values_changed = true;
+	let is_drawing = false;
+	let is_pressing = false;
+	let lazy = null;
+	let chain_length = null;
+	let canvas_container = null;
+	let canvas_observer = null;
+	let save_data = "";
 
-  onMount(() => {
-    Object.keys(canvas).forEach((key) => {
-      ctx[key] = canvas[key].getContext("2d");
-    });
-    lazy = new LazyBrush({
-      radius: brush_radius / 1.5,
-      enabled: true,
-      initialPoint: {
-        x: window.innerWidth / 2,
-        y: window.innerHeight / 2,
-      },
-    });
-    chain_length = brush_radius;
-    canvas_observer = new ResizeObserver((entries, observer) =>
-      handle_canvas_resize(entries, observer)
-    );
-    canvas_observer.observe(canvas_container);
-    loop();
+	onMount(() => {
+		Object.keys(canvas).forEach((key) => {
+			ctx[key] = canvas[key].getContext("2d");
+		});
+		lazy = new LazyBrush({
+			radius: brush_radius / 1.5,
+			enabled: true,
+			initialPoint: {
+				x: window.innerWidth / 2,
+				y: window.innerHeight / 2
+			}
+		});
+		chain_length = brush_radius;
+		canvas_observer = new ResizeObserver((entries, observer) =>
+			handle_canvas_resize(entries, observer)
+		);
+		canvas_observer.observe(canvas_container);
+		loop();
 
-    window.setTimeout(() => {
-      const initX = window.innerWidth / 2;
-      const initY = window.innerHeight / 2;
-      lazy.update({ x: initX - chain_length / 4, y: initY }, { both: true });
-      lazy.update({ x: initX + chain_length / 4, y: initY }, { both: false });
-      mouse_has_moved = true;
-      values_changed = true;
-      clear();
+		window.setTimeout(() => {
+			const initX = window.innerWidth / 2;
+			const initY = window.innerHeight / 2;
+			lazy.update({ x: initX - chain_length / 4, y: initY }, { both: true });
+			lazy.update({ x: initX + chain_length / 4, y: initY }, { both: false });
+			mouse_has_moved = true;
+			values_changed = true;
+			clear();
 
-      if (save_data) {
-        load_save_data(save_data);
-      }
-    }, 100);
-  });
+			if (save_data) {
+				load_save_data(save_data);
+			}
+		}, 100);
+	});
 
-  onDestroy(() => {
-    canvas_observer.unobserve(canvas_container);
-  });
+	onDestroy(() => {
+		canvas_observer.unobserve(canvas_container);
+	});
 
-  export function undo() {
-    const _lines = lines.slice(0, -1);
-    clear();
-    draw_lines({ lines: _lines });
-    trigger_on_change();
-  }
+	export function undo() {
+		const _lines = lines.slice(0, -1);
+		clear();
+		draw_lines({ lines: _lines });
+		trigger_on_change();
+	}
 
-  let get_save_data = () => {
-    return JSON.stringify({
-      lines: lines,
-      width: canvas_width,
-      height: canvas_height,
-    });
-  };
+	let get_save_data = () => {
+		return JSON.stringify({
+			lines: lines,
+			width: canvas_width,
+			height: canvas_height
+		});
+	};
 
-  let load_save_data = (save_data) => {
-    if (typeof save_data !== "string") {
-      throw new Error("save_data needs to be of type string!");
-    }
-    const { lines, width, height } = JSON.parse(save_data);
-    if (!lines || typeof lines.push !== "function") {
-      throw new Error("save_data.lines needs to be an array!");
-    }
-    clear();
-    if (width === canvas_width && height === canvas_height) {
-      draw_lines({
-        lines,
-      });
-    } else {
-      const scaleX = canvas_width / width;
-      const scaleY = canvas_height / height;
-      draw_lines({
-        lines: lines.map((line) => ({
-          ...line,
-          points: line.points.map((p) => ({
-            x: p.x * scaleX,
-            y: p.y * scaleY,
-          })),
-          brush_radius: line.brush_radius,
-        })),
-      });
-    }
-  };
+	let load_save_data = (save_data) => {
+		if (typeof save_data !== "string") {
+			throw new Error("save_data needs to be of type string!");
+		}
+		const { lines, width, height } = JSON.parse(save_data);
+		if (!lines || typeof lines.push !== "function") {
+			throw new Error("save_data.lines needs to be an array!");
+		}
+		clear();
+		if (width === canvas_width && height === canvas_height) {
+			draw_lines({
+				lines
+			});
+		} else {
+			const scaleX = canvas_width / width;
+			const scaleY = canvas_height / height;
+			draw_lines({
+				lines: lines.map((line) => ({
+					...line,
+					points: line.points.map((p) => ({
+						x: p.x * scaleX,
+						y: p.y * scaleY
+					})),
+					brush_radius: line.brush_radius
+				}))
+			});
+		}
+	};
 
-  let draw_lines = ({ lines }) => {
-    lines.forEach((line) => {
-      const { points: _points, brush_color, brush_radius } = line;
+	let draw_lines = ({ lines }) => {
+		lines.forEach((line) => {
+			const { points: _points, brush_color, brush_radius } = line;
 
-      draw_points({
-        points: _points,
-        brush_color,
-        brush_radius,
-      });
-      points = _points;
-      saveLine({ brush_color, brush_radius });
-      return;
-    });
-  };
+			draw_points({
+				points: _points,
+				brush_color,
+				brush_radius
+			});
+			points = _points;
+			saveLine({ brush_color, brush_radius });
+			return;
+		});
+	};
 
-  let handle_draw_start = (e) => {
-    e.preventDefault();
-    is_pressing = true;
-    const { x, y } = get_pointer_pos(e);
-    if (e.touches && e.touches.length > 0) {
-      lazy.update({ x, y }, { both: true });
-    }
-    handle_pointer_move(x, y);
-  };
+	let handle_draw_start = (e) => {
+		e.preventDefault();
+		is_pressing = true;
+		const { x, y } = get_pointer_pos(e);
+		if (e.touches && e.touches.length > 0) {
+			lazy.update({ x, y }, { both: true });
+		}
+		handle_pointer_move(x, y);
+	};
 
-  let handle_draw_move = (e) => {
-    e.preventDefault();
-    const { x, y } = get_pointer_pos(e);
-    handle_pointer_move(x, y);
-  };
+	let handle_draw_move = (e) => {
+		e.preventDefault();
+		const { x, y } = get_pointer_pos(e);
+		handle_pointer_move(x, y);
+	};
 
-  let handle_draw_end = (e) => {
-    e.preventDefault();
-    handle_draw_move(e);
-    is_drawing = false;
-    is_pressing = false;
-    saveLine();
-  };
+	let handle_draw_end = (e) => {
+		e.preventDefault();
+		handle_draw_move(e);
+		is_drawing = false;
+		is_pressing = false;
+		saveLine();
+	};
 
-  let handle_canvas_resize = (entries) => {
-    const save_data = get_save_data();
-    for (const entry of entries) {
-      const { width, height } = entry.contentRect;
-      set_canvas_size(canvas.interface, width, height);
-      set_canvas_size(canvas.drawing, width, height);
-      set_canvas_size(canvas.temp, width, height);
-      loop({ once: true });
-    }
-    load_save_data(save_data, true);
-  };
+	let handle_canvas_resize = (entries) => {
+		const save_data = get_save_data();
+		for (const entry of entries) {
+			const { width, height } = entry.contentRect;
+			set_canvas_size(canvas.interface, width, height);
+			set_canvas_size(canvas.drawing, width, height);
+			set_canvas_size(canvas.temp, width, height);
+			loop({ once: true });
+		}
+		load_save_data(save_data, true);
+	};
 
-  let set_canvas_size = (canvas, width, height) => {
-    canvas.width = width * 3;
-    canvas.height = height * 3;
-    canvas.style.width = width;
-    canvas.style.height = height;
-  };
+	let set_canvas_size = (canvas, width, height) => {
+		canvas.width = width * 3;
+		canvas.height = height * 3;
+		canvas.style.width = width;
+		canvas.style.height = height;
+	};
 
-  let get_pointer_pos = (e) => {
-    const rect = canvas.interface.getBoundingClientRect();
+	let get_pointer_pos = (e) => {
+		const rect = canvas.interface.getBoundingClientRect();
 
-    let clientX = e.clientX;
-    let clientY = e.clientY;
-    if (e.changedTouches && e.changedTouches.length > 0) {
-      clientX = e.changedTouches[0].clientX;
-      clientY = e.changedTouches[0].clientY;
-    }
-    return {
-      x: clientX - rect.left,
-      y: clientY - rect.top,
-    };
-  };
+		let clientX = e.clientX;
+		let clientY = e.clientY;
+		if (e.changedTouches && e.changedTouches.length > 0) {
+			clientX = e.changedTouches[0].clientX;
+			clientY = e.changedTouches[0].clientY;
+		}
+		return {
+			x: clientX - rect.left,
+			y: clientY - rect.top
+		};
+	};
 
-  let handle_pointer_move = (x, y) => {
-    lazy.update({ x: x * 3, y: y * 3 });
-    const is_disabled = !lazy.isEnabled();
-    if ((is_pressing && !is_drawing) || (is_disabled && is_pressing)) {
-      is_drawing = true;
-      points.push(lazy.brush.toObject());
-    }
-    if (is_drawing) {
-      points.push(lazy.brush.toObject());
+	let handle_pointer_move = (x, y) => {
+		lazy.update({ x: x * 3, y: y * 3 });
+		const is_disabled = !lazy.isEnabled();
+		if ((is_pressing && !is_drawing) || (is_disabled && is_pressing)) {
+			is_drawing = true;
+			points.push(lazy.brush.toObject());
+		}
+		if (is_drawing) {
+			points.push(lazy.brush.toObject());
 
-      draw_points({
-        points: points,
-        brush_color,
-        brush_radius,
-      });
-    }
-    mouse_has_moved = true;
-  };
+			draw_points({
+				points: points,
+				brush_color,
+				brush_radius
+			});
+		}
+		mouse_has_moved = true;
+	};
 
-  let draw_points = ({ points, brush_color, brush_radius }) => {
-    ctx.temp.lineJoin = "round";
-    ctx.temp.lineCap = "round";
-    ctx.temp.strokeStyle = brush_color;
-    ctx.temp.clearRect(0, 0, ctx.temp.canvas.width, ctx.temp.canvas.height);
-    ctx.temp.lineWidth = brush_radius;
-    let p1 = points[0];
-    let p2 = points[1];
-    ctx.temp.moveTo(p2.x, p2.y);
-    ctx.temp.beginPath();
-    for (var i = 1, len = points.length; i < len; i++) {
-      var midPoint = mid_point(p1, p2);
-      ctx.temp.quadraticCurveTo(p1.x, p1.y, midPoint.x, midPoint.y);
-      p1 = points[i];
-      p2 = points[i + 1];
-    }
+	let draw_points = ({ points, brush_color, brush_radius }) => {
+		ctx.temp.lineJoin = "round";
+		ctx.temp.lineCap = "round";
+		ctx.temp.strokeStyle = brush_color;
+		ctx.temp.clearRect(0, 0, ctx.temp.canvas.width, ctx.temp.canvas.height);
+		ctx.temp.lineWidth = brush_radius;
+		let p1 = points[0];
+		let p2 = points[1];
+		ctx.temp.moveTo(p2.x, p2.y);
+		ctx.temp.beginPath();
+		for (var i = 1, len = points.length; i < len; i++) {
+			var midPoint = mid_point(p1, p2);
+			ctx.temp.quadraticCurveTo(p1.x, p1.y, midPoint.x, midPoint.y);
+			p1 = points[i];
+			p2 = points[i + 1];
+		}
 
-    ctx.temp.lineTo(p1.x, p1.y);
-    ctx.temp.stroke();
-  };
+		ctx.temp.lineTo(p1.x, p1.y);
+		ctx.temp.stroke();
+	};
 
-  let saveLine = () => {
-    if (points.length < 2) return;
+	let saveLine = () => {
+		if (points.length < 2) return;
 
-    lines.push({
-      points: [...points],
-      brush_color: brush_color,
-      brush_radius,
-    });
-    points.length = 0;
-    const width = canvas.temp.width;
-    const height = canvas.temp.height;
-    ctx.drawing.drawImage(canvas.temp, 0, 0, width, height);
+		lines.push({
+			points: [...points],
+			brush_color: brush_color,
+			brush_radius
+		});
+		points.length = 0;
+		const width = canvas.temp.width;
+		const height = canvas.temp.height;
+		ctx.drawing.drawImage(canvas.temp, 0, 0, width, height);
 
-    ctx.temp.clearRect(0, 0, width, height);
-    trigger_on_change();
-  };
+		ctx.temp.clearRect(0, 0, width, height);
+		trigger_on_change();
+	};
 
-  let trigger_on_change = () => {
-    dispatch("change", get_image_data());
-  };
+	let trigger_on_change = () => {
+		dispatch("change", get_image_data());
+	};
 
-  export function clear() {
-    lines = [];
-    values_changed = true;
-    ctx.drawing.clearRect(0, 0, canvas.drawing.width, canvas.drawing.height);
-    ctx.temp.clearRect(0, 0, canvas.temp.width, canvas.temp.height);
-  }
+	export function clear() {
+		lines = [];
+		values_changed = true;
+		ctx.drawing.clearRect(0, 0, canvas.drawing.width, canvas.drawing.height);
+		ctx.temp.clearRect(0, 0, canvas.temp.width, canvas.temp.height);
+	}
 
-  let loop = ({ once = false } = {}) => {
-    if (mouse_has_moved || values_changed) {
-      const pointer = lazy.getPointerCoordinates();
-      const brush = lazy.getBrushCoordinates();
-      draw_interface(ctx.interface, pointer, brush);
-      mouse_has_moved = false;
-      values_changed = false;
-    }
-    if (!once) {
-      window.requestAnimationFrame(() => {
-        loop();
-      });
-    }
-  };
+	let loop = ({ once = false } = {}) => {
+		if (mouse_has_moved || values_changed) {
+			const pointer = lazy.getPointerCoordinates();
+			const brush = lazy.getBrushCoordinates();
+			draw_interface(ctx.interface, pointer, brush);
+			mouse_has_moved = false;
+			values_changed = false;
+		}
+		if (!once) {
+			window.requestAnimationFrame(() => {
+				loop();
+			});
+		}
+	};
 
-  let draw_interface = (ctx, pointer, brush) => {
-    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+	let draw_interface = (ctx, pointer, brush) => {
+		ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
 
-    // brush preview
-    ctx.beginPath();
-    ctx.fillStyle = brush_color;
-    ctx.arc(brush.x, brush.y, brush_radius / 2, 0, Math.PI * 2, true);
-    ctx.fill();
+		// brush preview
+		ctx.beginPath();
+		ctx.fillStyle = brush_color;
+		ctx.arc(brush.x, brush.y, brush_radius / 2, 0, Math.PI * 2, true);
+		ctx.fill();
 
-    // mouse point dangler
-    ctx.beginPath();
-    ctx.fillStyle = catenary_color;
-    ctx.arc(pointer.x, pointer.y, 4, 0, Math.PI * 2, true);
-    ctx.fill();
+		// mouse point dangler
+		ctx.beginPath();
+		ctx.fillStyle = catenary_color;
+		ctx.arc(pointer.x, pointer.y, 4, 0, Math.PI * 2, true);
+		ctx.fill();
 
-    //  catenary
-    if (lazy.isEnabled()) {
-      ctx.beginPath();
-      ctx.lineWidth = 2;
-      ctx.lineCap = "round";
-      ctx.setLineDash([2, 4]);
-      ctx.strokeStyle = catenary_color;
-      ctx.stroke();
-    }
+		//  catenary
+		if (lazy.isEnabled()) {
+			ctx.beginPath();
+			ctx.lineWidth = 2;
+			ctx.lineCap = "round";
+			ctx.setLineDash([2, 4]);
+			ctx.strokeStyle = catenary_color;
+			ctx.stroke();
+		}
 
-    // tiny brush point dot
-    ctx.beginPath();
-    ctx.fillStyle = catenary_color;
-    ctx.arc(brush.x, brush.y, 2, 0, Math.PI * 2, true);
-    ctx.fill();
-  };
+		// tiny brush point dot
+		ctx.beginPath();
+		ctx.fillStyle = catenary_color;
+		ctx.arc(brush.x, brush.y, 2, 0, Math.PI * 2, true);
+		ctx.fill();
+	};
 
-  export function get_image_data() {
-    return canvas.drawing.toDataURL("image/png");
-  }
+	export function get_image_data() {
+		return canvas.drawing.toDataURL("image/png");
+	}
 </script>
 
 <div
-  class="container"
-  style="height:100%; width:100%; background-color:{background_color}"
-  bind:this={canvas_container}
-  bind:offsetWidth={canvas_width}
-  bind:offsetHeight={canvas_height}
+	class="container"
+	style="height:100%; width:100%; background-color:{background_color}"
+	bind:this={canvas_container}
+	bind:offsetWidth={canvas_width}
+	bind:offsetHeight={canvas_height}
 >
-  {#each canvas_types as { name, zIndex }}
-    <canvas
-      key={name}
-      style="display:block;position:absolute; z-index:{zIndex}; width: {canvas_width}px; height: {canvas_height}px"
-      bind:this={canvas[name]}
-      on:mousedown={name === "interface" ? handle_draw_start : undefined}
-      on:mousemove={name === "interface" ? handle_draw_move : undefined}
-      on:mouseup={name === "interface" ? handle_draw_end : undefined}
-      on:mouseout={name === "interface" ? handle_draw_end : undefined}
-      on:touchstart={name === "interface" ? handle_draw_start : undefined}
-      on:touchmove={name === "interface" ? handle_draw_move : undefined}
-      on:touchend={name === "interface" ? handle_draw_end : undefined}
-      on:touchcancel={name === "interface" ? handle_draw_end : undefined}
-    />
-  {/each}
+	{#each canvas_types as { name, zIndex }}
+		<canvas
+			key={name}
+			style="display:block;position:absolute; z-index:{zIndex}; width: {canvas_width}px; height: {canvas_height}px"
+			bind:this={canvas[name]}
+			on:mousedown={name === "interface" ? handle_draw_start : undefined}
+			on:mousemove={name === "interface" ? handle_draw_move : undefined}
+			on:mouseup={name === "interface" ? handle_draw_end : undefined}
+			on:mouseout={name === "interface" ? handle_draw_end : undefined}
+			on:touchstart={name === "interface" ? handle_draw_start : undefined}
+			on:touchmove={name === "interface" ? handle_draw_move : undefined}
+			on:touchend={name === "interface" ? handle_draw_end : undefined}
+			on:touchcancel={name === "interface" ? handle_draw_end : undefined}
+		/>
+	{/each}
 </div>
 
 <style>
-  .container {
-    display: block;
-    touch-action: none;
-  }
+	.container {
+		display: block;
+		touch-action: none;
+	}
 </style>

--- a/ui/packages/app/src/components/utils/Tooltip.svelte
+++ b/ui/packages/app/src/components/utils/Tooltip.svelte
@@ -1,19 +1,19 @@
 <script>
-  export let text;
-  export let x;
-  export let y;
-  export let color;
+	export let text;
+	export let x;
+	export let y;
+	export let color;
 
-  let w, h;
+	let w, h;
 </script>
 
 <div
-  class="bg-black bg-opacity-80 text-white border-r-2 p-1 absolute text-xs flex items-center justify-center"
-  bind:offsetWidth={w}
-  bind:offsetHeight={h}
-  style="
+	class="bg-black bg-opacity-80 text-white border-r-2 p-1 absolute text-xs flex items-center justify-center"
+	bind:offsetWidth={w}
+	bind:offsetHeight={h}
+	style="
 		top: {y - h / 2}px;
 		left: {x - w - 7}px;"
 >
-  <span class="inline-block w-3 h-3 mr-1" style="background: {color}" />{text}
+	<span class="inline-block w-3 h-3 mr-1" style="background: {color}" />{text}
 </div>

--- a/ui/packages/app/src/components/utils/Upload.svelte
+++ b/ui/packages/app/src/components/utils/Upload.svelte
@@ -1,75 +1,79 @@
 <script>
-  export let load, filetype, theme;
-  export let single_file = true;
-  export let include_file_metadata = true;
-  let hidden_upload;
-  let dragging = false;
+	export let load, filetype, theme;
+	export let single_file = true;
+	export let include_file_metadata = true;
+	let hidden_upload;
+	let dragging = false;
 
-  const updateDragging = () => {dragging = !dragging}
-  const openFileUpload = () => {
-    hidden_upload.click();
-  };
-  const loadFiles = (files) => {
-    if (!files.length || !window.FileReader) {
-      return;
-    }
-    if (single_file) {
-      files = [files[0]];
-    }
-    var all_file_data = [];
-    files.forEach((file, i) => {
-      let ReaderObj = new FileReader();
-      ReaderObj.readAsDataURL(file);
-      ReaderObj.onloadend = function (e) {
-        all_file_data[i] = include_file_metadata
-          ? {
-              name: file.name,
-              size: file.size,
-              data: this.result,
-              is_example: false,
-            }
-          : this.result;
-        if (Object.keys(all_file_data).length === files.length) {
-          load(single_file ? all_file_data[0] : all_file_data);
-        }
-      };
-    });
-  };
-  const loadFilesFromUpload = (e) => {
-    loadFiles(e.target.files);
-  };
-  const loadFilesFromDrop = (e) => {
-    loadFiles(e.dataTransfer.files);
-  };
+	const updateDragging = () => {
+		dragging = !dragging;
+	};
+	const openFileUpload = () => {
+		hidden_upload.click();
+	};
+	const loadFiles = (files) => {
+		if (!files.length || !window.FileReader) {
+			return;
+		}
+		if (single_file) {
+			files = [files[0]];
+		}
+		var all_file_data = [];
+		files.forEach((file, i) => {
+			let ReaderObj = new FileReader();
+			ReaderObj.readAsDataURL(file);
+			ReaderObj.onloadend = function (e) {
+				all_file_data[i] = include_file_metadata
+					? {
+							name: file.name,
+							size: file.size,
+							data: this.result,
+							is_example: false
+					  }
+					: this.result;
+				if (Object.keys(all_file_data).length === files.length) {
+					load(single_file ? all_file_data[0] : all_file_data);
+				}
+			};
+		});
+	};
+	const loadFilesFromUpload = (e) => {
+		loadFiles(e.target.files);
+	};
+	const loadFilesFromDrop = (e) => {
+		loadFiles(e.dataTransfer.files);
+	};
 </script>
 
 <div
-  class={dragging ? "upload h-60 border-green-300 text-green-400 dark:text-green-500 dark:border-green-500 border-8 border-dashed w-full flex justify-center items-center text-3xl text-center cursor-pointer leading-10" : "upload h-60 border-gray-300 text-gray-400 dark:text-gray-500 dark:border-gray-500 border-8 border-dashed w-full flex justify-center items-center text-3xl text-center cursor-pointer leading-10"}
-  {theme}
-  on:drag|preventDefault|stopPropagation
-  on:dragstart|preventDefault|stopPropagation
-  on:dragend|preventDefault|stopPropagation
-  on:dragover|preventDefault|stopPropagation
-  on:dragenter|preventDefault|stopPropagation
-  on:dragleave|preventDefault|stopPropagation
-  on:drop|preventDefault|stopPropagation
-  on:click={openFileUpload}
-  on:drop={loadFilesFromDrop}
-  on:dragenter={updateDragging}
-  on:dragleave={updateDragging}
+	class={dragging
+		? "upload h-60 border-green-300 text-green-400 dark:text-green-500 dark:border-green-500 border-8 border-dashed w-full flex justify-center items-center text-3xl text-center cursor-pointer leading-10"
+		: "upload h-60 border-gray-300 text-gray-400 dark:text-gray-500 dark:border-gray-500 border-8 border-dashed w-full flex justify-center items-center text-3xl text-center cursor-pointer leading-10"}
+	{theme}
+	on:drag|preventDefault|stopPropagation
+	on:dragstart|preventDefault|stopPropagation
+	on:dragend|preventDefault|stopPropagation
+	on:dragover|preventDefault|stopPropagation
+	on:dragenter|preventDefault|stopPropagation
+	on:dragleave|preventDefault|stopPropagation
+	on:drop|preventDefault|stopPropagation
+	on:click={openFileUpload}
+	on:drop={loadFilesFromDrop}
+	on:dragenter={updateDragging}
+	on:dragleave={updateDragging}
 >
-  <slot />
-  <input
-    class="hidden-upload hidden"
-    type="file"
-    bind:this={hidden_upload}
-    on:change={loadFilesFromUpload}
-    accept={filetype}
-  />
+	<slot />
+	<input
+		class="hidden-upload hidden"
+		type="file"
+		bind:this={hidden_upload}
+		on:change={loadFilesFromUpload}
+		accept={filetype}
+	/>
 </div>
 
 <style lang="postcss" global>
-  .upload[theme="default"] {
-    @apply transition hover:border-gray-400 hover:text-gray-500 dark:hover:border-gray-300 dark:hover:text-gray-300;
-  }
+	.upload[theme="default"] {
+		@apply transition hover:border-gray-400 hover:text-gray-500 dark:hover:border-gray-300 dark:hover:text-gray-300;
+	}
 </style>

--- a/ui/packages/app/src/components/utils/Webcam.svelte
+++ b/ui/packages/app/src/components/utils/Webcam.svelte
@@ -1,66 +1,60 @@
 <script>
-  import { createEventDispatcher, onMount } from "svelte";
+	import { createEventDispatcher, onMount } from "svelte";
 
-  let video_source = null;
-  let canvas;
+	let video_source = null;
+	let canvas;
 
-  const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-  onMount(() => (canvas = document.createElement("canvas")));
+	onMount(() => (canvas = document.createElement("canvas")));
 
-  async function access_webcam() {
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({
-        video: true,
-      });
-      video_source.srcObject = stream;
-      video_source.play();
-    } catch (error) {
-      console.log(error);
-    }
-  }
+	async function access_webcam() {
+		try {
+			const stream = await navigator.mediaDevices.getUserMedia({
+				video: true
+			});
+			video_source.srcObject = stream;
+			video_source.play();
+		} catch (error) {
+			console.log(error);
+		}
+	}
 
-  function clearphoto() {
-    var context = canvas.getContext("2d");
-    context.fillStyle = "#AAA";
-    context.fillRect(0, 0, canvas.width, canvas.height);
-  }
+	function clearphoto() {
+		var context = canvas.getContext("2d");
+		context.fillStyle = "#AAA";
+		context.fillRect(0, 0, canvas.width, canvas.height);
+	}
 
-  function takepicture() {
-    var context = canvas.getContext("2d");
+	function takepicture() {
+		var context = canvas.getContext("2d");
 
-    if (video_source.videoWidth && video_source.videoHeight) {
-      canvas.width = video_source.videoWidth;
-      canvas.height = video_source.videoHeight;
-      context.drawImage(
-        video_source,
-        0,
-        0,
-        video_source.videoWidth,
-        video_source.videoHeight
-      );
+		if (video_source.videoWidth && video_source.videoHeight) {
+			canvas.width = video_source.videoWidth;
+			canvas.height = video_source.videoHeight;
+			context.drawImage(video_source, 0, 0, video_source.videoWidth, video_source.videoHeight);
 
-      var data = canvas.toDataURL("image/png");
-      dispatch("capture", data);
-    }
-  }
+			var data = canvas.toDataURL("image/png");
+			dispatch("capture", data);
+		}
+	}
 
-  access_webcam();
+	access_webcam();
 </script>
 
 <div class="h-full w-full relative">
-  <!-- svelte-ignore a11y-media-has-caption -->
-  <video bind:this={video_source} class=" h-full w-full" />
-  <button
-    on:click={takepicture}
-    style="background-color: #333;"
-    class="rounded-full w-10 h-10 flex justify-center items-center absolute inset-x-0 bottom-2 m-auto drop-shadow-lg"
-  >
-    <img
-      style="color: white"
-      src="static/img/camera.svg"
-      alt="take a screenshot"
-      class="w-2/4 h-2/4"
-    />
-  </button>
+	<!-- svelte-ignore a11y-media-has-caption -->
+	<video bind:this={video_source} class=" h-full w-full" />
+	<button
+		on:click={takepicture}
+		style="background-color: #333;"
+		class="rounded-full w-10 h-10 flex justify-center items-center absolute inset-x-0 bottom-2 m-auto drop-shadow-lg"
+	>
+		<img
+			style="color: white"
+			src="static/img/camera.svg"
+			alt="take a screenshot"
+			class="w-2/4 h-2/4"
+		/>
+	</button>
 </div>

--- a/ui/packages/app/src/components/utils/example_processors.js
+++ b/ui/packages/app/src/components/utils/example_processors.js
@@ -1,31 +1,31 @@
 export const loadAsFile = async (x, examples_dir) => {
-  return {
-    name: x,
-    data: examples_dir + x,
-    is_example: true
-  };
-}
+	return {
+		name: x,
+		data: examples_dir + x,
+		is_example: true
+	};
+};
 
 export const loadAsData = async (x, examples_dir) => {
-  let file_url = examples_dir + x;
-  let response = await fetch(file_url);
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-  let blob = await response.blob();
-  return new Promise((resolve, reject) => {
-    var reader = new FileReader();
-    reader.addEventListener(
-      "load",
-      function () {
-        resolve(reader.result);
-      },
-      false
-    );
+	let file_url = examples_dir + x;
+	let response = await fetch(file_url);
+	if (!response.ok) {
+		throw new Error(`HTTP error! status: ${response.status}`);
+	}
+	let blob = await response.blob();
+	return new Promise((resolve, reject) => {
+		var reader = new FileReader();
+		reader.addEventListener(
+			"load",
+			function () {
+				resolve(reader.result);
+			},
+			false
+		);
 
-    reader.onerror = () => {
-      return reject(this);
-    };
-    reader.readAsDataURL(blob);
-  });
-}
+		reader.onerror = () => {
+			return reject(this);
+		};
+		reader.readAsDataURL(blob);
+	});
+};

--- a/ui/packages/app/src/components/utils/helpers.js
+++ b/ui/packages/app/src/components/utils/helpers.js
@@ -1,117 +1,107 @@
 // import mime from "mime-types";
 
 export const playable = (filename) => {
-  // let video_element = document.createElement("video");
-  // let mime_type = mime.lookup(filename);
-  // return video_element.canPlayType(mime_type) != "";
-  return true; // FIX BEFORE COMMIT - mime import causing issues
+	// let video_element = document.createElement("video");
+	// let mime_type = mime.lookup(filename);
+	// return video_element.canPlayType(mime_type) != "";
+	return true; // FIX BEFORE COMMIT - mime import causing issues
 };
 
 export const deepCopy = (obj) => {
-  return JSON.parse(JSON.stringify(obj));
-}
+	return JSON.parse(JSON.stringify(obj));
+};
 
 export function randInt(min, max) {
-  return Math.floor(Math.random() * (max - min) + min);
+	return Math.floor(Math.random() * (max - min) + min);
 }
 
 export const getNextColor = (index, alpha) => {
-  alpha = alpha || 1;
-  let default_colors = [
-    [255, 99, 132],
-    [54, 162, 235],
-    [240, 176, 26],
-    [153, 102, 255],
-    [75, 192, 192],
-    [255, 159, 64],
-    [194, 88, 74],
-    [44, 102, 219],
-    [44, 163, 23],
-    [191, 46, 217],
-    [160, 162, 162],
-    [163, 151, 27],
-  ];
-  if (index < default_colors.length) {
-    var color_set = default_colors[index];
-  } else {
-    var color_set = [randInt(64, 196), randInt(64, 196), randInt(64, 196)];
-  }
-  return (
-    "rgba(" +
-    color_set[0] +
-    ", " +
-    color_set[1] +
-    ", " +
-    color_set[2] +
-    ", " +
-    alpha +
-    ")"
-  );
-}
+	alpha = alpha || 1;
+	let default_colors = [
+		[255, 99, 132],
+		[54, 162, 235],
+		[240, 176, 26],
+		[153, 102, 255],
+		[75, 192, 192],
+		[255, 159, 64],
+		[194, 88, 74],
+		[44, 102, 219],
+		[44, 163, 23],
+		[191, 46, 217],
+		[160, 162, 162],
+		[163, 151, 27]
+	];
+	if (index < default_colors.length) {
+		var color_set = default_colors[index];
+	} else {
+		var color_set = [randInt(64, 196), randInt(64, 196), randInt(64, 196)];
+	}
+	return "rgba(" + color_set[0] + ", " + color_set[1] + ", " + color_set[2] + ", " + alpha + ")";
+};
 
 export const prettyBytes = (bytes) => {
-  let units = ["B", "KB", "MB", "GB", "PB"];
-  let i = 0;
-  while (bytes > 1024) {
-    bytes /= 1024;
-    i++;
-  }
-  let unit = units[i];
-  return bytes.toFixed(1) + " " + unit;
-}
+	let units = ["B", "KB", "MB", "GB", "PB"];
+	let i = 0;
+	while (bytes > 1024) {
+		bytes /= 1024;
+		i++;
+	}
+	let unit = units[i];
+	return bytes.toFixed(1) + " " + unit;
+};
 
 export const getSaliencyColor = (value) => {
-  var color = null;
-  if (value < 0) {
-    color = [52, 152, 219];
-  } else {
-    color = [231, 76, 60];
-  }
-  return colorToString(interpolate(Math.abs(value), [255, 255, 255], color));
-}
+	var color = null;
+	if (value < 0) {
+		color = [52, 152, 219];
+	} else {
+		color = [231, 76, 60];
+	}
+	return colorToString(interpolate(Math.abs(value), [255, 255, 255], color));
+};
 
 const interpolate = (val, rgb1, rgb2) => {
-  if (val > 1) {
-    val = 1;
-  }
-  val = Math.sqrt(val);
-  var rgb = [0, 0, 0];
-  var i;
-  for (i = 0; i < 3; i++) {
-    rgb[i] = Math.round(rgb1[i] * (1.0 - val) + rgb2[i] * val);
-  }
-  return rgb;
-}
+	if (val > 1) {
+		val = 1;
+	}
+	val = Math.sqrt(val);
+	var rgb = [0, 0, 0];
+	var i;
+	for (i = 0; i < 3; i++) {
+		rgb[i] = Math.round(rgb1[i] * (1.0 - val) + rgb2[i] * val);
+	}
+	return rgb;
+};
 
 const colorToString = (rgb) => {
-  return "rgb(" + rgb[0] + ", " + rgb[1] + ", " + rgb[2] + ")";
-}
+	return "rgb(" + rgb[0] + ", " + rgb[1] + ", " + rgb[2] + ")";
+};
 
 export const getObjectFitSize = (
-  contains /* true = contain, false = cover */,
-  containerWidth,
-  containerHeight,
-  width,
-  height
+	contains /* true = contain, false = cover */,
+	containerWidth,
+	containerHeight,
+	width,
+	height
 ) => {
-  var doRatio = width / height;
-  var cRatio = containerWidth / containerHeight;
-  var targetWidth = 0;
-  var targetHeight = 0;
-  var test = contains ? doRatio > cRatio : doRatio < cRatio;
+	var doRatio = width / height;
+	var cRatio = containerWidth / containerHeight;
+	var targetWidth = 0;
+	var targetHeight = 0;
+	var test = contains ? doRatio > cRatio : doRatio < cRatio;
 
-  if (test) {
-    targetWidth = containerWidth;
-    targetHeight = targetWidth / doRatio;
-  } else {
-    targetHeight = containerHeight;
-    targetWidth = targetHeight * doRatio;
-  }
+	if (test) {
+		targetWidth = containerWidth;
+		targetHeight = targetWidth / doRatio;
+	} else {
+		targetHeight = containerHeight;
+		targetWidth = targetHeight * doRatio;
+	}
 
-  return {
-    width: targetWidth,
-    height: targetHeight,
-    x: (containerWidth - targetWidth) / 2,
-    y: (containerHeight - targetHeight) / 2
-  };
-}
+	return {
+		width: targetWidth,
+		height: targetHeight,
+		x: (containerWidth - targetWidth) / 2,
+		y: (containerHeight - targetHeight) / 2
+	};
+};

--- a/ui/packages/app/src/components/utils/tooltip.js
+++ b/ui/packages/app/src/components/utils/tooltip.js
@@ -1,38 +1,38 @@
 import Tooltip from "./Tooltip.svelte";
 
 export function tooltip(element, { color, text }) {
-  let div;
-  let tooltipComponent;
-  function mouseOver(event) {
-    tooltipComponent = new Tooltip({
-      props: {
-        text,
-        x: event.pageX,
-        y: event.pageY,
-        color,
-      },
-      target: document.body,
-    });
-  }
-  function mouseMove(event) {
-    tooltipComponent.$set({
-      x: event.pageX,
-      y: event.pageY,
-    });
-  }
-  function mouseLeave() {
-    tooltipComponent.$destroy();
-  }
+	let div;
+	let tooltipComponent;
+	function mouseOver(event) {
+		tooltipComponent = new Tooltip({
+			props: {
+				text,
+				x: event.pageX,
+				y: event.pageY,
+				color
+			},
+			target: document.body
+		});
+	}
+	function mouseMove(event) {
+		tooltipComponent.$set({
+			x: event.pageX,
+			y: event.pageY
+		});
+	}
+	function mouseLeave() {
+		tooltipComponent.$destroy();
+	}
 
-  element.addEventListener("mouseover", mouseOver);
-  element.addEventListener("mouseleave", mouseLeave);
-  element.addEventListener("mousemove", mouseMove);
+	element.addEventListener("mouseover", mouseOver);
+	element.addEventListener("mouseleave", mouseLeave);
+	element.addEventListener("mousemove", mouseMove);
 
-  return {
-    destroy() {
-      element.removeEventListener("mouseover", mouseOver);
-      element.removeEventListener("mouseleave", mouseLeave);
-      element.removeEventListener("mousemove", mouseMove);
-    },
-  };
+	return {
+		destroy() {
+			element.removeEventListener("mouseover", mouseOver);
+			element.removeEventListener("mouseleave", mouseLeave);
+			element.removeEventListener("mousemove", mouseMove);
+		}
+	};
 }

--- a/ui/packages/app/src/components/utils/utils.js
+++ b/ui/packages/app/src/components/utils/utils.js
@@ -1,54 +1,57 @@
 export function get_domains(values) {
-  let _vs;
-  if (Array.isArray(values)) {
-    _vs = values.reduce((acc, { values }) => {
-      return [...acc, ...values.map(({ x, y }) => y)];
-    }, []);
-  } else {
-    _vs = values.values;
-  }
-  return [Math.min(..._vs), Math.max(..._vs)];
+	let _vs;
+	if (Array.isArray(values)) {
+		_vs = values.reduce((acc, { values }) => {
+			return [...acc, ...values.map(({ x, y }) => y)];
+		}, []);
+	} else {
+		_vs = values.values;
+	}
+	return [Math.min(..._vs), Math.max(..._vs)];
 }
 
 export function transform_values(values, x, y) {
-  const transformed_values = Object.entries(values[0]).reduce((acc, next, i) => {
-    if ((!x && i === 0) || (x && next[0] === x)) {
-      acc.x.name = next[0];
-    } else if (!y || y && y.includes(next[0]) ) {
-      acc.y.push({name: next[0], values: []});
-    }
-    return acc;
-  }, {x: {name: '', values: []}, y: []});
+	const transformed_values = Object.entries(values[0]).reduce(
+		(acc, next, i) => {
+			if ((!x && i === 0) || (x && next[0] === x)) {
+				acc.x.name = next[0];
+			} else if (!y || (y && y.includes(next[0]))) {
+				acc.y.push({ name: next[0], values: [] });
+			}
+			return acc;
+		},
+		{ x: { name: "", values: [] }, y: [] }
+	);
 
-  for (let i = 0; i < values.length; i++) {
-    const _a = Object.entries(values[i]);
-    for (let j = 0; j < _a.length; j++) {
-      let [name, x] = _a[j];
-      if (name === transformed_values.x.name) {
-        transformed_values.x.values.push(x);
-      } else {
-        transformed_values.y[j - 1].values.push({ y: _a[j][1], x: _a[0][1] });
-      }
-    }
-  }
+	for (let i = 0; i < values.length; i++) {
+		const _a = Object.entries(values[i]);
+		for (let j = 0; j < _a.length; j++) {
+			let [name, x] = _a[j];
+			if (name === transformed_values.x.name) {
+				transformed_values.x.values.push(x);
+			} else {
+				transformed_values.y[j - 1].values.push({ y: _a[j][1], x: _a[0][1] });
+			}
+		}
+	}
 
-  return transformed_values;
+	return transformed_values;
 }
 
 let c = 0;
 export function get_color() {
-  let default_colors = [
-    [255, 99, 132],
-    [54, 162, 235],
-    [240, 176, 26],
-    [153, 102, 255],
-    [75, 192, 192],
-    [255, 159, 64],
-  ];
+	let default_colors = [
+		[255, 99, 132],
+		[54, 162, 235],
+		[240, 176, 26],
+		[153, 102, 255],
+		[75, 192, 192],
+		[255, 159, 64]
+	];
 
-  if (c >= default_colors.length) c = 0;
+	if (c >= default_colors.length) c = 0;
 
-  const [r, g, b] = default_colors[c++];
+	const [r, g, b] = default_colors[c++];
 
-  return `rgb(${r},${g},${b})`;
+	return `rgb(${r},${g},${b})`;
 }

--- a/ui/packages/app/src/main.js
+++ b/ui/packages/app/src/main.js
@@ -1,51 +1,51 @@
-import App from './App.svelte';
+import App from "./App.svelte";
 import Login from "./Login.svelte";
 import { fn } from "./api";
 
 window.launchGradio = (config, element_query) => {
-  let target = document.querySelector(element_query);
-  if (config.root === undefined) {
-    config.root = "BACKEND_URL";
-  }
-  if (config.detail === "Not authenticated") {
-    new Login({
-      target: target,
-      props: config
-    });
-  } else {
-    let url = new URL(window.location.toString());
-    if (config.theme !== null && config.theme.startsWith("dark")) {
-      target.classList.add("dark");
-      config.dark = true;
-      if (config.theme === "dark") {
-        config.theme = "default";
-      } else {
-        config.theme = config.theme.substring(5);
-      }
-    } else if (url.searchParams.get("__dark-theme") === "true") {
-      config.dark = true;
-      target.classList.add("dark");
-    }
-    config.fn = fn.bind(null, config.root + "api/");
-    new App({
-      target: target,
-      props: config
-    });
-  }
-}
+	let target = document.querySelector(element_query);
+	if (config.root === undefined) {
+		config.root = "BACKEND_URL";
+	}
+	if (config.detail === "Not authenticated") {
+		new Login({
+			target: target,
+			props: config
+		});
+	} else {
+		let url = new URL(window.location.toString());
+		if (config.theme !== null && config.theme.startsWith("dark")) {
+			target.classList.add("dark");
+			config.dark = true;
+			if (config.theme === "dark") {
+				config.theme = "default";
+			} else {
+				config.theme = config.theme.substring(5);
+			}
+		} else if (url.searchParams.get("__dark-theme") === "true") {
+			config.dark = true;
+			target.classList.add("dark");
+		}
+		config.fn = fn.bind(null, config.root + "api/");
+		new App({
+			target: target,
+			props: config
+		});
+	}
+};
 
 async function get_config() {
-  if ('BUILD_MODE' === "dev") {
-    let config = await fetch("BACKEND_URL" + "config");
-    config = await config.json();
-    return config;
-  } else {
-    return window.gradio_config;
-  }
+	if ("BUILD_MODE" === "dev") {
+		let config = await fetch("BACKEND_URL" + "config");
+		config = await config.json();
+		return config;
+	} else {
+		return window.gradio_config;
+	}
 }
 
 if (window.gradio_mode == "app") {
-  get_config().then((config) => {
-    launchGradio(config, "#root");
-  });
+	get_config().then((config) => {
+		launchGradio(config, "#root");
+	});
 }

--- a/ui/packages/app/tailwind.config.js
+++ b/ui/packages/app/tailwind.config.js
@@ -1,18 +1,16 @@
 const production = !process.env.ROLLUP_WATCH;
 module.exports = {
-  purge: {
-    content: [
-      "./src/**/*.svelte",
-    ],
-    enabled: production // disable purge in dev
-  },
-  mode: "jit",
-  darkMode: "class", // or 'media' or 'class'
-  theme: {
-    extend: {},
-  },
-  variants: {
-    extend: {},
-  },
-  plugins: [],
-}
+	purge: {
+		content: ["./src/**/*.svelte"],
+		enabled: production // disable purge in dev
+	},
+	mode: "jit",
+	darkMode: "class", // or 'media' or 'class'
+	theme: {
+		extend: {}
+	},
+	variants: {
+		extend: {}
+	},
+	plugins: []
+};

--- a/ui/packages/components/package.json
+++ b/ui/packages/components/package.json
@@ -1,10 +1,9 @@
 {
-  "name": "gradio-ui",
-  "version": "0.0.1",
-  "description": "Gradio UI packages",
-  "scripts": {
-  },
-  "author": "",
-  "license": "ISC",
-  "private": true
+	"name": "gradio-ui",
+	"version": "0.0.1",
+	"description": "Gradio UI packages",
+	"scripts": {},
+	"author": "",
+	"license": "ISC",
+	"private": true
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -1,19 +1,22 @@
 lockfileVersion: 5.3
 
 importers:
-
   .:
     specifiers:
+      prettier: ^2.5.1
+      prettier-plugin-svelte: ^2.6.0
       svelte: ^3.46.3
     dependencies:
+      prettier: 2.5.1
+      prettier-plugin-svelte: 2.6.0_prettier@2.5.1+svelte@3.46.3
       svelte: 3.46.3
 
   packages/app:
     specifiers:
-      '@rollup/plugin-commonjs': ^17.0.0
-      '@rollup/plugin-json': ^4.1.0
-      '@rollup/plugin-node-resolve': ^11.0.0
-      '@rollup/plugin-replace': ^3.0.1
+      "@rollup/plugin-commonjs": ^17.0.0
+      "@rollup/plugin-json": ^4.1.0
+      "@rollup/plugin-node-resolve": ^11.0.0
+      "@rollup/plugin-replace": ^3.0.1
       autoprefixer: ^9.8.8
       cropperjs: ^1.5.12
       d3-dsv: ^3.0.1
@@ -39,7 +42,7 @@ importers:
       tailwindcss: npm:@tailwindcss/postcss7-compat@^2.2.17
       tui-image-editor: ^3.15.2
     dependencies:
-      '@rollup/plugin-replace': 3.0.1_rollup@2.66.1
+      "@rollup/plugin-replace": 3.0.1_rollup@2.66.1
       autoprefixer: 9.8.8
       cropperjs: 1.5.12
       d3-dsv: 3.0.1
@@ -57,9 +60,9 @@ importers:
       tailwindcss: /@tailwindcss/postcss7-compat/2.2.17
       tui-image-editor: 3.15.2
     devDependencies:
-      '@rollup/plugin-commonjs': 17.1.0_rollup@2.66.1
-      '@rollup/plugin-json': 4.1.0_rollup@2.66.1
-      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.66.1
+      "@rollup/plugin-commonjs": 17.1.0_rollup@2.66.1
+      "@rollup/plugin-json": 4.1.0_rollup@2.66.1
+      "@rollup/plugin-node-resolve": 11.2.1_rollup@2.66.1
       postcss: 8.4.6
       postcss-nested: 5.0.6_postcss@8.4.6
       rollup: 2.66.1
@@ -73,31 +76,45 @@ importers:
     specifiers: {}
 
 packages:
-
   /@babel/code-frame/7.16.7:
-    resolution: {integrity: sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+      }
+    engines: { node: ">=6.9.0" }
     dependencies:
-      '@babel/highlight': 7.16.10
+      "@babel/highlight": 7.16.10
 
   /@babel/helper-validator-identifier/7.16.7:
-    resolution: {integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+      }
+    engines: { node: ">=6.9.0" }
 
   /@babel/highlight/7.16.10:
-    resolution: {integrity: sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
+      }
+    engines: { node: ">=6.9.0" }
     dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
+      "@babel/helper-validator-identifier": 7.16.7
       chalk: 2.4.2
       js-tokens: 4.0.0
 
   /@gar/promisify/1.1.2:
-    resolution: {integrity: sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==}
+    resolution:
+      {
+        integrity: sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
+      }
     dev: false
 
   /@mapbox/node-pre-gyp/1.0.8:
-    resolution: {integrity: sha512-CMGKi28CF+qlbXh26hDe6NxCd7amqeAzEqnS6IHeO6LoaKyM/n+Xw3HT1COdq8cuioOdlKdqn/hCmqPUOMOywg==}
+    resolution:
+      {
+        integrity: sha512-CMGKi28CF+qlbXh26hDe6NxCd7amqeAzEqnS6IHeO6LoaKyM/n+Xw3HT1COdq8cuioOdlKdqn/hCmqPUOMOywg==
+      }
     hasBin: true
     dependencies:
       detect-libc: 1.0.3
@@ -116,53 +133,74 @@ packages:
     optional: true
 
   /@nodelib/fs.scandir/2.1.5:
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
+      }
+    engines: { node: ">= 8" }
     dependencies:
-      '@nodelib/fs.stat': 2.0.5
+      "@nodelib/fs.stat": 2.0.5
       run-parallel: 1.2.0
     dev: false
 
   /@nodelib/fs.stat/2.0.5:
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
+      }
+    engines: { node: ">= 8" }
     dev: false
 
   /@nodelib/fs.walk/1.2.8:
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
+      }
+    engines: { node: ">= 8" }
     dependencies:
-      '@nodelib/fs.scandir': 2.1.5
+      "@nodelib/fs.scandir": 2.1.5
       fastq: 1.13.0
     dev: false
 
   /@npmcli/fs/1.1.0:
-    resolution: {integrity: sha512-VhP1qZLXcrXRIaPoqb4YA55JQxLNF3jNR4T55IdOJa3+IFJKNYHtPvtXx8slmeMavj37vCzCfrqQM1vWLsYKLA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16}
+    resolution:
+      {
+        integrity: sha512-VhP1qZLXcrXRIaPoqb4YA55JQxLNF3jNR4T55IdOJa3+IFJKNYHtPvtXx8slmeMavj37vCzCfrqQM1vWLsYKLA==
+      }
+    engines: { node: ^12.13.0 || ^14.15.0 || >=16 }
     dependencies:
-      '@gar/promisify': 1.1.2
+      "@gar/promisify": 1.1.2
       semver: 7.3.5
     dev: false
 
   /@npmcli/move-file/1.1.2:
-    resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==
+      }
+    engines: { node: ">=10" }
     dependencies:
       mkdirp: 1.0.4
       rimraf: 3.0.2
     dev: false
 
   /@polka/url/1.0.0-next.21:
-    resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
+    resolution:
+      {
+        integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
+      }
     dev: false
 
   /@rollup/plugin-commonjs/17.1.0_rollup@2.66.1:
-    resolution: {integrity: sha512-PoMdXCw0ZyvjpCMT5aV4nkL0QywxP29sODQsSGeDpr/oI49Qq9tRtAsb/LbYbDzFlOydVEqHmmZWFtXJEAX9ew==}
-    engines: {node: '>= 8.0.0'}
+    resolution:
+      {
+        integrity: sha512-PoMdXCw0ZyvjpCMT5aV4nkL0QywxP29sODQsSGeDpr/oI49Qq9tRtAsb/LbYbDzFlOydVEqHmmZWFtXJEAX9ew==
+      }
+    engines: { node: ">= 8.0.0" }
     peerDependencies:
       rollup: ^2.30.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.66.1
+      "@rollup/pluginutils": 3.1.0_rollup@2.66.1
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 7.2.0
@@ -173,22 +211,28 @@ packages:
     dev: true
 
   /@rollup/plugin-json/4.1.0_rollup@2.66.1:
-    resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
+    resolution:
+      {
+        integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
+      }
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.66.1
+      "@rollup/pluginutils": 3.1.0_rollup@2.66.1
       rollup: 2.66.1
     dev: true
 
   /@rollup/plugin-node-resolve/11.2.1_rollup@2.66.1:
-    resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
-    engines: {node: '>= 10.0.0'}
+    resolution:
+      {
+        integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==
+      }
+    engines: { node: ">= 10.0.0" }
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.66.1
-      '@types/resolve': 1.17.1
+      "@rollup/pluginutils": 3.1.0_rollup@2.66.1
+      "@types/resolve": 1.17.1
       builtin-modules: 3.2.0
       deepmerge: 4.2.2
       is-module: 1.0.0
@@ -197,37 +241,49 @@ packages:
     dev: true
 
   /@rollup/plugin-replace/3.0.1_rollup@2.66.1:
-    resolution: {integrity: sha512-989J5oRzf3mm0pO/0djTijdfEh9U3n63BIXN5X7T4U9BP+fN4oxQ6DvDuBvFaHA6scaHQRclqmKQEkBhB7k7Hg==}
+    resolution:
+      {
+        integrity: sha512-989J5oRzf3mm0pO/0djTijdfEh9U3n63BIXN5X7T4U9BP+fN4oxQ6DvDuBvFaHA6scaHQRclqmKQEkBhB7k7Hg==
+      }
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.66.1
+      "@rollup/pluginutils": 3.1.0_rollup@2.66.1
       magic-string: 0.25.7
       rollup: 2.66.1
     dev: false
 
   /@rollup/pluginutils/3.1.0_rollup@2.66.1:
-    resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
-    engines: {node: '>= 8.0.0'}
+    resolution:
+      {
+        integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+      }
+    engines: { node: ">= 8.0.0" }
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     dependencies:
-      '@types/estree': 0.0.39
+      "@types/estree": 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.1
       rollup: 2.66.1
 
   /@rollup/pluginutils/4.1.2:
-    resolution: {integrity: sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==}
-    engines: {node: '>= 8.0.0'}
+    resolution:
+      {
+        integrity: sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==
+      }
+    engines: { node: ">= 8.0.0" }
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.3.1
     dev: true
 
   /@tailwindcss/postcss7-compat/2.2.17:
-    resolution: {integrity: sha512-3h2svqQAqYHxRZ1KjsJjZOVTQ04m29LjfrLjXyZZEJuvUuJN+BCIF9GI8vhE1s0plS0mogd6E6YLg6mu4Wv/Vw==}
-    engines: {node: '>=12.13.0'}
+    resolution:
+      {
+        integrity: sha512-3h2svqQAqYHxRZ1KjsJjZOVTQ04m29LjfrLjXyZZEJuvUuJN+BCIF9GI8vhE1s0plS0mogd6E6YLg6mu4Wv/Vw==
+      }
+    engines: { node: ">=12.13.0" }
     hasBin: true
     dependencies:
       arg: 5.0.1
@@ -270,81 +326,132 @@ packages:
     dev: false
 
   /@tootallnate/once/1.1.2:
-    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+      }
+    engines: { node: ">= 6" }
     dev: false
 
   /@trysound/sax/0.2.0:
-    resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
-    engines: {node: '>=10.13.0'}
+    resolution:
+      {
+        integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
+      }
+    engines: { node: ">=10.13.0" }
     dev: false
 
   /@types/estree/0.0.39:
-    resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
+    resolution:
+      {
+        integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+      }
 
   /@types/estree/0.0.50:
-    resolution: {integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==}
+    resolution:
+      {
+        integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
+      }
     dev: true
 
   /@types/fs-extra/8.1.2:
-    resolution: {integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==}
+    resolution:
+      {
+        integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==
+      }
     dependencies:
-      '@types/node': 17.0.14
+      "@types/node": 17.0.14
     dev: false
 
   /@types/glob/7.2.0:
-    resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
+    resolution:
+      {
+        integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+      }
     dependencies:
-      '@types/minimatch': 3.0.5
-      '@types/node': 17.0.14
+      "@types/minimatch": 3.0.5
+      "@types/node": 17.0.14
     dev: false
 
   /@types/minimatch/3.0.5:
-    resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
+    resolution:
+      {
+        integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
+      }
     dev: false
 
   /@types/minimist/1.2.2:
-    resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
+    resolution:
+      {
+        integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+      }
     dev: false
 
   /@types/node/17.0.14:
-    resolution: {integrity: sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==}
+    resolution:
+      {
+        integrity: sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==
+      }
 
   /@types/normalize-package-data/2.4.1:
-    resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
+    resolution:
+      {
+        integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
+      }
     dev: false
 
   /@types/parse-json/4.0.0:
-    resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
+    resolution:
+      {
+        integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+      }
     dev: false
 
   /@types/pug/2.0.6:
-    resolution: {integrity: sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==}
+    resolution:
+      {
+        integrity: sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==
+      }
     dev: false
 
   /@types/resolve/1.17.1:
-    resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
+    resolution:
+      {
+        integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
+      }
     dependencies:
-      '@types/node': 17.0.14
+      "@types/node": 17.0.14
     dev: true
 
   /@types/sass/1.43.1:
-    resolution: {integrity: sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==}
+    resolution:
+      {
+        integrity: sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==
+      }
     dependencies:
-      '@types/node': 17.0.14
+      "@types/node": 17.0.14
     dev: false
 
   /abab/2.0.5:
-    resolution: {integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==}
+    resolution:
+      {
+        integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
+      }
     dev: false
     optional: true
 
   /abbrev/1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+    resolution:
+      {
+        integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+      }
     dev: false
 
   /acorn-globals/4.3.4:
-    resolution: {integrity: sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==}
+    resolution:
+      {
+        integrity: sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==
+      }
     dependencies:
       acorn: 6.4.2
       acorn-walk: 6.2.0
@@ -352,7 +459,10 @@ packages:
     optional: true
 
   /acorn-node/1.8.2:
-    resolution: {integrity: sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==}
+    resolution:
+      {
+        integrity: sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==
+      }
     dependencies:
       acorn: 7.4.1
       acorn-walk: 7.2.0
@@ -360,32 +470,47 @@ packages:
     dev: false
 
   /acorn-walk/6.2.0:
-    resolution: {integrity: sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
+      }
+    engines: { node: ">=0.4.0" }
     dev: false
     optional: true
 
   /acorn-walk/7.2.0:
-    resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
+      }
+    engines: { node: ">=0.4.0" }
     dev: false
 
   /acorn/6.4.2:
-    resolution: {integrity: sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
+      }
+    engines: { node: ">=0.4.0" }
     hasBin: true
     dev: false
     optional: true
 
   /acorn/7.4.1:
-    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+      }
+    engines: { node: ">=0.4.0" }
     hasBin: true
     dev: false
 
   /agent-base/6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
+    resolution:
+      {
+        integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+      }
+    engines: { node: ">= 6.0.0" }
     dependencies:
       debug: 4.3.3
     transitivePeerDependencies:
@@ -393,8 +518,11 @@ packages:
     dev: false
 
   /agentkeepalive/4.2.0:
-    resolution: {integrity: sha512-0PhAp58jZNw13UJv7NVdTGb0ZcghHUb3DrZ046JiiJY/BOaTTpbwdHq2VObPCBV8M2GPh7sgrJ3AQ8Ey468LJw==}
-    engines: {node: '>= 8.0.0'}
+    resolution:
+      {
+        integrity: sha512-0PhAp58jZNw13UJv7NVdTGb0ZcghHUb3DrZ046JiiJY/BOaTTpbwdHq2VObPCBV8M2GPh7sgrJ3AQ8Ey468LJw==
+      }
+    engines: { node: ">= 8.0.0" }
     dependencies:
       debug: 4.3.3
       depd: 1.1.2
@@ -404,15 +532,21 @@ packages:
     dev: false
 
   /aggregate-error/3.1.0:
-    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
+      }
+    engines: { node: ">=8" }
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
     dev: false
 
   /ajv/6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+    resolution:
+      {
+        integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+      }
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -421,82 +555,112 @@ packages:
     dev: false
 
   /ansi-regex/5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /ansi-styles/3.2.1:
-    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+      }
+    engines: { node: ">=4" }
     dependencies:
       color-convert: 1.9.3
 
   /ansi-styles/4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+      }
+    engines: { node: ">=8" }
     dependencies:
       color-convert: 2.0.1
     dev: false
 
   /anymatch/3.1.2:
-    resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
+      }
+    engines: { node: ">= 8" }
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
   /aproba/2.0.0:
-    resolution: {integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==}
+    resolution:
+      {
+        integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
+      }
     dev: false
 
   /are-we-there-yet/2.0.0:
-    resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==
+      }
+    engines: { node: ">=10" }
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.0
     dev: false
 
   /arg/5.0.1:
-    resolution: {integrity: sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==}
+    resolution:
+      {
+        integrity: sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==
+      }
     dev: false
 
   /array-equal/1.0.0:
-    resolution: {integrity: sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=}
+    resolution: { integrity: sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM= }
     dev: false
     optional: true
 
   /array-union/2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /arrify/1.0.1:
-    resolution: {integrity: sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=}
-    engines: {node: '>=0.10.0'}
+    resolution: { integrity: sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0= }
+    engines: { node: ">=0.10.0" }
     dev: false
 
   /asn1/0.2.6:
-    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+    resolution:
+      {
+        integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
+      }
     dependencies:
       safer-buffer: 2.1.2
     dev: false
 
   /assert-plus/1.0.0:
-    resolution: {integrity: sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=}
-    engines: {node: '>=0.8'}
+    resolution: { integrity: sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU= }
+    engines: { node: ">=0.8" }
     dev: false
 
   /async-foreach/0.1.3:
-    resolution: {integrity: sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=}
+    resolution: { integrity: sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI= }
     dev: false
 
   /asynckit/0.4.0:
-    resolution: {integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=}
+    resolution: { integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k= }
     dev: false
 
   /autoprefixer/9.8.8:
-    resolution: {integrity: sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==}
+    resolution:
+      {
+        integrity: sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==
+      }
     hasBin: true
     dependencies:
       browserslist: 4.19.1
@@ -509,50 +673,71 @@ packages:
     dev: false
 
   /aws-sign2/0.7.0:
-    resolution: {integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=}
+    resolution: { integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg= }
     dev: false
 
   /aws4/1.11.0:
-    resolution: {integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==}
+    resolution:
+      {
+        integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+      }
     dev: false
 
   /balanced-match/1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    resolution:
+      {
+        integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+      }
 
   /bcrypt-pbkdf/1.0.2:
-    resolution: {integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=}
+    resolution: { integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4= }
     dependencies:
       tweetnacl: 0.14.5
     dev: false
 
   /binary-extensions/2.2.0:
-    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+      }
+    engines: { node: ">=8" }
 
   /boolbase/1.0.0:
-    resolution: {integrity: sha1-aN/1++YMUes3cl6p4+0xDcwed24=}
+    resolution: { integrity: sha1-aN/1++YMUes3cl6p4+0xDcwed24= }
     dev: false
 
   /brace-expansion/1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+    resolution:
+      {
+        integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+      }
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
   /braces/3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+      }
+    engines: { node: ">=8" }
     dependencies:
       fill-range: 7.0.1
 
   /browser-process-hrtime/1.0.0:
-    resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
+    resolution:
+      {
+        integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
+      }
     dev: false
     optional: true
 
   /browserslist/4.19.1:
-    resolution: {integrity: sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    resolution:
+      {
+        integrity: sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==
+      }
+    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001304
@@ -563,29 +748,41 @@ packages:
     dev: false
 
   /buffer-crc32/0.2.13:
-    resolution: {integrity: sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=}
+    resolution: { integrity: sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI= }
     dev: false
 
   /buffer-from/1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    resolution:
+      {
+        integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+      }
     dev: true
 
   /builtin-modules/3.2.0:
-    resolution: {integrity: sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
+      }
+    engines: { node: ">=6" }
     dev: true
 
   /bytes/3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
+      }
+    engines: { node: ">= 0.8" }
     dev: false
 
   /cacache/15.3.0:
-    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==
+      }
+    engines: { node: ">= 10" }
     dependencies:
-      '@npmcli/fs': 1.1.0
-      '@npmcli/move-file': 1.1.2
+      "@npmcli/fs": 1.1.0
+      "@npmcli/move-file": 1.1.2
       chownr: 2.0.0
       fs-minipass: 2.1.0
       glob: 7.2.0
@@ -605,18 +802,27 @@ packages:
     dev: false
 
   /callsites/3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+      }
+    engines: { node: ">=6" }
     dev: false
 
   /camelcase-css/2.0.1:
-    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
+      }
+    engines: { node: ">= 6" }
     dev: false
 
   /camelcase-keys/6.2.2:
-    resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==
+      }
+    engines: { node: ">=8" }
     dependencies:
       camelcase: 5.3.1
       map-obj: 4.3.0
@@ -624,12 +830,18 @@ packages:
     dev: false
 
   /camelcase/5.3.1:
-    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+      }
+    engines: { node: ">=6" }
     dev: false
 
   /caniuse-api/3.0.0:
-    resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
+    resolution:
+      {
+        integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==
+      }
     dependencies:
       browserslist: 4.19.1
       caniuse-lite: 1.0.30001304
@@ -638,15 +850,21 @@ packages:
     dev: false
 
   /caniuse-lite/1.0.30001304:
-    resolution: {integrity: sha512-bdsfZd6K6ap87AGqSHJP/s1V+U6Z5lyrcbBu3ovbCCf8cSYpwTtGrCBObMpJqwxfTbLW6YTIdbb1jEeTelcpYQ==}
+    resolution:
+      {
+        integrity: sha512-bdsfZd6K6ap87AGqSHJP/s1V+U6Z5lyrcbBu3ovbCCf8cSYpwTtGrCBObMpJqwxfTbLW6YTIdbb1jEeTelcpYQ==
+      }
     dev: false
 
   /canvas/2.9.0:
-    resolution: {integrity: sha512-0l93g7uxp7rMyr7H+XRQ28A3ud0dKIUTIEkUe1Dxh4rjUYN7B93+SjC3r1PDKA18xcQN87OFGgUnyw7LSgNLSQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-0l93g7uxp7rMyr7H+XRQ28A3ud0dKIUTIEkUe1Dxh4rjUYN7B93+SjC3r1PDKA18xcQN87OFGgUnyw7LSgNLSQ==
+      }
+    engines: { node: ">=6" }
     requiresBuild: true
     dependencies:
-      '@mapbox/node-pre-gyp': 1.0.8
+      "@mapbox/node-pre-gyp": 1.0.8
       nan: 2.15.0
       simple-get: 3.1.0
     transitivePeerDependencies:
@@ -656,28 +874,37 @@ packages:
     optional: true
 
   /caseless/0.12.0:
-    resolution: {integrity: sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=}
+    resolution: { integrity: sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw= }
     dev: false
 
   /chalk/2.4.2:
-    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+      }
+    engines: { node: ">=4" }
     dependencies:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
 
   /chalk/4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+      }
+    engines: { node: ">=10" }
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
     dev: false
 
   /chokidar/3.5.3:
-    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
-    engines: {node: '>= 8.10.0'}
+    resolution:
+      {
+        integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+      }
+    engines: { node: ">= 8.10.0" }
     dependencies:
       anymatch: 3.1.2
       braces: 3.0.2
@@ -690,17 +917,26 @@ packages:
       fsevents: 2.3.2
 
   /chownr/2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+      }
+    engines: { node: ">=10" }
     dev: false
 
   /clean-stack/2.2.0:
-    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+      }
+    engines: { node: ">=6" }
     dev: false
 
   /cliui/7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+    resolution:
+      {
+        integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+      }
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
@@ -708,107 +944,155 @@ packages:
     dev: false
 
   /color-convert/1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    resolution:
+      {
+        integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+      }
     dependencies:
       color-name: 1.1.3
 
   /color-convert/2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
+    resolution:
+      {
+        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+      }
+    engines: { node: ">=7.0.0" }
     dependencies:
       color-name: 1.1.4
     dev: false
 
   /color-name/1.1.3:
-    resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=}
+    resolution: { integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU= }
 
   /color-name/1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    resolution:
+      {
+        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+      }
     dev: false
 
   /color-string/1.9.0:
-    resolution: {integrity: sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==}
+    resolution:
+      {
+        integrity: sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==
+      }
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
     dev: false
 
   /color-support/1.1.3:
-    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    resolution:
+      {
+        integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
+      }
     hasBin: true
     dev: false
 
   /color/4.2.0:
-    resolution: {integrity: sha512-hHTcrbvEnGjC7WBMk6ibQWFVDgEFTVmjrz2Q5HlU6ltwxv0JJN2Z8I7uRbWeQLF04dikxs8zgyZkazRJvSMtyQ==}
+    resolution:
+      {
+        integrity: sha512-hHTcrbvEnGjC7WBMk6ibQWFVDgEFTVmjrz2Q5HlU6ltwxv0JJN2Z8I7uRbWeQLF04dikxs8zgyZkazRJvSMtyQ==
+      }
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.0
     dev: false
 
   /colord/2.9.2:
-    resolution: {integrity: sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==}
+    resolution:
+      {
+        integrity: sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==
+      }
     dev: false
 
   /colorette/1.4.0:
-    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
+    resolution:
+      {
+        integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
+      }
     dev: false
 
   /combined-stream/1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+      }
+    engines: { node: ">= 0.8" }
     dependencies:
       delayed-stream: 1.0.0
     dev: false
 
   /commander/2.20.3:
-    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+    resolution:
+      {
+        integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+      }
     dev: true
 
   /commander/7.2.0:
-    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+      }
+    engines: { node: ">= 10" }
     dev: false
 
   /commander/8.3.0:
-    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
-    engines: {node: '>= 12'}
+    resolution:
+      {
+        integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+      }
+    engines: { node: ">= 12" }
     dev: false
 
   /commondir/1.0.1:
-    resolution: {integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=}
+    resolution: { integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs= }
     dev: true
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: { integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s= }
 
   /concat-with-sourcemaps/1.1.0:
-    resolution: {integrity: sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==}
+    resolution:
+      {
+        integrity: sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==
+      }
     dependencies:
       source-map: 0.6.1
     dev: false
 
   /console-clear/1.1.1:
-    resolution: {integrity: sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ==
+      }
+    engines: { node: ">=4" }
     dev: false
 
   /console-control-strings/1.1.0:
-    resolution: {integrity: sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=}
+    resolution: { integrity: sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4= }
     dev: false
 
   /core-util-is/1.0.2:
-    resolution: {integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=}
+    resolution: { integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac= }
     dev: false
 
   /core-util-is/1.0.3:
-    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+    resolution:
+      {
+        integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+      }
     dev: false
 
   /cosmiconfig/7.0.1:
-    resolution: {integrity: sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
+      }
+    engines: { node: ">=10" }
     dependencies:
-      '@types/parse-json': 4.0.0
+      "@types/parse-json": 4.0.0
       import-fresh: 3.3.0
       parse-json: 5.2.0
       path-type: 4.0.0
@@ -816,12 +1100,18 @@ packages:
     dev: false
 
   /cropperjs/1.5.12:
-    resolution: {integrity: sha512-re7UdjE5UnwdrovyhNzZ6gathI4Rs3KGCBSc8HCIjUo5hO42CtzyblmWLj6QWVw7huHyDMfpKxhiO2II77nhDw==}
+    resolution:
+      {
+        integrity: sha512-re7UdjE5UnwdrovyhNzZ6gathI4Rs3KGCBSc8HCIjUo5hO42CtzyblmWLj6QWVw7huHyDMfpKxhiO2II77nhDw==
+      }
     dev: false
 
   /cross-spawn/7.0.3:
-    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+      }
+    engines: { node: ">= 8" }
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -829,12 +1119,15 @@ packages:
     dev: false
 
   /css-color-names/0.0.4:
-    resolution: {integrity: sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=}
+    resolution: { integrity: sha1-gIrcLnnPhHOAabZGyyDsJ762KeA= }
     dev: false
 
   /css-declaration-sorter/6.1.4_postcss@8.4.6:
-    resolution: {integrity: sha512-lpfkqS0fctcmZotJGhnxkIyJWvBXgpyi2wsFd4J8VB7wzyrT6Ch/3Q+FMNJpjK4gu1+GN5khOnpU2ZVKrLbhCw==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-lpfkqS0fctcmZotJGhnxkIyJWvBXgpyi2wsFd4J8VB7wzyrT6Ch/3Q+FMNJpjK4gu1+GN5khOnpU2ZVKrLbhCw==
+      }
+    engines: { node: ">= 10" }
     peerDependencies:
       postcss: ^8.0.9
     dependencies:
@@ -843,7 +1136,10 @@ packages:
     dev: false
 
   /css-select/4.2.1:
-    resolution: {integrity: sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==}
+    resolution:
+      {
+        integrity: sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==
+      }
     dependencies:
       boolbase: 1.0.0
       css-what: 5.1.0
@@ -853,30 +1149,45 @@ packages:
     dev: false
 
   /css-tree/1.1.3:
-    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
-    engines: {node: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
+      }
+    engines: { node: ">=8.0.0" }
     dependencies:
       mdn-data: 2.0.14
       source-map: 0.6.1
     dev: false
 
   /css-unit-converter/1.1.2:
-    resolution: {integrity: sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==}
+    resolution:
+      {
+        integrity: sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==
+      }
     dev: false
 
   /css-what/5.1.0:
-    resolution: {integrity: sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
+      }
+    engines: { node: ">= 6" }
     dev: false
 
   /cssesc/3.0.0:
-    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+      }
+    engines: { node: ">=4" }
     hasBin: true
 
   /cssnano-preset-default/5.1.11_postcss@8.4.6:
-    resolution: {integrity: sha512-ETet5hqHxmzQq2ynXMOQofKuLm7VOjMiOB7E2zdtm/hSeCKlD9fabzIUV4GoPcRyJRHi+4kGf0vsfGYbQ4nmPw==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-ETet5hqHxmzQq2ynXMOQofKuLm7VOjMiOB7E2zdtm/hSeCKlD9fabzIUV4GoPcRyJRHi+4kGf0vsfGYbQ4nmPw==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -913,8 +1224,11 @@ packages:
     dev: false
 
   /cssnano-utils/3.0.1_postcss@8.4.6:
-    resolution: {integrity: sha512-VNCHL364lh++/ono+S3j9NlUK+d97KNkxI77NlqZU2W3xd2/qmyN61dsa47pTpb55zuU4G4lI7qFjAXZJH1OAQ==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-VNCHL364lh++/ono+S3j9NlUK+d97KNkxI77NlqZU2W3xd2/qmyN61dsa47pTpb55zuU4G4lI7qFjAXZJH1OAQ==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -922,8 +1236,11 @@ packages:
     dev: false
 
   /cssnano/5.0.16_postcss@8.4.6:
-    resolution: {integrity: sha512-ryhRI9/B9VFCwPbb1z60LLK5/ldoExi7nwdnJzpkLZkm2/r7j2X3jfY+ZvDVJhC/0fPZlrAguYdHNFg0iglPKQ==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-ryhRI9/B9VFCwPbb1z60LLK5/ldoExi7nwdnJzpkLZkm2/r7j2X3jfY+ZvDVJhC/0fPZlrAguYdHNFg0iglPKQ==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -934,45 +1251,66 @@ packages:
     dev: false
 
   /csso/4.2.0:
-    resolution: {integrity: sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==}
-    engines: {node: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==
+      }
+    engines: { node: ">=8.0.0" }
     dependencies:
       css-tree: 1.1.3
     dev: false
 
   /cssom/0.3.8:
-    resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
+    resolution:
+      {
+        integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
+      }
     dev: false
     optional: true
 
   /cssom/0.4.4:
-    resolution: {integrity: sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==}
+    resolution:
+      {
+        integrity: sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
+      }
     dev: false
     optional: true
 
   /cssstyle/2.3.0:
-    resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
+      }
+    engines: { node: ">=8" }
     dependencies:
       cssom: 0.3.8
     dev: false
     optional: true
 
   /d3-array/3.1.1:
-    resolution: {integrity: sha512-33qQ+ZoZlli19IFiQx4QEpf2CBEayMRzhlisJHSCsSUbDXv6ZishqS1x7uFVClKG4Wr7rZVHvaAttoLow6GqdQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-33qQ+ZoZlli19IFiQx4QEpf2CBEayMRzhlisJHSCsSUbDXv6ZishqS1x7uFVClKG4Wr7rZVHvaAttoLow6GqdQ==
+      }
+    engines: { node: ">=12" }
     dependencies:
       internmap: 2.0.3
     dev: false
 
   /d3-color/3.0.1:
-    resolution: {integrity: sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw==
+      }
+    engines: { node: ">=12" }
     dev: false
 
   /d3-dsv/3.0.1:
-    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
+      }
+    engines: { node: ">=12" }
     hasBin: true
     dependencies:
       commander: 7.2.0
@@ -981,25 +1319,37 @@ packages:
     dev: false
 
   /d3-format/3.1.0:
-    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
+      }
+    engines: { node: ">=12" }
     dev: false
 
   /d3-interpolate/3.0.1:
-    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+      }
+    engines: { node: ">=12" }
     dependencies:
       d3-color: 3.0.1
     dev: false
 
   /d3-path/3.0.1:
-    resolution: {integrity: sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w==
+      }
+    engines: { node: ">=12" }
     dev: false
 
   /d3-scale/4.0.2:
-    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+      }
+    engines: { node: ">=12" }
     dependencies:
       d3-array: 3.1.1
       d3-format: 3.1.0
@@ -1009,35 +1359,47 @@ packages:
     dev: false
 
   /d3-shape/3.1.0:
-    resolution: {integrity: sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==
+      }
+    engines: { node: ">=12" }
     dependencies:
       d3-path: 3.0.1
     dev: false
 
   /d3-time-format/4.1.0:
-    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+      }
+    engines: { node: ">=12" }
     dependencies:
       d3-time: 3.0.0
     dev: false
 
   /d3-time/3.0.0:
-    resolution: {integrity: sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==
+      }
+    engines: { node: ">=12" }
     dependencies:
       d3-array: 3.1.1
     dev: false
 
   /dashdash/1.14.1:
-    resolution: {integrity: sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=}
-    engines: {node: '>=0.10'}
+    resolution: { integrity: sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA= }
+    engines: { node: ">=0.10" }
     dependencies:
       assert-plus: 1.0.0
     dev: false
 
   /data-urls/1.1.0:
-    resolution: {integrity: sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==}
+    resolution:
+      {
+        integrity: sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==
+      }
     dependencies:
       abab: 2.0.5
       whatwg-mimetype: 2.3.0
@@ -1046,10 +1408,13 @@ packages:
     optional: true
 
   /debug/4.3.3:
-    resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==}
-    engines: {node: '>=6.0'}
+    resolution:
+      {
+        integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+      }
+    engines: { node: ">=6.0" }
     peerDependencies:
-      supports-color: '*'
+      supports-color: "*"
     peerDependenciesMeta:
       supports-color:
         optional: true
@@ -1058,69 +1423,84 @@ packages:
     dev: false
 
   /decamelize-keys/1.1.0:
-    resolution: {integrity: sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=}
-    engines: {node: '>=0.10.0'}
+    resolution: { integrity: sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       decamelize: 1.2.0
       map-obj: 1.0.1
     dev: false
 
   /decamelize/1.2.0:
-    resolution: {integrity: sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=}
-    engines: {node: '>=0.10.0'}
+    resolution: { integrity: sha1-9lNNFRSCabIDUue+4m9QH5oZEpA= }
+    engines: { node: ">=0.10.0" }
     dev: false
 
   /decompress-response/4.2.1:
-    resolution: {integrity: sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
+      }
+    engines: { node: ">=8" }
     dependencies:
       mimic-response: 2.1.0
     dev: false
     optional: true
 
   /deep-is/0.1.4:
-    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    resolution:
+      {
+        integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+      }
     dev: false
     optional: true
 
   /deepmerge/4.2.2:
-    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+      }
+    engines: { node: ">=0.10.0" }
     dev: true
 
   /defined/1.0.0:
-    resolution: {integrity: sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=}
+    resolution: { integrity: sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM= }
     dev: false
 
   /delayed-stream/1.0.0:
-    resolution: {integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk=}
-    engines: {node: '>=0.4.0'}
+    resolution: { integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk= }
+    engines: { node: ">=0.4.0" }
     dev: false
 
   /delegates/1.0.0:
-    resolution: {integrity: sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=}
+    resolution: { integrity: sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o= }
     dev: false
 
   /depd/1.1.2:
-    resolution: {integrity: sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=}
-    engines: {node: '>= 0.6'}
+    resolution: { integrity: sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak= }
+    engines: { node: ">= 0.6" }
     dev: false
 
   /detect-indent/6.1.0:
-    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /detect-libc/1.0.3:
-    resolution: {integrity: sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=}
-    engines: {node: '>=0.10'}
+    resolution: { integrity: sha1-+hN8S9aY7fVc1c0CrFWfkaTEups= }
+    engines: { node: ">=0.10" }
     hasBin: true
     dev: false
     optional: true
 
   /detective/5.2.0:
-    resolution: {integrity: sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==}
-    engines: {node: '>=0.8.0'}
+    resolution:
+      {
+        integrity: sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==
+      }
+    engines: { node: ">=0.8.0" }
     hasBin: true
     dependencies:
       acorn-node: 1.8.2
@@ -1129,22 +1509,34 @@ packages:
     dev: false
 
   /didyoumean/1.2.2:
-    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+    resolution:
+      {
+        integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==
+      }
     dev: false
 
   /dir-glob/3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+      }
+    engines: { node: ">=8" }
     dependencies:
       path-type: 4.0.0
     dev: false
 
   /dlv/1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+    resolution:
+      {
+        integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
+      }
     dev: false
 
   /dom-serializer/1.3.2:
-    resolution: {integrity: sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==}
+    resolution:
+      {
+        integrity: sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
+      }
     dependencies:
       domelementtype: 2.2.0
       domhandler: 4.3.0
@@ -1152,25 +1544,37 @@ packages:
     dev: false
 
   /domelementtype/2.2.0:
-    resolution: {integrity: sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==}
+    resolution:
+      {
+        integrity: sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+      }
     dev: false
 
   /domexception/1.0.1:
-    resolution: {integrity: sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==}
+    resolution:
+      {
+        integrity: sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
+      }
     dependencies:
       webidl-conversions: 4.0.2
     dev: false
     optional: true
 
   /domhandler/4.3.0:
-    resolution: {integrity: sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==
+      }
+    engines: { node: ">= 4" }
     dependencies:
       domelementtype: 2.2.0
     dev: false
 
   /domutils/2.8.0:
-    resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
+    resolution:
+      {
+        integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+      }
     dependencies:
       dom-serializer: 1.3.2
       domelementtype: 2.2.0
@@ -1178,22 +1582,31 @@ packages:
     dev: false
 
   /ecc-jsbn/0.1.2:
-    resolution: {integrity: sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=}
+    resolution: { integrity: sha1-OoOpBOVDUyh4dMVkt1SThoSamMk= }
     dependencies:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
     dev: false
 
   /electron-to-chromium/1.4.59:
-    resolution: {integrity: sha512-AOJ3cAE0TWxz4fQ9zkND5hWrQg16nsZKVz9INOot1oV//u4wWu5xrj9CQMmPTYskkZRunSRc9sAnr4EkexXokg==}
+    resolution:
+      {
+        integrity: sha512-AOJ3cAE0TWxz4fQ9zkND5hWrQg16nsZKVz9INOot1oV//u4wWu5xrj9CQMmPTYskkZRunSRc9sAnr4EkexXokg==
+      }
     dev: false
 
   /emoji-regex/8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    resolution:
+      {
+        integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+      }
     dev: false
 
   /encoding/0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+    resolution:
+      {
+        integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+      }
     requiresBuild: true
     dependencies:
       iconv-lite: 0.6.3
@@ -1201,40 +1614,58 @@ packages:
     optional: true
 
   /entities/2.2.0:
-    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+    resolution:
+      {
+        integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+      }
     dev: false
 
   /env-paths/2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
+      }
+    engines: { node: ">=6" }
     dev: false
 
   /err-code/2.0.3:
-    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+    resolution:
+      {
+        integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
+      }
     dev: false
 
   /error-ex/1.3.2:
-    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+    resolution:
+      {
+        integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+      }
     dependencies:
       is-arrayish: 0.2.1
     dev: false
 
   /es6-promise/3.3.1:
-    resolution: {integrity: sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=}
+    resolution: { integrity: sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM= }
     dev: false
 
   /escalade/3.1.1:
-    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+      }
+    engines: { node: ">=6" }
     dev: false
 
   /escape-string-regexp/1.0.5:
-    resolution: {integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=}
-    engines: {node: '>=0.8.0'}
+    resolution: { integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ= }
+    engines: { node: ">=0.8.0" }
 
   /escodegen/1.14.3:
-    resolution: {integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
+      }
+    engines: { node: ">=4.0" }
     hasBin: true
     dependencies:
       esprima: 4.0.1
@@ -1247,50 +1678,77 @@ packages:
     optional: true
 
   /esprima/4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+      }
+    engines: { node: ">=4" }
     hasBin: true
     dev: false
     optional: true
 
   /estraverse/4.3.0:
-    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+      }
+    engines: { node: ">=4.0" }
     dev: false
     optional: true
 
   /estree-walker/0.6.1:
-    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
+    resolution:
+      {
+        integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
+      }
 
   /estree-walker/1.0.1:
-    resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
+    resolution:
+      {
+        integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+      }
 
   /estree-walker/2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    resolution:
+      {
+        integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+      }
     dev: true
 
   /esutils/2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+      }
+    engines: { node: ">=0.10.0" }
     dev: false
     optional: true
 
   /eventemitter3/4.0.7:
-    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+    resolution:
+      {
+        integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+      }
     dev: false
 
   /extend/3.0.2:
-    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    resolution:
+      {
+        integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+      }
     dev: false
 
   /extsprintf/1.3.0:
-    resolution: {integrity: sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=}
-    engines: {'0': node >=0.6.0}
+    resolution: { integrity: sha1-lpGEQOMEGnpBT4xS48V06zw+HgU= }
+    engines: { "0": node >=0.6.0 }
     dev: false
 
   /fabric/4.6.0:
-    resolution: {integrity: sha512-MhJXCD/ZugOGV5aPHIG0MY1q2EfrlzC2sasrAHj0HHXN50JTe1bHFrlRdkXBijCJ0dG81fGu/A/Pct9DyuwCzQ==}
-    engines: {node: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-MhJXCD/ZugOGV5aPHIG0MY1q2EfrlzC2sasrAHj0HHXN50JTe1bHFrlRdkXBijCJ0dG81fGu/A/Pct9DyuwCzQ==
+      }
+    engines: { node: ">=8.0.0" }
     optionalDependencies:
       canvas: 2.9.0
       jsdom: 15.2.1_canvas@2.9.0
@@ -1302,56 +1760,77 @@ packages:
     dev: false
 
   /fast-deep-equal/3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    resolution:
+      {
+        integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+      }
     dev: false
 
   /fast-glob/3.2.11:
-    resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
-    engines: {node: '>=8.6.0'}
+    resolution:
+      {
+        integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+      }
+    engines: { node: ">=8.6.0" }
     dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
+      "@nodelib/fs.stat": 2.0.5
+      "@nodelib/fs.walk": 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.4
     dev: false
 
   /fast-json-stable-stringify/2.1.0:
-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    resolution:
+      {
+        integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+      }
     dev: false
 
   /fast-levenshtein/2.0.6:
-    resolution: {integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=}
+    resolution: { integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc= }
     dev: false
     optional: true
 
   /fastq/1.13.0:
-    resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
+    resolution:
+      {
+        integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
+      }
     dependencies:
       reusify: 1.0.4
     dev: false
 
   /fill-range/7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+      }
+    engines: { node: ">=8" }
     dependencies:
       to-regex-range: 5.0.1
 
   /find-up/4.1.0:
-    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+      }
+    engines: { node: ">=8" }
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
     dev: false
 
   /forever-agent/0.6.1:
-    resolution: {integrity: sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=}
+    resolution: { integrity: sha1-+8cfDEGt6zf5bFd60e1C2P2sypE= }
     dev: false
 
   /form-data/2.3.3:
-    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
-    engines: {node: '>= 0.12'}
+    resolution:
+      {
+        integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+      }
+    engines: { node: ">= 0.12" }
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -1359,8 +1838,11 @@ packages:
     dev: false
 
   /fs-extra/10.0.0:
-    resolution: {integrity: sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+      }
+    engines: { node: ">=12" }
     dependencies:
       graceful-fs: 4.2.9
       jsonfile: 6.1.0
@@ -1368,8 +1850,11 @@ packages:
     dev: false
 
   /fs-extra/8.1.0:
-    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
-    engines: {node: '>=6 <7 || >=8'}
+    resolution:
+      {
+        integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+      }
+    engines: { node: ">=6 <7 || >=8" }
     dependencies:
       graceful-fs: 4.2.9
       jsonfile: 4.0.0
@@ -1377,28 +1862,40 @@ packages:
     dev: false
 
   /fs-minipass/2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+      }
+    engines: { node: ">= 8" }
     dependencies:
       minipass: 3.1.6
     dev: false
 
   /fs.realpath/1.0.0:
-    resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
+    resolution: { integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8= }
 
   /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    resolution:
+      {
+        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
     os: [darwin]
     requiresBuild: true
     optional: true
 
   /function-bind/1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    resolution:
+      {
+        integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+      }
 
   /gauge/3.0.2:
-    resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==
+      }
+    engines: { node: ">=10" }
     dependencies:
       aproba: 2.0.0
       color-support: 1.1.3
@@ -1412,8 +1909,11 @@ packages:
     dev: false
 
   /gauge/4.0.0:
-    resolution: {integrity: sha512-F8sU45yQpjQjxKkm1UOAhf0U/O0aFt//Fl7hsrNVto+patMHjs7dPI9mFOGUKbhrgKm0S3EjW3scMFuQmWSROw==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16}
+    resolution:
+      {
+        integrity: sha512-F8sU45yQpjQjxKkm1UOAhf0U/O0aFt//Fl7hsrNVto+patMHjs7dPI9mFOGUKbhrgKm0S3EjW3scMFuQmWSROw==
+      }
+    engines: { node: ^12.13.0 || ^14.15.0 || >=16 }
     dependencies:
       ansi-regex: 5.0.1
       aproba: 2.0.0
@@ -1427,54 +1927,72 @@ packages:
     dev: false
 
   /gaze/1.1.3:
-    resolution: {integrity: sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==}
-    engines: {node: '>= 4.0.0'}
+    resolution:
+      {
+        integrity: sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==
+      }
+    engines: { node: ">= 4.0.0" }
     dependencies:
       globule: 1.3.3
     dev: false
 
   /generic-names/4.0.0:
-    resolution: {integrity: sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==}
+    resolution:
+      {
+        integrity: sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==
+      }
     dependencies:
       loader-utils: 3.2.0
     dev: false
 
   /get-caller-file/2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
+    resolution:
+      {
+        integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+      }
+    engines: { node: 6.* || 8.* || >= 10.* }
     dev: false
 
   /get-port/3.2.0:
-    resolution: {integrity: sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=}
-    engines: {node: '>=4'}
+    resolution: { integrity: sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw= }
+    engines: { node: ">=4" }
     dev: false
 
   /get-stdin/4.0.1:
-    resolution: {integrity: sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=}
-    engines: {node: '>=0.10.0'}
+    resolution: { integrity: sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4= }
+    engines: { node: ">=0.10.0" }
     dev: false
 
   /getpass/0.1.7:
-    resolution: {integrity: sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=}
+    resolution: { integrity: sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo= }
     dependencies:
       assert-plus: 1.0.0
     dev: false
 
   /glob-parent/5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+      }
+    engines: { node: ">= 6" }
     dependencies:
       is-glob: 4.0.3
 
   /glob-parent/6.0.2:
-    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
-    engines: {node: '>=10.13.0'}
+    resolution:
+      {
+        integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+      }
+    engines: { node: ">=10.13.0" }
     dependencies:
       is-glob: 4.0.3
     dev: false
 
   /glob/7.1.7:
-    resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
+    resolution:
+      {
+        integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+      }
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -1485,7 +2003,10 @@ packages:
     dev: false
 
   /glob/7.2.0:
-    resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
+    resolution:
+      {
+        integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+      }
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -1495,10 +2016,13 @@ packages:
       path-is-absolute: 1.0.1
 
   /globby/10.0.1:
-    resolution: {integrity: sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==
+      }
+    engines: { node: ">=8" }
     dependencies:
-      '@types/glob': 7.2.0
+      "@types/glob": 7.2.0
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.2.11
@@ -1509,8 +2033,11 @@ packages:
     dev: false
 
   /globule/1.3.3:
-    resolution: {integrity: sha512-mb1aYtDbIjTu4ShMB85m3UzjX9BVKe9WCzsnfMSZk+K5GpIbBOexgg4PPCt5eHDEG5/ZQAUX2Kct02zfiPLsKg==}
-    engines: {node: '>= 0.10'}
+    resolution:
+      {
+        integrity: sha512-mb1aYtDbIjTu4ShMB85m3UzjX9BVKe9WCzsnfMSZk+K5GpIbBOexgg4PPCt5eHDEG5/ZQAUX2Kct02zfiPLsKg==
+      }
+    engines: { node: ">= 0.10" }
     dependencies:
       glob: 7.1.7
       lodash: 4.17.21
@@ -1518,17 +2045,23 @@ packages:
     dev: false
 
   /graceful-fs/4.2.9:
-    resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==}
+    resolution:
+      {
+        integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
+      }
     dev: false
 
   /har-schema/2.0.0:
-    resolution: {integrity: sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=}
-    engines: {node: '>=4'}
+    resolution: { integrity: sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI= }
+    engines: { node: ">=4" }
     dev: false
 
   /har-validator/5.1.5:
-    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
+      }
+    engines: { node: ">=6" }
     deprecated: this library is no longer supported
     dependencies:
       ajv: 6.12.6
@@ -1536,72 +2069,102 @@ packages:
     dev: false
 
   /hard-rejection/2.1.0:
-    resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
+      }
+    engines: { node: ">=6" }
     dev: false
 
   /has-flag/3.0.0:
-    resolution: {integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=}
-    engines: {node: '>=4'}
+    resolution: { integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0= }
+    engines: { node: ">=4" }
 
   /has-flag/4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+      }
+    engines: { node: ">=8" }
 
   /has-unicode/2.0.1:
-    resolution: {integrity: sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=}
+    resolution: { integrity: sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk= }
     dev: false
 
   /has/1.0.3:
-    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
-    engines: {node: '>= 0.4.0'}
+    resolution:
+      {
+        integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+      }
+    engines: { node: ">= 0.4.0" }
     dependencies:
       function-bind: 1.1.1
 
   /hex-color-regex/1.1.0:
-    resolution: {integrity: sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==}
+    resolution:
+      {
+        integrity: sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
+      }
     dev: false
 
   /hosted-git-info/2.8.9:
-    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+    resolution:
+      {
+        integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
+      }
     dev: false
 
   /hosted-git-info/4.1.0:
-    resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
+      }
+    engines: { node: ">=10" }
     dependencies:
       lru-cache: 6.0.0
     dev: false
 
   /hsl-regex/1.0.0:
-    resolution: {integrity: sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=}
+    resolution: { integrity: sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4= }
     dev: false
 
   /hsla-regex/1.0.0:
-    resolution: {integrity: sha1-wc56MWjIxmFAM6S194d/OyJfnDg=}
+    resolution: { integrity: sha1-wc56MWjIxmFAM6S194d/OyJfnDg= }
     dev: false
 
   /html-encoding-sniffer/1.0.2:
-    resolution: {integrity: sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==}
+    resolution:
+      {
+        integrity: sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==
+      }
     dependencies:
       whatwg-encoding: 1.0.5
     dev: false
     optional: true
 
   /html-tags/3.1.0:
-    resolution: {integrity: sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /http-cache-semantics/4.1.0:
-    resolution: {integrity: sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==}
+    resolution:
+      {
+        integrity: sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
+      }
     dev: false
 
   /http-proxy-agent/4.0.1:
-    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
+      }
+    engines: { node: ">= 6" }
     dependencies:
-      '@tootallnate/once': 1.1.2
+      "@tootallnate/once": 1.1.2
       agent-base: 6.0.2
       debug: 4.3.3
     transitivePeerDependencies:
@@ -1609,8 +2172,8 @@ packages:
     dev: false
 
   /http-signature/1.2.0:
-    resolution: {integrity: sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=}
-    engines: {node: '>=0.8', npm: '>=1.3.7'}
+    resolution: { integrity: sha1-muzZJRFHcvPZW2WmCruPfBj7rOE= }
+    engines: { node: ">=0.8", npm: ">=1.3.7" }
     dependencies:
       assert-plus: 1.0.0
       jsprim: 1.4.2
@@ -1618,8 +2181,11 @@ packages:
     dev: false
 
   /https-proxy-agent/5.0.0:
-    resolution: {integrity: sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+      }
+    engines: { node: ">= 6" }
     dependencies:
       agent-base: 6.0.2
       debug: 4.3.3
@@ -1628,33 +2194,42 @@ packages:
     dev: false
 
   /humanize-ms/1.2.1:
-    resolution: {integrity: sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=}
+    resolution: { integrity: sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0= }
     dependencies:
       ms: 2.1.3
     dev: false
 
   /iconv-lite/0.4.24:
-    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       safer-buffer: 2.1.2
     dev: false
     optional: true
 
   /iconv-lite/0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       safer-buffer: 2.1.2
     dev: false
 
   /icss-replace-symbols/1.1.0:
-    resolution: {integrity: sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=}
+    resolution: { integrity: sha1-Bupvg2ead0njhs/h/oEq5dsiPe0= }
     dev: false
 
   /icss-utils/5.1.0_postcss@8.4.6:
-    resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
-    engines: {node: ^10 || ^12 || >= 14}
+    resolution:
+      {
+        integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
+      }
+    engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
@@ -1662,86 +2237,116 @@ packages:
     dev: false
 
   /ignore/5.2.0:
-    resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+      }
+    engines: { node: ">= 4" }
     dev: false
 
   /import-cwd/3.0.0:
-    resolution: {integrity: sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==
+      }
+    engines: { node: ">=8" }
     dependencies:
       import-from: 3.0.0
     dev: false
 
   /import-fresh/3.3.0:
-    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
+      }
+    engines: { node: ">=6" }
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
     dev: false
 
   /import-from/3.0.0:
-    resolution: {integrity: sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==
+      }
+    engines: { node: ">=8" }
     dependencies:
       resolve-from: 5.0.0
     dev: false
 
   /imurmurhash/0.1.4:
-    resolution: {integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=}
-    engines: {node: '>=0.8.19'}
+    resolution: { integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o= }
+    engines: { node: ">=0.8.19" }
     dev: false
 
   /indent-string/4.0.0:
-    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /infer-owner/1.0.4:
-    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
+    resolution:
+      {
+        integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
+      }
     dev: false
 
   /inflight/1.0.6:
-    resolution: {integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=}
+    resolution: { integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk= }
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
 
   /inherits/2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    resolution:
+      {
+        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+      }
 
   /internmap/2.0.3:
-    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
+      }
+    engines: { node: ">=12" }
     dev: false
 
   /ip-regex/2.1.0:
-    resolution: {integrity: sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=}
-    engines: {node: '>=4'}
+    resolution: { integrity: sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk= }
+    engines: { node: ">=4" }
     dev: false
     optional: true
 
   /ip/1.1.5:
-    resolution: {integrity: sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=}
+    resolution: { integrity: sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo= }
     dev: false
 
   /is-arrayish/0.2.1:
-    resolution: {integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=}
+    resolution: { integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0= }
     dev: false
 
   /is-arrayish/0.3.2:
-    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+    resolution:
+      {
+        integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+      }
     dev: false
 
   /is-binary-path/2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+      }
+    engines: { node: ">=8" }
     dependencies:
       binary-extensions: 2.2.0
 
   /is-color-stop/1.1.0:
-    resolution: {integrity: sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=}
+    resolution: { integrity: sha1-z/9HGu5N1cnhWFmPvhKWe1za00U= }
     dependencies:
       css-color-names: 0.0.4
       hex-color-regex: 1.1.0
@@ -1752,92 +2357,122 @@ packages:
     dev: false
 
   /is-core-module/2.8.1:
-    resolution: {integrity: sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==}
+    resolution:
+      {
+        integrity: sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
+      }
     dependencies:
       has: 1.0.3
 
   /is-extglob/2.1.1:
-    resolution: {integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=}
-    engines: {node: '>=0.10.0'}
+    resolution: { integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI= }
+    engines: { node: ">=0.10.0" }
 
   /is-fullwidth-code-point/3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /is-glob/4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       is-extglob: 2.1.1
 
   /is-lambda/1.0.1:
-    resolution: {integrity: sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=}
+    resolution: { integrity: sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU= }
     dev: false
 
   /is-module/1.0.0:
-    resolution: {integrity: sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=}
+    resolution: { integrity: sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE= }
     dev: true
 
   /is-number/7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
+    resolution:
+      {
+        integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+      }
+    engines: { node: ">=0.12.0" }
 
   /is-plain-obj/1.1.0:
-    resolution: {integrity: sha1-caUMhCnfync8kqOQpKA7OfzVHT4=}
-    engines: {node: '>=0.10.0'}
+    resolution: { integrity: sha1-caUMhCnfync8kqOQpKA7OfzVHT4= }
+    engines: { node: ">=0.10.0" }
     dev: false
 
   /is-plain-object/3.0.1:
-    resolution: {integrity: sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==
+      }
+    engines: { node: ">=0.10.0" }
     dev: false
 
   /is-reference/1.2.1:
-    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+    resolution:
+      {
+        integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+      }
     dependencies:
-      '@types/estree': 0.0.50
+      "@types/estree": 0.0.50
     dev: true
 
   /is-typedarray/1.0.0:
-    resolution: {integrity: sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=}
+    resolution: { integrity: sha1-5HnICFjfDBsR3dppQPlgEfzaSpo= }
     dev: false
 
   /isarray/1.0.0:
-    resolution: {integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=}
+    resolution: { integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE= }
     dev: false
 
   /isexe/2.0.0:
-    resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
+    resolution: { integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA= }
     dev: false
 
   /isstream/0.1.2:
-    resolution: {integrity: sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=}
+    resolution: { integrity: sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo= }
     dev: false
 
   /jest-worker/26.6.2:
-    resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
-    engines: {node: '>= 10.13.0'}
+    resolution:
+      {
+        integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
+      }
+    engines: { node: ">= 10.13.0" }
     dependencies:
-      '@types/node': 17.0.14
+      "@types/node": 17.0.14
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
 
   /js-base64/2.6.4:
-    resolution: {integrity: sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==}
+    resolution:
+      {
+        integrity: sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
+      }
     dev: false
 
   /js-tokens/4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    resolution:
+      {
+        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+      }
 
   /jsbn/0.1.1:
-    resolution: {integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=}
+    resolution: { integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM= }
     dev: false
 
   /jsdom/15.2.1_canvas@2.9.0:
-    resolution: {integrity: sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==
+      }
+    engines: { node: ">=8" }
     requiresBuild: true
     peerDependencies:
       canvas: ^2.5.0
@@ -1879,29 +2514,41 @@ packages:
     optional: true
 
   /json-parse-even-better-errors/2.3.1:
-    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+    resolution:
+      {
+        integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+      }
     dev: false
 
   /json-schema-traverse/0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    resolution:
+      {
+        integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+      }
     dev: false
 
   /json-schema/0.4.0:
-    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+    resolution:
+      {
+        integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+      }
     dev: false
 
   /json-stringify-safe/5.0.1:
-    resolution: {integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=}
+    resolution: { integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus= }
     dev: false
 
   /jsonfile/4.0.0:
-    resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
+    resolution: { integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss= }
     optionalDependencies:
       graceful-fs: 4.2.9
     dev: false
 
   /jsonfile/6.1.0:
-    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+    resolution:
+      {
+        integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+      }
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
@@ -1909,8 +2556,11 @@ packages:
     dev: false
 
   /jsprim/1.4.2:
-    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
-    engines: {node: '>=0.6.0'}
+    resolution:
+      {
+        integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
+      }
+    engines: { node: ">=0.6.0" }
     dependencies:
       assert-plus: 1.0.0
       extsprintf: 1.3.0
@@ -1919,22 +2569,31 @@ packages:
     dev: false
 
   /kind-of/6.0.3:
-    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+      }
+    engines: { node: ">=0.10.0" }
     dev: false
 
   /kleur/3.0.3:
-    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+      }
+    engines: { node: ">=6" }
     dev: false
 
   /lazy-brush/1.0.1:
-    resolution: {integrity: sha512-xT/iSClTVi7vLoF8dCWTBhCuOWqsLXCMPa6ucVmVAk6hyNCM5JeS1NLhXqIrJktUg+caEYKlqSOUU4u3cpXzKg==}
+    resolution:
+      {
+        integrity: sha512-xT/iSClTVi7vLoF8dCWTBhCuOWqsLXCMPa6ucVmVAk6hyNCM5JeS1NLhXqIrJktUg+caEYKlqSOUU4u3cpXzKg==
+      }
     dev: false
 
   /levn/0.3.0:
-    resolution: {integrity: sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=}
-    engines: {node: '>= 0.8.0'}
+    resolution: { integrity: sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4= }
+    engines: { node: ">= 0.8.0" }
     dependencies:
       prelude-ls: 1.1.2
       type-check: 0.3.2
@@ -1942,21 +2601,33 @@ packages:
     optional: true
 
   /lilconfig/2.0.4:
-    resolution: {integrity: sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==
+      }
+    engines: { node: ">=10" }
     dev: false
 
   /lines-and-columns/1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+    resolution:
+      {
+        integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+      }
     dev: false
 
   /livereload-js/3.3.3:
-    resolution: {integrity: sha512-a7Jipme3XIBIryJluWP5LQrEAvhobDPyScBe+q+MYwxBiMT2Ck7msy4tAdF8TAa33FMdJqX4guP81Yhiu6BkmQ==}
+    resolution:
+      {
+        integrity: sha512-a7Jipme3XIBIryJluWP5LQrEAvhobDPyScBe+q+MYwxBiMT2Ck7msy4tAdF8TAa33FMdJqX4guP81Yhiu6BkmQ==
+      }
     dev: true
 
   /livereload/0.9.3:
-    resolution: {integrity: sha512-q7Z71n3i4X0R9xthAryBdNGVGAO2R5X+/xXpmKeuPMrteg+W2U8VusTKV3YiJbXZwKsOlFlHe+go6uSNjfxrZw==}
-    engines: {node: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-q7Z71n3i4X0R9xthAryBdNGVGAO2R5X+/xXpmKeuPMrteg+W2U8VusTKV3YiJbXZwKsOlFlHe+go6uSNjfxrZw==
+      }
+    engines: { node: ">=8.0.0" }
     hasBin: true
     dependencies:
       chokidar: 3.5.3
@@ -1969,70 +2640,94 @@ packages:
     dev: true
 
   /loader-utils/3.2.0:
-    resolution: {integrity: sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==}
-    engines: {node: '>= 12.13.0'}
+    resolution:
+      {
+        integrity: sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==
+      }
+    engines: { node: ">= 12.13.0" }
     dev: false
 
   /local-access/1.1.0:
-    resolution: {integrity: sha512-XfegD5pyTAfb+GY6chk283Ox5z8WexG56OvM06RWLpAc/UHozO8X6xAxEkIitZOtsSMM1Yr3DkHgW5W+onLhCw==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-XfegD5pyTAfb+GY6chk283Ox5z8WexG56OvM06RWLpAc/UHozO8X6xAxEkIitZOtsSMM1Yr3DkHgW5W+onLhCw==
+      }
+    engines: { node: ">=6" }
     dev: false
 
   /locate-path/5.0.0:
-    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+      }
+    engines: { node: ">=8" }
     dependencies:
       p-locate: 4.1.0
     dev: false
 
   /lodash.camelcase/4.3.0:
-    resolution: {integrity: sha1-soqmKIorn8ZRA1x3EfZathkDMaY=}
+    resolution: { integrity: sha1-soqmKIorn8ZRA1x3EfZathkDMaY= }
     dev: false
 
   /lodash.memoize/4.1.2:
-    resolution: {integrity: sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=}
+    resolution: { integrity: sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4= }
     dev: false
 
   /lodash.sortby/4.7.0:
-    resolution: {integrity: sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=}
+    resolution: { integrity: sha1-7dFMgk4sycHgsKG0K7UhBRakJDg= }
     dev: false
     optional: true
 
   /lodash.topath/4.5.2:
-    resolution: {integrity: sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=}
+    resolution: { integrity: sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak= }
     dev: false
 
   /lodash.uniq/4.5.0:
-    resolution: {integrity: sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=}
+    resolution: { integrity: sha1-0CJTc662Uq3BvILklFM5qEJ1R3M= }
     dev: false
 
   /lodash/4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    resolution:
+      {
+        integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+      }
     dev: false
 
   /lru-cache/6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+      }
+    engines: { node: ">=10" }
     dependencies:
       yallist: 4.0.0
     dev: false
 
   /magic-string/0.25.7:
-    resolution: {integrity: sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==}
+    resolution:
+      {
+        integrity: sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+      }
     dependencies:
       sourcemap-codec: 1.4.8
 
   /make-dir/3.1.0:
-    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+      }
+    engines: { node: ">=8" }
     dependencies:
       semver: 6.3.0
     dev: false
     optional: true
 
   /make-fetch-happen/9.1.0:
-    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==
+      }
+    engines: { node: ">= 10" }
     dependencies:
       agentkeepalive: 4.2.0
       cacache: 15.3.0
@@ -2055,24 +2750,33 @@ packages:
     dev: false
 
   /map-obj/1.0.1:
-    resolution: {integrity: sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=}
-    engines: {node: '>=0.10.0'}
+    resolution: { integrity: sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0= }
+    engines: { node: ">=0.10.0" }
     dev: false
 
   /map-obj/4.3.0:
-    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /mdn-data/2.0.14:
-    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+    resolution:
+      {
+        integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
+      }
     dev: false
 
   /meow/9.0.0:
-    resolution: {integrity: sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==
+      }
+    engines: { node: ">=10" }
     dependencies:
-      '@types/minimist': 1.2.2
+      "@types/minimist": 1.2.2
       camelcase-keys: 6.2.2
       decamelize: 1.2.0
       decamelize-keys: 1.1.0
@@ -2087,53 +2791,80 @@ packages:
     dev: false
 
   /merge-stream/2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+    resolution:
+      {
+        integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+      }
     dev: true
 
   /merge2/1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+      }
+    engines: { node: ">= 8" }
     dev: false
 
   /micromatch/4.0.4:
-    resolution: {integrity: sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+      }
+    engines: { node: ">=8.6" }
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
     dev: false
 
   /mime-db/1.51.0:
-    resolution: {integrity: sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
+      }
+    engines: { node: ">= 0.6" }
     dev: false
 
   /mime-types/2.1.34:
-    resolution: {integrity: sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
+      }
+    engines: { node: ">= 0.6" }
     dependencies:
       mime-db: 1.51.0
     dev: false
 
   /mimic-response/2.1.0:
-    resolution: {integrity: sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+      }
+    engines: { node: ">=8" }
     dev: false
     optional: true
 
   /min-indent/1.0.1:
-    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+      }
+    engines: { node: ">=4" }
     dev: false
 
   /minimatch/3.0.4:
-    resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
+    resolution:
+      {
+        integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+      }
     dependencies:
       brace-expansion: 1.1.11
 
   /minimist-options/4.1.0:
-    resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
+      }
+    engines: { node: ">= 6" }
     dependencies:
       arrify: 1.0.1
       is-plain-obj: 1.1.0
@@ -2141,19 +2872,28 @@ packages:
     dev: false
 
   /minimist/1.2.5:
-    resolution: {integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==}
+    resolution:
+      {
+        integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+      }
     dev: false
 
   /minipass-collect/1.0.2:
-    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==
+      }
+    engines: { node: ">= 8" }
     dependencies:
       minipass: 3.1.6
     dev: false
 
   /minipass-fetch/1.4.1:
-    resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==
+      }
+    engines: { node: ">=8" }
     dependencies:
       minipass: 3.1.6
       minipass-sized: 1.0.3
@@ -2163,100 +2903,151 @@ packages:
     dev: false
 
   /minipass-flush/1.0.5:
-    resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==
+      }
+    engines: { node: ">= 8" }
     dependencies:
       minipass: 3.1.6
     dev: false
 
   /minipass-pipeline/1.2.4:
-    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==
+      }
+    engines: { node: ">=8" }
     dependencies:
       minipass: 3.1.6
     dev: false
 
   /minipass-sized/1.0.3:
-    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==
+      }
+    engines: { node: ">=8" }
     dependencies:
       minipass: 3.1.6
     dev: false
 
   /minipass/3.1.6:
-    resolution: {integrity: sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==
+      }
+    engines: { node: ">=8" }
     dependencies:
       yallist: 4.0.0
     dev: false
 
   /minizlib/2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+      }
+    engines: { node: ">= 8" }
     dependencies:
       minipass: 3.1.6
       yallist: 4.0.0
     dev: false
 
   /mkdirp/0.5.5:
-    resolution: {integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==}
+    resolution:
+      {
+        integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+      }
     hasBin: true
     dependencies:
       minimist: 1.2.5
     dev: false
 
   /mkdirp/1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+      }
+    engines: { node: ">=10" }
     hasBin: true
     dev: false
 
   /modern-normalize/1.1.0:
-    resolution: {integrity: sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==
+      }
+    engines: { node: ">=6" }
     dev: false
 
   /mri/1.2.0:
-    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
+      }
+    engines: { node: ">=4" }
     dev: false
 
   /mrmime/1.0.0:
-    resolution: {integrity: sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==
+      }
+    engines: { node: ">=10" }
     dev: false
 
   /ms/2.1.2:
-    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    resolution:
+      {
+        integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+      }
     dev: false
 
   /ms/2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    resolution:
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+      }
     dev: false
 
   /nan/2.15.0:
-    resolution: {integrity: sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==}
+    resolution:
+      {
+        integrity: sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
+      }
     dev: false
 
   /nanoid/3.2.0:
-    resolution: {integrity: sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    resolution:
+      {
+        integrity: sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
   /negotiator/0.6.3:
-    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
+      }
+    engines: { node: ">= 0.6" }
     dev: false
 
   /node-emoji/1.11.0:
-    resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
+    resolution:
+      {
+        integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==
+      }
     dependencies:
       lodash: 4.17.21
     dev: false
 
   /node-fetch/2.6.7:
-    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
-    engines: {node: 4.x || >=6.0.0}
+    resolution:
+      {
+        integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+      }
+    engines: { node: 4.x || >=6.0.0 }
     peerDependencies:
       encoding: ^0.1.0
     peerDependenciesMeta:
@@ -2268,8 +3059,11 @@ packages:
     optional: true
 
   /node-gyp/8.4.1:
-    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
-    engines: {node: '>= 10.12.0'}
+    resolution:
+      {
+        integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==
+      }
+    engines: { node: ">= 10.12.0" }
     hasBin: true
     dependencies:
       env-paths: 2.2.1
@@ -2287,12 +3081,18 @@ packages:
     dev: false
 
   /node-releases/2.0.1:
-    resolution: {integrity: sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==}
+    resolution:
+      {
+        integrity: sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
+      }
     dev: false
 
   /node-sass/7.0.1:
-    resolution: {integrity: sha512-uMy+Xt29NlqKCFdFRZyXKOTqGt+QaKHexv9STj2WeLottnlqZEEWx6Bj0MXNthmFRRdM/YwyNo/8Tr46TOM0jQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-uMy+Xt29NlqKCFdFRZyXKOTqGt+QaKHexv9STj2WeLottnlqZEEWx6Bj0MXNthmFRRdM/YwyNo/8Tr46TOM0jQ==
+      }
+    engines: { node: ">=12" }
     hasBin: true
     requiresBuild: true
     dependencies:
@@ -2316,15 +3116,21 @@ packages:
     dev: false
 
   /nopt/5.0.0:
-    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
+      }
+    engines: { node: ">=6" }
     hasBin: true
     dependencies:
       abbrev: 1.1.1
     dev: false
 
   /normalize-package-data/2.5.0:
-    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+    resolution:
+      {
+        integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
+      }
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.22.0
@@ -2333,8 +3139,11 @@ packages:
     dev: false
 
   /normalize-package-data/3.0.3:
-    resolution: {integrity: sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==
+      }
+    engines: { node: ">=10" }
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.8.1
@@ -2343,21 +3152,30 @@ packages:
     dev: false
 
   /normalize-path/3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+      }
+    engines: { node: ">=0.10.0" }
 
   /normalize-range/0.1.2:
-    resolution: {integrity: sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=}
-    engines: {node: '>=0.10.0'}
+    resolution: { integrity: sha1-LRDAa9/TEuqXd2laTShDlFa3WUI= }
+    engines: { node: ">=0.10.0" }
     dev: false
 
   /normalize-url/6.1.0:
-    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
+      }
+    engines: { node: ">=10" }
     dev: false
 
   /npmlog/5.0.1:
-    resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    resolution:
+      {
+        integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==
+      }
     dependencies:
       are-we-there-yet: 2.0.0
       console-control-strings: 1.1.0
@@ -2366,8 +3184,11 @@ packages:
     dev: false
 
   /npmlog/6.0.0:
-    resolution: {integrity: sha512-03ppFRGlsyUaQFbGC2C8QWJN/C/K7PsfyD9aQdhVKAQIH4sQBc8WASqFBP7O+Ut4d2oo5LoeoboB3cGdBZSp6Q==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16}
+    resolution:
+      {
+        integrity: sha512-03ppFRGlsyUaQFbGC2C8QWJN/C/K7PsfyD9aQdhVKAQIH4sQBc8WASqFBP7O+Ut4d2oo5LoeoboB3cGdBZSp6Q==
+      }
+    engines: { node: ^12.13.0 || ^14.15.0 || >=16 }
     dependencies:
       are-we-there-yet: 2.0.0
       console-control-strings: 1.1.0
@@ -2376,42 +3197,57 @@ packages:
     dev: false
 
   /nth-check/2.0.1:
-    resolution: {integrity: sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==}
+    resolution:
+      {
+        integrity: sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
+      }
     dependencies:
       boolbase: 1.0.0
     dev: false
 
   /num2fraction/1.2.2:
-    resolution: {integrity: sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=}
+    resolution: { integrity: sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4= }
     dev: false
 
   /nwsapi/2.2.0:
-    resolution: {integrity: sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==}
+    resolution:
+      {
+        integrity: sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
+      }
     dev: false
     optional: true
 
   /oauth-sign/0.9.0:
-    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+    resolution:
+      {
+        integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
+      }
     dev: false
 
   /object-assign/4.1.1:
-    resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
-    engines: {node: '>=0.10.0'}
+    resolution: { integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM= }
+    engines: { node: ">=0.10.0" }
     dev: false
 
   /object-hash/2.2.0:
-    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
+      }
+    engines: { node: ">= 6" }
     dev: false
 
   /once/1.4.0:
-    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    resolution: { integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E= }
     dependencies:
       wrappy: 1.0.2
 
   /optionator/0.8.3:
-    resolution: {integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+      }
+    engines: { node: ">= 0.8.0" }
     dependencies:
       deep-is: 0.1.4
       fast-levenshtein: 2.0.6
@@ -2423,126 +3259,186 @@ packages:
     optional: true
 
   /opts/2.0.2:
-    resolution: {integrity: sha512-k41FwbcLnlgnFh69f4qdUfvDQ+5vaSDnVPFI/y5XuhKRq97EnVVneO9F1ESVCdiVu4fCS2L8usX3mU331hB7pg==}
+    resolution:
+      {
+        integrity: sha512-k41FwbcLnlgnFh69f4qdUfvDQ+5vaSDnVPFI/y5XuhKRq97EnVVneO9F1ESVCdiVu4fCS2L8usX3mU331hB7pg==
+      }
     dev: true
 
   /p-finally/1.0.0:
-    resolution: {integrity: sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=}
-    engines: {node: '>=4'}
+    resolution: { integrity: sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4= }
+    engines: { node: ">=4" }
     dev: false
 
   /p-limit/2.3.0:
-    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+      }
+    engines: { node: ">=6" }
     dependencies:
       p-try: 2.2.0
     dev: false
 
   /p-locate/4.1.0:
-    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+      }
+    engines: { node: ">=8" }
     dependencies:
       p-limit: 2.3.0
     dev: false
 
   /p-map/4.0.0:
-    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
+      }
+    engines: { node: ">=10" }
     dependencies:
       aggregate-error: 3.1.0
     dev: false
 
   /p-queue/6.6.2:
-    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+      }
+    engines: { node: ">=8" }
     dependencies:
       eventemitter3: 4.0.7
       p-timeout: 3.2.0
     dev: false
 
   /p-timeout/3.2.0:
-    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+      }
+    engines: { node: ">=8" }
     dependencies:
       p-finally: 1.0.0
     dev: false
 
   /p-try/2.2.0:
-    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+      }
+    engines: { node: ">=6" }
     dev: false
 
   /parent-module/1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+      }
+    engines: { node: ">=6" }
     dependencies:
       callsites: 3.1.0
     dev: false
 
   /parse-json/5.2.0:
-    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
+      }
+    engines: { node: ">=8" }
     dependencies:
-      '@babel/code-frame': 7.16.7
+      "@babel/code-frame": 7.16.7
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
     dev: false
 
   /parse5/5.1.0:
-    resolution: {integrity: sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==}
+    resolution:
+      {
+        integrity: sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
+      }
     dev: false
     optional: true
 
   /path-exists/4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /path-is-absolute/1.0.1:
-    resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
-    engines: {node: '>=0.10.0'}
+    resolution: { integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18= }
+    engines: { node: ">=0.10.0" }
 
   /path-key/3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /path-parse/1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    resolution:
+      {
+        integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+      }
 
   /path-type/4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /performance-now/2.1.0:
-    resolution: {integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=}
+    resolution: { integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns= }
     dev: false
 
   /picocolors/0.2.1:
-    resolution: {integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==}
+    resolution:
+      {
+        integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
+      }
     dev: false
 
   /picocolors/1.0.0:
-    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    resolution:
+      {
+        integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+      }
 
   /picomatch/2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+      }
+    engines: { node: ">=8.6" }
 
   /pify/5.0.0:
-    resolution: {integrity: sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==
+      }
+    engines: { node: ">=10" }
     dev: false
 
   /pn/1.1.0:
-    resolution: {integrity: sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==}
+    resolution:
+      {
+        integrity: sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
+      }
     dev: false
     optional: true
 
   /postcss-calc/8.2.3_postcss@8.4.6:
-    resolution: {integrity: sha512-EGM2EBBWqP57N0E7N7WOLT116PJ39dwHVU01WO4XPPQLJfkL2xVgkMZ+TZvCfapj/uJH07UEfKHQNPHzSw/14Q==}
+    resolution:
+      {
+        integrity: sha512-EGM2EBBWqP57N0E7N7WOLT116PJ39dwHVU01WO4XPPQLJfkL2xVgkMZ+TZvCfapj/uJH07UEfKHQNPHzSw/14Q==
+      }
     peerDependencies:
       postcss: ^8.2.2
     dependencies:
@@ -2552,8 +3448,11 @@ packages:
     dev: false
 
   /postcss-colormin/5.2.4_postcss@8.4.6:
-    resolution: {integrity: sha512-rYlC5015aNqVQt/B6Cy156g7sH5tRUJGmT9xeagYthtKehetbKx7jHxhyLpulP4bs4vbp8u/B2rac0J7S7qPQg==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-rYlC5015aNqVQt/B6Cy156g7sH5tRUJGmT9xeagYthtKehetbKx7jHxhyLpulP4bs4vbp8u/B2rac0J7S7qPQg==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2565,8 +3464,11 @@ packages:
     dev: false
 
   /postcss-convert-values/5.0.3_postcss@8.4.6:
-    resolution: {integrity: sha512-fVkjHm2T0PSMqXUCIhHNWVGjhB9mHEWX2GboVs7j3iCgr6FpIl9c/IdXy0PHWZSQ9LFTRgmj98amxJE6KOnlsA==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-fVkjHm2T0PSMqXUCIhHNWVGjhB9mHEWX2GboVs7j3iCgr6FpIl9c/IdXy0PHWZSQ9LFTRgmj98amxJE6KOnlsA==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2575,8 +3477,11 @@ packages:
     dev: false
 
   /postcss-discard-comments/5.0.2_postcss@8.4.6:
-    resolution: {integrity: sha512-6VQ3pYTsJHEsN2Bic88Aa7J/Brn4Bv8j/rqaFQZkH+pcVkKYwxCIvoMQkykEW7fBjmofdTnQgcivt5CCBJhtrg==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-6VQ3pYTsJHEsN2Bic88Aa7J/Brn4Bv8j/rqaFQZkH+pcVkKYwxCIvoMQkykEW7fBjmofdTnQgcivt5CCBJhtrg==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2584,8 +3489,11 @@ packages:
     dev: false
 
   /postcss-discard-duplicates/5.0.2_postcss@8.4.6:
-    resolution: {integrity: sha512-LKY81YjUjc78p6rbXIsnppsaFo8XzCoMZkXVILJU//sK0DgPkPSpuq/cZvHss3EtdKvWNYgWzQL+wiJFtEET4g==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-LKY81YjUjc78p6rbXIsnppsaFo8XzCoMZkXVILJU//sK0DgPkPSpuq/cZvHss3EtdKvWNYgWzQL+wiJFtEET4g==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2593,8 +3501,11 @@ packages:
     dev: false
 
   /postcss-discard-empty/5.0.2_postcss@8.4.6:
-    resolution: {integrity: sha512-SxBsbTjlsKUvZLL+dMrdWauuNZU8TBq5IOL/DHa6jBUSXFEwmDqeXRfTIK/FQpPTa8MJMxEHjSV3UbiuyLARPQ==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-SxBsbTjlsKUvZLL+dMrdWauuNZU8TBq5IOL/DHa6jBUSXFEwmDqeXRfTIK/FQpPTa8MJMxEHjSV3UbiuyLARPQ==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2602,8 +3513,11 @@ packages:
     dev: false
 
   /postcss-discard-overridden/5.0.3_postcss@8.4.6:
-    resolution: {integrity: sha512-yRTXknIZA4k8Yo4FiF1xbsLj/VBxfXEWxJNIrtIy6HC9KQ4xJxcPtoaaskh6QptCGrrcGnhKsTsENTRPZOBu4g==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-yRTXknIZA4k8Yo4FiF1xbsLj/VBxfXEWxJNIrtIy6HC9KQ4xJxcPtoaaskh6QptCGrrcGnhKsTsENTRPZOBu4g==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2611,7 +3525,7 @@ packages:
     dev: false
 
   /postcss-functions/3.0.0:
-    resolution: {integrity: sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4=}
+    resolution: { integrity: sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4= }
     dependencies:
       glob: 7.2.0
       object-assign: 4.1.1
@@ -2620,17 +3534,23 @@ packages:
     dev: false
 
   /postcss-js/2.0.3:
-    resolution: {integrity: sha512-zS59pAk3deu6dVHyrGqmC3oDXBdNdajk4k1RyxeVXCrcEDBUBHoIhE4QTsmhxgzXxsaqFDAkUZfmMa5f/N/79w==}
+    resolution:
+      {
+        integrity: sha512-zS59pAk3deu6dVHyrGqmC3oDXBdNdajk4k1RyxeVXCrcEDBUBHoIhE4QTsmhxgzXxsaqFDAkUZfmMa5f/N/79w==
+      }
     dependencies:
       camelcase-css: 2.0.1
       postcss: 7.0.39
     dev: false
 
   /postcss-load-config/3.1.1:
-    resolution: {integrity: sha512-c/9XYboIbSEUZpiD1UQD0IKiUe8n9WHYV7YFe7X7J+ZwCsEKkUJSFWjS9hBU1RR9THR7jMXst8sxiqP0jjo2mg==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-c/9XYboIbSEUZpiD1UQD0IKiUe8n9WHYV7YFe7X7J+ZwCsEKkUJSFWjS9hBU1RR9THR7jMXst8sxiqP0jjo2mg==
+      }
+    engines: { node: ">= 10" }
     peerDependencies:
-      ts-node: '>=9.0.0'
+      ts-node: ">=9.0.0"
     peerDependenciesMeta:
       ts-node:
         optional: true
@@ -2640,8 +3560,11 @@ packages:
     dev: false
 
   /postcss-merge-longhand/5.0.5_postcss@8.4.6:
-    resolution: {integrity: sha512-R2BCPJJ/U2oh1uTWEYn9CcJ7MMcQ1iIbj9wfr2s/zHu5om5MP/ewKdaunpfJqR1WYzqCsgnXuRoVXPAzxdqy8g==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-R2BCPJJ/U2oh1uTWEYn9CcJ7MMcQ1iIbj9wfr2s/zHu5om5MP/ewKdaunpfJqR1WYzqCsgnXuRoVXPAzxdqy8g==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2651,8 +3574,11 @@ packages:
     dev: false
 
   /postcss-merge-rules/5.0.5_postcss@8.4.6:
-    resolution: {integrity: sha512-3Oa26/Pb9VOFVksJjFG45SNoe4nhGvJ2Uc6TlRimqF8uhfOCEhVCaJ3rvEat5UFOn2UZqTY5Da8dFgCh3Iq0Ug==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-3Oa26/Pb9VOFVksJjFG45SNoe4nhGvJ2Uc6TlRimqF8uhfOCEhVCaJ3rvEat5UFOn2UZqTY5Da8dFgCh3Iq0Ug==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2664,8 +3590,11 @@ packages:
     dev: false
 
   /postcss-minify-font-values/5.0.3_postcss@8.4.6:
-    resolution: {integrity: sha512-bC45rVzEwsLhv/cL1eCjoo2OOjbSk9I7HKFBYnBvtyuIZlf7uMipMATXtA0Fc3jwPo3wuPIW1jRJWKzflMh1sA==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-bC45rVzEwsLhv/cL1eCjoo2OOjbSk9I7HKFBYnBvtyuIZlf7uMipMATXtA0Fc3jwPo3wuPIW1jRJWKzflMh1sA==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2674,8 +3603,11 @@ packages:
     dev: false
 
   /postcss-minify-gradients/5.0.5_postcss@8.4.6:
-    resolution: {integrity: sha512-/YjvXs8PepsoiZAIpjstOO4IHKwFAqYNqbA1yVdqklM84tbUUneh6omJxGlRlF3mi6K5Pa067Mg6IwqEnYC8Zg==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-/YjvXs8PepsoiZAIpjstOO4IHKwFAqYNqbA1yVdqklM84tbUUneh6omJxGlRlF3mi6K5Pa067Mg6IwqEnYC8Zg==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2686,8 +3618,11 @@ packages:
     dev: false
 
   /postcss-minify-params/5.0.4_postcss@8.4.6:
-    resolution: {integrity: sha512-Z0vjod9lRZEmEPfEmA2sCfjbfEEFKefMD3RDIQSUfXK4LpCyWkX1CniUgyNvnjJFLDPSxtgKzozhHhPHKoeGkg==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-Z0vjod9lRZEmEPfEmA2sCfjbfEEFKefMD3RDIQSUfXK4LpCyWkX1CniUgyNvnjJFLDPSxtgKzozhHhPHKoeGkg==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2698,8 +3633,11 @@ packages:
     dev: false
 
   /postcss-minify-selectors/5.1.2_postcss@8.4.6:
-    resolution: {integrity: sha512-gpn1nJDMCf3g32y/7kl+jsdamhiYT+/zmEt57RoT9GmzlixBNRPohI7k8UIHelLABhdLf3MSZhtM33xuH5eQOQ==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-gpn1nJDMCf3g32y/7kl+jsdamhiYT+/zmEt57RoT9GmzlixBNRPohI7k8UIHelLABhdLf3MSZhtM33xuH5eQOQ==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2708,8 +3646,11 @@ packages:
     dev: false
 
   /postcss-modules-extract-imports/3.0.0_postcss@8.4.6:
-    resolution: {integrity: sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==}
-    engines: {node: ^10 || ^12 || >= 14}
+    resolution:
+      {
+        integrity: sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==
+      }
+    engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
@@ -2717,8 +3658,11 @@ packages:
     dev: false
 
   /postcss-modules-local-by-default/4.0.0_postcss@8.4.6:
-    resolution: {integrity: sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==}
-    engines: {node: ^10 || ^12 || >= 14}
+    resolution:
+      {
+        integrity: sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==
+      }
+    engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
@@ -2729,8 +3673,11 @@ packages:
     dev: false
 
   /postcss-modules-scope/3.0.0_postcss@8.4.6:
-    resolution: {integrity: sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==}
-    engines: {node: ^10 || ^12 || >= 14}
+    resolution:
+      {
+        integrity: sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==
+      }
+    engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
@@ -2739,8 +3686,11 @@ packages:
     dev: false
 
   /postcss-modules-values/4.0.0_postcss@8.4.6:
-    resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
-    engines: {node: ^10 || ^12 || >= 14}
+    resolution:
+      {
+        integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==
+      }
+    engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
@@ -2749,7 +3699,10 @@ packages:
     dev: false
 
   /postcss-modules/4.3.0_postcss@8.4.6:
-    resolution: {integrity: sha512-zoUttLDSsbWDinJM9jH37o7hulLRyEgH6fZm2PchxN7AZ8rkdWiALyNhnQ7+jg7cX9f10m6y5VhHsrjO0Mf/DA==}
+    resolution:
+      {
+        integrity: sha512-zoUttLDSsbWDinJM9jH37o7hulLRyEgH6fZm2PchxN7AZ8rkdWiALyNhnQ7+jg7cX9f10m6y5VhHsrjO0Mf/DA==
+      }
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
@@ -2765,15 +3718,21 @@ packages:
     dev: false
 
   /postcss-nested/4.2.3:
-    resolution: {integrity: sha512-rOv0W1HquRCamWy2kFl3QazJMMe1ku6rCFoAAH+9AcxdbpDeBr6k968MLWuLjvjMcGEip01ak09hKOEgpK9hvw==}
+    resolution:
+      {
+        integrity: sha512-rOv0W1HquRCamWy2kFl3QazJMMe1ku6rCFoAAH+9AcxdbpDeBr6k968MLWuLjvjMcGEip01ak09hKOEgpK9hvw==
+      }
     dependencies:
       postcss: 7.0.39
       postcss-selector-parser: 6.0.9
     dev: false
 
   /postcss-nested/5.0.6_postcss@8.4.6:
-    resolution: {integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==}
-    engines: {node: '>=12.0'}
+    resolution:
+      {
+        integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==
+      }
+    engines: { node: ">=12.0" }
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
@@ -2782,8 +3741,11 @@ packages:
     dev: true
 
   /postcss-normalize-charset/5.0.2_postcss@8.4.6:
-    resolution: {integrity: sha512-fEMhYXzO8My+gC009qDc/3bgnFP8Fv1Ic8uw4ec4YTlhIOw63tGPk1YFd7fk9bZUf1DAbkhiL/QPWs9JLqdF2g==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-fEMhYXzO8My+gC009qDc/3bgnFP8Fv1Ic8uw4ec4YTlhIOw63tGPk1YFd7fk9bZUf1DAbkhiL/QPWs9JLqdF2g==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2791,8 +3753,11 @@ packages:
     dev: false
 
   /postcss-normalize-display-values/5.0.2_postcss@8.4.6:
-    resolution: {integrity: sha512-RxXoJPUR0shSjkMMzgEZDjGPrgXUVYyWA/YwQRicb48H15OClPuaDR7tYokLAlGZ2tCSENEN5WxjgxSD5m4cUw==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-RxXoJPUR0shSjkMMzgEZDjGPrgXUVYyWA/YwQRicb48H15OClPuaDR7tYokLAlGZ2tCSENEN5WxjgxSD5m4cUw==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2801,8 +3766,11 @@ packages:
     dev: false
 
   /postcss-normalize-positions/5.0.3_postcss@8.4.6:
-    resolution: {integrity: sha512-U+rmhjrNBvIGYqr/1tD4wXPFFMKUbXsYXvlUCzLi0tOCUS6LoeEAnmVXXJY/MEB/1CKZZwBSs2tmzGawcygVBA==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-U+rmhjrNBvIGYqr/1tD4wXPFFMKUbXsYXvlUCzLi0tOCUS6LoeEAnmVXXJY/MEB/1CKZZwBSs2tmzGawcygVBA==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2811,8 +3779,11 @@ packages:
     dev: false
 
   /postcss-normalize-repeat-style/5.0.3_postcss@8.4.6:
-    resolution: {integrity: sha512-uk1+xYx0AMbA3nLSNhbDrqbf/rx+Iuq5tVad2VNyaxxJzx79oGieJ6D9F6AfOL2GtiIbP7vTYlpYHtG+ERFXTg==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-uk1+xYx0AMbA3nLSNhbDrqbf/rx+Iuq5tVad2VNyaxxJzx79oGieJ6D9F6AfOL2GtiIbP7vTYlpYHtG+ERFXTg==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2821,8 +3792,11 @@ packages:
     dev: false
 
   /postcss-normalize-string/5.0.3_postcss@8.4.6:
-    resolution: {integrity: sha512-Mf2V4JbIDboNGQhW6xW0YREDiYXoX3WrD3EjKkjvnpAJ6W4qqjLnK/c9aioyVFaWWHVdP5zVRw/9DI5S3oLDFw==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-Mf2V4JbIDboNGQhW6xW0YREDiYXoX3WrD3EjKkjvnpAJ6W4qqjLnK/c9aioyVFaWWHVdP5zVRw/9DI5S3oLDFw==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2831,8 +3805,11 @@ packages:
     dev: false
 
   /postcss-normalize-timing-functions/5.0.2_postcss@8.4.6:
-    resolution: {integrity: sha512-Ao0PP6MoYsRU1LxeVUW740ioknvdIUmfr6uAA3xWlQJ9s69/Tupy8qwhuKG3xWfl+KvLMAP9p2WXF9cwuk/7Bg==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-Ao0PP6MoYsRU1LxeVUW740ioknvdIUmfr6uAA3xWlQJ9s69/Tupy8qwhuKG3xWfl+KvLMAP9p2WXF9cwuk/7Bg==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2841,8 +3818,11 @@ packages:
     dev: false
 
   /postcss-normalize-unicode/5.0.3_postcss@8.4.6:
-    resolution: {integrity: sha512-uNC7BmS/7h6to2UWa4RFH8sOTzu2O9dVWPE/F9Vm9GdhONiD/c1kNaCLbmsFHlKWcEx7alNUChQ+jH/QAlqsQw==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-uNC7BmS/7h6to2UWa4RFH8sOTzu2O9dVWPE/F9Vm9GdhONiD/c1kNaCLbmsFHlKWcEx7alNUChQ+jH/QAlqsQw==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2852,8 +3832,11 @@ packages:
     dev: false
 
   /postcss-normalize-url/5.0.4_postcss@8.4.6:
-    resolution: {integrity: sha512-cNj3RzK2pgQQyNp7dzq0dqpUpQ/wYtdDZM3DepPmFjCmYIfceuD9VIAcOdvrNetjIU65g1B4uwdP/Krf6AFdXg==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-cNj3RzK2pgQQyNp7dzq0dqpUpQ/wYtdDZM3DepPmFjCmYIfceuD9VIAcOdvrNetjIU65g1B4uwdP/Krf6AFdXg==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2863,8 +3846,11 @@ packages:
     dev: false
 
   /postcss-normalize-whitespace/5.0.3_postcss@8.4.6:
-    resolution: {integrity: sha512-333JWRnX655fSoUbufJ10HJop3c8mrpKkCCUnEmgz/Cb/QEtW+/TMZwDAUt4lnwqP6tCCk0x0b58jqvDgiQm/A==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-333JWRnX655fSoUbufJ10HJop3c8mrpKkCCUnEmgz/Cb/QEtW+/TMZwDAUt4lnwqP6tCCk0x0b58jqvDgiQm/A==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2873,8 +3859,11 @@ packages:
     dev: false
 
   /postcss-ordered-values/5.0.4_postcss@8.4.6:
-    resolution: {integrity: sha512-taKtGDZtyYUMVYkg+MuJeBUiTF6cGHZmo/qcW7ibvW79UlyKuSHbo6dpCIiqI+j9oJsXWzP+ovIxoyLDOeQFdw==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-taKtGDZtyYUMVYkg+MuJeBUiTF6cGHZmo/qcW7ibvW79UlyKuSHbo6dpCIiqI+j9oJsXWzP+ovIxoyLDOeQFdw==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2884,8 +3873,11 @@ packages:
     dev: false
 
   /postcss-reduce-initial/5.0.2_postcss@8.4.6:
-    resolution: {integrity: sha512-v/kbAAQ+S1V5v9TJvbGkV98V2ERPdU6XvMcKMjqAlYiJ2NtsHGlKYLPjWWcXlaTKNxooId7BGxeraK8qXvzKtw==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-v/kbAAQ+S1V5v9TJvbGkV98V2ERPdU6XvMcKMjqAlYiJ2NtsHGlKYLPjWWcXlaTKNxooId7BGxeraK8qXvzKtw==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2895,8 +3887,11 @@ packages:
     dev: false
 
   /postcss-reduce-transforms/5.0.3_postcss@8.4.6:
-    resolution: {integrity: sha512-yDnTUab5i7auHiNwdcL1f+pBnqQFf+7eC4cbC7D8Lc1FkvNZhtpkdad+9U4wDdFb84haupMf0rA/Zc5LcTe/3A==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-yDnTUab5i7auHiNwdcL1f+pBnqQFf+7eC4cbC7D8Lc1FkvNZhtpkdad+9U4wDdFb84haupMf0rA/Zc5LcTe/3A==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2905,15 +3900,21 @@ packages:
     dev: false
 
   /postcss-selector-parser/6.0.9:
-    resolution: {integrity: sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==
+      }
+    engines: { node: ">=4" }
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
   /postcss-svgo/5.0.3_postcss@8.4.6:
-    resolution: {integrity: sha512-41XZUA1wNDAZrQ3XgWREL/M2zSw8LJPvb5ZWivljBsUQAGoEKMYm6okHsTjJxKYI4M75RQEH4KYlEM52VwdXVA==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-41XZUA1wNDAZrQ3XgWREL/M2zSw8LJPvb5ZWivljBsUQAGoEKMYm6okHsTjJxKYI4M75RQEH4KYlEM52VwdXVA==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2923,8 +3924,11 @@ packages:
     dev: false
 
   /postcss-unique-selectors/5.0.3_postcss@8.4.6:
-    resolution: {integrity: sha512-V5tX2hadSSn+miVCluuK1IDGy+7jAXSOfRZ2DQ+s/4uQZb/orDYBjH0CHgFrXsRw78p4QTuEFA9kI6C956UnHQ==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-V5tX2hadSSn+miVCluuK1IDGy+7jAXSOfRZ2DQ+s/4uQZb/orDYBjH0CHgFrXsRw78p4QTuEFA9kI6C956UnHQ==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -2933,16 +3937,25 @@ packages:
     dev: false
 
   /postcss-value-parser/3.3.1:
-    resolution: {integrity: sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==}
+    resolution:
+      {
+        integrity: sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
+      }
     dev: false
 
   /postcss-value-parser/4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+    resolution:
+      {
+        integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
+      }
     dev: false
 
   /postcss/6.0.23:
-    resolution: {integrity: sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==}
-    engines: {node: '>=4.0.0'}
+    resolution:
+      {
+        integrity: sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
+      }
+    engines: { node: ">=4.0.0" }
     dependencies:
       chalk: 2.4.2
       source-map: 0.6.1
@@ -2950,64 +3963,107 @@ packages:
     dev: false
 
   /postcss/7.0.39:
-    resolution: {integrity: sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==}
-    engines: {node: '>=6.0.0'}
+    resolution:
+      {
+        integrity: sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
+      }
+    engines: { node: ">=6.0.0" }
     dependencies:
       picocolors: 0.2.1
       source-map: 0.6.1
     dev: false
 
   /postcss/8.4.6:
-    resolution: {integrity: sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==}
-    engines: {node: ^10 || ^12 || >=14}
+    resolution:
+      {
+        integrity: sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==
+      }
+    engines: { node: ^10 || ^12 || >=14 }
     dependencies:
       nanoid: 3.2.0
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
   /prelude-ls/1.1.2:
-    resolution: {integrity: sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=}
-    engines: {node: '>= 0.8.0'}
+    resolution: { integrity: sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ= }
+    engines: { node: ">= 0.8.0" }
     dev: false
     optional: true
 
+  /prettier-plugin-svelte/2.6.0_prettier@2.5.1+svelte@3.46.3:
+    resolution:
+      {
+        integrity: sha512-NPSRf6Y5rufRlBleok/pqg4+1FyGsL0zYhkYP6hnueeL1J/uCm3OfOZPsLX4zqD9VAdcXfyEL2PYqGv8ZoOSfA==
+      }
+    peerDependencies:
+      prettier: ^1.16.4 || ^2.0.0
+      svelte: ^3.2.0
+    dependencies:
+      prettier: 2.5.1
+      svelte: 3.46.3
+    dev: false
+
+  /prettier/2.5.1:
+    resolution:
+      {
+        integrity: sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
+      }
+    engines: { node: ">=10.13.0" }
+    hasBin: true
+    dev: false
+
   /pretty-hrtime/1.0.3:
-    resolution: {integrity: sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=}
-    engines: {node: '>= 0.8'}
+    resolution: { integrity: sha1-t+PqQkNaTJsnWdmeDyAesZWALuE= }
+    engines: { node: ">= 0.8" }
     dev: false
 
   /process-nextick-args/2.0.1:
-    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+    resolution:
+      {
+        integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+      }
     dev: false
 
   /promise-inflight/1.0.1:
-    resolution: {integrity: sha1-mEcocL8igTL8vdhoEputEsPAKeM=}
+    resolution: { integrity: sha1-mEcocL8igTL8vdhoEputEsPAKeM= }
     dev: false
 
   /promise-retry/2.0.1:
-    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==
+      }
+    engines: { node: ">=10" }
     dependencies:
       err-code: 2.0.3
       retry: 0.12.0
     dev: false
 
   /promise.series/0.2.0:
-    resolution: {integrity: sha1-LMfr6Vn8OmYZwEq029yeRS2GS70=}
-    engines: {node: '>=0.12'}
+    resolution: { integrity: sha1-LMfr6Vn8OmYZwEq029yeRS2GS70= }
+    engines: { node: ">=0.12" }
     dev: false
 
   /psl/1.8.0:
-    resolution: {integrity: sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==}
+    resolution:
+      {
+        integrity: sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
+      }
     dev: false
 
   /punycode/2.1.1:
-    resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+      }
+    engines: { node: ">=6" }
     dev: false
 
   /purgecss/4.1.3:
-    resolution: {integrity: sha512-99cKy4s+VZoXnPxaoM23e5ABcP851nC2y2GROkkjS8eJaJtlciGavd7iYAw2V84WeBqggZ12l8ef44G99HmTaw==}
+    resolution:
+      {
+        integrity: sha512-99cKy4s+VZoXnPxaoM23e5ABcP851nC2y2GROkkjS8eJaJtlciGavd7iYAw2V84WeBqggZ12l8ef44G99HmTaw==
+      }
     hasBin: true
     dependencies:
       commander: 8.3.0
@@ -3017,33 +4073,51 @@ packages:
     dev: false
 
   /qs/6.5.3:
-    resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
-    engines: {node: '>=0.6'}
+    resolution:
+      {
+        integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
+      }
+    engines: { node: ">=0.6" }
     dev: false
 
   /queue-microtask/1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    resolution:
+      {
+        integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+      }
     dev: false
 
   /quick-lru/4.0.1:
-    resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /quick-lru/5.1.1:
-    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+      }
+    engines: { node: ">=10" }
     dev: false
 
   /randombytes/2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+    resolution:
+      {
+        integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
+      }
     dependencies:
       safe-buffer: 5.2.1
     dev: true
 
   /read-pkg-up/7.0.1:
-    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
+      }
+    engines: { node: ">=8" }
     dependencies:
       find-up: 4.1.0
       read-pkg: 5.2.0
@@ -3051,17 +4125,23 @@ packages:
     dev: false
 
   /read-pkg/5.2.0:
-    resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
+      }
+    engines: { node: ">=8" }
     dependencies:
-      '@types/normalize-package-data': 2.4.1
+      "@types/normalize-package-data": 2.4.1
       normalize-package-data: 2.5.0
       parse-json: 5.2.0
       type-fest: 0.6.0
     dev: false
 
   /readable-stream/2.3.7:
-    resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==}
+    resolution:
+      {
+        integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+      }
     dependencies:
       core-util-is: 1.0.3
       inherits: 2.0.4
@@ -3073,8 +4153,11 @@ packages:
     dev: false
 
   /readable-stream/3.6.0:
-    resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+      }
+    engines: { node: ">= 6" }
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
@@ -3082,29 +4165,41 @@ packages:
     dev: false
 
   /readdirp/3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
+    resolution:
+      {
+        integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+      }
+    engines: { node: ">=8.10.0" }
     dependencies:
       picomatch: 2.3.1
 
   /redent/3.0.0:
-    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+      }
+    engines: { node: ">=8" }
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
     dev: false
 
   /reduce-css-calc/2.1.8:
-    resolution: {integrity: sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==}
+    resolution:
+      {
+        integrity: sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==
+      }
     dependencies:
       css-unit-converter: 1.1.2
       postcss-value-parser: 3.3.1
     dev: false
 
   /request-promise-core/1.1.4_request@2.88.2:
-    resolution: {integrity: sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==
+      }
+    engines: { node: ">=0.10.0" }
     peerDependencies:
       request: ^2.34
     dependencies:
@@ -3114,8 +4209,11 @@ packages:
     optional: true
 
   /request-promise-native/1.0.9_request@2.88.2:
-    resolution: {integrity: sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==}
-    engines: {node: '>=0.12.0'}
+    resolution:
+      {
+        integrity: sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==
+      }
+    engines: { node: ">=0.12.0" }
     deprecated: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
     peerDependencies:
       request: ^2.34
@@ -3128,8 +4226,11 @@ packages:
     optional: true
 
   /request/2.88.2:
-    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
+      }
+    engines: { node: ">= 6" }
     deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
     dependencies:
       aws-sign2: 0.7.0
@@ -3155,30 +4256,42 @@ packages:
     dev: false
 
   /require-directory/2.1.1:
-    resolution: {integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I=}
-    engines: {node: '>=0.10.0'}
+    resolution: { integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I= }
+    engines: { node: ">=0.10.0" }
     dev: false
 
   /require-relative/0.8.7:
-    resolution: {integrity: sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=}
+    resolution: { integrity: sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4= }
     dev: true
 
   /resize-observer-polyfill/1.5.1:
-    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
+    resolution:
+      {
+        integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+      }
     dev: false
 
   /resolve-from/4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+      }
+    engines: { node: ">=4" }
     dev: false
 
   /resolve-from/5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /resolve/1.22.0:
-    resolution: {integrity: sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==}
+    resolution:
+      {
+        integrity: sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
+      }
     hasBin: true
     dependencies:
       is-core-module: 2.8.1
@@ -3186,42 +4299,54 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
 
   /retry/0.12.0:
-    resolution: {integrity: sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=}
-    engines: {node: '>= 4'}
+    resolution: { integrity: sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs= }
+    engines: { node: ">= 4" }
     dev: false
 
   /reusify/1.0.4:
-    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+      }
+    engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
     dev: false
 
   /rgb-regex/1.0.1:
-    resolution: {integrity: sha1-wODWiC3w4jviVKR16O3UGRX+rrE=}
+    resolution: { integrity: sha1-wODWiC3w4jviVKR16O3UGRX+rrE= }
     dev: false
 
   /rgba-regex/1.0.0:
-    resolution: {integrity: sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=}
+    resolution: { integrity: sha1-QzdOLiyglosO8VI0YLfXMP8i7rM= }
     dev: false
 
   /rimraf/2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    resolution:
+      {
+        integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+      }
     hasBin: true
     dependencies:
       glob: 7.2.0
     dev: false
 
   /rimraf/3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    resolution:
+      {
+        integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+      }
     hasBin: true
     dependencies:
       glob: 7.2.0
     dev: false
 
   /rollup-plugin-copy/3.4.0:
-    resolution: {integrity: sha512-rGUmYYsYsceRJRqLVlE9FivJMxJ7X6jDlP79fmFkL8sJs7VVMSVyA2yfyL+PGyO/vJs4A87hwhgVfz61njI+uQ==}
-    engines: {node: '>=8.3'}
+    resolution:
+      {
+        integrity: sha512-rGUmYYsYsceRJRqLVlE9FivJMxJ7X6jDlP79fmFkL8sJs7VVMSVyA2yfyL+PGyO/vJs4A87hwhgVfz61njI+uQ==
+      }
+    engines: { node: ">=8.3" }
     dependencies:
-      '@types/fs-extra': 8.1.2
+      "@types/fs-extra": 8.1.2
       colorette: 1.4.0
       fs-extra: 8.1.0
       globby: 10.0.1
@@ -3229,18 +4354,24 @@ packages:
     dev: false
 
   /rollup-plugin-css-only/3.1.0_rollup@2.66.1:
-    resolution: {integrity: sha512-TYMOE5uoD76vpj+RTkQLzC9cQtbnJNktHPB507FzRWBVaofg7KhIqq1kGbcVOadARSozWF883Ho9KpSPKH8gqA==}
-    engines: {node: '>=10.12.0'}
+    resolution:
+      {
+        integrity: sha512-TYMOE5uoD76vpj+RTkQLzC9cQtbnJNktHPB507FzRWBVaofg7KhIqq1kGbcVOadARSozWF883Ho9KpSPKH8gqA==
+      }
+    engines: { node: ">=10.12.0" }
     peerDependencies:
       rollup: 1 || 2
     dependencies:
-      '@rollup/pluginutils': 4.1.2
+      "@rollup/pluginutils": 4.1.2
       rollup: 2.66.1
     dev: true
 
   /rollup-plugin-livereload/2.0.5:
-    resolution: {integrity: sha512-vqQZ/UQowTW7VoiKEM5ouNW90wE5/GZLfdWuR0ELxyKOJUIaj+uismPZZaICU4DnWPVjnpCDDxEqwU7pcKY/PA==}
-    engines: {node: '>=8.3'}
+    resolution:
+      {
+        integrity: sha512-vqQZ/UQowTW7VoiKEM5ouNW90wE5/GZLfdWuR0ELxyKOJUIaj+uismPZZaICU4DnWPVjnpCDDxEqwU7pcKY/PA==
+      }
+    engines: { node: ">=8.3" }
     dependencies:
       livereload: 0.9.3
     transitivePeerDependencies:
@@ -3249,8 +4380,11 @@ packages:
     dev: true
 
   /rollup-plugin-postcss/4.0.2_postcss@8.4.6:
-    resolution: {integrity: sha512-05EaY6zvZdmvPUDi3uCcAQoESDcYnv8ogJJQRp6V5kZ6J6P7uAVJlrTZcaaA20wTH527YTnKfkAoPxWI/jPp4w==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-05EaY6zvZdmvPUDi3uCcAQoESDcYnv8ogJJQRp6V5kZ6J6P7uAVJlrTZcaaA20wTH527YTnKfkAoPxWI/jPp4w==
+      }
+    engines: { node: ">=10" }
     peerDependencies:
       postcss: 8.x
     dependencies:
@@ -3273,11 +4407,14 @@ packages:
     dev: false
 
   /rollup-plugin-svelte/7.1.0_rollup@2.66.1+svelte@3.46.3:
-    resolution: {integrity: sha512-vopCUq3G+25sKjwF5VilIbiY6KCuMNHP1PFvx2Vr3REBNMDllKHFZN2B9jwwC+MqNc3UPKkjXnceLPEjTjXGXg==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-vopCUq3G+25sKjwF5VilIbiY6KCuMNHP1PFvx2Vr3REBNMDllKHFZN2B9jwwC+MqNc3UPKkjXnceLPEjTjXGXg==
+      }
+    engines: { node: ">=10" }
     peerDependencies:
-      rollup: '>=2.0.0'
-      svelte: '>=3.5.0'
+      rollup: ">=2.0.0"
+      svelte: ">=3.5.0"
     dependencies:
       require-relative: 0.8.7
       rollup: 2.66.1
@@ -3286,11 +4423,14 @@ packages:
     dev: true
 
   /rollup-plugin-terser/7.0.2_rollup@2.66.1:
-    resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
+    resolution:
+      {
+        integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==
+      }
     peerDependencies:
       rollup: ^2.0.0
     dependencies:
-      '@babel/code-frame': 7.16.7
+      "@babel/code-frame": 7.16.7
       jest-worker: 26.6.2
       rollup: 2.66.1
       serialize-javascript: 4.0.0
@@ -3300,52 +4440,76 @@ packages:
     dev: true
 
   /rollup-pluginutils/2.8.2:
-    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
+    resolution:
+      {
+        integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
+      }
     dependencies:
       estree-walker: 0.6.1
 
   /rollup/2.66.1:
-    resolution: {integrity: sha512-crSgLhSkLMnKr4s9iZ/1qJCplgAgrRY+igWv8KhG/AjKOJ0YX/WpmANyn8oxrw+zenF3BXWDLa7Xl/QZISH+7w==}
-    engines: {node: '>=10.0.0'}
+    resolution:
+      {
+        integrity: sha512-crSgLhSkLMnKr4s9iZ/1qJCplgAgrRY+igWv8KhG/AjKOJ0YX/WpmANyn8oxrw+zenF3BXWDLa7Xl/QZISH+7w==
+      }
+    engines: { node: ">=10.0.0" }
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
   /run-parallel/1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+    resolution:
+      {
+        integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
+      }
     dependencies:
       queue-microtask: 1.2.3
     dev: false
 
   /rw/1.3.3:
-    resolution: {integrity: sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=}
+    resolution: { integrity: sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q= }
     dev: false
 
   /sade/1.8.1:
-    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==
+      }
+    engines: { node: ">=6" }
     dependencies:
       mri: 1.2.0
     dev: false
 
   /safe-buffer/5.1.2:
-    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+    resolution:
+      {
+        integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+      }
     dev: false
 
   /safe-buffer/5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    resolution:
+      {
+        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+      }
 
   /safe-identifier/0.4.2:
-    resolution: {integrity: sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==}
+    resolution:
+      {
+        integrity: sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==
+      }
     dev: false
 
   /safer-buffer/2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    resolution:
+      {
+        integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+      }
     dev: false
 
   /sander/0.5.1:
-    resolution: {integrity: sha1-dB4kXiMfB8r7b98PEzrfohalAq0=}
+    resolution: { integrity: sha1-dB4kXiMfB8r7b98PEzrfohalAq0= }
     dependencies:
       es6-promise: 3.3.1
       graceful-fs: 4.2.9
@@ -3354,8 +4518,11 @@ packages:
     dev: false
 
   /sass-graph/4.0.0:
-    resolution: {integrity: sha512-WSO/MfXqKH7/TS8RdkCX3lVkPFQzCgbqdGsmSKq6tlPU+GpGEsa/5aW18JqItnqh+lPtcjifqdZ/VmiILkKckQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-WSO/MfXqKH7/TS8RdkCX3lVkPFQzCgbqdGsmSKq6tlPU+GpGEsa/5aW18JqItnqh+lPtcjifqdZ/VmiILkKckQ==
+      }
+    engines: { node: ">=12" }
     hasBin: true
     dependencies:
       glob: 7.2.0
@@ -3365,77 +4532,113 @@ packages:
     dev: false
 
   /saxes/3.1.11:
-    resolution: {integrity: sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==
+      }
+    engines: { node: ">=8" }
     dependencies:
       xmlchars: 2.2.0
     dev: false
     optional: true
 
   /scss-tokenizer/0.3.0:
-    resolution: {integrity: sha512-14Zl9GcbBvOT9057ZKjpz5yPOyUWG2ojd9D5io28wHRYsOrs7U95Q+KNL87+32p8rc+LvDpbu/i9ZYjM9Q+FsQ==}
+    resolution:
+      {
+        integrity: sha512-14Zl9GcbBvOT9057ZKjpz5yPOyUWG2ojd9D5io28wHRYsOrs7U95Q+KNL87+32p8rc+LvDpbu/i9ZYjM9Q+FsQ==
+      }
     dependencies:
       js-base64: 2.6.4
       source-map: 0.7.3
     dev: false
 
   /semiver/1.1.0:
-    resolution: {integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==
+      }
+    engines: { node: ">=6" }
     dev: false
 
   /semver/5.7.1:
-    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
+    resolution:
+      {
+        integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+      }
     hasBin: true
     dev: false
 
   /semver/6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
+    resolution:
+      {
+        integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+      }
     hasBin: true
     dev: false
     optional: true
 
   /semver/7.3.5:
-    resolution: {integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+      }
+    engines: { node: ">=10" }
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
     dev: false
 
   /serialize-javascript/4.0.0:
-    resolution: {integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==}
+    resolution:
+      {
+        integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+      }
     dependencies:
       randombytes: 2.1.0
     dev: true
 
   /set-blocking/2.0.0:
-    resolution: {integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=}
+    resolution: { integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc= }
     dev: false
 
   /shebang-command/2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+      }
+    engines: { node: ">=8" }
     dependencies:
       shebang-regex: 3.0.0
     dev: false
 
   /shebang-regex/3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /signal-exit/3.0.6:
-    resolution: {integrity: sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==}
+    resolution:
+      {
+        integrity: sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
+      }
     dev: false
 
   /simple-concat/1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+    resolution:
+      {
+        integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+      }
     dev: false
     optional: true
 
   /simple-get/3.1.0:
-    resolution: {integrity: sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==}
+    resolution:
+      {
+        integrity: sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
+      }
     dependencies:
       decompress-response: 4.2.1
       once: 1.4.0
@@ -3444,14 +4647,17 @@ packages:
     optional: true
 
   /simple-swizzle/0.2.2:
-    resolution: {integrity: sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=}
+    resolution: { integrity: sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo= }
     dependencies:
       is-arrayish: 0.3.2
     dev: false
 
   /sirv-cli/1.0.14:
-    resolution: {integrity: sha512-yyUTNr984ANKDloqepkYbBSqvx3buwYg2sQKPWjSU+IBia5loaoka2If8N9CMwt8AfP179cdEl7kYJ//iWJHjQ==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-yyUTNr984ANKDloqepkYbBSqvx3buwYg2sQKPWjSU+IBia5loaoka2If8N9CMwt8AfP179cdEl7kYJ//iWJHjQ==
+      }
+    engines: { node: ">= 10" }
     hasBin: true
     dependencies:
       console-clear: 1.1.1
@@ -3465,27 +4671,39 @@ packages:
     dev: false
 
   /sirv/1.0.19:
-    resolution: {integrity: sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==
+      }
+    engines: { node: ">= 10" }
     dependencies:
-      '@polka/url': 1.0.0-next.21
+      "@polka/url": 1.0.0-next.21
       mrmime: 1.0.0
       totalist: 1.1.0
     dev: false
 
   /slash/3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /smart-buffer/4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+    resolution:
+      {
+        integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
+      }
+    engines: { node: ">= 6.0.0", npm: ">= 3.0.0" }
     dev: false
 
   /socks-proxy-agent/6.1.1:
-    resolution: {integrity: sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==
+      }
+    engines: { node: ">= 10" }
     dependencies:
       agent-base: 6.0.2
       debug: 4.3.3
@@ -3495,15 +4713,18 @@ packages:
     dev: false
 
   /socks/2.6.1:
-    resolution: {integrity: sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==}
-    engines: {node: '>= 10.13.0', npm: '>= 3.0.0'}
+    resolution:
+      {
+        integrity: sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==
+      }
+    engines: { node: ">= 10.13.0", npm: ">= 3.0.0" }
     dependencies:
       ip: 1.1.5
       smart-buffer: 4.2.0
     dev: false
 
   /sorcery/0.10.0:
-    resolution: {integrity: sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=}
+    resolution: { integrity: sha1-iukK19fLBfxZ8asMY3hF1cFaUrc= }
     hasBin: true
     dependencies:
       buffer-crc32: 0.2.13
@@ -3513,52 +4734,82 @@ packages:
     dev: false
 
   /source-map-js/1.0.2:
-    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+      }
+    engines: { node: ">=0.10.0" }
 
   /source-map-support/0.5.21:
-    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    resolution:
+      {
+        integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+      }
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
     dev: true
 
   /source-map/0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+      }
+    engines: { node: ">=0.10.0" }
 
   /source-map/0.7.3:
-    resolution: {integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+      }
+    engines: { node: ">= 8" }
 
   /sourcemap-codec/1.4.8:
-    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    resolution:
+      {
+        integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+      }
 
   /spdx-correct/3.1.1:
-    resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}
+    resolution:
+      {
+        integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==
+      }
     dependencies:
       spdx-expression-parse: 3.0.1
       spdx-license-ids: 3.0.11
     dev: false
 
   /spdx-exceptions/2.3.0:
-    resolution: {integrity: sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==}
+    resolution:
+      {
+        integrity: sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
+      }
     dev: false
 
   /spdx-expression-parse/3.0.1:
-    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+    resolution:
+      {
+        integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
+      }
     dependencies:
       spdx-exceptions: 2.3.0
       spdx-license-ids: 3.0.11
     dev: false
 
   /spdx-license-ids/3.0.11:
-    resolution: {integrity: sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==}
+    resolution:
+      {
+        integrity: sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==
+      }
     dev: false
 
   /sshpk/1.17.0:
-    resolution: {integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==
+      }
+    engines: { node: ">=0.10.0" }
     hasBin: true
     dependencies:
       asn1: 0.2.6
@@ -3573,35 +4824,47 @@ packages:
     dev: false
 
   /ssri/8.0.1:
-    resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
+      }
+    engines: { node: ">= 8" }
     dependencies:
       minipass: 3.1.6
     dev: false
 
   /stable/0.1.8:
-    resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
+    resolution:
+      {
+        integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
+      }
     dev: false
 
   /stdout-stream/1.4.1:
-    resolution: {integrity: sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==}
+    resolution:
+      {
+        integrity: sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==
+      }
     dependencies:
       readable-stream: 2.3.7
     dev: false
 
   /stealthy-require/1.1.1:
-    resolution: {integrity: sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=}
-    engines: {node: '>=0.10.0'}
+    resolution: { integrity: sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks= }
+    engines: { node: ">=0.10.0" }
     dev: false
     optional: true
 
   /string-hash/1.1.3:
-    resolution: {integrity: sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=}
+    resolution: { integrity: sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs= }
     dev: false
 
   /string-width/4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+      }
+    engines: { node: ">=8" }
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
@@ -3609,38 +4872,56 @@ packages:
     dev: false
 
   /string_decoder/1.1.1:
-    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+    resolution:
+      {
+        integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+      }
     dependencies:
       safe-buffer: 5.1.2
     dev: false
 
   /string_decoder/1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    resolution:
+      {
+        integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+      }
     dependencies:
       safe-buffer: 5.2.1
     dev: false
 
   /strip-ansi/6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+      }
+    engines: { node: ">=8" }
     dependencies:
       ansi-regex: 5.0.1
     dev: false
 
   /strip-indent/3.0.0:
-    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+      }
+    engines: { node: ">=8" }
     dependencies:
       min-indent: 1.0.1
     dev: false
 
   /style-inject/0.3.0:
-    resolution: {integrity: sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==}
+    resolution:
+      {
+        integrity: sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==
+      }
     dev: false
 
   /stylehacks/5.0.2_postcss@8.4.6:
-    resolution: {integrity: sha512-114zeJdOpTrbQYRD4OU5UWJ99LKUaqCPJTU1HQ/n3q3BwmllFN8kHENaLnOeqVq6AhXrWfxHNZTl33iJ4oy3cQ==}
-    engines: {node: ^10 || ^12 || >=14.0}
+    resolution:
+      {
+        integrity: sha512-114zeJdOpTrbQYRD4OU5UWJ99LKUaqCPJTU1HQ/n3q3BwmllFN8kHENaLnOeqVq6AhXrWfxHNZTl33iJ4oy3cQ==
+      }
+    engines: { node: ^10 || ^12 || >=14.0 }
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
@@ -3650,30 +4931,42 @@ packages:
     dev: false
 
   /supports-color/5.5.0:
-    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+      }
+    engines: { node: ">=4" }
     dependencies:
       has-flag: 3.0.0
 
   /supports-color/7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+      }
+    engines: { node: ">=8" }
     dependencies:
       has-flag: 4.0.0
 
   /supports-preserve-symlinks-flag/1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+      }
+    engines: { node: ">= 0.4" }
 
   /svelte-preprocess/4.10.2_36f39d064d5beb925d67dc28a3bdfdc5:
-    resolution: {integrity: sha512-aPpkCreSo8EL/y8kJSa1trhiX0oyAtTjlNNM7BNjRAsMJ8Yy2LtqHt0zyd4pQPXt+D4PzbO3qTjjio3kwOxDlA==}
-    engines: {node: '>= 9.11.2'}
+    resolution:
+      {
+        integrity: sha512-aPpkCreSo8EL/y8kJSa1trhiX0oyAtTjlNNM7BNjRAsMJ8Yy2LtqHt0zyd4pQPXt+D4PzbO3qTjjio3kwOxDlA==
+      }
+    engines: { node: ">= 9.11.2" }
     requiresBuild: true
     peerDependencies:
-      '@babel/core': ^7.10.2
+      "@babel/core": ^7.10.2
       coffeescript: ^2.5.1
       less: ^3.11.3 || ^4.0.0
-      node-sass: '*'
+      node-sass: "*"
       postcss: ^7 || ^8
       postcss-load-config: ^2.1.0 || ^3.0.0
       pug: ^3.0.0
@@ -3683,7 +4976,7 @@ packages:
       svelte: ^3.23.0
       typescript: ^4.5.2
     peerDependenciesMeta:
-      '@babel/core':
+      "@babel/core":
         optional: true
       coffeescript:
         optional: true
@@ -3706,8 +4999,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@types/pug': 2.0.6
-      '@types/sass': 1.43.1
+      "@types/pug": 2.0.6
+      "@types/sass": 1.43.1
       detect-indent: 6.1.0
       magic-string: 0.25.7
       node-sass: 7.0.1
@@ -3718,19 +5011,28 @@ packages:
     dev: false
 
   /svelte-range-slider-pips/2.0.2:
-    resolution: {integrity: sha512-VTWHOdwDyWbndGZnI0PQJY9DO7hgQlNubtCcCL6Wlypv5dU4vEsc4A1sX9TWMuvebEe4332SgsQQHzOdZ+guhQ==}
+    resolution:
+      {
+        integrity: sha512-VTWHOdwDyWbndGZnI0PQJY9DO7hgQlNubtCcCL6Wlypv5dU4vEsc4A1sX9TWMuvebEe4332SgsQQHzOdZ+guhQ==
+      }
     dev: false
 
   /svelte/3.46.3:
-    resolution: {integrity: sha512-mTOXvv74CVQqJHqoIZDprVfRKVVmYNadXP0VKnOEA54223kLGCr1nMrifS4Zx29qMt/xRB38Eq1D7dDH/fM8fQ==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-mTOXvv74CVQqJHqoIZDprVfRKVVmYNadXP0VKnOEA54223kLGCr1nMrifS4Zx29qMt/xRB38Eq1D7dDH/fM8fQ==
+      }
+    engines: { node: ">= 8" }
 
   /svgo/2.8.0:
-    resolution: {integrity: sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==}
-    engines: {node: '>=10.13.0'}
+    resolution:
+      {
+        integrity: sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==
+      }
+    engines: { node: ">=10.13.0" }
     hasBin: true
     dependencies:
-      '@trysound/sax': 0.2.0
+      "@trysound/sax": 0.2.0
       commander: 7.2.0
       css-select: 4.2.1
       css-tree: 1.1.3
@@ -3740,13 +5042,19 @@ packages:
     dev: false
 
   /symbol-tree/3.2.4:
-    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+    resolution:
+      {
+        integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+      }
     dev: false
     optional: true
 
   /tar/6.1.11:
-    resolution: {integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==}
-    engines: {node: '>= 10'}
+    resolution:
+      {
+        integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
+      }
+    engines: { node: ">= 10" }
     dependencies:
       chownr: 2.0.0
       fs-minipass: 2.1.0
@@ -3757,8 +5065,11 @@ packages:
     dev: false
 
   /terser/5.10.0:
-    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==
+      }
+    engines: { node: ">=10" }
     hasBin: true
     peerDependencies:
       acorn: ^8.5.0
@@ -3772,43 +5083,61 @@ packages:
     dev: true
 
   /timsort/0.3.0:
-    resolution: {integrity: sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=}
+    resolution: { integrity: sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q= }
     dev: false
 
   /tinydate/1.3.0:
-    resolution: {integrity: sha512-7cR8rLy2QhYHpsBDBVYnnWXm8uRTr38RoZakFSW7Bs7PzfMPNZthuMLkwqZv7MTu8lhQ91cOFYS5a7iFj2oR3w==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-7cR8rLy2QhYHpsBDBVYnnWXm8uRTr38RoZakFSW7Bs7PzfMPNZthuMLkwqZv7MTu8lhQ91cOFYS5a7iFj2oR3w==
+      }
+    engines: { node: ">=4" }
     dev: false
 
   /tmp/0.2.1:
-    resolution: {integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==}
-    engines: {node: '>=8.17.0'}
+    resolution:
+      {
+        integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+      }
+    engines: { node: ">=8.17.0" }
     dependencies:
       rimraf: 3.0.2
     dev: false
 
   /to-regex-range/5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
+    resolution:
+      {
+        integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+      }
+    engines: { node: ">=8.0" }
     dependencies:
       is-number: 7.0.0
 
   /totalist/1.1.0:
-    resolution: {integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
+      }
+    engines: { node: ">=6" }
     dev: false
 
   /tough-cookie/2.5.0:
-    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
-    engines: {node: '>=0.8'}
+    resolution:
+      {
+        integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+      }
+    engines: { node: ">=0.8" }
     dependencies:
       psl: 1.8.0
       punycode: 2.1.1
     dev: false
 
   /tough-cookie/3.0.1:
-    resolution: {integrity: sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
+      }
+    engines: { node: ">=6" }
     dependencies:
       ip-regex: 2.1.0
       psl: 1.8.0
@@ -3817,38 +5146,53 @@ packages:
     optional: true
 
   /tr46/0.0.3:
-    resolution: {integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=}
+    resolution: { integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o= }
     dev: false
     optional: true
 
   /tr46/1.0.1:
-    resolution: {integrity: sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=}
+    resolution: { integrity: sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk= }
     dependencies:
       punycode: 2.1.1
     dev: false
     optional: true
 
   /trim-newlines/3.0.1:
-    resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /true-case-path/1.0.3:
-    resolution: {integrity: sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==}
+    resolution:
+      {
+        integrity: sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==
+      }
     dependencies:
       glob: 7.2.0
     dev: false
 
   /tui-code-snippet/1.5.2:
-    resolution: {integrity: sha512-6UqTlQaaC1KLcmC0HAoq5dtl1G4Fib+R+NC7pmaV7kiIlZ7JqKhUmnOoGRcreAyzd81UTK/vCvhrw9QJskpCFQ==}
+    resolution:
+      {
+        integrity: sha512-6UqTlQaaC1KLcmC0HAoq5dtl1G4Fib+R+NC7pmaV7kiIlZ7JqKhUmnOoGRcreAyzd81UTK/vCvhrw9QJskpCFQ==
+      }
     dev: false
 
   /tui-color-picker/2.2.7:
-    resolution: {integrity: sha512-y7gUe6PdVBq8ruZbiOkeaN7N/DX+ogVyLkK53OM4qW5Vrc4pDWYEKlnOBCsPODb4/RSzS9iTd6fXYirXxeakJA==}
+    resolution:
+      {
+        integrity: sha512-y7gUe6PdVBq8ruZbiOkeaN7N/DX+ogVyLkK53OM4qW5Vrc4pDWYEKlnOBCsPODb4/RSzS9iTd6fXYirXxeakJA==
+      }
     dev: false
 
   /tui-image-editor/3.15.2:
-    resolution: {integrity: sha512-gnpRURbLCeSA+ak7mY6J7JzhJ5dcvcKID3Q/ob6R8H/ttEXHaQ8nrMeIMTtSHqI4rrS437TZsCOeNjlipYQLXQ==}
+    resolution:
+      {
+        integrity: sha512-gnpRURbLCeSA+ak7mY6J7JzhJ5dcvcKID3Q/ob6R8H/ttEXHaQ8nrMeIMTtSHqI4rrS437TZsCOeNjlipYQLXQ==
+      }
     dependencies:
       fabric: 4.6.0
       tui-code-snippet: 1.5.2
@@ -3861,85 +5205,115 @@ packages:
     dev: false
 
   /tunnel-agent/0.6.0:
-    resolution: {integrity: sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=}
+    resolution: { integrity: sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0= }
     dependencies:
       safe-buffer: 5.2.1
     dev: false
 
   /tweetnacl/0.14.5:
-    resolution: {integrity: sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=}
+    resolution: { integrity: sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q= }
     dev: false
 
   /type-check/0.3.2:
-    resolution: {integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=}
-    engines: {node: '>= 0.8.0'}
+    resolution: { integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I= }
+    engines: { node: ">= 0.8.0" }
     dependencies:
       prelude-ls: 1.1.2
     dev: false
     optional: true
 
   /type-fest/0.18.1:
-    resolution: {integrity: sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
+      }
+    engines: { node: ">=10" }
     dev: false
 
   /type-fest/0.6.0:
-    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /type-fest/0.8.1:
-    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+      }
+    engines: { node: ">=8" }
     dev: false
 
   /unique-filename/1.1.1:
-    resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
+    resolution:
+      {
+        integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==
+      }
     dependencies:
       unique-slug: 2.0.2
     dev: false
 
   /unique-slug/2.0.2:
-    resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
+    resolution:
+      {
+        integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
+      }
     dependencies:
       imurmurhash: 0.1.4
     dev: false
 
   /universalify/0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
+    resolution:
+      {
+        integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+      }
+    engines: { node: ">= 4.0.0" }
     dev: false
 
   /universalify/2.0.0:
-    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
-    engines: {node: '>= 10.0.0'}
+    resolution:
+      {
+        integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+      }
+    engines: { node: ">= 10.0.0" }
     dev: false
 
   /uri-js/4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    resolution:
+      {
+        integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+      }
     dependencies:
       punycode: 2.1.1
     dev: false
 
   /util-deprecate/1.0.2:
-    resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
+    resolution: { integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8= }
 
   /uuid/3.4.0:
-    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    resolution:
+      {
+        integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+      }
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
     dev: false
 
   /validate-npm-package-license/3.0.4:
-    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+    resolution:
+      {
+        integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
+      }
     dependencies:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
     dev: false
 
   /verror/1.10.0:
-    resolution: {integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=}
-    engines: {'0': node >=0.6.0}
+    resolution: { integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA= }
+    engines: { "0": node >=0.6.0 }
     dependencies:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
@@ -3947,14 +5321,20 @@ packages:
     dev: false
 
   /w3c-hr-time/1.0.2:
-    resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
+    resolution:
+      {
+        integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
+      }
     dependencies:
       browser-process-hrtime: 1.0.0
     dev: false
     optional: true
 
   /w3c-xmlserializer/1.1.2:
-    resolution: {integrity: sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==}
+    resolution:
+      {
+        integrity: sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==
+      }
     dependencies:
       domexception: 1.0.1
       webidl-conversions: 4.0.2
@@ -3963,29 +5343,38 @@ packages:
     optional: true
 
   /webidl-conversions/3.0.1:
-    resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}
+    resolution: { integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE= }
     dev: false
     optional: true
 
   /webidl-conversions/4.0.2:
-    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+    resolution:
+      {
+        integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+      }
     dev: false
     optional: true
 
   /whatwg-encoding/1.0.5:
-    resolution: {integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==}
+    resolution:
+      {
+        integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
+      }
     dependencies:
       iconv-lite: 0.4.24
     dev: false
     optional: true
 
   /whatwg-mimetype/2.3.0:
-    resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
+    resolution:
+      {
+        integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+      }
     dev: false
     optional: true
 
   /whatwg-url/5.0.0:
-    resolution: {integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0=}
+    resolution: { integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0= }
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
@@ -3993,7 +5382,10 @@ packages:
     optional: true
 
   /whatwg-url/7.1.0:
-    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
+    resolution:
+      {
+        integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==
+      }
     dependencies:
       lodash.sortby: 4.7.0
       tr46: 1.0.1
@@ -4002,28 +5394,40 @@ packages:
     optional: true
 
   /which/2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+      }
+    engines: { node: ">= 8" }
     hasBin: true
     dependencies:
       isexe: 2.0.0
     dev: false
 
   /wide-align/1.1.5:
-    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+    resolution:
+      {
+        integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
+      }
     dependencies:
       string-width: 4.2.3
     dev: false
 
   /word-wrap/1.2.3:
-    resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+      }
+    engines: { node: ">=0.10.0" }
     dev: false
     optional: true
 
   /wrap-ansi/7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+      }
+    engines: { node: ">=10" }
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
@@ -4031,11 +5435,14 @@ packages:
     dev: false
 
   /wrappy/1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: { integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8= }
 
   /ws/7.5.6:
-    resolution: {integrity: sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==}
-    engines: {node: '>=8.3.0'}
+    resolution:
+      {
+        integrity: sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==
+      }
+    engines: { node: ">=8.3.0" }
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
@@ -4046,47 +5453,74 @@ packages:
         optional: true
 
   /xml-name-validator/3.0.0:
-    resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}
+    resolution:
+      {
+        integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+      }
     dev: false
     optional: true
 
   /xmlchars/2.2.0:
-    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+    resolution:
+      {
+        integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+      }
     dev: false
     optional: true
 
   /xtend/4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
+    resolution:
+      {
+        integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+      }
+    engines: { node: ">=0.4" }
     dev: false
 
   /y18n/5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+      }
+    engines: { node: ">=10" }
     dev: false
 
   /yallist/4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    resolution:
+      {
+        integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+      }
     dev: false
 
   /yaml/1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+      }
+    engines: { node: ">= 6" }
     dev: false
 
   /yargs-parser/20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+      }
+    engines: { node: ">=10" }
     dev: false
 
   /yargs-parser/21.0.0:
-    resolution: {integrity: sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
+      }
+    engines: { node: ">=12" }
     dev: false
 
   /yargs/17.3.1:
-    resolution: {integrity: sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==
+      }
+    engines: { node: ">=12" }
     dependencies:
       cliui: 7.0.4
       escalade: 3.1.1


### PR DESCRIPTION
Adds `prettier` for code formatting (will format JS/TS/Svelte/CSS).

This also adds some format scripts for checking and formatting the codebase.

Closes #508.