### PR TITLE
Fixing guides url 

### DIFF
--- a/website/homepage/render_html.py
+++ b/website/homepage/render_html.py
@@ -68,7 +68,9 @@ def render_guides_main():
     with open("src/guides_main_template.html", encoding='utf-8') as template_file:
         template = Template(template_file.read())
         output_html = template.render(guides=guides, navbar_html=navbar_html)
-    with open(os.path.join("generated", "guides.html"), "w", encoding='utf-8') as generated_template:
+    with open(os.path.join("generated", "guides", "index.html"), "w", encoding='utf-8') as generated_template:
+        generated_template.write(output_html)
+    with open(os.path.join("generated", "guide.html"), "w", encoding='utf-8') as generated_template:
         generated_template.write(output_html)
 
 

--- a/website/homepage/render_html.py
+++ b/website/homepage/render_html.py
@@ -68,9 +68,10 @@ def render_guides_main():
     with open("src/guides_main_template.html", encoding='utf-8') as template_file:
         template = Template(template_file.read())
         output_html = template.render(guides=guides, navbar_html=navbar_html)
+    os.makedirs(os.path.join("generated", "guides"), exist_ok=True)
     with open(os.path.join("generated", "guides", "index.html"), "w", encoding='utf-8') as generated_template:
         generated_template.write(output_html)
-    with open(os.path.join("generated", "guide.html"), "w", encoding='utf-8') as generated_template:
+    with open(os.path.join("generated", "guides.html"), "w", encoding='utf-8') as generated_template:
         generated_template.write(output_html)
 
 

--- a/website/homepage/src/navbar.html
+++ b/website/homepage/src/navbar.html
@@ -5,7 +5,7 @@
     <nav class="flex gap-12 sm:gap-16">
       <a class="link" href="/getting_started">⚡ Getting Started</a>
       <a class="link" href="/docs">✍️ Docs</a>
-      <a class="link" href="/guides.html">💡 Guides</a>
+      <a class="link" href="/guides">💡 Guides</a>
       <div class="group relative cursor-pointer font-semibold flex items-center gap-1" onClick="document.querySelector('.help-menu').classList.toggle('flex'); document.querySelector('.help-menu').classList.toggle('hidden');">
         🖐 Community
         <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">


### PR DESCRIPTION
# fixing the guides url so gradio.app/guides/ will work 

Currently only gradio.app/guides.html works which is inconsistent with /docs/ /getting_started/ and all the other links on the page. We will still also support gradio.app/guides.html 