### PR TITLE
Update requirements.in

### DIFF
--- a/test/requirements.in
+++ b/test/requirements.in
@@ -10,3 +10,4 @@ shap
 pytest
 wandb
 huggingface_hub
+black>=22.1.0


### PR DESCRIPTION
To include `black>=22.1.0`. Because the `test/requirements.txt` are generated after these requirements are installed.