### PR TITLE
Restoring Style on Guides

### DIFF
--- a/website/homepage/src/guides_template.html
+++ b/website/homepage/src/guides_template.html
@@ -28,7 +28,7 @@
 
     .prose p>img {
       margin: 0 auto;
-      width: 600px;
+      width: 900px;
       max-width: 100%;
     }
 

--- a/website/homepage/src/guides_template.html
+++ b/website/homepage/src/guides_template.html
@@ -53,6 +53,27 @@
     .prose h1 {
       font-weight: 600;
     }
+
+    .space-link {
+      display: inline-block;
+      margin: 4px;
+      padding-left: 6px;
+      padding-right: 6px;
+      border-radius: 7px;
+    }
+
+    .space-link a {
+      text-decoration: none;
+    }
+
+    #spaces-holder img {
+      display: inherit;
+      margin: 0 auto 0 auto;
+      width: 20px;
+      max-width: 100%;
+      padding-bottom: 7px;
+    }
+
   </style>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-156449732-1"></script>
   <script>
@@ -69,23 +90,18 @@
   {{navbar_html|safe}}
   <div class="container mx-auto max-w-4xl px-4 mb-12 mt-6" id="guide-template">
     {% if spaces is not none %}
-    <p class='mb-2 text-sm text-gray-500'>
-      <span class="italic">Related Spaces:</span>
-      {% for space in spaces %}
-        <a href='{{ space }}' target='_blank' class="hover:text-blue-500 transition">{{ space[30:] }}</a>
-        {% if not loop.last %}, {% endif %}
-      {% endfor %}
-    </p>
-    {% endif %}
+    <div id='spaces-holder'>
+      <a href='https://hf.co/spaces' target='_blank'>
+        <img src='/assets/img/spaces-logo.svg'>
+      </a>
+      <p style='margin: 0;display: inline;font-size: large;font-weight: 400;'>Related Spaces: </p>
 
-    {% if tags is not none %}
-    <p class='mb-2 text-sm text-gray-500'>
-      <span class="italic">Tags:</span>
-      {% for tag in tags %}
-        <span>{{ tag }}</span><!--
-     -->{% if not loop.last %}, {% endif %}
+      {% for space in spaces %}
+      <div class='space-link'>
+        <a href='{{space}}' target='_blank'>{{space[30:]}}</a>
+      </div>
       {% endfor %}
-    </p>
+      </div>
     {% endif %}
 
     <div class="prose mt-6">
@@ -121,6 +137,38 @@
           });
       });
     });
+
+
+    var spacesHolder, spaces;
+    spacesHolder = document.getElementById("spaces-holder");
+    spaces = spacesHolder.getElementsByTagName('div');
+
+    var backgrounds = ['rgba(255,254,188,0.3)',
+                       'rgba(255,205,188,0.3)',
+                       'rgba(255,188,188,0.3)',
+                       'rgba(194,255,169,0.3)',
+                       'rgba(169,255,237,0.3)',
+                       'rgba(182,169,255,0.3)',
+                       'rgba(255,183,245,0.3)']
+
+    function shuffleBackgrounds(array) {
+      for (let i = array.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [array[i], array[j]] = [array[j], array[i]];
+      }
+    }
+
+    shuffleBackgrounds(backgrounds);
+
+    color_counter = 0
+    for (let i = 0; i < spaces.length; i++) {
+      spaces[i].style.background = backgrounds[color_counter];
+      color_counter += 1
+      if (color_counter == backgrounds.length) {
+        color_counter = 0;
+      }
+    }
+
   </script>
 
 </body>


### PR DESCRIPTION
### Brought back original "related spaces" styling (but mobile responsive) and removed tags. before/after: 

<img width="827" alt="Screen Shot 2022-02-10 at 5 47 47 PM" src="https://user-images.githubusercontent.com/9021060/153420793-5a17d960-03c1-4893-aa5a-6afa55f51b81.png">
<img width="873" alt="Screen Shot 2022-02-10 at 5 46 51 PM" src="https://user-images.githubusercontent.com/9021060/153420803-e93ca2b0-e570-4a4f-a1f3-1ce39d7dcd4a.png">
<img width="390" alt="Screen Shot 2022-02-10 at 5 22 47 PM" src="https://user-images.githubusercontent.com/9021060/153420982-cc9eab33-8f38-48ae-a5c2-19e7611ec55a.png">

### Increased img widths, before/after: 

<img width="864" alt="Screen Shot 2022-02-10 at 5 50 20 PM" src="https://user-images.githubusercontent.com/9021060/153421261-c1921b53-a06b-42d0-b052-a13337adb9d9.png">
<img width="858" alt="Screen Shot 2022-02-10 at 5 50 38 PM" src="https://user-images.githubusercontent.com/9021060/153421288-502f1819-86e6-4e12-9e2c-e4a3b616da5a.png">

<img width="384" alt="Screen Shot 2022-02-10 at 5 34 57 PM" src="https://user-images.githubusercontent.com/9021060/153421226-c2838e55-e983-4f0d-8ab9-1b2702624ddb.png">

