### PR TITLE
fixes PermissionError for non-writable flagging path

### DIFF
--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -684,7 +684,7 @@ class Interface:
 
         if self.enable_queue is None:
             self.enable_queue = enable_queue
-        if self.allow_flagging:
+        if self.allow_flagging != "never": 
             self.flagging_callback.setup(self.flagging_dir)
 
         config = self.get_config_file()

--- a/test/test_flagging.py
+++ b/test/test_flagging.py
@@ -67,5 +67,28 @@ class TestHuggingFaceDatasetSaver(unittest.TestCase):
             self.assertEqual(row_count, 2)  # 3 rows written including header
 
 
+class TestDisableFlagging(unittest.TestCase):
+    def test_flagging_no_permission_error_with_flagging_disabled(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            os.chmod(tmpdirname, 0o444)  # Make directory read-only
+            nonwritable_path = os.path.join(
+                tmpdirname, 'flagging_dir')
+            
+            io = gr.Interface(
+                lambda x: x,
+                "text",
+                "text",
+                allow_flagging="never",
+                flagging_dir=nonwritable_path
+            )
+            try:
+                io.launch(prevent_thread_lock=True)
+            except PermissionError:
+                self.fail("launch() raised a PermissionError unexpectedly")
+            
+        io.close()
+            
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Description

Launching the interface crashes if the flagging directory is read-only. This happens even if flagging is set to never. 

It looks like one of the if conditions was expecting allow_flagging to be a boolean even though it is now a string, so I've fixed that and added a test case for it.

Fixes: # (issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
