### PR TITLE
Fixing related spaces and tags on guides template

### DIFF
--- a/website/homepage/src/guides_template.html
+++ b/website/homepage/src/guides_template.html
@@ -111,24 +111,7 @@
       </div>
       {% endfor %}
       </div>
-    <p class='mb-2 text-sm text-gray-500'>
-      <span class="italic">Related Spaces:</span>
-      {% for space in spaces %}
-        <a href='{{ space }}' target='_blank' class="hover:text-blue-500 transition">{{ space[30:] }}</a>
-        {% if not loop.last %}, {% endif %}
-      {% endfor %}
-    </p>
-    {% endif %}
-
-    {% if tags is not none %}
-    <p class='mb-2 text-sm text-gray-500'>
-      <span class="italic">Tags:</span>
-      {% for tag in tags %}
-        <span>{{ tag }}</span><!--
-     -->{% if not loop.last %}, {% endif %}
-      {% endfor %}
-    </p>
-    {% endif %}
+   {% endif %}
 
     <div class="prose mt-6">
       {{ template_html|safe }}


### PR DESCRIPTION
The old related spaces and tags were added back in PR #546 by accident (see [this comment](https://github.com/gradio-app/gradio/pull/546/files#r808970717)). This fixes that and removes them. Before and after: 

<img width="865" alt="Screen Shot 2022-02-17 at 4 05 06 PM" src="https://user-images.githubusercontent.com/9021060/154478282-d9f740a3-c146-4c42-8140-7ff9e885d8da.png">
<img width="927" alt="Screen Shot 2022-02-17 at 4 04 46 PM" src="https://user-images.githubusercontent.com/9021060/154478241-02fff1f3-023b-4b2a-a772-0a886b0b9748.png">

