### PR TITLE
Persian Language Support

### DIFF
--- a/ui/packages/app/src/lang/fa.json
+++ b/ui/packages/app/src/lang/fa.json
@@ -1,0 +1,18 @@
+{
+	"interface": {
+		"submit": "ثبت",
+		"clear": "پاک کردن",
+		"interpret": "تحلیل",
+		"flag": "علامت گذاری",
+		"examples": "مثال ها",
+		"drop_image": "تصویر را اینجا بیندازید",
+		"drop_video": "ویدیو را اینجا بیندازید",
+		"drop_audio": "فایل صوتی را اینجا بیندازید",
+		"drop_file": "فایل را اینجا بیندازید",
+		"drop_csv": "فایل CSV را اینجا بیندازید",
+		"or": "یا",
+		"click_to_upload": "برای آپلود کلیک کنید",
+		"view_api": "مشاهده api",
+		"built_with_Gradio": "ساخته شده با gradio"
+	}
+}


### PR DESCRIPTION
# Description

As a Persian user of Gradio, I thought it would be nice if it also supported my language. This helps Persian (Farsi) speakers use gradio with more ease. also, it would be my little contribution to this great project.

I simply used JSON files in `ui\packages\app\src\lang` directory as a blueprint and Created `fa.json` according to the guidelines in `README.md`.