### PR TITLE
Refresh rate

### DIFF
--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -629,6 +629,7 @@ class Interface:
         favicon_path: Optional[str] = None,
         ssl_keyfile: Optional[str] = None,
         ssl_certfile: Optional[str] = None,
+        ssl_keyfile_password: Optional[str] = None,
     ) -> Tuple[flask.Flask, str, str]:
         """
         Launches the webserver that serves the UI for the interface.
@@ -653,6 +654,7 @@ class Interface:
         favicon_path (str): If a path to a file (.png, .gif, or .ico) is provided, it will be used as the favicon for the web page.
         ssl_keyfile (str): If a path to a file is provided, will use this as the private key file to create a local server running on https.
         ssl_certfile (str): If a path to a file is provided, will use this as the signed certificate for https. Needs to be provided if ssl_keyfile is provided.
+        ssl_keyfile_password (str): If a password is provided, will use this with the ssl certificate for https.
         Returns:
         app (flask.Flask): Flask app object
         path_to_local_server (str): Locally accessible link
@@ -694,7 +696,8 @@ class Interface:
             cache_interface_examples(self)
 
         server_port, path_to_local_server, app, server = networking.start_server(
-            self, server_name, server_port, ssl_keyfile, ssl_certfile
+            self, server_name, server_port, ssl_keyfile, ssl_certfile, 
+            ssl_keyfile_password
         )
 
         self.local_url = path_to_local_server

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -146,7 +146,7 @@ class Interface:
         examples (Union[List[List[Any]], str]): sample inputs for the function; if provided, appears below the UI components and can be used to populate the interface. Should be nested list, in which the outer list consists of samples and each inner list consists of an input corresponding to each input component. A string path to a directory of examples can also be provided. If there are multiple input components and a directory is provided, a log.csv file must be present in the directory to link corresponding inputs.
         examples_per_page (int): If examples are provided, how many to display per page.
         live (bool): whether the interface should automatically reload on change in any of the inputs.
-        refresh_rate (float): the minimal amount of time, in seconds, between automatic reloads. 0 means reload whenever the input changes. Used only if live=True. 
+        refresh_rate (float): the minimal amount of time, in seconds, between automatic reloads. 0 means reload whenever the input changes. Used only if live=True.
         layout (str): Layout of input and output panels. "horizontal" arranges them as two columns of equal height, "unaligned" arranges them as two columns of unequal height, and "vertical" arranges them vertically.
         capture_session (bool): DEPRECATED. If True, captures the default graph and session (needed for Tensorflow 1.x)
         interpretation (Union[Callable, str]): function that provides interpretation explaining prediction output. Pass "default" to use simple built-in interpreter, "shap" to use a built-in shapley-based interpreter, or your own custom interpretation function.
@@ -699,8 +699,12 @@ class Interface:
             cache_interface_examples(self)
 
         server_port, path_to_local_server, app, server = networking.start_server(
-            self, server_name, server_port, ssl_keyfile, ssl_certfile, 
-            ssl_keyfile_password
+            self,
+            server_name,
+            server_port,
+            ssl_keyfile,
+            ssl_certfile,
+            ssl_keyfile_password,
         )
 
         self.local_url = path_to_local_server

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -108,6 +108,7 @@ class Interface:
         examples: Optional[List[Any] | List[List[Any]] | str] = None,
         examples_per_page: int = 10,
         live: bool = False,
+        refresh_rate: float = 0,
         layout: str = "unaligned",
         show_input: bool = True,
         show_output: bool = True,
@@ -144,7 +145,8 @@ class Interface:
         verbose (bool): DEPRECATED. Whether to print detailed information during launch.
         examples (Union[List[List[Any]], str]): sample inputs for the function; if provided, appears below the UI components and can be used to populate the interface. Should be nested list, in which the outer list consists of samples and each inner list consists of an input corresponding to each input component. A string path to a directory of examples can also be provided. If there are multiple input components and a directory is provided, a log.csv file must be present in the directory to link corresponding inputs.
         examples_per_page (int): If examples are provided, how many to display per page.
-        live (bool): whether the interface should automatically reload on change.
+        live (bool): whether the interface should automatically reload on change in any of the inputs.
+        refresh_rate (float): the minimal amount of time, in seconds, between automatic reloads. 0 means reload whenever the input changes. Used only if live=True. 
         layout (str): Layout of input and output panels. "horizontal" arranges them as two columns of equal height, "unaligned" arranges them as two columns of unequal height, and "vertical" arranges them vertically.
         capture_session (bool): DEPRECATED. If True, captures the default graph and session (needed for Tensorflow 1.x)
         interpretation (Union[Callable, str]): function that provides interpretation explaining prediction output. Pass "default" to use simple built-in interpreter, "shap" to use a built-in shapley-based interpreter, or your own custom interpretation function.
@@ -220,6 +222,7 @@ class Interface:
 
         self.status = "OFF"
         self.live = live
+        self.refresh_rate = refresh_rate
         self.layout = layout
         self.show_input = show_input
         self.show_output = show_output

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -76,6 +76,7 @@ def start_server(
     server_port: Optional[int] = None,
     ssl_keyfile: Optional[str] = None,
     ssl_certfile: Optional[str] = None,
+    ssl_keyfile_password: Optional[str] = None,
 ) -> Tuple[int, str, fastapi.FastAPI, threading.Thread, None]:
     """Launches a local server running the provided Interface
     Parameters:
@@ -85,6 +86,7 @@ def start_server(
     auth: If provided, username and password (or list of username-password tuples) required to access interface. Can also provide function that takes username and password and returns True if valid login.
     ssl_keyfile: If a path to a file is provided, will use this as the private key file to create a local server running on https.
     ssl_certfile: If a path to a file is provided, will use this as the signed certificate for https. Needs to be provided if ssl_keyfile is provided.
+    ssl_keyfile_password (str): If a password is provided, will use this with the ssl certificate for https.
     """
     server_name = server_name or LOCALHOST_NAME
     # if port is not specified, search for first available port
@@ -147,6 +149,7 @@ def start_server(
         log_level="warning",
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
+        ssl_keyfile_password=ssl_keyfile_password,
     )
     server = Server(config=config)
     server.run_in_thread()

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -189,6 +189,7 @@ def get_config_file(interface: Interface) -> Dict[str, Any]:
         ],
         "function_count": len(interface.predict),
         "live": interface.live,
+        "refresh_rate": interface.refresh_rate,
         "examples_per_page": interface.examples_per_page,
         "layout": interface.layout,
         "show_input": interface.show_input,


### PR DESCRIPTION
# Description

For demos in which the machine learning model has a large inference time, `live=True` causes issues as it reruns the model every time the input changes (e.g. on every keystroke for a text input model). A solution to this is add a parameter that delays the re-running of the model based on a user-specified `refresh_rate`.

This PR adds this functionality. Currently, the backend is implemented. The `Interface` class now takes a `refresh_rate` parameter, which is saved to the config file. By default, this is set to 0, which means that the output is refreshed every single time the input is changed at all. This is the current behavior, so this does not break any interfaces which currently have `live=True`. 

If this is provided as some value > 0, then the Interface should start a timer and make sure that at least `refresh_rate` seconds have passed before rerunning the input. @pngwn @dawoodkhan82 @aliabid94 can one of you take the front end for this?

Fixes: #645 