### PR TITLE
Switched from `json` to `orjson`

### DIFF
--- a/gradio.egg-info/requires.txt
+++ b/gradio.egg-info/requires.txt
@@ -5,6 +5,7 @@ ffmpy
 markdown-it-py[linkify,plugins]
 matplotlib
 numpy
+orjson
 pandas
 paramiko
 pillow

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -19,6 +19,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi.templating import Jinja2Templates
+from jinja2.exceptions import TemplateNotFound
 from starlette.responses import RedirectResponse
 
 from gradio import encryptor, queueing, utils
@@ -107,10 +108,15 @@ def main(request: Request, user: str = Depends(get_current_user)):
         config = app.interface.config
     else:
         config = {"auth_required": True, "auth_message": app.interface.auth_message}
-
-    return templates.TemplateResponse(
-        "frontend/index.html", {"request": request, "config": config}
-    )
+        
+    try:
+        return templates.TemplateResponse(
+            "frontend/index.html", {"request": request, "config": config}
+        )
+    except TemplateNotFound:
+        raise ValueError("Did you install Gradio from source files? You need to build "
+                         "the frontend by running /scripts/build_frontend.sh")
+        
 
 
 @app.get("/config/", dependencies=[Depends(login_check)])

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "markdown-it-py[linkify,plugins]",
         "matplotlib",
         "numpy",
+        "orjson",
         "pandas",
         "paramiko",
         "pillow",


### PR DESCRIPTION
Switched FastAPI from using `json` to `orjson` to render the responses.

**Why did we go from a built-in library to a 3rd-party library**? Understandable question...

- [orjson](https://github.com/ijl/orjson) is a well-maintained library that is faster than `json`, which means everything runs a tad bit faster, especially for large responses (e.g. images, big data frames, etc.)
-  More importantly, it correctly serializes things like `numpy` arrays and `pandas` dataframes, which `json` does not always handle correctly. This allows us to close #371 with a general fix