### PR TITLE
[hotfix] fixed loading from spaces

### DIFF
--- a/gradio/external.py
+++ b/gradio/external.py
@@ -294,7 +294,7 @@ def get_spaces_interface(model_name, api_key, alias):
 
     r = requests.get(iframe_url)
     result = re.search(
-        "window.gradio_config = (.*?);[\s]*</script>", r.text
+        r"window.gradio_config = (.*?);[\s]*</script>", r.text
     )  # some basic regex to extract the config
     try:
         config = json.loads(result.group(1))

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -294,7 +294,7 @@ def get_spaces_interface(model_name, api_key, alias):
 
     r = requests.get(iframe_url)
     result = re.search(
-        "window.gradio_config = (.*?);</script>", r.text
+        "window.gradio_config = (.*?);[\s]*</script>", r.text
     )  # some basic regex to extract the config
     try:
         config = json.loads(result.group(1))

--- a/gradio/inputs.py
+++ b/gradio/inputs.py
@@ -448,8 +448,8 @@ class Checkbox(InputComponent):
     """
 
     def __init__(
-        self, 
-        default: bool = False, 
+        self,
+        default: bool = False,
         label: Optional[str] = None,
         optional: bool = False,
     ):
@@ -1598,8 +1598,8 @@ class State(InputComponent):
     """
 
     def __init__(
-        self, 
-        label: str = None, 
+        self,
+        label: str = None,
         default: Any = None,
         optional: bool = False,
     ):

--- a/gradio/inputs.py
+++ b/gradio/inputs.py
@@ -123,6 +123,7 @@ class Textbox(InputComponent):
         numeric: Optional[bool] = False,
         type: Optional[str] = "str",
         label: Optional[str] = None,
+        optional: bool = False,
     ):
         """
         Parameters:
@@ -132,6 +133,7 @@ class Textbox(InputComponent):
         numeric (bool): DEPRECATED. Whether the input should be parsed as a number instead of a string.
         type (str): DEPRECATED. Type of value to be returned by component. "str" returns a string, "number" returns a float value. Use Number component in place of number type.
         label (str): component name in interface.
+        optional (bool): this parameter is ignored.
         """
         self.lines = lines
         self.placeholder = placeholder
@@ -356,6 +358,7 @@ class Slider(InputComponent):
         step: Optional[float] = None,
         default: Optional[float] = None,
         label: Optional[str] = None,
+        optional: bool = False,
     ):
         """
         Parameters:
@@ -364,6 +367,7 @@ class Slider(InputComponent):
         step (float): increment between slider values.
         default (float): default value.
         label (str): component name in interface.
+        optional (bool): this parameter is ignored.
         """
         self.minimum = minimum
         self.maximum = maximum
@@ -443,11 +447,17 @@ class Checkbox(InputComponent):
     Demos: sentence_builder, titanic_survival
     """
 
-    def __init__(self, default: bool = False, label: Optional[str] = None):
+    def __init__(
+        self, 
+        default: bool = False, 
+        label: Optional[str] = None,
+        optional: bool = False,
+    ):
         """
         Parameters:
         label (str): component name in interface.
         default (bool): if True, checked by default.
+        optional (bool): this parameter is ignored.
         """
         self.test_input = True
         self.default = default
@@ -515,6 +525,7 @@ class CheckboxGroup(InputComponent):
         default: List[str] = [],
         type: str = "value",
         label: Optional[str] = None,
+        optional: bool = False,
     ):
         """
         Parameters:
@@ -522,6 +533,7 @@ class CheckboxGroup(InputComponent):
         default (List[str]): default selected list of options.
         type (str): Type of value to be returned by component. "value" returns the list of strings of the choices selected, "index" returns the list of indicies of the choices selected.
         label (str): component name in interface.
+        optional (bool): this parameter is ignored.
         """
         self.choices = choices
         self.default = default
@@ -612,6 +624,7 @@ class Radio(InputComponent):
         type: str = "value",
         default: Optional[str] = None,
         label: Optional[str] = None,
+        optional: bool = False,
     ):
         """
         Parameters:
@@ -619,6 +632,7 @@ class Radio(InputComponent):
         type (str): Type of value to be returned by component. "value" returns the string of the choice selected, "index" returns the index of the choice selected.
         default (str): the button selected by default. If None, no button is selected by default.
         label (str): component name in interface.
+        optional (bool): this parameter is ignored.
         """
         self.choices = choices
         self.type = type
@@ -688,6 +702,7 @@ class Dropdown(InputComponent):
         type: str = "value",
         default: Optional[str] = None,
         label: Optional[str] = None,
+        optional: bool = False,
     ):
         """
         Parameters:
@@ -695,6 +710,7 @@ class Dropdown(InputComponent):
         type (str): Type of value to be returned by component. "value" returns the string of the choice selected, "index" returns the index of the choice selected.
         default (str): default value selected in dropdown. If None, no value is selected by default.
         label (str): component name in interface.
+        optional (bool): this parameter is ignored.
         """
         self.choices = choices
         self.type = type
@@ -1401,6 +1417,7 @@ class Dataframe(InputComponent):
         default: Optional[List[List[Any]]] = None,
         type: str = "pandas",
         label: Optional[str] = None,
+        optional: bool = False,
     ):
         """
         Parameters:
@@ -1412,6 +1429,7 @@ class Dataframe(InputComponent):
         default (List[List[Any]]): Default value
         type (str): Type of value to be returned by component. "pandas" for pandas dataframe, "numpy" for numpy array, or "array" for a Python array.
         label (str): component name in interface.
+        optional (bool): this parameter is ignored.
         """
         self.headers = headers
         self.datatype = datatype
@@ -1579,11 +1597,17 @@ class State(InputComponent):
     Demos: chatbot
     """
 
-    def __init__(self, label: str = None, default: Any = None):
+    def __init__(
+        self, 
+        label: str = None, 
+        default: Any = None,
+        optional: bool = False,
+    ):
         """
         Parameters:
         label (str): component name in interface (not used).
         default (Any): the initial value of the state.
+        optional (bool): this parameter is ignored.
         """
 
         self.default = default


### PR DESCRIPTION
Spaces changed how they were rendering Gradio demos, so this broke our regex for extracting the config for the demo. This hotfixes it, though perhaps we should identify a more robust solution for extracting the config.

