### PR TITLE
Fix search bug in guides

### DIFF
--- a/website/homepage/render_html.py
+++ b/website/homepage/render_html.py
@@ -52,8 +52,11 @@ def render_index():
         generated_template.write(output_html)
 
 
+guide_files = ["getting_started.md"]
+all_guides = sorted(os.listdir(GRADIO_GUIDES_DIR))
+guide_files.extend([file for file in all_guides if file != "getting_started.md"])
 guides = []
-for guide in sorted(os.listdir(GRADIO_GUIDES_DIR)):
+for guide in guide_files:
     if guide.lower() == "readme.md":
         continue
     guide_name = guide[:-3]
@@ -107,10 +110,9 @@ for guide in sorted(os.listdir(GRADIO_GUIDES_DIR)):
 
 
 def render_guides_main():
-    filtered_guides = [guide for guide in guides if guide["name"] != "getting_started"]
     with open("src/guides_main_template.html", encoding="utf-8") as template_file:
         template = Template(template_file.read())
-        output_html = template.render(guides=filtered_guides, navbar_html=navbar_html)
+        output_html = template.render(guides=guides, navbar_html=navbar_html)
     os.makedirs(os.path.join("generated", "guides"), exist_ok=True)
     with open(
         os.path.join("generated", "guides", "index.html"), "w", encoding="utf-8"

--- a/website/homepage/src/guides_main_template.html
+++ b/website/homepage/src/guides_main_template.html
@@ -122,18 +122,6 @@
     </div>
 
     <div id="guide-list" class="grid grid-cols-1 lg:grid-cols-3 gap-12 pt-12">
-
-      <a class="flex lg:col-span-1 flex-col group overflow-hidden relative rounded-xl shadow-sm hover:shadow-alternate transition-shadow" href="/getting_started">
-        <div class="flex flex-col p-4" style="
-      height: min-content;">
-          <h2 class="font-semibold group-hover:underline text-xl">Getting Started
-          </h2>
-          <div class="tags-holder">
-          </div>
-        </div>
-      </a>
-
-
       {% for guide in guides %}
       <a class="flex lg:col-span-1 flex-col group overflow-hidden relative rounded-xl shadow-sm hover:shadow-alternate transition-shadow" href="/{{ guide.name }}">
         <div class="flex flex-col p-4" style="
@@ -141,12 +129,14 @@
           <h2 class="font-semibold group-hover:underline text-xl">{{ guide.pretty_name }}
           </h2>
           <div class="tags-holder">
+            {% if guide.tags is not none %}
             <p>
               {% for tag in guide.tags %}
                 {{ tag }}<!--
              -->{% if not loop.last %}, {% endif %}
               {% endfor %}
             </p>
+            {% endif %}
           </div>
         </div>
       </a>
@@ -232,7 +222,7 @@
       if (txtValue.toUpperCase().indexOf(filter) > -1 || guideContent.toUpperCase().indexOf(filter) > -1) {
         a[{{ loop.index - 1}}].style.display = "";
       } else {
-        a[{{ loop.index - 1 }}].style.display = "none";
+        a[{{ loop.index - 1}}].style.display = "none";
         counter++;
       }
     {% endfor %}


### PR DESCRIPTION
Small issue with search in guides where getting_started caused an off by one error. Fixed now, getting started is always the first guide, but is still included in search.