### PR TITLE
Adding custom css kwarg directly to a component [WIP]

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -7,8 +7,9 @@ from gradio.routes import PredictBody
 
 
 class Block:
-    def __init__(self):
+    def __init__(self, css=None):
         self._id = Context.id
+        self.css = css
         Context.id += 1
         if Context.block is not None:
             Context.block.children.append(self)


### PR DESCRIPTION
# Directly adding custom CSS to components

Users should be able to add css directly to components without having to know class names of elements. Adding a css kwarg to all components will make this possible in most basic cases:

e.g.

A red button:
```python
gr.Button(css={"background-color": "pink", "color": "red"})
```

A custom layout resembling the current Interface
```python
with gr.Row(css={"gap": "2rem"}):
  with gr.Column(css={
    "background-color": "whitesmoke",
    "padding": "2rem",
    "border-radius": "1rem"
  }):
    # components
    with gr.Row():
      clear = gr.Button()
      submit = gr.Button(css={"background-color": "orange"})
  # ...
```

CSS variables can also be passed in at any component level or at the top Blocks element:
```python
app = Blocks(css={"--primary-color": "red"})

with app:
   gr.Button(css={"--secondary-color": "blue"})
```

