### PR TITLE
Add better default labels to form elements

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -225,7 +225,7 @@ class Textbox(Component):
         *,
         lines: int = 1,
         placeholder: Optional[str] = None,
-        label: Optional[str] = None,
+        label: Optional[str] = "Textbox",
         css: Optional[Dict] = None,
         **kwargs,
     ):


### PR DESCRIPTION
Some fix(es) that I noticed going through the demos:

- added default label of Textbox to be Textbox (to avoid the "null" label being shown up by default, see below)

<img width="718" alt="image" src="https://user-images.githubusercontent.com/1778297/162051244-3551c949-47b3-4bb2-8caf-9963ddfbf74b.png">
