### PR TITLE
Fixes dataframe nulls

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2038,18 +2038,16 @@ class Dataframe(Component):
             "number": 0,
             "bool": False,
             "date": "01/01/1970",
-        }        
+        }
         column_dtypes = (
             [datatype] * self.col_count if isinstance(datatype, str) else datatype
         )
         self.test_input = [
             [default_values[c] for c in column_dtypes] for _ in range(row_count)
-        ]        
+        ]
         self.default_value = (
-            default_value
-            if default_value is not None
-            else self.test_input
-        )        
+            default_value if default_value is not None else self.test_input
+        )
         self.max_rows = max_rows
         self.max_cols = max_cols
         self.overflow_row_behaviour = overflow_row_behaviour

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2033,23 +2033,23 @@ class Dataframe(Component):
         self.col_width = col_width
         self.type = type
         self.output_type = "auto"
-        self.default_value = (
-            default_value
-            if default_value is not None
-            else [[None for _ in range(self.col_count)] for _ in range(self.row_count)]
-        )
-        sample_values = {
-            "str": "abc",
-            "number": 786,
-            "bool": True,
-            "date": "02/08/1993",
-        }
+        default_values = {
+            "str": "",
+            "number": 0,
+            "bool": False,
+            "date": "01/01/1970",
+        }        
         column_dtypes = (
             [datatype] * self.col_count if isinstance(datatype, str) else datatype
         )
         self.test_input = [
-            [sample_values[c] for c in column_dtypes] for _ in range(row_count)
-        ]
+            [default_values[c] for c in column_dtypes] for _ in range(row_count)
+        ]        
+        self.default_value = (
+            default_value
+            if default_value is not None
+            else self.test_input
+        )        
         self.max_rows = max_rows
         self.max_cols = max_cols
         self.overflow_row_behaviour = overflow_row_behaviour

--- a/gradio/templates/frontend/index.html
+++ b/gradio/templates/frontend/index.html
@@ -45,8 +45,8 @@
 		</script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js"></script>
 		<title>Gradio</title>
-		<script type="module" crossorigin src="./assets/index.8cbcb26d.js"></script>
-		<link rel="stylesheet" href="./assets/index.4f55c05a.css">
+		<script type="module" crossorigin src="./assets/index.693bb58e.js"></script>
+		<link rel="stylesheet" href="./assets/index.38c11487.css">
 	</head>
 
 	<body style="height: 100%; margin: 0; padding: 0">

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -832,9 +832,9 @@ class TestDataframe(unittest.TestCase):
                 "col_count": 3,
                 "col_width": None,
                 "default_value": [
-                    [None, None, None],
-                    [None, None, None],
-                    [None, None, None],
+                    ["", "", ""],
+                    ["", "", ""],
+                    ["", "", ""],
                 ],
                 "name": "dataframe",
                 "label": "Dataframe Input",

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -882,9 +882,9 @@ class TestDataframe(unittest.TestCase):
                 "col_count": 3,
                 "col_width": None,
                 "default_value": [
-                    [None, None, None],
-                    [None, None, None],
-                    [None, None, None],
+                    ["", "", ""],
+                    ["", "", ""],
+                    ["", "", ""],
                 ],
             },
         )

--- a/test/test_inputs.py
+++ b/test/test_inputs.py
@@ -594,9 +594,9 @@ class TestDataframe(unittest.TestCase):
                 "col_count": 3,
                 "col_width": None,
                 "default_value": [
-                    [None, None, None],
-                    [None, None, None],
-                    [None, None, None],
+                    ["", "", ""],
+                    ["", "", ""],
+                    ["", "", ""],
                 ],
                 "name": "dataframe",
                 "label": "Dataframe Input",

--- a/test/test_outputs.py
+++ b/test/test_outputs.py
@@ -369,9 +369,9 @@ class TestDataframe(unittest.TestCase):
                 "col_count": 3,
                 "col_width": None,
                 "default_value": [
-                    [None, None, None],
-                    [None, None, None],
-                    [None, None, None],
+                    ["", "", ""],
+                    ["", "", ""],
+                    ["", "", ""],
                 ],
                 "name": "dataframe",
             },


### PR DESCRIPTION
Replaces nulls with "" (for str type), 0 (for number), False (for boolean), or "01/01/1970" (for date)

So for example, the `demo\filter_records` demo looks like this:

<img width="950" alt="image" src="https://user-images.githubusercontent.com/1778297/163064303-743cb697-775d-48c6-8d15-9e682bd3ca84.png">
