### PR TITLE
Fixed image input for absolute path

### DIFF
--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -212,7 +212,7 @@ def file(path):
             io.BytesIO(file_data), attachment_filename=os.path.basename(path)
         )
     else:
-        return FileResponse(safe_join(app.cwd, path))
+        return FileResponse(app.cwd, path)
 
 
 @app.get("/api", response_class=HTMLResponse)  # Needed for Spaces

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -10,6 +10,7 @@ import secrets
 import traceback
 import urllib
 from typing import Any, Dict, List, Optional, Tuple, Type
+from pathlib import Path
 
 import orjson
 import pkg_resources
@@ -212,7 +213,9 @@ def file(path):
             io.BytesIO(file_data), attachment_filename=os.path.basename(path)
         )
     else:
-        return FileResponse(app.cwd, path)
+        if Path(app.cwd) in Path(path).parents:
+            path = str(Path(path).relative_to(app.cwd))
+        return FileResponse(safe_join(app.cwd, path))
 
 
 @app.get("/api", response_class=HTMLResponse)  # Needed for Spaces
@@ -333,7 +336,7 @@ def safe_join(directory: str, path: str) -> Optional[str]:
     _os_alt_seps: List[str] = list(
         sep for sep in [os.path.sep, os.path.altsep] if sep is not None and sep != "/"
     )
-
+    
     if path != "":
         filename = posixpath.normpath(path)
 
@@ -344,7 +347,6 @@ def safe_join(directory: str, path: str) -> Optional[str]:
         or filename.startswith("../")
     ):
         return None
-
     return posixpath.join(directory, filename)
 
 

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -9,8 +9,8 @@ import posixpath
 import secrets
 import traceback
 import urllib
-from typing import Any, Dict, List, Optional, Tuple, Type
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 import orjson
 import pkg_resources
@@ -213,9 +213,8 @@ def file(path):
             io.BytesIO(file_data), attachment_filename=os.path.basename(path)
         )
     else:
-        if Path(app.cwd) in Path(path).parents:
-            path = str(Path(path).relative_to(app.cwd))
-        return FileResponse(safe_join(app.cwd, path))
+        if Path(app.cwd).resolve() in Path(path).resolve().parents:
+            return FileResponse(Path(path).resolve())
 
 
 @app.get("/api", response_class=HTMLResponse)  # Needed for Spaces
@@ -336,7 +335,7 @@ def safe_join(directory: str, path: str) -> Optional[str]:
     _os_alt_seps: List[str] = list(
         sep for sep in [os.path.sep, os.path.altsep] if sep is not None and sep != "/"
     )
-    
+
     if path != "":
         filename = posixpath.normpath(path)
 


### PR DESCRIPTION
Changed the File function in route.py to make image input available for absolute path.
I tested the absolute, relative path and same folder for image, and it worked properly.

# Description

Please include: 
* relevant motivation
* a summary of the change
* which issue is fixed. 
* any additional dependencies that are required for this change.

Fixes: #988  (issue)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
