### PR TITLE
Update readmes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Prequisites:
 
 More than 30 awesome developers have contributed to the `gradio` library, and we'd be thrilled if you would like be the next `gradio` contributor! You can start by forking or cloning the repo (https://github.com/gradio-app/gradio.git) and creating your own branch to work from.
 
-### Install Gradio locally from the `master` branch
+### Install Gradio locally from the `main` branch
 
 * Clone this repo
 * Navigate to the repo folder and run
@@ -51,7 +51,7 @@ It's helpful to know the overall structure of the repository so that you can foc
 
 * `/gradio`: contains the Python source code for the library
     * `/gradio/interface.py`: contains the Python source code for the core `Interface` class (**start HERE!**)
-* `/frontend`: contains the HTML/JS/CSS source code for the library
+* `/ui`: contains the HTML/JS/CSS source code for the library
 * `/test`: contains Python unit tests for the library
 * `/demo`: contains demos that are used in the documentation as well as for integration tests
 * `/website`: contains the code for the Gradio website (www.gradio.app). See the README in the `/website` folder for more details
@@ -62,7 +62,7 @@ All PRs must pass the continuous integration tests before merging. To test local
 
 ## Submitting PRs
 
-All PRs should be against `master`. Direct commits to master are blocked, and PRs require an approving review to merge into master. By convention, the Gradio maintainers will review PRs when:
+All PRs should be against `main`. Direct commits to main are blocked, and PRs require an approving review to merge into main. By convention, the Gradio maintainers will review PRs when:
 
 * An initial review has been requested, and
 * A maintainer (@abidlabs, @aliabid94, @aliabd, @AK391, or @dawoodkhan82) is tagged in the PR comments and asked to complete a review

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ It's helpful to know the overall structure of the repository so that you can foc
 
 * `/gradio`: contains the Python source code for the library
     * `/gradio/interface.py`: contains the Python source code for the core `Interface` class (**start HERE!**)
-* `/ui`: contains the HTML/JS/CSS source code for the library
+* `/ui`: contains the HTML/JS/CSS source code for the library ([start here for frontend changes](/ui/README.md))
 * `/test`: contains Python unit tests for the library
 * `/demo`: contains demos that are used in the documentation as well as for integration tests
 * `/website`: contains the code for the Gradio website (www.gradio.app). See the README in the `/website` folder for more details

--- a/ui/README.md
+++ b/ui/README.md
@@ -31,7 +31,7 @@ This will install the dependencies for all packages within the `ui` folder and l
 
 ## local development
 
-To develop locally, open two browser tabs from the root of the repository.
+To develop locally, open two terminal tabs from the root of the repository.
 
 Run the python test server, from the root directory:
 
@@ -40,7 +40,7 @@ cd demo/kitchen_sink
 python run.py
 ```
 
-This will start a development server on port `7863` that the web app is expecting.
+This will start a development server on port `7860` that the web app is expecting.
 
 Run the web app:
 

--- a/ui/packages/app/src/main.ts
+++ b/ui/packages/app/src/main.ts
@@ -62,7 +62,7 @@ window.launchGradio = (config: Config, element_query: string) => {
 
 	if (!target) {
 		throw new Error(
-			"The target element could not be found. Please ensure atht element exists."
+			"The target element could not be found. Please ensure that element exists."
 		);
 	}
 


### PR DESCRIPTION
# Description

These were just minor things I noticed while navigating this repo for the first time.

**CONTRIBUTING.md**
- master -> main
- /frontend -> /ui
- run_tests.sh -> run_all_tests.sh (note the actual filename has a typo `run_all_tests,.sh` but I've left this as-is in case editing it has flow-on effects for CI)

**ui/README.md**
- add a link to this from the contributing guide
- port 7863 -> 7860
- "open two browser tabs" -> "open two terminal tabs" for commands

**main.ts**
- "Please ensure atht element exists." -> "Please ensure that element exists.""