### PR TITLE
fixed failing test on main

### DIFF
--- a/gradio/templates/frontend/index.html
+++ b/gradio/templates/frontend/index.html
@@ -55,7 +55,7 @@
 		</script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js"></script>
 		<title>Gradio</title>
-		<script type="module" crossorigin src="./assets/index.ebb592c6.js"></script>
+		<script type="module" crossorigin src="./assets/index.a2163344.js"></script>
 		<link rel="stylesheet" href="./assets/index.39bf42f9.css">
 	</head>
 

--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -34,8 +34,7 @@ class ImagePreprocessing(unittest.TestCase):
 
     def test_encode_url_to_base64(self):
         output_base64 = gr.processing_utils.encode_url_to_base64(
-            "https://raw.githubusercontent.com/gradio-app/gradio/master/test"
-            "/test_data/test_image.png"
+            "https://raw.githubusercontent.com/gradio-app/gradio/main/gradio/test_data/test_image.png"
         )
         self.assertEqual(output_base64, deepcopy(media_data.BASE64_IMAGE))
 


### PR DESCRIPTION
Because of the ways the files were reorganized in `blocks-dev`, one of the tests that loaded an image from a URL from the GitHub repo failed. This hotfixes it.