### PR TITLE
Use smaller ASR model in external test

### DIFF
--- a/test/test_external.py
+++ b/test/test_external.py
@@ -214,7 +214,7 @@ class TestLoadInterface(unittest.TestCase):
 
     def test_speech_recognition_model(self):
         interface_info = gr.external.load_interface(
-            "models/facebook/wav2vec2-large-960h-lv60-self"
+            "models/facebook/wav2vec2-base-960h"
         )
         io = gr.Interface(**interface_info)
         io.api_mode = True


### PR DESCRIPTION
The `facebook/wav2vec2-large` takes a long time to load which causes our `external` tests to fail sometimes. This replaces it with `facebook/wav2vec2-base-960h`, which is more reliable (I had made this change in `blocks-dev`, but it didn't get ported over)