### PR TITLE
Explicitly list pnpm version 6 in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Prequisites:
 
 * Python 3.7+
 * Node 16.0+ (optional for backend-only changes, but needed for any frontend changes)
+* pnpm version 6.x
 
 More than 30 awesome developers have contributed to the `gradio` library, and we'd be thrilled if you would like be the next `gradio` contributor! You can start by forking or cloning the repo (https://github.com/gradio-app/gradio.git) and creating your own branch to work from.
 
@@ -36,7 +37,7 @@ bash scripts/install_test_requirements.sh
 * Run the tests
 
 ```
-bash scripts/run_tests.sh
+bash scripts/run_all_tests.sh
 ```
 
 * You can also start a local frontend development server (on port 3000 by default) that responds to any changes in the frontend.


### PR DESCRIPTION
# Description

Small change to contributing guide to explicitly list pnpm version 6 as a requirement. 

Closes: #1084

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
