### PR TITLE
Website Reload Error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,6 @@ from pathlib import Path
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
-print(long_description)
-
 setup(
     name="gradio",
     version="2.9.0b9",

--- a/website/homepage/Dockerfile
+++ b/website/homepage/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /gradio
 COPY ./gradio ./gradio
 COPY ./setup.py ./setup.py
 COPY ./MANIFEST.in ./MANIFEST.in
+COPY ./README.md ./README.md
 RUN python setup.py install
 WORKDIR /gradio
 COPY ./website ./website


### PR DESCRIPTION
- Fixing the website reload error. `README.md` was missing from the docker but referenced in `setup.py`
- Removing a print statement from `setup.py`