### PR TITLE
Examples state

### DIFF
--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -202,10 +202,12 @@ class Interface(Blocks):
             state_variable = Variable(default_value=default)
             inputs[inputs.index("state")] = state_variable
             outputs[outputs.index("state")] = state_variable
-            
+
             if cache_examples:
-                warnings.warn("Cache examples cannot be used with state inputs and outputs."
-                              "Setting cache_examples to False.")
+                warnings.warn(
+                    "Cache examples cannot be used with state inputs and outputs."
+                    "Setting cache_examples to False."
+                )
             self.cache_examples = False
 
         self.input_components = [get_component_instance(i).unrender() for i in inputs]
@@ -604,8 +606,10 @@ class Interface(Blocks):
                 ),
             )
             if self.examples:
-                non_state_inputs = [c for c in self.input_components if not isinstance(c, Variable)]
-                    
+                non_state_inputs = [
+                    c for c in self.input_components if not isinstance(c, Variable)
+                ]
+
                 examples = Dataset(
                     components=non_state_inputs,
                     samples=self.examples,


### PR DESCRIPTION
Fixes examples for stateful interfaces. Closes: #851

You can test with a code snippet like the following:

```py
import random

import gradio as gr


def chat(message, history):
    history = history or []
    if message.startswith("How many"):
        response = random.randint(1, 10)
    elif message.startswith("How"):
        response = random.choice(["Great", "Good", "Okay", "Bad"])
    elif message.startswith("Where"):
        response = random.choice(["Here", "There", "Somewhere"])
    else:
        response = "I don't know"
    history.append((message, response))
    return history, history


iface = gr.Interface(
    chat,
    ["text", "state"],
    ["chatbot", "state"],
    allow_screenshot=False,
    allow_flagging="never",
    examples=[["How many?"], ["How are you?"]]
)

iface.launch()
```