### PR TITLE
move styling for interface panels to frontend

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -166,7 +166,7 @@ class Column(BlockContext):
     ):
         """
         css: Css rules to apply to block.
-        variant: row type, 'default' or 'panel'
+        variant: column type, 'default' (no background) or 'panel' (gray background color and rounded corners)
         """
         self.variant = variant
         super().__init__(visible, css)

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -158,15 +158,23 @@ class Row(BlockContext):
 
 
 class Column(BlockContext):
-    def __init__(self, visible: bool = True, css: Optional[Dict[str, str]] = None):
+    def __init__(
+        self,
+        visible: bool = True,
+        css: Optional[Dict[str, str]] = None,
+        variant: str = "default",
+    ):
         """
         css: Css rules to apply to block.
+        variant: row type, 'default' or 'panel'
         """
+        self.variant = variant
         super().__init__(visible, css)
 
     def get_template_context(self):
         return {
             "type": "column",
+            "variant": self.variant,
             **super().get_template_context(),
         }
 

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -468,13 +468,7 @@ class Interface(Blocks):
                     self.InterfaceTypes.INPUT_ONLY,
                     self.InterfaceTypes.UNIFIED,
                 ]:
-                    with Column(
-                        css={
-                            "background-color": "rgb(249,250,251)",
-                            "padding": "0.5rem",
-                            "border-radius": "0.5rem",
-                        }
-                    ):
+                    with Column(variant="panel"):
                         input_component_column = Column()
                         if self.interface_type in [
                             self.InterfaceTypes.INPUT_ONLY,
@@ -516,13 +510,7 @@ class Interface(Blocks):
                     self.InterfaceTypes.OUTPUT_ONLY,
                 ]:
 
-                    with Column(
-                        css={
-                            "background-color": "rgb(249,250,251)",
-                            "padding": "0.5rem",
-                            "border-radius": "0.5rem",
-                        }
-                    ):
+                    with Column(variant="panel"):
                         status_tracker = StatusTracker(cover_container=True)
                         for component in self.output_components:
                             component.render()

--- a/ui/packages/app/src/Render.svelte
+++ b/ui/packages/app/src/Render.svelte
@@ -49,9 +49,12 @@
 	];
 
 	function get_types(i) {
-		const current = children[i]?.id && instance_map[children[i].id];
-		const next = children[i + 1]?.id && instance_map[children[i + 1].id];
-		const prev = children[i - 1]?.id && instance_map[children[i - 1].id];
+		const current =
+			children[i]?.id != undefined && instance_map[children[i].id];
+		const next =
+			children[i + 1]?.id != undefined && instance_map[children[i + 1].id];
+		const prev =
+			children[i - 1]?.id != undefined && instance_map[children[i - 1].id];
 
 		return {
 			current: current?.type && forms.includes(current.type),

--- a/ui/packages/app/src/components/Column/Column.svelte
+++ b/ui/packages/app/src/components/Column/Column.svelte
@@ -2,13 +2,19 @@
 	export let value: boolean = true;
 	export let default_value: boolean;
 	export let style: string = "";
+	export let variant: "default" | "panel" = "default";
 
 	if (default_value) value = default_value;
+
+	$: console.log($$props);
 </script>
 
 <div
 	{style}
 	class:hidden={!value}
+	class:bg-gray-50={variant === "panel"}
+	class:p-2={variant === "panel"}
+	class:rounded-lg={variant === "panel"}
 	class="flex flex-1 flex-col gr-gap gr-form-gap relative"
 >
 	<slot />

--- a/ui/packages/app/src/components/Column/Column.svelte
+++ b/ui/packages/app/src/components/Column/Column.svelte
@@ -5,8 +5,6 @@
 	export let variant: "default" | "panel" = "default";
 
 	if (default_value) value = default_value;
-
-	$: console.log($$props);
 </script>
 
 <div


### PR DESCRIPTION
Adds a `variant` kwarg to `Column`. Closes #999.

@gary149 If you want to tweak the 'panel' styling for interfaces, feel feree to push to this branch. 