### PR TITLE
enable flex grow for gr-box

### DIFF
--- a/ui/packages/theme/src/tokens.css
+++ b/ui/packages/theme/src/tokens.css
@@ -4,6 +4,7 @@
 	relative 
 	rounded-lg 
 	bg-white 
+	flex-1
 	shadow-sm;
 }
 


### PR DESCRIPTION
# Description

For individual elements on a row, use `flex-1` so it grows and shrinks as needed

Before:
<img width="775" alt="image" src="https://user-images.githubusercontent.com/102277/166978545-0efd6a83-13fc-4b3e-8eea-1d1ba4dd3405.png">

After:

<img width="645" alt="image" src="https://user-images.githubusercontent.com/102277/166978654-616c0b9e-b9d4-4948-a4a8-8b4866bf4e4f.png">

