### PR TITLE
1183 component height

### DIFF
--- a/demo/blocks_layout/run.py
+++ b/demo/blocks_layout/run.py
@@ -1,4 +1,3 @@
-from matplotlib import interactive
 import gradio as gr
 
 

--- a/demo/blocks_layout/run.py
+++ b/demo/blocks_layout/run.py
@@ -1,0 +1,23 @@
+from matplotlib import interactive
+import gradio as gr
+
+
+demo = gr.Blocks()
+
+with demo:
+    with gr.Row():
+
+        gr.Image(interactive=True)
+        gr.Image()
+    with gr.Row():
+        with gr.Row():
+            gr.Image(interactive=True)
+            gr.Image()
+            with gr.Column():
+                gr.Image(interactive=True)
+                gr.Image()
+    gr.Image()
+
+
+if __name__ == "__main__":
+    demo.launch()

--- a/demo/blocks_layout/run.py
+++ b/demo/blocks_layout/run.py
@@ -6,17 +6,26 @@ demo = gr.Blocks()
 
 with demo:
     with gr.Row():
-
         gr.Image(interactive=True)
         gr.Image()
     with gr.Row():
+        gr.Textbox(label="Text")
+        gr.Number(label="Count")
+        gr.Radio(choices=["One", "Two"])
+    with gr.Row():
         with gr.Row():
-            gr.Image(interactive=True)
+            with gr.Column():
+                gr.Textbox(label="Text")
+                gr.Number(label="Count")
+                gr.Radio(choices=["One", "Two"])
             gr.Image()
             with gr.Column():
                 gr.Image(interactive=True)
                 gr.Image()
     gr.Image()
+    gr.Textbox(label="Text")
+    gr.Number(label="Count")
+    gr.Radio(choices=["One", "Two"])
 
 
 if __name__ == "__main__":

--- a/ui/packages/app/src/Blocks.svelte
+++ b/ui/packages/app/src/Blocks.svelte
@@ -3,6 +3,7 @@
 	import { component_map } from "./components/directory";
 	import { loading_status } from "./stores";
 	import type { LoadingStatus } from "./stores";
+	import { Component as Column } from "./components/Column";
 
 	import { _ } from "svelte-i18n";
 	import { setupi18n } from "./i18n";
@@ -193,8 +194,6 @@
 				target_instances.forEach(([id, { instance }]: [number, Instance]) => {
 					if (handled_dependencies[i]?.includes(id) || !instance) return;
 					instance?.$on(trigger, () => {
-						console.log(loading_status.get_status_for_fn(i));
-
 						if (loading_status.get_status_for_fn(i) === "pending") {
 							return;
 						}
@@ -259,25 +258,27 @@
 	{/if}
 </svelte:head>
 
-<div class="mx-auto container space-y-4 px-4 py-6 dark:bg-gray-950">
-	{#if tree}
-		{#each tree as { component, id, props, children, has_modes }}
-			<Render
-				{has_modes}
-				{dynamic_ids}
-				{component}
-				{id}
-				{props}
-				{children}
-				{instance_map}
-				{theme}
-				{root}
-				{status_tracker_values}
-				on:mount={handle_mount}
-				on:destroy={({ detail }) => handle_destroy(detail)}
-			/>
-		{/each}
-	{/if}
+<div class="mx-auto container px-4 py-6 dark:bg-gray-950">
+	<Column default_value={true}>
+		{#if tree}
+			{#each tree as { component, id, props, children, has_modes }}
+				<Render
+					{has_modes}
+					{dynamic_ids}
+					{component}
+					{id}
+					{props}
+					{children}
+					{instance_map}
+					{theme}
+					{root}
+					{status_tracker_values}
+					on:mount={handle_mount}
+					on:destroy={({ detail }) => handle_destroy(detail)}
+				/>
+			{/each}
+		{/if}
+	</Column>
 </div>
 <div
 	class="gradio-page container mx-auto flex flex-col box-border flex-grow text-gray-700 dark:text-gray-50"

--- a/ui/packages/app/src/Render.svelte
+++ b/ui/packages/app/src/Render.svelte
@@ -90,7 +90,6 @@
 		children.filter((v) => instance_map[v.id].type !== "statustracker");
 
 	setContext(BLOCK_KEY, parent);
-	console.log(parent, children, instance_map[id]);
 </script>
 
 <svelte:component

--- a/ui/packages/app/src/Render.svelte
+++ b/ui/packages/app/src/Render.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { onMount, createEventDispatcher } from "svelte";
+	import { onMount, createEventDispatcher, setContext } from "svelte";
+	import { BLOCK_KEY } from "@gradio/atoms";
 
 	export let root: string;
 	export let component;
@@ -11,6 +12,7 @@
 	export let dynamic_ids: Set<number>;
 	export let has_modes: boolean;
 	export let status_tracker_values: Record<number, string>;
+	export let parent: string | null = null;
 
 	const dispatch = createEventDispatcher<{ mount: number; destroy: number }>();
 
@@ -86,6 +88,9 @@
 	children =
 		children &&
 		children.filter((v) => instance_map[v.id].type !== "statustracker");
+
+	setContext(BLOCK_KEY, parent);
+	console.log(parent, children, instance_map[id]);
 </script>
 
 <svelte:component
@@ -98,10 +103,11 @@
 	tracked_status={status_tracker_values[id]}
 >
 	{#if children && children.length}
-		{#each children as { component, id, props, children, has_modes } (id)}
+		{#each children as { component, id: each_id, props, children, has_modes } (each_id)}
 			<svelte:self
+				parent={instance_map[id].type}
 				{component}
-				{id}
+				id={each_id}
 				{props}
 				{theme}
 				{root}

--- a/ui/packages/app/src/api.ts
+++ b/ui/packages/app/src/api.ts
@@ -122,8 +122,6 @@ export const fn = async (
 			session_hash
 		});
 
-		console.log();
-
 		loading_status.update(
 			fn_index,
 			"complete",

--- a/ui/packages/app/src/components/Column/Column.svelte
+++ b/ui/packages/app/src/components/Column/Column.svelte
@@ -14,7 +14,7 @@
 	class:bg-gray-50={variant === "panel"}
 	class:p-2={variant === "panel"}
 	class:rounded-lg={variant === "panel"}
-	class="flex flex-col gr-gap gr-form-gap relative"
+	class="flex flex-col gr-gap gr-form-gap relative col"
 	class:flex-1={parent === "row" || !parent}
 >
 	<slot />

--- a/ui/packages/app/src/components/Column/Column.svelte
+++ b/ui/packages/app/src/components/Column/Column.svelte
@@ -3,6 +3,7 @@
 	export let default_value: boolean;
 	export let style: string = "";
 	export let variant: "default" | "panel" = "default";
+	export let parent: string | null = null;
 
 	if (default_value) value = default_value;
 </script>
@@ -13,7 +14,8 @@
 	class:bg-gray-50={variant === "panel"}
 	class:p-2={variant === "panel"}
 	class:rounded-lg={variant === "panel"}
-	class="flex flex-1 flex-col gr-gap gr-form-gap relative"
+	class="flex flex-col gr-gap gr-form-gap relative"
+	class:flex-1={parent === "row" || !parent}
 >
 	<slot />
 </div>

--- a/ui/packages/app/src/components/Row/Row.svelte
+++ b/ui/packages/app/src/components/Row/Row.svelte
@@ -2,10 +2,16 @@
 	export let value: boolean;
 	export let default_value: boolean;
 	export let style: string = "";
+	export let parent: string | null = null;
 
 	if (default_value) value = default_value;
 </script>
 
-<div {style} class:hidden={!value} class="flex flex-col md:flex-row gap-3">
+<div
+	{style}
+	class:hidden={!value}
+	class="flex flex-col md:flex-row gap-3 "
+	class:flex-1={parent === "row" || !parent}
+>
 	<slot />
 </div>

--- a/ui/packages/app/src/components/Row/Row.svelte
+++ b/ui/packages/app/src/components/Row/Row.svelte
@@ -10,8 +10,8 @@
 <div
 	{style}
 	class:hidden={!value}
-	class="flex flex-col md:flex-row gap-3 "
-	class:flex-1={parent === "row" || !parent}
+	class="flex flex-col md:flex-row gr-gap gr-form-gap row w-full"
+	class:flex-1={parent === "row"}
 >
 	<slot />
 </div>

--- a/ui/packages/atoms/src/Block.svelte
+++ b/ui/packages/atoms/src/Block.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import { getContext } from "svelte";
+	import { BLOCK_KEY } from "./";
+
 	export let variant: "solid" | "dashed" = "solid";
 	export let color: "grey" | "green" = "grey";
 	export let padding: boolean = true;
@@ -15,6 +18,10 @@
 	};
 
 	let tag = type === "fieldset" ? "fieldset" : "div";
+
+	const parent = getContext<string | null>(BLOCK_KEY);
+
+	console.log(parent);
 </script>
 
 <svelte:element
@@ -26,6 +33,7 @@
 	class:!rounded-none={form_position === "mid"}
 	class:!rounded-b-none={form_position === "first"}
 	class:!rounded-t-none={form_position === "last"}
+	class:flex-1={parent === "row" || null}
 >
 	<slot />
 </svelte:element>

--- a/ui/packages/atoms/src/Block.svelte
+++ b/ui/packages/atoms/src/Block.svelte
@@ -2,7 +2,7 @@
 	import { getContext } from "svelte";
 	import { BLOCK_KEY } from "./";
 
-	export let variant: "solid" | "dashed" = "solid";
+	export let variant: "solid" | "dashed" | "none" = "solid";
 	export let color: "grey" | "green" = "grey";
 	export let padding: boolean = true;
 	export let form_position: "first" | "last" | "mid" | "single" | undefined =
@@ -14,25 +14,40 @@
 		dashed: "border-dashed border-[3px]",
 		solid: "border-solid border",
 		grey: "border-gray-200",
-		green: "border-green-400"
+		green: "border-green-400",
+		none: "!border-0"
+	};
+
+	const form_styles = {
+		column: {
+			first: "!rounded-b-none",
+			last: "!rounded-t-none",
+			mid: "!rounded-none",
+			single: ""
+		},
+		row: {
+			first: "!rounded-r-none",
+			last: "!rounded-l-none",
+			mid: "!rounded-none",
+			single: ""
+		}
 	};
 
 	let tag = type === "fieldset" ? "fieldset" : "div";
 
 	const parent = getContext<string | null>(BLOCK_KEY);
 
-	console.log(parent);
+	$: form_class = form_position
+		? form_styles?.[(parent as "column" | "row") || "column"][form_position]
+		: "";
 </script>
 
 <svelte:element
 	this={tag}
 	data-testid={test_id}
-	class="gr-box overflow-hidden {styles[variant]} {styles[color]}"
+	class="gr-box overflow-hidden {styles[variant]} {styles[color]} {form_class}"
 	class:gr-panel={padding}
 	class:form={form_position}
-	class:!rounded-none={form_position === "mid"}
-	class:!rounded-b-none={form_position === "first"}
-	class:!rounded-t-none={form_position === "last"}
 	class:flex-1={parent === "row" || null}
 >
 	<slot />

--- a/ui/packages/atoms/src/index.ts
+++ b/ui/packages/atoms/src/index.ts
@@ -3,3 +3,4 @@ export { default as Block } from "./Block.svelte";
 export { default as BlockTitle } from "./BlockTitle.svelte";
 export { default as BlockLabel } from "./BlockLabel.svelte";
 export { default as IconButton } from "./IconButton.svelte";
+export const BLOCK_KEY = {};

--- a/ui/packages/theme/src/global.css
+++ b/ui/packages/theme/src/global.css
@@ -3,11 +3,19 @@
 @tailwind utilities;
 
 @layer components {
-	.gr-gap > *:not(.absolute) + * {
-		@apply mt-2;
+	.col.gr-gap > *:not(.absolute) + * {
+		@apply mt-3;
 	}
-	.gr-form-gap > .form + .form {
+	.col.gr-form-gap > .form + .form {
 		@apply mt-0 border-t-0;
+	}
+
+	.row.gr-gap > *:not(.absolute) + * {
+		@apply ml-3;
+	}
+
+	.row.gr-form-gap > .form + .form {
+		@apply ml-0 border-l-0;
 	}
 
 	.scroll-hide {

--- a/ui/packages/theme/src/tokens.css
+++ b/ui/packages/theme/src/tokens.css
@@ -4,7 +4,6 @@
 	relative 
 	rounded-lg 
 	bg-white 
-	flex-1
 	shadow-sm;
 }
 


### PR DESCRIPTION
This was more involved that I thought it would be. Closes #1183. Closes #1184.

### Notes for #1183

In #1165 we changed some flex behaviour but this didn't work in all contexts, most notably it forced everything to grow regardless of its parent. This worked well for one case but broke some others (including the default interface layout). 

Most components are now aware of their parent and selectively apply `flex-1`.

I've also made some other tweaks as I found a few additional bugs when fixing this, all relating to layout.

**Interface**
<details>
 <summary>before</summary>
<img width="1043" alt="Screenshot 2022-05-07 at 10 16 38" src="https://user-images.githubusercontent.com/12937446/167255015-6e46eebd-7b66-4372-8750-572ac079c27c.png">
</details>

<details>
 <summary>after</summary>
<img width="1284" alt="Screenshot 2022-05-07 at 13 45 39" src="https://user-images.githubusercontent.com/12937446/167255115-3d36a391-4ae9-4c73-8410-dcefa232feea.png">
</details>

**Custom Layout**

<details>
<summary>before</summary>
<img width="1558" alt="Screenshot 2022-05-07 at 12 26 04" src="https://user-images.githubusercontent.com/12937446/167255253-ab3e37f4-3af1-4fa5-8c44-6b46ff7d4dd8.png">
</details>

<details>
<summary>after</summary>
<img width="1558" alt="Screenshot 2022-05-07 at 11 42 42" src="https://user-images.githubusercontent.com/12937446/167255178-cfbc88eb-219e-4724-8fa5-4fdda839e0dc.png">
</details>

### Notes for #1184

We had some custom logic to detect when form components were adjacent to one another, removing spacing and top  + bottom border radiuses where necessary. However, this logic assumed that form elements always appeared in a column (one on top of the other). Side-by-side form elements _also_ applied the exact same logic leading to very broken layouts. With the above change making components aware of their parent, we can easily change the layout behaviour depending on whether the parent is a column or a row.

- If adjacent forms are in a column, they will be grouped 'stacked' (one on top of the other with top and bottom border radiuses modified).
- - if adjacent forms are in a row, they will grouped alongside one another with left + right border radiuses modified.

We might need to modify this if we change how layouts work.

<details>
<summary>before</summary>
<img width="1198" alt="Screenshot 2022-05-07 at 14 05 27" src="https://user-images.githubusercontent.com/12937446/167255734-3371ee0c-592b-4017-a43b-c30d6bdb1388.png">


</details>

<details>
<summary>after</summary>
<img width="1277" alt="Screenshot 2022-05-07 at 14 06 39" src="https://user-images.githubusercontent.com/12937446/167255805-14001b78-bdc4-40e0-b52b-a908a69a676e.png">

</details>