### PR TITLE
move init script into index.html

### DIFF
--- a/ui/packages/app/index.html
+++ b/ui/packages/app/index.html
@@ -74,5 +74,26 @@
 			id="root"
 			style="display: flex; flex-direction: column; flex-grow: 1"
 		></div>
+
+		<script type="module">
+			if (window.gradio_mode == "app") {
+				get_config().then((config) => {
+					window.launchGradio(config, "#root");
+				});
+			}
+
+			async function get_config() {
+				if (
+					window.__BUILD_MODE__ === "dev" ||
+					location.origin === "http://localhost:3000"
+				) {
+					let config = await fetch(window.__BACKEND_URL__ + "config");
+					config = await config.json();
+					return config;
+				} else {
+					return window.gradio_config;
+				}
+			}
+		</script>
 	</body>
 </html>

--- a/ui/packages/app/index.html
+++ b/ui/packages/app/index.html
@@ -74,26 +74,5 @@
 			id="root"
 			style="display: flex; flex-direction: column; flex-grow: 1"
 		></div>
-
-		<script type="module">
-			if (window.gradio_mode == "app") {
-				get_config().then((config) => {
-					window.launchGradio(config, "#root");
-				});
-			}
-
-			async function get_config() {
-				if (
-					window.__BUILD_MODE__ === "dev" ||
-					location.origin === "http://localhost:3000"
-				) {
-					let config = await fetch(window.__BACKEND_URL__ + "config");
-					config = await config.json();
-					return config;
-				} else {
-					return window.gradio_config;
-				}
-			}
-		</script>
 	</body>
 </html>

--- a/ui/packages/app/src/main.ts
+++ b/ui/packages/app/src/main.ts
@@ -9,17 +9,12 @@ interface CustomWindow extends Window {
 	launchGradio: Function;
 	launchGradioFromSpaces: Function;
 	gradio_config: Config;
-	__BACEKND_URL__: string | false;
-	__BUILD_MODE__: string;
 }
 
 declare let window: CustomWindow;
 declare let BACKEND_URL: string;
 declare let BACKEND_URL_TEST: string;
 declare let BUILD_MODE: string;
-
-window.__BACKEND_URL__ = BACKEND_URL || "";
-window.__BUILD_MODE__ = BUILD_MODE || false;
 
 interface Component {
 	name: string;
@@ -147,3 +142,24 @@ window.launchGradioFromSpaces = async (space: string, target: string) => {
 	_config.space = space;
 	window.launchGradio(_config, target);
 };
+
+window.loading = false;
+
+if (window.gradio_mode == "app") {
+	if (!window.loading) {
+		window.loading = true;
+		get_config().then((config) => {
+			window.launchGradio(config, "#root");
+		});
+	}
+}
+
+async function get_config() {
+	if (BUILD_MODE === "dev" || location.origin === "http://localhost:3000") {
+		let config = await fetch(BACKEND_URL + "config");
+		config = await config.json();
+		return config;
+	} else {
+		return window.gradio_config;
+	}
+}

--- a/ui/packages/app/src/main.ts
+++ b/ui/packages/app/src/main.ts
@@ -18,7 +18,7 @@ declare let BACKEND_URL: string;
 declare let BACKEND_URL_TEST: string;
 declare let BUILD_MODE: string;
 
-window.__BACKEND_URL__ = BACKEND_URL || false;
+window.__BACKEND_URL__ = BACKEND_URL || "";
 window.__BUILD_MODE__ = BUILD_MODE || false;
 
 interface Component {

--- a/ui/packages/app/src/main.ts
+++ b/ui/packages/app/src/main.ts
@@ -146,7 +146,7 @@ window.launchGradioFromSpaces = async (space: string, target: string) => {
 	window.launchGradio(_config, target);
 };
 
-function run() {
+function init() {
 	if (window.gradio_mode == "app") {
 		get_config().then((config) => {
 			window.launchGradio(config, "#root");
@@ -163,3 +163,5 @@ async function get_config() {
 		return window.gradio_config;
 	}
 }
+
+init();

--- a/ui/packages/app/src/main.ts
+++ b/ui/packages/app/src/main.ts
@@ -57,6 +57,9 @@ interface Config {
 }
 
 window.launchGradio = (config: Config, element_query: string) => {
+	if (window.loading) return;
+	window.loading = true;
+
 	let target: HTMLElement = document.querySelector(element_query)!;
 
 	if (!target) {
@@ -143,11 +146,8 @@ window.launchGradioFromSpaces = async (space: string, target: string) => {
 	window.launchGradio(_config, target);
 };
 
-window.loading = false;
-
-if (window.gradio_mode == "app") {
-	if (!window.loading) {
-		window.loading = true;
+function run() {
+	if (window.gradio_mode == "app") {
 		get_config().then((config) => {
 			window.launchGradio(config, "#root");
 		});

--- a/ui/packages/app/src/main.ts
+++ b/ui/packages/app/src/main.ts
@@ -9,12 +9,17 @@ interface CustomWindow extends Window {
 	launchGradio: Function;
 	launchGradioFromSpaces: Function;
 	gradio_config: Config;
+	__BACEKND_URL__: string | false;
+	__BUILD_MODE__: string;
 }
 
 declare let window: CustomWindow;
 declare let BACKEND_URL: string;
 declare let BACKEND_URL_TEST: string;
 declare let BUILD_MODE: string;
+
+window.__BACKEND_URL__ = BACKEND_URL || false;
+window.__BUILD_MODE__ = BUILD_MODE || false;
 
 interface Component {
 	name: string;
@@ -142,19 +147,3 @@ window.launchGradioFromSpaces = async (space: string, target: string) => {
 	_config.space = space;
 	window.launchGradio(_config, target);
 };
-
-async function get_config() {
-	if (BUILD_MODE === "dev" || location.origin === "http://localhost:3000") {
-		let config = await fetch(BACKEND_URL + "config");
-		config = await config.json();
-		return config;
-	} else {
-		return window.gradio_config;
-	}
-}
-
-if (window.gradio_mode == "app") {
-	get_config().then((config) => {
-		window.launchGradio(config, "#root");
-	});
-}


### PR DESCRIPTION
We currently have an issue where the scripts are evaluated even when they are redirected. I haven't had the time to debug this properly (and we do need to stop it from happening) but this is a quick fix that should prevent the app from initialising twice (causing duplicated content) as we do not redirect the HTML file as far as I am aware.

Will create a follow up to look more closely at the redirect issue post 3.0.

This will need to be published before it can really be tested.

Closes #1028.