### PR TITLE
Default Label label value

### DIFF
--- a/ui/packages/app/src/components/Label/Label.svelte
+++ b/ui/packages/app/src/components/Label/Label.svelte
@@ -11,7 +11,7 @@
 		label: string;
 		confidences?: Array<{ label: string; confidence: number }>;
 	};
-	export let label: string;
+	export let label: string = "Label";
 
 	export let loading_status: LoadingStatus;
 	export let show_label: boolean;


### PR DESCRIPTION
small fix for `gr.Label()` 

<img width="563" alt="image" src="https://user-images.githubusercontent.com/102277/168187587-fe347659-e41d-4c5a-a7ff-9d8e1a3c2b1c.png">

vs

<img width="607" alt="image" src="https://user-images.githubusercontent.com/102277/168187618-55c3f95e-e167-473a-b0e0-8d79a6f66fa2.png">

