### PR TITLE
Layout bugs

### DIFF
--- a/demo/blocks_flashcards/run.py
+++ b/demo/blocks_flashcards/run.py
@@ -14,22 +14,22 @@ with demo:
             flashcards_table = gr.Dataframe(headers=["front", "back"], type="array")
         with gr.TabItem("Practice"):
             with gr.Row():
-                front = gr.Textbox(label="Prompt")
-                answer_row = gr.Row(visible=False)
-                with answer_row:
+                with gr.Column():
+                    front = gr.Textbox(label="Prompt")
+                    with gr.Row():
+                        new_btn = gr.Button("New Card").style(full_width=True)
+                        flip_btn = gr.Button("Flip Card").style(full_width=True)
+                with gr.Column(visible=False) as answer_col:
                     back = gr.Textbox(label="Answer")
-            with gr.Row():
-                new_btn = gr.Button("New Card").style(full_width=True)
-                flip_btn = gr.Button("Flip Card").style(full_width=True)
-                selected_card = gr.Variable()
-                feedback_row = gr.Row(visible=False)
-                with feedback_row:
-                    correct_btn = gr.Button(
-                        "Correct",
-                    ).style(bg_color="green", text_color="black", full_width=True)
-                    incorrect_btn = gr.Button("Incorrect").style(
-                        bg_color="pink", text_color="black", full_width=True
-                    )
+                    selected_card = gr.Variable()
+                    with gr.Row():
+                        correct_btn = gr.Button(
+                            "Correct",
+                        ).style(bg_color="green", text_color="black", full_width=True)
+                        incorrect_btn = gr.Button("Incorrect").style(
+                            bg_color="pink", text_color="black", full_width=True
+                        )
+
         with gr.TabItem("Results"):
             results = gr.Variable(value={})
             correct_field = gr.Markdown("# Correct: 0")
@@ -39,18 +39,22 @@ with demo:
 
         def load_new_card(flashcards):
             card = random.choice(flashcards)
-            return card, card[0], False, False
+            return (
+                card,
+                card[0],
+                gr.Column.update(visible=False),
+            )
 
         new_btn.click(
             load_new_card,
             [flashcards_table],
-            [selected_card, front, answer_row, feedback_row],
+            [selected_card, front, answer_col],
         )
 
         def flip_card(card):
-            return card[1], True, True
+            return card[1], gr.Column.update(visible=True)
 
-        flip_btn.click(flip_card, [selected_card], [back, answer_row, feedback_row])
+        flip_btn.click(flip_card, [selected_card], [back, answer_col])
 
         def mark_correct(card, results):
             if card[0] not in results:

--- a/demo/blocks_flashcards/run.py
+++ b/demo/blocks_flashcards/run.py
@@ -14,22 +14,21 @@ with demo:
             flashcards_table = gr.Dataframe(headers=["front", "back"], type="array")
         with gr.TabItem("Practice"):
             with gr.Row():
-                front = gr.Textbox()
+                front = gr.Textbox(label="Prompt")
                 answer_row = gr.Row(visible=False)
                 with answer_row:
-                    back = gr.Textbox()
+                    back = gr.Textbox(label="Answer")
             with gr.Row():
-                new_btn = gr.Button("New Card")
-                flip_btn = gr.Button("Flip Card")
+                new_btn = gr.Button("New Card").style(full_width=True)
+                flip_btn = gr.Button("Flip Card").style(full_width=True)
                 selected_card = gr.Variable()
                 feedback_row = gr.Row(visible=False)
                 with feedback_row:
                     correct_btn = gr.Button(
                         "Correct",
-                        css={"background-color": "lightgreen", "color": "green"},
-                    )
-                    incorrect_btn = gr.Button(
-                        "Incorrect", css={"background-color": "pink", "color": "red"}
+                    ).style(bg_color="green", text_color="black", full_width=True)
+                    incorrect_btn = gr.Button("Incorrect").style(
+                        bg_color="pink", text_color="black", full_width=True
                     )
         with gr.TabItem("Results"):
             results = gr.Variable(value={})

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -171,9 +171,16 @@ class Row(BlockContext):
             "__type__": "update",
         }
 
-    def style(self, equal_height: Optional[bool] = None):
+    def style(
+        self,
+        equal_height: Optional[bool] = None,
+        mobile_collapse: Optional[bool] = None,
+    ):
         if equal_height is not None:
             self._style["equal_height"] = equal_height
+        if mobile_collapse is not None:
+            self._style["mobile_collapse"] = mobile_collapse
+
         return self
 
 

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3580,6 +3580,7 @@ class Button(Clickable, Component):
         rounded: Optional[bool] = None,
         bg_color: Optional[str] = None,
         text_color: Optional[str] = None,
+        full_width: Optional[str] = None,
     ):
         if rounded is not None:
             self._style["rounded"] = rounded
@@ -3587,6 +3588,8 @@ class Button(Clickable, Component):
             self._style["bg_color"] = bg_color
         if text_color is not None:
             self._style["text_color"] = text_color
+        if full_width is not None:
+            self._style["full_width"] = full_width
         return self
 
 

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -489,7 +489,7 @@ class Interface(Blocks):
                             with interpret_component_column:
                                 for component in self.input_components:
                                     interpretation_set.append(Interpretation(component))
-                        with Row():
+                        with Row().style(mobile_collapse=False):
                             if self.interface_type in [
                                 self.InterfaceTypes.STANDARD,
                                 self.InterfaceTypes.INPUT_ONLY,
@@ -512,7 +512,7 @@ class Interface(Blocks):
                         status_tracker = StatusTracker(cover_container=True)
                         for component in self.output_components:
                             component.render()
-                        with Row():
+                        with Row().style(mobile_collapse=False):
                             if self.interface_type == self.InterfaceTypes.OUTPUT_ONLY:
                                 clear_btn = Button("Clear", variant="secondary")
                                 submit_btn = Button("Generate")

--- a/gradio/templates/frontend/index.html
+++ b/gradio/templates/frontend/index.html
@@ -59,8 +59,8 @@
 			rel="stylesheet"
 		/>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js"></script>
-		<script type="module" crossorigin src="./assets/index.a2f558b6.js"></script>
-		<link rel="stylesheet" href="./assets/index.3b6da8df.css">
+		<script type="module" crossorigin src="./assets/index.c5f2277d.js"></script>
+		<link rel="stylesheet" href="./assets/index.267add2a.css">
 	</head>
 
 	<body

--- a/ui/packages/app/package.json
+++ b/ui/packages/app/package.json
@@ -31,6 +31,7 @@
 		"@gradio/tabs": "workspace:^0.0.1",
 		"@gradio/theme": "workspace:^0.0.1",
 		"@gradio/upload": "workspace:^0.0.1",
+		"@gradio/utils": "workspace:^0.0.1",
 		"@gradio/video": "workspace:^0.0.1",
 		"mime-types": "^2.1.34",
 		"svelte-i18n": "^3.3.13"

--- a/ui/packages/app/src/Render.svelte
+++ b/ui/packages/app/src/Render.svelte
@@ -40,9 +40,6 @@
 		return () => dispatch("destroy", id);
 	});
 
-	function log(x) {
-		console.log("rerunning", props.visible, instance_map[id].type);
-	}
 	$: {
 		if (typeof props.visible === "boolean") {
 			props.style.visible = props.visible;

--- a/ui/packages/app/src/Render.svelte
+++ b/ui/packages/app/src/Render.svelte
@@ -103,7 +103,7 @@
 		children &&
 		children.filter((v) => instance_map[v.id].type !== "statustracker");
 
-	setContext(BLOCK_KEY, parent);
+	setContext("BLOCK_KEY", parent);
 </script>
 
 <svelte:component

--- a/ui/packages/app/src/Render.svelte
+++ b/ui/packages/app/src/Render.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
 	import { onMount, createEventDispatcher, setContext } from "svelte";
-	import { BLOCK_KEY } from "@gradio/atoms";
 
 	export let root: string;
 	export let component;
 	export let instance_map;
 	export let id: number;
 	export let props: {
-		css: Record<string, string>;
+		style: Record<string, unknown>;
 		visible: boolean;
 		[key: string]: unknown;
 	};
@@ -16,7 +15,6 @@
 		children: Array<LayoutNode>;
 	}
 	export let children: Array<LayoutNode>;
-	export let theme;
 	export let dynamic_ids: Set<number>;
 	export let has_modes: boolean | undefined;
 	export let status_tracker_values: Record<number, string>;
@@ -42,15 +40,12 @@
 		return () => dispatch("destroy", id);
 	});
 
-	let style: string = "";
+	function log(x) {
+		console.log("rerunning", props.visible, instance_map[id].type);
+	}
 	$: {
-		style = props.css
-			? Object.entries(props.css)
-					.map((rule) => rule[0] + ": " + rule[1])
-					.join("; ")
-			: "";
-		if (props.visible === false) {
-			style += " display: none !important;";
+		if (typeof props.visible === "boolean") {
+			props.style.visible = props.visible;
 		}
 	}
 
@@ -122,7 +117,6 @@
 				{component}
 				id={each_id}
 				{props}
-				{theme}
 				{root}
 				{instance_map}
 				{children}

--- a/ui/packages/app/src/components/Column/Column.svelte
+++ b/ui/packages/app/src/components/Column/Column.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+	import { create_classes } from "@gradio/utils";
+
 	export let elem_id: string = "";
 	export let variant: "default" | "panel" = "default";
 	export let parent: string | null = null;
+	export let style: Record<string, unknown> = {};
 </script>
 
 <div
@@ -9,7 +12,9 @@
 	class:bg-gray-50={variant === "panel"}
 	class:p-2={variant === "panel"}
 	class:rounded-lg={variant === "panel"}
-	class="flex flex-col gr-gap gr-form-gap relative col w-full"
+	class="flex flex-col gr-gap gr-form-gap relative col w-full {create_classes(
+		style
+	)}"
 >
 	<slot />
 </div>

--- a/ui/packages/app/src/components/Column/Column.svelte
+++ b/ui/packages/app/src/components/Column/Column.svelte
@@ -9,8 +9,7 @@
 	class:bg-gray-50={variant === "panel"}
 	class:p-2={variant === "panel"}
 	class:rounded-lg={variant === "panel"}
-	class="flex flex-col gr-gap gr-form-gap relative col"
-	class:flex-1={parent === "row" || !parent}
+	class="flex flex-col gr-gap gr-form-gap relative col w-full"
 >
 	<slot />
 </div>

--- a/ui/packages/app/src/components/Json/Json.svelte
+++ b/ui/packages/app/src/components/Json/Json.svelte
@@ -2,7 +2,7 @@
 	import { createEventDispatcher } from "svelte";
 	import { JSON } from "@gradio/json";
 	import { Block, BlockLabel } from "@gradio/atoms";
-	import { JSON as JSONIcon, Tree } from "@gradio/icons";
+	import { JSON as JSONIcon } from "@gradio/icons";
 
 	import StatusTracker from "../StatusTracker/StatusTracker.svelte";
 	import type { LoadingStatus } from "../StatusTracker/types";
@@ -19,7 +19,7 @@
 
 <Block test_id="json" {elem_id}>
 	{#if label}
-		<BlockLabel Icon={Tree} {label} />
+		<BlockLabel Icon={JSONIcon} {label} />
 	{/if}
 
 	<StatusTracker {...loading_status} />

--- a/ui/packages/app/src/components/Row/Row.svelte
+++ b/ui/packages/app/src/components/Row/Row.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
 	export let parent: string | null = null;
-	export let styles: Record<string, unknown> = {};
+	export let style: Record<string, unknown> = {};
+
+	if (typeof style.mobile_collapse !== "boolean") {
+		style.mobile_collapse = true;
+	}
+	$: console.log($$props);
 </script>
 
 <div
-	class="flex flex-col md:flex-row gr-gap gr-form-gap row w-full flex-none"
-	class:flex-1={parent === "row"}
-	class:unequal-height={styles.equal_height !== false}
+	class="flex md:flex-row gr-gap gr-form-gap row w-full"
+	class:mobile-row={style.mobile_collapse === false}
+	class:unequal-height={style.equal_height === false}
+	class:flex-col={style.mobile_collapse}
 >
 	<slot />
 </div>

--- a/ui/packages/app/src/components/Row/Row.svelte
+++ b/ui/packages/app/src/components/Row/Row.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
+	import { create_classes } from "@gradio/utils";
 	export let parent: string | null = null;
 	export let style: Record<string, unknown> = {};
 
 	if (typeof style.mobile_collapse !== "boolean") {
 		style.mobile_collapse = true;
 	}
-	$: console.log($$props);
+
+	$: console.log(style, $$props);
 </script>
 
 <div
-	class="flex md:flex-row gr-gap gr-form-gap row w-full"
+	class="flex md:flex-row gr-gap gr-form-gap row w-full {create_classes(style)}"
 	class:mobile-row={style.mobile_collapse === false}
 	class:unequal-height={style.equal_height === false}
 	class:flex-col={style.mobile_collapse}

--- a/ui/packages/app/src/components/Row/Row.svelte
+++ b/ui/packages/app/src/components/Row/Row.svelte
@@ -6,8 +6,6 @@
 	if (typeof style.mobile_collapse !== "boolean") {
 		style.mobile_collapse = true;
 	}
-
-	$: console.log(style, $$props);
 </script>
 
 <div

--- a/ui/packages/atoms/src/Block.svelte
+++ b/ui/packages/atoms/src/Block.svelte
@@ -24,33 +24,35 @@
 
 	const form_styles = {
 		column: {
-			first: "!rounded-b-none",
-			last: "!rounded-t-none",
-			mid: "!rounded-none",
-			single: ""
+			first: "rounded-t-lg",
+			last: "rounded-b-lg",
+			mid: "",
+			single: "rounded-lg"
 		},
 		row: {
-			first: "!rounded-r-none",
-			last: "!rounded-l-none",
-			mid: "!rounded-none",
-			single: ""
+			first: "rounded-t-lg md:rounded-t-none md:rounded-l-lg ",
+			last: "rounded-b-lg md:rounded-b-none md:rounded-r-lg",
+			mid: "",
+			single: "rounded-lg"
 		}
 	};
 
 	let tag = type === "fieldset" ? "fieldset" : "div";
 
-	const parent = getContext<string | null>(BLOCK_KEY);
+	const parent = getContext<string | null>("BLOCK_KEY");
 
 	$: form_class = form_position
 		? form_styles?.[(parent as "column" | "row") || "column"][form_position]
 		: "";
+
+	$: console.log(parent);
 </script>
 
 <svelte:element
 	this={tag}
 	data-testid={test_id}
 	id={elem_id}
-	class={"gr-box overflow-hidden " +
+	class={"w-full overflow-hidden " +
 		styles[variant] +
 		" " +
 		styles[color] +
@@ -59,7 +61,8 @@
 		styleClasses(style, "container")}
 	class:gr-panel={padding}
 	class:form={form_position}
-	class:flex-1={parent === "row" || null}
+	class:gr-box-unrounded={form_position}
+	class:gr-box={!form_position}
 >
 	<slot />
 </svelte:element>

--- a/ui/packages/atoms/src/Block.svelte
+++ b/ui/packages/atoms/src/Block.svelte
@@ -41,11 +41,11 @@
 
 	const parent = getContext<string | null>("BLOCK_KEY");
 
-	$: form_class = form_position
-		? form_styles?.[(parent as "column" | "row") || "column"][form_position]
-		: "";
+	$: _parent = parent === "column" || parent == "row" ? parent : "column";
 
-	$: console.log(parent);
+	$: form_class = form_position
+		? form_styles?.[(_parent as "column" | "row") || "column"][form_position]
+		: "";
 </script>
 
 <svelte:element

--- a/ui/packages/atoms/src/Block.svelte
+++ b/ui/packages/atoms/src/Block.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { styleClasses } from "../../utils";
+	import { create_classes } from "../../utils";
 
 	import { getContext } from "svelte";
 	import { BLOCK_KEY } from "./";
@@ -58,7 +58,7 @@
 		styles[color] +
 		" " +
 		form_class +
-		styleClasses(style, "container")}
+		create_classes(style, "container")}
 	class:gr-panel={padding}
 	class:form={form_position}
 	class:gr-box-unrounded={form_position}

--- a/ui/packages/button/src/Button.svelte
+++ b/ui/packages/button/src/Button.svelte
@@ -9,7 +9,7 @@
 
 <button
 	on:click
-	class={`gr-button gr-button-${size} gr-button-${variant} self-start flex-1` +
+	class={`gr-button gr-button-${size} gr-button-${variant} self-start` +
 		styleClasses(style)}
 	id={elem_id}
 >

--- a/ui/packages/button/src/Button.svelte
+++ b/ui/packages/button/src/Button.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { styleClasses } from "../../utils";
+	import { create_classes } from "../../utils";
 
 	export let style: Record<string, any> = {};
 	export let elem_id: string = "";
@@ -10,7 +10,7 @@
 <button
 	on:click
 	class={`gr-button gr-button-${size} gr-button-${variant} self-start` +
-		styleClasses(style)}
+		create_classes(style)}
 	id={elem_id}
 >
 	<slot />

--- a/ui/packages/form/src/Checkbox.svelte
+++ b/ui/packages/form/src/Checkbox.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { styleClasses } from "@gradio/utils";
+	import { create_classes } from "@gradio/utils";
 	import { createEventDispatcher } from "svelte";
 
 	export let value: boolean;
@@ -28,5 +28,5 @@
 		name="test"
 		class="gr-check-radio gr-checkbox"
 	/>
-	<span class={"ml-2" + styleClasses(style)}>{label}</span></label
+	<span class={"ml-2" + create_classes(style)}>{label}</span></label
 >

--- a/ui/packages/form/src/CheckboxGroup.svelte
+++ b/ui/packages/form/src/CheckboxGroup.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
 	import { BlockTitle } from "@gradio/atoms";
-	import { styleClasses } from "@gradio/utils";
+	import { create_classes } from "@gradio/utils";
 
 	export let value: Array<string> = [];
 	export let style: Record<string, string> = {};
@@ -30,7 +30,7 @@
 		<label
 			class:!cursor-not-allowed={disabled}
 			class={"flex items-center text-gray-700 text-sm space-x-2 border py-1.5 px-3 rounded-lg cursor-pointer bg-white shadow-sm checked:shadow-inner" +
-				styleClasses(style)}
+				create_classes(style)}
 		>
 			<input
 				{disabled}

--- a/ui/packages/form/src/Dropdown.svelte
+++ b/ui/packages/form/src/Dropdown.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
 	import { Block, BlockTitle } from "@gradio/atoms";
-	import { styleClasses } from "@gradio/utils";
+	import { create_classes } from "@gradio/utils";
 
 	export let label: string;
 	export let value: string | undefined = undefined;
@@ -19,7 +19,7 @@
 	<BlockTitle {show_label}>{label}</BlockTitle>
 	<select
 		class={"gr-box gr-input w-full disabled:cursor-not-allowed" +
-			styleClasses(style)}
+			create_classes(style)}
 		bind:value
 		{disabled}
 	>

--- a/ui/packages/form/src/Number.svelte
+++ b/ui/packages/form/src/Number.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { createEventDispatcher, tick } from "svelte";
-	import { styleClasses } from "@gradio/utils";
+	import { create_classes } from "@gradio/utils";
 	import { BlockTitle, Block } from "@gradio/atoms";
 
 	export let value: number = 0;
@@ -35,7 +35,7 @@
 	<BlockTitle {show_label}>{label}</BlockTitle>
 	<input
 		type="number"
-		class={"gr-box gr-input w-full gr-text-input" + styleClasses(style)}
+		class={"gr-box gr-input w-full gr-text-input" + create_classes(style)}
 		bind:value
 		on:keypress={handle_keypress}
 		{disabled}

--- a/ui/packages/form/src/Radio.svelte
+++ b/ui/packages/form/src/Radio.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
 	import { BlockTitle } from "@gradio/atoms";
-	import { styleClasses } from "@gradio/utils";
+	import { create_classes } from "@gradio/utils";
 
 	export let value: string;
 	export let style: Record<string, string> = {};
@@ -23,7 +23,7 @@
 		<label
 			class:!cursor-not-allowed={disabled}
 			class={"flex items-center text-gray-700 text-sm space-x-2 border py-1.5 px-3 rounded-lg cursor-pointer bg-white shadow-sm checked:shadow-inner" +
-				styleClasses(style)}
+				create_classes(style)}
 		>
 			<input
 				{disabled}

--- a/ui/packages/form/src/Range.svelte
+++ b/ui/packages/form/src/Range.svelte
@@ -5,7 +5,7 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
 	import { Block, BlockTitle } from "@gradio/atoms";
-	import { styleClasses } from "@gradio/utils";
+	import { create_classes } from "@gradio/utils";
 
 	export let value: number = 0;
 	export let style: Record<string, string> = {};
@@ -28,7 +28,7 @@
 		<label for={id}>
 			<BlockTitle {show_label}>{label}</BlockTitle>
 		</label>
-		<div class={"font-medium dark:text-gray-300" + styleClasses(style)}>
+		<div class={"font-medium dark:text-gray-300" + create_classes(style)}>
 			{value}
 		</div>
 	</div>

--- a/ui/packages/form/src/Textbox.svelte
+++ b/ui/packages/form/src/Textbox.svelte
@@ -77,7 +77,7 @@
 </script>
 
 <!-- svelte-ignore a11y-label-has-associated-control -->
-<label class="block">
+<label class="block w-full">
 	<BlockTitle {show_label}>{label}</BlockTitle>
 
 	<textarea

--- a/ui/packages/form/src/Textbox.svelte
+++ b/ui/packages/form/src/Textbox.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { createEventDispatcher, tick } from "svelte";
-	import { styleClasses } from "@gradio/utils";
+	import { create_classes } from "@gradio/utils";
 	import { BlockTitle } from "@gradio/atoms";
 
 	export let value: string = "";
@@ -82,7 +82,8 @@
 
 	<textarea
 		use:text_area_resize={value}
-		class={"block gr-box gr-input w-full gr-text-input " + styleClasses(style)}
+		class={"block gr-box gr-input w-full gr-text-input " +
+			create_classes(style)}
 		bind:value
 		bind:this={el}
 		{placeholder}

--- a/ui/packages/icons/src/JSON.svelte
+++ b/ui/packages/icons/src/JSON.svelte
@@ -3,13 +3,13 @@
 	xmlns:xlink="http://www.w3.org/1999/xlink"
 	aria-hidden="true"
 	role="img"
-	class="iconify iconify--carbon"
+	class="iconify iconify--mdi"
 	width="100%"
 	height="100%"
 	preserveAspectRatio="xMidYMid meet"
-	viewBox="0 0 32 32"
+	viewBox="0 0 24 24"
 	><path
 		fill="currentColor"
-		d="M31 11v10h-2l-2-6v6h-2V11h2l2 6v-6h2zm-9.666 10h-2.667A1.668 1.668 0 0 1 17 19.334v-6.667A1.668 1.668 0 0 1 18.666 11h2.667A1.668 1.668 0 0 1 23 12.666v6.667A1.668 1.668 0 0 1 21.334 21zM19 19h2v-6h-2zm-5.666 2H9v-2h4v-2h-2a2.002 2.002 0 0 1-2-2v-2.334A1.668 1.668 0 0 1 10.666 11H15v2h-4v2h2a2.002 2.002 0 0 1 2 2v2.333A1.668 1.668 0 0 1 13.334 21zm-8 0H2.667A1.668 1.668 0 0 1 1 19.334V17h2v2h2v-8h2v8.334A1.668 1.668 0 0 1 5.333 21z"
+		d="M5 3h2v2H5v5a2 2 0 0 1-2 2a2 2 0 0 1 2 2v5h2v2H5c-1.07-.27-2-.9-2-2v-4a2 2 0 0 0-2-2H0v-2h1a2 2 0 0 0 2-2V5a2 2 0 0 1 2-2m14 0a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h1v2h-1a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2h-2v-2h2v-5a2 2 0 0 1 2-2a2 2 0 0 1-2-2V5h-2V3h2m-7 12a1 1 0 0 1 1 1a1 1 0 0 1-1 1a1 1 0 0 1-1-1a1 1 0 0 1 1-1m-4 0a1 1 0 0 1 1 1a1 1 0 0 1-1 1a1 1 0 0 1-1-1a1 1 0 0 1 1-1m8 0a1 1 0 0 1 1 1a1 1 0 0 1-1 1a1 1 0 0 1-1-1a1 1 0 0 1 1-1Z"
 	/></svg
 >

--- a/ui/packages/theme/src/global.css
+++ b/ui/packages/theme/src/global.css
@@ -51,16 +51,21 @@
 	.col.gr-gap > *:not(.absolute) + * {
 		@apply mt-3;
 	}
+
 	.col.gr-form-gap > .form + .form {
 		@apply mt-0 border-t-0;
 	}
 
 	.row.gr-gap > *:not(.absolute) + * {
-		@apply ml-3;
+		@apply ml-0 mt-3;
+	}
+
+	.row.gr-gap.mobile-row > *:not(.absolute) + * {
+		@apply !ml-3 mt-0;
 	}
 
 	.row.gr-form-gap > .form + .form {
-		@apply ml-0 border-l-0;
+		@apply mt-0 border-t-0;
 	}
 
 	.scroll-hide {
@@ -70,6 +75,19 @@
 
 	.scroll-hide::-webkit-scrollbar {
 		display: none;
+	}
+
+	@media (min-width: 768px) {
+		.row.gr-gap > *:not(.absolute) + * {
+			@apply mt-0 ml-3;
+		}
+		.row.gr-gap > *:not(.absolute) + * {
+			@apply ml-3;
+		}
+
+		.row.gr-form-gap > .form + .form {
+			@apply ml-0 border-l-0 border-t;
+		}
 	}
 }
 

--- a/ui/packages/theme/src/tokens.css
+++ b/ui/packages/theme/src/tokens.css
@@ -8,6 +8,15 @@
 	dark:bg-gray-800;
 }
 
+.gr-box-unrounded {
+	@apply text-gray-700 
+	text-sm 
+	relative 
+	bg-white 
+	shadow-sm
+	dark:bg-gray-800;
+}
+
 .gr-input {
 	@apply focus:border-blue-300 
 	focus:ring 

--- a/ui/packages/utils/src/styles.ts
+++ b/ui/packages/utils/src/styles.ts
@@ -22,6 +22,13 @@ export const styleClasses = (
 			classes.push("!rounded-none");
 			break;
 	}
+
+	switch (target_styles.full_width) {
+		case true:
+			classes.push("!w-full");
+			break;
+	}
+
 	switch (target_styles.text_color) {
 		case "red":
 			classes.push("!text-red-500", "dark:text-red-100");
@@ -58,7 +65,7 @@ export const styleClasses = (
 		case "green":
 			classes.push(
 				"!bg-green-100 !from-green-100 !to-green-200 !border-green-300",
-				"dark:!bg-green-700 dark:!from-green-700 dark:!to-green-800 dark:!border-green-900"
+				"dark:!bg-green-700 dark:!from-green-700 dark:!to-green-800 dark:!border-green-900  !text-gray-800"
 			);
 			break;
 		case "blue":
@@ -77,6 +84,11 @@ export const styleClasses = (
 			classes.push(
 				"!bg-gray-100 !from-gray-100 !to-gray-200 !border-gray-300",
 				"dark:!bg-gray-700 dark:!from-gray-700 dark:!to-gray-800 dark:!border-gray-900"
+			);
+		case "pink":
+			classes.push(
+				"!bg-pink-100 !from-pink-100 !to-pink-200 !border-pink-300",
+				"dark:!bg-pink-700 dark:!from-pink-700 dark:!to-pink-800 dark:!border-pink-900 !text-gray-800"
 			);
 			break;
 	}

--- a/ui/packages/utils/src/styles.ts
+++ b/ui/packages/utils/src/styles.ts
@@ -1,4 +1,4 @@
-export const styleClasses = (
+export const create_classes = (
 	styles: Record<string, any>,
 	prefix: string = ""
 ): string => {
@@ -14,6 +14,13 @@ export const styleClasses = (
 			}
 		}
 	}
+
+	switch (target_styles.visible) {
+		case false:
+			classes.push("!hidden");
+			break;
+	}
+
 	switch (target_styles.rounded) {
 		case true:
 			classes.push("!rounded-lg");

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -88,6 +88,7 @@ importers:
       '@gradio/tabs': workspace:^0.0.1
       '@gradio/theme': workspace:^0.0.1
       '@gradio/upload': workspace:^0.0.1
+      '@gradio/utils': workspace:^0.0.1
       '@gradio/video': workspace:^0.0.1
       mime-types: ^2.1.34
       svelte-i18n: ^3.3.13
@@ -113,6 +114,7 @@ importers:
       '@gradio/tabs': link:../tabs
       '@gradio/theme': link:../theme
       '@gradio/upload': link:../upload
+      '@gradio/utils': link:../utils
       '@gradio/video': link:../video
       mime-types: 2.1.34
       svelte-i18n: 3.3.13_svelte@3.47.0


### PR DESCRIPTION
Okay.

Closes #1233. Closes #1237. Closes #1238.

- #1237 was just a classic bug/ oversight.
- #1233 `visible=True|False` wasn't working as we had switched out styling to a new system, reimplemented.
- tweaked the mobile styles for form grouping, so they work when we are in asmaller screen view (where columns collapse into rows)
- added a style option to `Row` (`mobile_collapse`) so that users can disable the mobile collumn collapsing. This is important because we use flex for everything and need to switch this off for some small elements, like buttons, that we want to appear side by side even on mobile (such as the 'Clear' and 'Submit' buttons in interface)
- added a style option to `Button` (`full_width`) as buttons will not fill the width of their container typically (which is good but sometimes it is needed for certain layouts).
- tweaked a demo to make it a bit nicer.
- The layout stuff was a bit more involved (#1233 and #1238):
   I had to rethink how we were handling layouts as it was causing a number of issue. I think we were adding more and more classes to workaround issues that were arising and it was becoming difficult to manage all of the different case. I decided to go backa nd clean up a little by removing some of the probl;ematic classes and relying on things being full width (which will cause them to flex correctly most of the time), rather than tweaking the flex properties of the individual children.

I've tested this pretty extensively across screensizes here are some screengrabs showing current behaviour:


https://user-images.githubusercontent.com/12937446/168308485-4ac01a29-c778-46f2-b6ad-b3517a744283.mov

https://user-images.githubusercontent.com/12937446/168308669-f13f3649-6551-4598-ab22-4ba5097f0bbd.mov


