### PR TITLE
Fixes to components

### DIFF
--- a/gradio/__init__.py
+++ b/gradio/__init__.py
@@ -11,6 +11,7 @@ from gradio.components import (
     JSON,
     Audio,
     Button,
+    Carousel,
     Chatbot,
     Checkbox,
     Checkboxgroup,

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3023,13 +3023,15 @@ class Gallery(IOComponent):
     ):
         if grid is not None:
             self._style["grid"] = grid
+        if height is not None:
+            self._style["height"] = height
+
         return IOComponent.style(
             self,
             rounded=rounded,
             bg_color=bg_color,
             text_color=text_color,
             margin=margin,
-            height=height,
         )
 
 

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3053,7 +3053,7 @@ class Carousel(IOComponent):
         warnings.warn(
             "The Carousel component is partially deprecated. It may not behave as expected.",
             DeprecationWarning,
-        )        
+        )
         if not isinstance(components, list):
             components = [components]
         self.components = [

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3026,6 +3026,112 @@ class Gallery(IOComponent):
         )
 
 
+class Carousel(IOComponent):
+    """
+    Component displays a set of output components that can be scrolled through.
+    Output type: List[List[Any]]
+    Demos: disease_report
+    """
+
+    def __init__(
+        self,
+        *,
+        components: Component | List[Component],
+        label: Optional[str] = None,
+        show_label: bool = True,
+        visible: bool = True,
+        elem_id: Optional[str] = None,
+        **kwargs,
+    ):
+        """
+        Parameters:
+        components (Union[List[OutputComponent], OutputComponent]): Classes of component(s) that will be scrolled through.
+        label (Optional[str]): component name in interface.
+        show_label (bool): if True, will display label.
+        visible (bool): If False, component will be hidden.
+        """
+        warnings.warn(
+            "The Carousel component is partially deprecated. It may not behave as expected.",
+            DeprecationWarning,
+        )        
+        if not isinstance(components, list):
+            components = [components]
+        self.components = [
+            get_component_instance(component) for component in components
+        ]
+        IOComponent.__init__(
+            self,
+            label=label,
+            show_label=show_label,
+            visible=visible,
+            elem_id=elem_id,
+            **kwargs,
+        )
+
+    def get_config(self):
+        return {
+            "components": [component.get_config() for component in self.components],
+            **IOComponent.get_config(self),
+        }
+
+    @staticmethod
+    def update(
+        value: Optional[Any] = None,
+        label: Optional[str] = None,
+        show_label: Optional[bool] = None,
+        visible: Optional[bool] = None,
+    ):
+        return {
+            "label": label,
+            "show_label": show_label,
+            "visible": visible,
+            "value": value,
+            "__type__": "update",
+        }
+
+    def postprocess(self, y):
+        """
+        Parameters:
+        y (List[List[Any]]): carousel output
+        Returns:
+        (List[List[Any]]): 2D array, where each sublist represents one set of outputs or 'slide' in the carousel
+        """
+        if isinstance(y, list):
+            if len(y) != 0 and not isinstance(y[0], list):
+                y = [[z] for z in y]
+            output = []
+            for row in y:
+                output_row = []
+                for i, cell in enumerate(row):
+                    output_row.append(self.components[i].postprocess(cell))
+                output.append(output_row)
+            return output
+        else:
+            raise ValueError("Unknown type. Please provide a list for the Carousel.")
+
+    def save_flagged(self, dir, label, data, encryption_key):
+        return json.dumps(
+            [
+                [
+                    component.save_flagged(
+                        dir, f"{label}_{j}", data[i][j], encryption_key
+                    )
+                    for j, component in enumerate(self.components)
+                ]
+                for i, _ in enumerate(data)
+            ]
+        )
+
+    def restore_flagged(self, dir, data, encryption_key):
+        return [
+            [
+                component.restore_flagged(dir, sample, encryption_key)
+                for component, sample in zip(self.components, sample_set)
+            ]
+            for sample_set in json.loads(data)
+        ]
+
+
 class Chatbot(Changeable, IOComponent):
     """
     Displays a chatbot output showing both user submitted messages and responses

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2932,15 +2932,6 @@ class HTML(Changeable, IOComponent):
             "__type__": "update",
         }
 
-    def postprocess(self, x):
-        """
-        Parameters:
-        y (str): HTML output
-        Returns:
-        (str): HTML output
-        """
-        return x
-
 
 class Gallery(IOComponent):
     """
@@ -3303,7 +3294,7 @@ class Plot(Changeable, Clearable, IOComponent):
         return {"type": dtype, "plot": out_y}
 
 
-class Markdown(Component):
+class Markdown(IOComponent, Changeable):
     """
     Used to render arbitrary Markdown output.
     Preprocessing: this component does *not* accept input.
@@ -3325,7 +3316,7 @@ class Markdown(Component):
         value (str): Default value
         visible (bool): If False, component will be hidden.
         """
-        Component.__init__(self, visible=visible, elem_id=elem_id, **kwargs)
+        IOComponent.__init__(self, visible=visible, elem_id=elem_id, **kwargs)
         self.md = MarkdownIt()
         unindented_value = inspect.cleandoc(value)
         self.value = self.md.render(unindented_value)

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -16,7 +16,7 @@ import tempfile
 import warnings
 from copy import deepcopy
 from types import ModuleType
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 import matplotlib.figure
 import numpy as np
@@ -3026,7 +3026,7 @@ class Gallery(IOComponent):
         )
 
 
-class Carousel(IOComponent):
+class Carousel(IOComponent, Changeable):
     """
     Component displays a set of output components that can be scrolled through.
     Output type: List[List[Any]]

--- a/gradio/inputs.py
+++ b/gradio/inputs.py
@@ -9,24 +9,10 @@ from __future__ import annotations
 import warnings
 from typing import Any, List, Optional, Tuple
 
-from gradio.components import Audio as C_Audio
-from gradio.components import Checkbox as C_Checkbox
-from gradio.components import CheckboxGroup as C_CheckboxGroup
-from gradio.components import Dataframe as C_Dataframe
-from gradio.components import Dropdown as C_Dropdown
-from gradio.components import File as C_File
-from gradio.components import Image as C_Image
-from gradio.components import Model3D as C_Model3D
-from gradio.components import Number as C_Number
-from gradio.components import Radio as C_Radio
-from gradio.components import Slider as C_Slider
-from gradio.components import Textbox as C_Textbox
-from gradio.components import Timeseries as C_Timeseries
-from gradio.components import Variable as C_Variable
-from gradio.components import Video as C_Video
+from gradio import components
 
 
-class Textbox(C_Textbox):
+class Textbox(components.Textbox):
     def __init__(
         self,
         lines: int = 1,
@@ -52,7 +38,7 @@ class Textbox(C_Textbox):
         )
 
 
-class Number(C_Number):
+class Number(components.Number):
     """
     Component creates a field for user to enter numeric input. Provides a number as an argument to the wrapped function.
     Input type: float
@@ -78,7 +64,7 @@ class Number(C_Number):
         super().__init__(value=default, label=label, optional=optional)
 
 
-class Slider(C_Slider):
+class Slider(components.Slider):
     """
     Component creates a slider that ranges from `minimum` to `maximum`. Provides number as an argument to the wrapped function.
     Input type: float
@@ -118,7 +104,7 @@ class Slider(C_Slider):
         )
 
 
-class Checkbox(C_Checkbox):
+class Checkbox(components.Checkbox):
     """
     Component creates a checkbox that can be set to `True` or `False`. Provides a boolean as an argument to the wrapped function.
     Input type: bool
@@ -144,7 +130,7 @@ class Checkbox(C_Checkbox):
         super().__init__(value=default, label=label, optional=optional)
 
 
-class CheckboxGroup(C_CheckboxGroup):
+class CheckboxGroup(components.CheckboxGroup):
     """
     Component creates a set of checkboxes of which a subset can be selected. Provides a list of strings representing the selected choices as an argument to the wrapped function.
     Input type: Union[List[str], List[int]]
@@ -180,7 +166,7 @@ class CheckboxGroup(C_CheckboxGroup):
         )
 
 
-class Radio(C_Radio):
+class Radio(components.Radio):
     """
     Component creates a set of radio buttons of which only one can be selected. Provides string representing selected choice as an argument to the wrapped function.
     Input type: Union[str, int]
@@ -216,7 +202,7 @@ class Radio(C_Radio):
         )
 
 
-class Dropdown(C_Dropdown):
+class Dropdown(components.Dropdown):
     """
     Component creates a dropdown of which only one can be selected. Provides string representing selected choice as an argument to the wrapped function.
     Input type: Union[str, int]
@@ -252,7 +238,7 @@ class Dropdown(C_Dropdown):
         )
 
 
-class Image(C_Image):
+class Image(components.Image):
     """
     Component creates an image upload box with editing capabilities.
     Input type: Union[numpy.array, PIL.Image, file-object]
@@ -297,7 +283,7 @@ class Image(C_Image):
         )
 
 
-class Video(C_Video):
+class Video(components.Video):
     """
     Component creates a video file upload that is converted to a file path.
 
@@ -326,7 +312,7 @@ class Video(C_Video):
         super().__init__(format=type, source=source, label=label, optional=optional)
 
 
-class Audio(C_Audio):
+class Audio(components.Audio):
     """
     Component accepts audio input files.
     Input type: Union[Tuple[int, numpy.array], file-object, numpy.array]
@@ -354,7 +340,7 @@ class Audio(C_Audio):
         super().__init__(source=source, type=type, label=label, optional=optional)
 
 
-class File(C_File):
+class File(components.File):
     """
     Component accepts generic file uploads.
     Input type: Union[file-object, bytes, List[Union[file-object, bytes]]]
@@ -390,7 +376,7 @@ class File(C_File):
         )
 
 
-class Dataframe(C_Dataframe):
+class Dataframe(components.Dataframe):
     """
     Component accepts 2D input through a spreadsheet interface.
     Input type: Union[pandas.DataFrame, numpy.array, List[Union[str, float]], List[List[Union[str, float]]]]
@@ -438,7 +424,7 @@ class Dataframe(C_Dataframe):
         )
 
 
-class Timeseries(C_Timeseries):
+class Timeseries(components.Timeseries):
     """
     Component accepts pandas.DataFrame uploaded as a timeseries csv file.
     Input type: pandas.DataFrame
@@ -466,7 +452,7 @@ class Timeseries(C_Timeseries):
         super().__init__(x=x, y=y, label=label, optional=optional)
 
 
-class State(C_Variable):
+class State(components.Variable):
     """
     Special hidden component that stores state across runs of the interface.
     Input type: Any
@@ -491,7 +477,7 @@ class State(C_Variable):
         super().__init__(value=default, label=label)
 
 
-class Image3D(C_Model3D):
+class Image3D(components.Model3D):
     """
     Used for 3D image model output.
     Input type: File object of type (.obj, glb, or .gltf)

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -206,10 +206,12 @@ class Interface(Blocks):
 
         self.input_components = [get_component_instance(i).unrender() for i in inputs]
         self.output_components = [get_component_instance(o).unrender() for o in outputs]
-        
+
         for component in self.input_components + self.output_components:
-            if not(isinstance(component, IOComponent)):
-                raise ValueError(f"{component} is not a valid input/output component for Interface.")
+            if not (isinstance(component, IOComponent)):
+                raise ValueError(
+                    f"{component} is not a valid input/output component for Interface."
+                )
 
         if len(self.input_components) == len(self.output_components):
             same_components = [

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -27,6 +27,7 @@ from gradio.components import (
     Component,
     Dataset,
     Interpretation,
+    IOComponent,
     Markdown,
     StatusTracker,
     Variable,
@@ -205,6 +206,10 @@ class Interface(Blocks):
 
         self.input_components = [get_component_instance(i).unrender() for i in inputs]
         self.output_components = [get_component_instance(o).unrender() for o in outputs]
+        
+        for component in self.input_components + self.output_components:
+            if not(isinstance(component, IOComponent)):
+                raise ValueError(f"{component} is not a valid input/output component for Interface.")
 
         if len(self.input_components) == len(self.output_components):
             same_components = [

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -208,7 +208,9 @@ class Interface(Blocks):
         self.output_components = [get_component_instance(o).unrender() for o in outputs]
 
         for component in self.input_components + self.output_components:
-            if not (isinstance(component, IOComponent) or isinstance(component, Variable)):
+            if not (
+                isinstance(component, IOComponent) or isinstance(component, Variable)
+            ):
                 raise ValueError(
                     f"{component} is not a valid input/output component for Interface."
                 )

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -208,7 +208,7 @@ class Interface(Blocks):
         self.output_components = [get_component_instance(o).unrender() for o in outputs]
 
         for component in self.input_components + self.output_components:
-            if not (isinstance(component, IOComponent)):
+            if not (isinstance(component, IOComponent) or isinstance(component, Variable)):
                 raise ValueError(
                     f"{component} is not a valid input/output component for Interface."
                 )

--- a/gradio/outputs.py
+++ b/gradio/outputs.py
@@ -295,7 +295,7 @@ class HTML(components.HTML):
         """
         super().__init__(label=label)
 
-        
+
 class Carousel(components.Carousel):
     """
     Component displays a set of output components that can be scrolled through.
@@ -318,7 +318,7 @@ class Carousel(components.Carousel):
             DeprecationWarning,
         )
         super().__init__(components=components, label=label)
-    
+
 
 class Chatbot(components.Chatbot):
     """

--- a/gradio/outputs.py
+++ b/gradio/outputs.py
@@ -9,24 +9,10 @@ from __future__ import annotations
 import warnings
 from typing import Dict, List, Optional
 
-from gradio.components import HTML as C_HTML
-from gradio.components import JSON as C_JSON
-from gradio.components import Audio as C_Audio
-from gradio.components import Chatbot as C_Chatbot
-from gradio.components import Component as Component
-from gradio.components import Dataframe as C_Dataframe
-from gradio.components import File as C_File
-from gradio.components import HighlightedText as C_HighlightedText
-from gradio.components import Image as C_Image
-from gradio.components import Label as C_Label
-from gradio.components import Model3D as C_Model3D
-from gradio.components import Textbox as C_Textbox
-from gradio.components import Timeseries as C_Timeseries
-from gradio.components import Variable as C_State
-from gradio.components import Video as C_Video
+from gradio import components
 
 
-class Textbox(C_Textbox):
+class Textbox(components.Textbox):
     def __init__(
         self,
         type: str = "auto",
@@ -39,7 +25,7 @@ class Textbox(C_Textbox):
         super().__init__(label=label, type=type)
 
 
-class Image(C_Image):
+class Image(components.Image):
     """
     Component displays an output image.
     Output type: Union[numpy.array, PIL.Image, str, matplotlib.pyplot, Tuple[Union[numpy.array, PIL.Image, str], List[Tuple[str, float, float, float, float]]]]
@@ -64,7 +50,7 @@ class Image(C_Image):
         super().__init__(type=type, label=label)
 
 
-class Video(C_Video):
+class Video(components.Video):
     """
     Used for video output.
     Output type: filepath
@@ -84,7 +70,7 @@ class Video(C_Video):
         super().__init__(format=type, label=label)
 
 
-class Audio(C_Audio):
+class Audio(components.Audio):
     """
     Creates an audio player that plays the output audio.
     Output type: Union[Tuple[int, numpy.array], str]
@@ -104,7 +90,7 @@ class Audio(C_Audio):
         super().__init__(type=type, label=label)
 
 
-class File(C_File):
+class File(components.File):
     """
     Used for file output.
     Output type: Union[file-like, str]
@@ -123,7 +109,7 @@ class File(C_File):
         super().__init__(label=label)
 
 
-class Dataframe(C_Dataframe):
+class Dataframe(components.Dataframe):
     """
     Component displays 2D output through a spreadsheet interface.
     Output type: Union[pandas.DataFrame, numpy.array, List[Union[str, float]], List[List[Union[str, float]]]]
@@ -162,7 +148,7 @@ class Dataframe(C_Dataframe):
         )
 
 
-class Timeseries(C_Timeseries):
+class Timeseries(components.Timeseries):
     """
     Component accepts pandas.DataFrame.
     Output type: pandas.DataFrame
@@ -185,7 +171,7 @@ class Timeseries(C_Timeseries):
         super().__init__(x=x, y=y, label=label)
 
 
-class State(C_State):
+class State(components.State):
     """
     Special hidden component that stores state across runs of the interface.
     Output type: Any
@@ -204,7 +190,7 @@ class State(C_State):
         super().__init__(label=label)
 
 
-class Label(C_Label):
+class Label(components.Label):
     """
     Component outputs a classification label, along with confidence scores of top categories if provided. Confidence scores are represented as a dictionary mapping labels to scores between 0 and 1.
     Output type: Union[Dict[str, float], str, int, float]
@@ -249,7 +235,7 @@ class KeyValues:
         )
 
 
-class HighlightedText(C_HighlightedText):
+class HighlightedText(components.HighlightedText):
     """
     Component creates text that contains spans that are highlighted by category or numerical value.
     Output is represent as a list of Tuple pairs, where the first element represents the span of text represented by the tuple, and the second element represents the category or value of the text.
@@ -276,7 +262,7 @@ class HighlightedText(C_HighlightedText):
         super().__init__(color_map=color_map, label=label, show_legend=show_legend)
 
 
-class JSON(C_JSON):
+class JSON(components.JSON):
     """
     Used for JSON output. Expects a JSON string or a Python object that is JSON serializable.
     Output type: Union[str, Any]
@@ -295,7 +281,7 @@ class JSON(C_JSON):
         super().__init__(label=label)
 
 
-class HTML(C_HTML):
+class HTML(components.HTML):
     """
     Used for HTML output. Expects an HTML valid string.
     Output type: str
@@ -309,8 +295,8 @@ class HTML(C_HTML):
         """
         super().__init__(label=label)
 
-
-class Carousel:
+        
+class Carousel(components.Carousel):
     """
     Component displays a set of output components that can be scrolled through.
     Output type: List[List[Any]]
@@ -319,21 +305,22 @@ class Carousel:
 
     def __init__(
         self,
-        components: Component | List[Component],
+        components: components.Component | List[components.Component],
         label: Optional[str] = None,
     ):
         """
         Parameters:
-        components (Union[List[OutputComponent], OutputComponent]): Classes of component(s) that will be scrolled through.
+        components (Union[List[Component], Component]): Classes of component(s) that will be scrolled through.
         label (str): component name in interface.
         """
-        raise NotImplementedError(
-            "The Carousel component has not been implemented in Gradio 3.0. Please "
-            "consider using the Gallery component instead."
+        warnings.warn(
+            "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
+            DeprecationWarning,
         )
+        super().__init__(components=components, label=label)
+    
 
-
-class Chatbot(C_Chatbot):
+class Chatbot(components.Chatbot):
     """
     Component displays a chatbot output showing both user submitted messages and responses
     Output type: List[Tuple[str, str]]
@@ -352,7 +339,7 @@ class Chatbot(C_Chatbot):
         super().__init__(label=label)
 
 
-class Image3D(C_Model3D):
+class Image3D(components.Model3D):
     """
     Used for 3D image model output.
     Input type: File object of type (.obj, glb, or .gltf)

--- a/gradio/outputs.py
+++ b/gradio/outputs.py
@@ -171,7 +171,7 @@ class Timeseries(components.Timeseries):
         super().__init__(x=x, y=y, label=label)
 
 
-class State(components.State):
+class State(components.Variable):
     """
     Special hidden component that stores state across runs of the interface.
     Output type: Any


### PR DESCRIPTION
* added style components for dall-e mini demo
* added support for Markdown as an IO component (closes: #1241)
* brings back basic implementation of carousel for backwards-compatibility with gradio 2.x for `gr.Interface.load()`
* small cleanups


Started working on this, but will move to a dedicated PR as it is quite complex:
* fixes gr.Interface.load for 3.0 demos (#1248)  
