### PR TITLE
Dm

### DIFF
--- a/ui/packages/app/src/Blocks.svelte
+++ b/ui/packages/app/src/Blocks.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { onMount, SvelteComponentTyped } from "svelte";
+	import type { SvelteComponentTyped } from "svelte";
+	import { onMount } from "svelte";
 	import { component_map } from "./components/directory";
 	import { loading_status } from "./stores";
 	import type { LoadingStatus } from "./stores";

--- a/ui/packages/app/src/Blocks.svelte
+++ b/ui/packages/app/src/Blocks.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { SvelteComponentTyped } from "svelte";
+	import { onMount, SvelteComponentTyped } from "svelte";
 	import { component_map } from "./components/directory";
 	import { loading_status } from "./stores";
 	import type { LoadingStatus } from "./stores";
@@ -320,6 +320,49 @@
 			set_prop(instance_map[id], "loading_status", statuses[id]);
 		}
 	}
+
+	let mode = "";
+
+	function handle_darkmode() {
+		let url = new URL(window.location.toString());
+
+		const color_mode: "light" | "dark" | "system" | null = url.searchParams.get(
+			"__theme"
+		) as "light" | "dark" | "system" | null;
+
+		if (color_mode !== null) {
+			if (color_mode === "dark") {
+				mode = "dark";
+			} else if (color_mode === "system") {
+				use_system_theme();
+			}
+			// light is default, so we don't need to do anything else
+		} else if (url.searchParams.get("__dark-theme") === "true") {
+			mode = "dark";
+		} else {
+			use_system_theme();
+		}
+	}
+
+	function use_system_theme() {
+		update_scheme();
+		window
+			?.matchMedia("(prefers-color-scheme: dark)")
+			?.addEventListener("change", update_scheme);
+
+		function update_scheme() {
+			const is_dark =
+				window?.matchMedia?.("(prefers-color-scheme: dark)").matches ?? null;
+
+			mode = is_dark ? "dark" : "";
+		}
+	}
+
+	onMount(() => {
+		if (window.__gradio_mode__ !== "website") {
+			handle_darkmode();
+		}
+	});
 </script>
 
 <svelte:head>
@@ -331,37 +374,38 @@
 			src="https://www.googletagmanager.com/gtag/js?id=UA-156449732-1"></script>
 	{/if}
 </svelte:head>
-
-<div class="mx-auto container px-4 py-6 dark:bg-gray-950">
-	{#if ready}
-		<Render
-			component={rootNode.component}
-			id={rootNode.id}
-			props={rootNode.props}
-			children={rootNode.children}
-			{dynamic_ids}
-			{instance_map}
-			{theme}
-			{root}
-			{status_tracker_values}
-			on:mount={handle_mount}
-			on:destroy={({ detail }) => handle_destroy(detail)}
-		/>
-	{/if}
-</div>
-<div
-	class="gradio-page container mx-auto flex flex-col box-border flex-grow text-gray-700 dark:text-gray-50"
->
-	<div
-		class="footer flex-shrink-0 inline-flex gap-2.5 items-center text-gray-600 dark:text-gray-300 justify-center py-2"
-	>
-		<a href="https://gradio.app" target="_blank" rel="noreferrer">
-			{$_("interface.built_with_Gradio")}
-			<img
-				class="h-5 inline-block pb-0.5"
-				src="{static_src}/static/img/logo.svg"
-				alt="logo"
+<div class="w-full h-full min-h-screen {mode}">
+	<div class="mx-auto container px-4 py-6 dark:bg-gray-950">
+		{#if ready}
+			<Render
+				component={rootNode.component}
+				id={rootNode.id}
+				props={rootNode.props}
+				children={rootNode.children}
+				{dynamic_ids}
+				{instance_map}
+				{theme}
+				{root}
+				{status_tracker_values}
+				on:mount={handle_mount}
+				on:destroy={({ detail }) => handle_destroy(detail)}
 			/>
-		</a>
+		{/if}
+	</div>
+	<div
+		class="gradio-page container mx-auto flex flex-col box-border flex-grow text-gray-700 dark:text-gray-50"
+	>
+		<div
+			class="footer flex-shrink-0 inline-flex gap-2.5 items-center text-gray-600 dark:text-gray-300 justify-center py-2"
+		>
+			<a href="https://gradio.app" target="_blank" rel="noreferrer">
+				{$_("interface.built_with_Gradio")}
+				<img
+					class="h-5 inline-block pb-0.5"
+					src="{static_src}/static/img/logo.svg"
+					alt="logo"
+				/>
+			</a>
+		</div>
 	</div>
 </div>

--- a/ui/packages/app/src/components/Label/Label.svelte
+++ b/ui/packages/app/src/components/Label/Label.svelte
@@ -25,7 +25,7 @@
 	<StatusTracker {...loading_status} />
 	<BlockLabel Icon={LabelIcon} {label} />
 
-	{#if value !== undefined && value !== null}
+	{#if typeof value === "object" && value !== undefined && value !== null}
 		<Label {value} {show_label} />
 	{:else}
 		<div class="h-full min-h-[6rem] flex justify-center items-center">

--- a/ui/packages/app/src/main.ts
+++ b/ui/packages/app/src/main.ts
@@ -65,7 +65,7 @@ window.launchGradio = (config: Config, element_query: string) => {
 			"The target element could not be found. Please ensure that element exists."
 		);
 	}
-	document.body.classList.add("gradio-container");
+	target.classList.add("gradio-container");
 
 	if (config.root === undefined) {
 		config.root = BACKEND_URL;
@@ -89,10 +89,6 @@ window.launchGradio = (config: Config, element_query: string) => {
 		});
 		window.__gradio_loader__.$set({ status: "complete" });
 	} else {
-		if (window.__gradio_mode__ !== "website") {
-			handle_darkmode(target);
-		}
-
 		let session_hash = Math.random().toString(36).substring(2);
 		config.fn = fn.bind(null, session_hash, config.root + "api/");
 
@@ -102,41 +98,6 @@ window.launchGradio = (config: Config, element_query: string) => {
 		});
 	}
 };
-
-function handle_darkmode(target: HTMLElement) {
-	let url = new URL(window.location.toString());
-
-	const color_mode: "light" | "dark" | "system" | null = url.searchParams.get(
-		"__theme"
-	) as "light" | "dark" | "system" | null;
-
-	if (color_mode !== null) {
-		if (color_mode === "dark") {
-			target.classList.add("dark");
-		} else if (color_mode === "system") {
-			use_system_theme(target);
-		}
-		// light is default, so we don't need to do anything else
-	} else if (url.searchParams.get("__dark-theme") === "true") {
-		target.classList.add("dark");
-	} else {
-		use_system_theme(target);
-	}
-}
-
-function use_system_theme(target: HTMLElement) {
-	update_scheme();
-	window
-		?.matchMedia("(prefers-color-scheme: dark)")
-		?.addEventListener("change", update_scheme);
-
-	function update_scheme() {
-		const is_dark =
-			window?.matchMedia?.("(prefers-color-scheme: dark)").matches ?? null;
-
-		target.classList[is_dark ? "add" : "remove"]("dark");
-	}
-}
 
 window.launchGradioFromSpaces = async (space: string, target: string) => {
 	const space_url = `https://hf.space/embed/${space}/+/`;

--- a/ui/packages/app/src/main.ts
+++ b/ui/packages/app/src/main.ts
@@ -65,7 +65,7 @@ window.launchGradio = (config: Config, element_query: string) => {
 			"The target element could not be found. Please ensure that element exists."
 		);
 	}
-	target.classList.add("gradio-container");
+	document.body.classList.add("gradio-container");
 
 	if (config.root === undefined) {
 		config.root = BACKEND_URL;

--- a/ui/packages/chart/src/Chart.svelte
+++ b/ui/packages/chart/src/Chart.svelte
@@ -57,11 +57,11 @@
 </script>
 
 <div class="mt-3">
-	<div class="flex justify-center items-center text-sm">
+	<div class="flex justify-center items-center text-sm dark:text-slate-200">
 		{#each _y as { name }}
 			<div class="mx-2 flex gap-1 items-center">
 				<span
-					class="inline-block w-[12px] h-[12px] rounded-sm"
+					class="inline-block w-[12px] h-[12px] rounded-sm "
 					style="background-color: {color_map[name]}"
 				/>
 				{name}
@@ -84,7 +84,7 @@
 					stroke="#aaa"
 				/>
 				<text
-					class="font-mono text-xs"
+					class="font-mono text-xs dark:fill-slate-200"
 					text-anchor="middle"
 					x={scale_x(tick)}
 					y={scale_y(y_ticks[0]) + 30}
@@ -108,7 +108,7 @@
 				/>
 
 				<text
-					class="font-mono text-xs"
+					class="font-mono text-xs dark:fill-slate-200"
 					text-anchor="end"
 					y={scale_y(tick) + 4}
 					x={scale_x(x_ticks[0]) - 20}
@@ -127,7 +127,7 @@
 					stroke="#aaa"
 				/>
 				<text
-					class="font-mono text-xs"
+					class="font-mono text-xs dark:fill-slate-200"
 					text-anchor="end"
 					y={scale_y(y_domain[1]) + 4}
 					x={scale_x(x_ticks[0]) - 20}
@@ -175,7 +175,9 @@
 		{/each}
 	</svg>
 
-	<div class="flex justify-center align-items-center text-sm">
+	<div
+		class="flex justify-center align-items-center text-sm dark:text-slate-200"
+	>
 		{_x.name}
 	</div>
 </div>

--- a/ui/packages/file/src/File.svelte
+++ b/ui/packages/file/src/File.svelte
@@ -13,7 +13,7 @@
 
 {#if value}
 	<a
-		class="output-file w-full h-full flex flex-row flex-wrap justify-center items-center relative"
+		class="output-file w-full h-full flex flex-row flex-wrap justify-center items-center relative dark:text-slate-200"
 		href={value.data}
 		download={value.name}
 	>

--- a/ui/packages/file/src/FileUpload.svelte
+++ b/ui/packages/file/src/FileUpload.svelte
@@ -54,7 +54,7 @@
 	</Upload>
 {:else}
 	<div
-		class="file-preview w-full flex flex-row justify-between overflow-y-auto mt-7"
+		class="file-preview w-full flex flex-row justify-between overflow-y-auto mt-7 dark:text-slate-200"
 	>
 		<ModifyUpload on:clear={handle_clear} absolute />
 
@@ -65,8 +65,10 @@
 			{prettyBytes(value.size || 0)}
 		</div>
 		<div class="file-size p-2 hover:underline">
-			<a href={value.data} download class="text-indigo-600 hover:underline"
-				>Download</a
+			<a
+				href={value.data}
+				download
+				class="text-indigo-600 hover:underline dark:text-indigo-300">Download</a
 			>
 		</div>
 	</div>

--- a/ui/packages/highlighted-text/src/HighlightedText.svelte
+++ b/ui/packages/highlighted-text/src/HighlightedText.svelte
@@ -87,7 +87,7 @@
 
 {#if mode === "categories"}
 	{#if show_legend}
-		<div class="category-legend flex flex-wrap gap-1 mb-2 text-black">
+		<div class="category-legend flex flex-wrap gap-1 mb-2 text-black mt-7">
 			{#each Object.entries(_color_map) as [category, color], i}
 				<div
 					on:mouseover={() => handle_mouseover(category)}
@@ -103,7 +103,7 @@
 		</div>
 	{/if}
 	<div
-		class="textfield bg-white dark:bg-transparent rounded-sm text-sm box-border max-w-full break-word leading-7"
+		class="textfield bg-white dark:bg-transparent rounded-sm text-sm box-border max-w-full break-word leading-7 mt-7"
 	>
 		{#each value as [text, category]}
 			<span
@@ -134,7 +134,7 @@
 {:else}
 	{#if show_legend}
 		<div
-			class="color_legend flex px-2 py-1 justify-between rounded mb-3 font-semibold"
+			class="color_legend flex px-2 py-1 justify-between rounded mb-3 font-semibold mt-7"
 			style="background: -webkit-linear-gradient(to right,#8d83d6,(255,255,255,0),#eb4d4b); background: linear-gradient(to right,#8d83d6,rgba(255,255,255,0),#eb4d4b);"
 		>
 			<span>-1</span>

--- a/ui/packages/json/src/JSON.svelte
+++ b/ui/packages/json/src/JSON.svelte
@@ -30,7 +30,7 @@
 
 <button
 	on:click={handle_copy}
-	class="transition-color overflow-hidden font-sans absolute right-0 top-0  rounded-bl-lg shadow-sm text-xs text-gray-500 flex items-center  bg-white z-20 border-l border-b border-gray-100"
+	class="transition-color overflow-hidden font-sans absolute right-0 top-0  rounded-bl-lg shadow-sm text-xs text-gray-500 flex items-center  bg-white z-20 border-l border-b border-gray-100 dark:text-slate-200"
 >
 	<span class="py-1 px-2">copy to clipboard</span>
 	{#if copied}

--- a/ui/packages/json/src/JSONNode.svelte
+++ b/ui/packages/json/src/JSONNode.svelte
@@ -4,7 +4,10 @@
 	export let collapsed = depth > 4;
 </script>
 
-<div class="json-node inline text-sm font-mono leading-tight ">
+<span class="inline-block h-0 w-0" class:mt-10={depth === 0} />
+<div
+	class="json-node inline text-sm font-mono leading-tight dark:text-slate-200"
+>
 	{#if value instanceof Array}
 		{#if collapsed}
 			<button

--- a/ui/packages/label/src/Label.svelte
+++ b/ui/packages/label/src/Label.svelte
@@ -11,15 +11,15 @@
 <div class="output-label" space-y-4 {theme}>
 	<div
 		class:sr-only={!show_label}
-		class="output-class font-bold text-2xl py-6 px-4 flex-grow flex items-center justify-center"
+		class="output-class font-bold text-2xl py-6 px-4 flex-grow flex items-center justify-center dark:text-slate-200"
 		class:no-confidence={!("confidences" in value)}
 	>
 		{value.label}
 	</div>
-	{#if value.confidences}
+	{#if typeof value === "object" && value.confidences}
 		{#each value.confidences as confidence_set}
 			<div
-				class="flex items-start justify-between font-mono text-sm leading-none group mb-2 last:mb-0"
+				class="flex items-start justify-between font-mono text-sm leading-none group mb-2 last:mb-0 dark:text-slate-300"
 			>
 				<div class="flex-1">
 					<div

--- a/ui/packages/theme/src/global.css
+++ b/ui/packages/theme/src/global.css
@@ -6,39 +6,39 @@
 	.bg-gray-950 {
 		background-color: #090f1f;
 	}
-	.dark:bg-gray-950 {
+	.gradio-container .dark:bg-gray-950 {
 	}
 
-	.dark {
+	.gradio-container .dark {
 		@apply text-gray-300 bg-gray-950;
 	}
-	.dark .text-gray-500,
-	.dark .text-gray-600 {
+	.gradio-container .dark .text-gray-500,
+	.gradio-container .dark .text-gray-600 {
 		@apply text-gray-300;
 	}
 
-	.dark .text-gray-700,
-	.dark .text-gray-800,
-	.dark .text-gray-900 {
+	.gradio-container .dark .text-gray-700,
+	.gradio-container .dark .text-gray-800,
+	.gradio-container .dark .text-gray-900 {
 		@apply text-gray-200;
 	}
 
-	.dark .border,
-	.dark .border-gray-100,
-	.dark .border-gray-200,
-	.dark .border-gray-300 {
+	.gradio-container .dark .border,
+	.gradio-container .dark .border-gray-100,
+	.gradio-container .dark .border-gray-200,
+	.gradio-container .dark .border-gray-300 {
 		@apply border-gray-700;
 	}
 
-	.dark .bg-white {
+	.gradio-container .dark .bg-white {
 		@apply bg-gray-950;
 	}
 
-	.dark .bg-gray-50 {
+	.gradio-container .dark .bg-gray-50 {
 		@apply bg-gray-900;
 	}
 
-	.dark .bg-gray-200 {
+	.gradio-container .dark .bg-gray-200 {
 		@apply bg-gray-800;
 	}
 


### PR DESCRIPTION
- makes dark mode work again by adding loads of selectors to increase specificty (this is really bad but will fix it some other time)
- ensure the `gradio-container` and `dark` classes are on different element to avoid specificity nightmares (`.gradio-container.dark` etc)
- final dark mode tweaks to ensure text is the correct color.