### PR TITLE
Small bugs

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3011,7 +3011,7 @@ class Gallery(IOComponent):
 
     def __init__(
         self,
-        value: List[numpy.array | PIL.Image | str] = [],
+        value: List[numpy.array | PIL.Image | str] = None,
         *,
         label: Optional[str] = None,
         show_label: bool = True,

--- a/ui/packages/app/src/components/Gallery/Gallery.svelte
+++ b/ui/packages/app/src/components/Gallery/Gallery.svelte
@@ -4,7 +4,7 @@
 	import { tick } from "svelte";
 	import type { LoadingStatus } from "../StatusTracker/types";
 	import StatusTracker from "../StatusTracker/StatusTracker.svelte";
-	import ImageIcon from "./ImageIcon.svelte";
+	import { Image } from "@gradio/icons";
 
 	export let loading_status: LoadingStatus;
 	export let show_label: boolean;
@@ -82,16 +82,18 @@
 
 	let height = 0;
 	let window_height = 0;
+
+	$: console.log(value);
 </script>
 
 <svelte:window bind:innerHeight={window_height} />
 
 <Block variant="solid" color="grey" padding={false} {elem_id}>
 	<StatusTracker {...loading_status} />
-	<BlockLabel {show_label} Icon={ImageIcon} label={label || "Gallery"} />
+	<BlockLabel {show_label} Icon={Image} label={label || "Gallery"} />
 	{#if value === null}
 		<div class="h-full min-h-[15rem] flex justify-center items-center">
-			<ImageIcon />
+			<div class="h-5 dark:text-white opacity-50"><Image /></div>
 		</div>
 	{:else}
 		{#if selected_image !== null}

--- a/ui/packages/app/src/components/Gallery/Gallery.svelte
+++ b/ui/packages/app/src/components/Gallery/Gallery.svelte
@@ -82,7 +82,6 @@
 
 	let height = 0;
 	let window_height = 0;
-
 </script>
 
 <svelte:window bind:innerHeight={window_height} />

--- a/ui/packages/app/src/components/Gallery/Gallery.svelte
+++ b/ui/packages/app/src/components/Gallery/Gallery.svelte
@@ -83,7 +83,6 @@
 	let height = 0;
 	let window_height = 0;
 
-	$: console.log(value);
 </script>
 
 <svelte:window bind:innerHeight={window_height} />

--- a/ui/packages/form/src/Textbox.svelte
+++ b/ui/packages/form/src/Textbox.svelte
@@ -12,7 +12,7 @@
 	export let show_label: boolean = true;
 	export let max_lines: number | false;
 
-	let el: HTMLTextAreaElement;
+	let el: HTMLTextAreaElement | HTMLInputElement;
 
 	$: value, el && lines !== max_lines && resize({ target: el });
 	$: handle_change(value);
@@ -35,7 +35,9 @@
 		}
 	}
 
-	async function resize(event: Event | { target: HTMLTextAreaElement }) {
+	async function resize(
+		event: Event | { target: HTMLTextAreaElement | HTMLInputElement }
+	) {
 		await tick();
 		if (lines === max_lines) return;
 
@@ -89,6 +91,7 @@
 			bind:this={el}
 			{placeholder}
 			{disabled}
+			on:keypress={handle_keypress}
 		/>
 	{:else}
 		<textarea


### PR DESCRIPTION
- Set the default value of Gallery to `None` for some reason this had been changed recently but an empty list is not the same as a null value. A predict function could return an empty list and we need to handle that slightly differently to `None` (which is translated to `null` in js). We display the placeholder for `null` false but not for empty lists of images.
- Adds the submit event listener to the `Textbox` when the lines are equal to 1. For some reason this got removed (it was probably me).