### PR TITLE
Style updates

### DIFF
--- a/demo/blocks_flashcards/run.py
+++ b/demo/blocks_flashcards/run.py
@@ -25,10 +25,8 @@ with demo:
                     with gr.Row():
                         correct_btn = gr.Button(
                             "Correct",
-                        ).style(bg_color="green", text_color="black", full_width=True)
-                        incorrect_btn = gr.Button("Incorrect").style(
-                            bg_color="pink", text_color="black", full_width=True
-                        )
+                        ).style(full_width=True)
+                        incorrect_btn = gr.Button("Incorrect").style(full_width=True)
 
         with gr.TabItem("Results"):
             results = gr.Variable(value={})

--- a/demo/blocks_simple_squares/run.py
+++ b/demo/blocks_simple_squares/run.py
@@ -4,8 +4,8 @@ demo = gr.Blocks(css="#btn {color: red}")
 
 with demo:
     num = gr.Variable(value=0)
-    squared = gr.Number(value=0).style(text_color="blue", container_bg_color="yellow")
-    btn = gr.Button("Next Square", elem_id="btn").style(rounded=False, bg_color="purple")
+    squared = gr.Number(value=0)
+    btn = gr.Button("Next Square", elem_id="btn").style(rounded=False)
 
     def increase(var):
         var += 1

--- a/demo/blocks_style/run.py
+++ b/demo/blocks_style/run.py
@@ -1,0 +1,175 @@
+import gradio as gr
+
+with gr.Blocks() as demo:
+    with gr.Column():
+        txt = gr.Textbox(label="Small Textbox", lines=1).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+
+        num = gr.Number(label="Number", show_label=False).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        check = gr.Checkbox(label="Checkbox", show_label=False).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        check_g = gr.CheckboxGroup(
+            label="Checkbox Group", choices=["One", "Two", "Three"], show_label=False
+        ).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        radio = gr.Radio(
+            label="Radio", choices=["One", "Two", "Three"], show_label=False
+        ).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        drop = gr.Dropdown(
+            label="Dropdown", choices=["One", "Two", "Three"], show_label=False
+        ).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        slider = gr.Slider(label="Slider", show_label=False).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        audio = gr.Audio(show_label=False).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        file = gr.File(show_label=False).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        video = gr.Video(show_label=False).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        image = gr.Image(show_label=False).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        ts = gr.Timeseries(show_label=False).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        df = gr.Dataframe(show_label=False).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        html = gr.HTML(show_label=False).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        json = gr.JSON(show_label=False).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        md = gr.Markdown(show_label=False).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        label = gr.Label(show_label=False).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        highlight = gr.HighlightedText(show_label=False).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        gr.Dataframe(interactive=True, col_count=(3, "fixed")).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+        gr.Dataframe(interactive=True, col_count=4).style(
+            rounded=False,
+            bg_color="green",
+            text_color="blue",
+            container_bg_color="red",
+            margin=False,
+            border=False,
+        )
+
+
+if __name__ == "__main__":
+    demo.launch()

--- a/demo/blocks_style/run.py
+++ b/demo/blocks_style/run.py
@@ -4,171 +4,125 @@ with gr.Blocks() as demo:
     with gr.Column():
         txt = gr.Textbox(label="Small Textbox", lines=1).style(
             rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
             margin=False,
             border=False,
+            container=False,
         )
 
         num = gr.Number(label="Number", show_label=False).style(
             rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
             margin=False,
             border=False,
+            container=False,
+        )
+        slider = gr.Slider(label="Slider", show_label=False).style(
+            margin=False,
+            container=False,
         )
         check = gr.Checkbox(label="Checkbox", show_label=False).style(
             rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
             margin=False,
             border=False,
+            container=False,
         )
         check_g = gr.CheckboxGroup(
             label="Checkbox Group", choices=["One", "Two", "Three"], show_label=False
         ).style(
             rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
             margin=False,
             border=False,
+            container=False,
         )
         radio = gr.Radio(
             label="Radio", choices=["One", "Two", "Three"], show_label=False
         ).style(
             rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
             margin=False,
             border=False,
+            container=False,
         )
         drop = gr.Dropdown(
             label="Dropdown", choices=["One", "Two", "Three"], show_label=False
         ).style(
             rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
             margin=False,
             border=False,
-        )
-        slider = gr.Slider(label="Slider", show_label=False).style(
-            rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
-            margin=False,
-            border=False,
-        )
-        audio = gr.Audio(show_label=False).style(
-            rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
-            margin=False,
-            border=False,
-        )
-        file = gr.File(show_label=False).style(
-            rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
-            margin=False,
-            border=False,
-        )
-        video = gr.Video(show_label=False).style(
-            rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
-            margin=False,
-            border=False,
+            container=False,
         )
         image = gr.Image(show_label=False).style(
             rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
-            margin=False,
-            border=False,
         )
-        ts = gr.Timeseries(show_label=False).style(
+        video = gr.Video(show_label=False).style(
             rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
-            margin=False,
-            border=False,
+        )
+        audio = gr.Audio(show_label=False).style(
+            rounded=False,
+        )
+        file = gr.File(show_label=False).style(
+            rounded=False,
         )
         df = gr.Dataframe(show_label=False).style(
             rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
-            margin=False,
-            border=False,
         )
-        html = gr.HTML(show_label=False).style(
+
+        ts = gr.Timeseries(show_label=False).style(
             rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
-            margin=False,
-            border=False,
-        )
-        json = gr.JSON(show_label=False).style(
-            rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
-            margin=False,
-            border=False,
-        )
-        md = gr.Markdown(show_label=False).style(
-            rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
-            margin=False,
-            border=False,
         )
         label = gr.Label(show_label=False).style(
-            rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
-            margin=False,
-            border=False,
+            container=False,
         )
         highlight = gr.HighlightedText(show_label=False).style(
+            rounded=False, color_map={"+": "green", "-": "red"}, container=False
+        )
+        json = gr.JSON(show_label=False).style(container=False)
+        html = gr.HTML(show_label=False).style(
+            margin=False,
+        )
+        gallery = gr.Gallery().style(
             rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
+            margin=False,
+            grid=(3, 3, 1),
+            height="auto",
+            border=False,
+            container=False,
+        )
+        chat = gr.Chatbot().style(
+            rounded=False,
+            color_map={"user": "pink", "bot": "blue"},
+        )
+
+        model = gr.Model3D().style(
+            rounded=False,
+        )
+
+        gr.Plot().style(
+            rounded=False,
+            margin=False,
+            border=False,
+            container=False,
+        )
+        md = gr.Markdown(show_label=False).style(
+            margin=False,
+        )
+
+        highlight = gr.HighlightedText(show_label=False).style(
+            rounded=False,
+        )
+
+        btn = gr.Button("Run").style(
+            rounded=False,
+            full_width=True,
             margin=False,
             border=False,
         )
-        gr.Dataframe(interactive=True, col_count=(3, "fixed")).style(
-            rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
-            margin=False,
-            border=False,
-        )
-        gr.Dataframe(interactive=True, col_count=4).style(
-            rounded=False,
-            bg_color="green",
-            text_color="blue",
-            container_bg_color="red",
-            margin=False,
-            border=False,
-        )
+
+        # Not currently public
+        # TODO: Uncomment at next release
+        # gr.Dataset().style(
+        #     rounded=False,
+        #     margin=False,
+        #     border=False,
+        # )
 
 
 if __name__ == "__main__":

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -240,7 +240,22 @@ class IOComponent(Component):
         border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         container: Optional[bool] = None,
     ):
-        valid_colors = ["red", "yellow", "green", "blue", "purple", "black"]
+        valid_colors = [
+            "red",
+            "green",
+            "blue",
+            "yellow",
+            "purple",
+            "teal",
+            "orange",
+            "cyan",
+            "lime",
+            "pink",
+            "black",
+            "grey",
+            "gray",
+        ]
+
         if rounded is not None:
             self._style["rounded"] = rounded
         if bg_color is not None:

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -234,36 +234,12 @@ class IOComponent(Component):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
         margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         container: Optional[bool] = None,
     ):
-        valid_colors = [
-            "red",
-            "green",
-            "blue",
-            "yellow",
-            "purple",
-            "teal",
-            "orange",
-            "cyan",
-            "lime",
-            "pink",
-            "black",
-            "grey",
-            "gray",
-        ]
-
         if rounded is not None:
             self._style["rounded"] = rounded
-        if bg_color is not None:
-            assert bg_color in valid_colors
-            self._style["bg_color"] = bg_color
-        if text_color is not None:
-            assert text_color in valid_colors
-            self._style["text_color"] = text_color
         if margin is not None:
             self._style["margin"] = margin
         if border is not None:
@@ -456,25 +432,6 @@ class Textbox(Changeable, Submittable, IOComponent):
         """
         return x
 
-    def style(
-        self,
-        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        container: Optional[bool] = None,
-    ):
-        return IOComponent.style(
-            self,
-            rounded=rounded,
-            bg_color=bg_color,
-            text_color=text_color,
-            margin=margin,
-            border=border,
-            container=container,
-        )
-
 
 class Number(Changeable, Submittable, IOComponent):
     """
@@ -656,25 +613,6 @@ class Number(Changeable, Submittable, IOComponent):
         """
         return y
 
-    def style(
-        self,
-        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        container: Optional[bool] = None,
-    ):
-        return IOComponent.style(
-            self,
-            rounded=rounded,
-            bg_color=bg_color,
-            text_color=text_color,
-            margin=margin,
-            border=border,
-            container=container,
-        )
-
 
 class Slider(Changeable, IOComponent):
     """
@@ -821,13 +759,11 @@ class Slider(Changeable, IOComponent):
 
     def style(
         self,
-        text_color: Optional[str] = None,
         margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         container: Optional[bool] = None,
     ):
         return IOComponent.style(
             self,
-            text_color=text_color,
             margin=margin,
             container=container,
         )
@@ -947,25 +883,6 @@ class Checkbox(Changeable, IOComponent):
         Convert from serialized output (e.g. base64 representation) from a call() to the interface to a human-readable version of the output (path of an image, etc.)
         """
         return x
-
-    def style(
-        self,
-        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        container: Optional[bool] = None,
-    ):
-        return IOComponent.style(
-            self,
-            rounded=rounded,
-            bg_color=bg_color,
-            text_color=text_color,
-            margin=margin,
-            border=border,
-            container=container,
-        )
 
 
 class CheckboxGroup(Changeable, IOComponent):
@@ -1119,25 +1036,6 @@ class CheckboxGroup(Changeable, IOComponent):
         """
         return x
 
-    def style(
-        self,
-        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        container: Optional[bool] = None,
-    ):
-        return IOComponent.style(
-            self,
-            rounded=rounded,
-            bg_color=bg_color,
-            text_color=text_color,
-            margin=margin,
-            border=border,
-            container=container,
-        )
-
 
 class Radio(Changeable, IOComponent):
     """
@@ -1273,25 +1171,6 @@ class Radio(Changeable, IOComponent):
         Convert from serialized output (e.g. base64 representation) from a call() to the interface to a human-readable version of the output (path of an image, etc.)
         """
         return x
-
-    def style(
-        self,
-        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        container: Optional[bool] = None,
-    ):
-        return IOComponent.style(
-            self,
-            rounded=rounded,
-            bg_color=bg_color,
-            text_color=text_color,
-            margin=margin,
-            border=border,
-            container=container,
-        )
 
 
 class Dropdown(Radio):
@@ -1664,12 +1543,10 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
     ):
         return IOComponent.style(
             self,
             rounded=rounded,
-            bg_color=bg_color,
         )
 
     def stream(
@@ -1835,14 +1712,10 @@ class Video(Changeable, Clearable, Playable, IOComponent):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
     ):
         return IOComponent.style(
             self,
             rounded=rounded,
-            bg_color=bg_color,
-            margin=margin,
         )
 
 
@@ -2157,18 +2030,10 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        container: Optional[bool] = None,
     ):
         return IOComponent.style(
             self,
             rounded=rounded,
-            bg_color=bg_color,
-            margin=margin,
-            border=border,
-            container=container,
         )
 
 
@@ -2318,14 +2183,10 @@ class File(Changeable, Clearable, IOComponent):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
     ):
         return IOComponent.style(
             self,
             rounded=rounded,
-            bg_color=bg_color,
-            text_color=text_color,
         )
 
 
@@ -2540,14 +2401,11 @@ class Dataframe(Changeable, IOComponent):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        text_color: Optional[str] = None,
         border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
     ):
         return IOComponent.style(
             self,
             rounded=rounded,
-            text_color=text_color,
-            border=border,
         )
 
 
@@ -2675,16 +2533,11 @@ class Timeseries(Changeable, IOComponent):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
         border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
     ):
         return IOComponent.style(
             self,
             rounded=rounded,
-            bg_color=bg_color,
-            text_color=text_color,
-            border=border,
         )
 
 
@@ -2861,20 +2714,9 @@ class Label(Changeable, IOComponent):
 
     def style(
         self,
-        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        container: Optional[bool] = None,
     ):
-        return IOComponent.style(
-            self,
-            rounded=rounded,
-            bg_color=bg_color,
-            text_color=text_color,
-            margin=margin,
-            border=border,
-        )
+        return IOComponent.style(self, container=container)
 
 
 class HighlightedText(Changeable, IOComponent):
@@ -2977,21 +2819,13 @@ class HighlightedText(Changeable, IOComponent):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         color_map: Optional[Dict[str, str]] = None,
+        container: Optional[bool] = None,
     ):
         if color_map is not None:
             self._style["color_map"] = color_map
 
-        return IOComponent.style(
-            self,
-            rounded=rounded,
-            bg_color=bg_color,
-            margin=margin,
-            border=border,
-        )
+        return IOComponent.style(self, rounded=rounded, container=container)
 
 
 class JSON(Changeable, IOComponent):
@@ -3069,20 +2903,8 @@ class JSON(Changeable, IOComponent):
     def restore_flagged(self, dir, data, encryption_key):
         return json.loads(data)
 
-    def style(
-        self,
-        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-    ):
-        return IOComponent.style(
-            self,
-            rounded=rounded,
-            bg_color=bg_color,
-            margin=margin,
-            border=border,
-        )
+    def style(self, container: Optional[bool] = None):
+        return IOComponent.style(container=container)
 
 
 class HTML(Changeable, IOComponent):
@@ -3141,17 +2963,6 @@ class HTML(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-
-    def style(
-        self,
-        text_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-    ):
-        return IOComponent.style(
-            self,
-            text_color=text_color,
-            margin=margin,
-        )
 
 
 class Gallery(IOComponent):
@@ -3236,26 +3047,18 @@ class Gallery(IOComponent):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
         margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         grid: Optional[int] = None,
         height: Optional[str] = None,
         border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        container: Optional[bool] = None,
     ):
         if grid is not None:
             self._style["grid"] = grid
         if height is not None:
             self._style["height"] = height
 
-        return IOComponent.style(
-            self,
-            rounded=rounded,
-            bg_color=bg_color,
-            text_color=text_color,
-            margin=margin,
-            border=border,
-        )
+        return IOComponent.style(self, rounded=rounded, container=container)
 
 
 class Carousel(IOComponent, Changeable):
@@ -3433,12 +3236,7 @@ class Chatbot(Changeable, IOComponent):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        container: Optional[bool] = None,
-        color_map: Tuple[str, str] = None,
+        color_map: Optional[Dict[str, str]] = None,
     ):
         if color_map is not None:
             self._style["color_map"] = color_map
@@ -3446,11 +3244,6 @@ class Chatbot(Changeable, IOComponent):
         return IOComponent.style(
             self,
             rounded=rounded,
-            bg_color=bg_color,
-            text_color=text_color,
-            margin=margin,
-            border=border,
-            container=container,
         )
 
 
@@ -3584,18 +3377,10 @@ class Model3D(Changeable, Editable, Clearable, IOComponent):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
     ):
         return IOComponent.style(
             self,
             rounded=rounded,
-            bg_color=bg_color,
-            text_color=text_color,
-            margin=margin,
-            border=border,
         )
 
 
@@ -3723,17 +3508,6 @@ class Markdown(IOComponent, Changeable):
             "__type__": "update",
         }
 
-    def style(
-        self,
-        text_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-    ):
-        return IOComponent.style(
-            self,
-            text_color=text_color,
-            margin=margin,
-        )
-
 
 ############################
 # Static Components
@@ -3789,8 +3563,6 @@ class Button(Clickable, Component):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
         full_width: Optional[str] = None,
         margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
@@ -3801,8 +3573,6 @@ class Button(Clickable, Component):
         return IOComponent.style(
             self,
             rounded=rounded,
-            bg_color=bg_color,
-            text_color=text_color,
             margin=margin,
             border=border,
         )
@@ -3869,15 +3639,11 @@ class Dataset(Clickable, Component):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        text_color: Optional[str] = None,
-        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
     ):
         return IOComponent.style(
             self,
             rounded=rounded,
-            text_color=text_color,
-            margin=margin,
             border=border,
         )
 

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -236,7 +236,6 @@ class IOComponent(Component):
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         bg_color: Optional[str] = None,
         text_color: Optional[str] = None,
-        container_bg_color: Optional[str] = None,
         margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         container: Optional[bool] = None,
@@ -250,9 +249,6 @@ class IOComponent(Component):
         if text_color is not None:
             assert text_color in valid_colors
             self._style["text_color"] = text_color
-        if container_bg_color is not None:
-            assert container_bg_color in valid_colors
-            self._style["container_bg_color"] = container_bg_color
         if margin is not None:
             self._style["margin"] = margin
         if border is not None:
@@ -450,7 +446,6 @@ class Textbox(Changeable, Submittable, IOComponent):
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         bg_color: Optional[str] = None,
         text_color: Optional[str] = None,
-        container_bg_color: Optional[str] = None,
         margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         container: Optional[bool] = None,
@@ -460,7 +455,6 @@ class Textbox(Changeable, Submittable, IOComponent):
             rounded=rounded,
             bg_color=bg_color,
             text_color=text_color,
-            container_bg_color=container_bg_color,
             margin=margin,
             border=border,
             container=container,
@@ -652,14 +646,18 @@ class Number(Changeable, Submittable, IOComponent):
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         bg_color: Optional[str] = None,
         text_color: Optional[str] = None,
-        container_bg_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        container: Optional[bool] = None,
     ):
         return IOComponent.style(
             self,
             rounded=rounded,
             bg_color=bg_color,
             text_color=text_color,
-            container_bg_color=container_bg_color,
+            margin=margin,
+            border=border,
+            container=container,
         )
 
 
@@ -809,12 +807,14 @@ class Slider(Changeable, IOComponent):
     def style(
         self,
         text_color: Optional[str] = None,
-        container_bg_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        container: Optional[bool] = None,
     ):
         return IOComponent.style(
             self,
             text_color=text_color,
-            container_bg_color=container_bg_color,
+            margin=margin,
+            container=container,
         )
 
 
@@ -935,13 +935,21 @@ class Checkbox(Changeable, IOComponent):
 
     def style(
         self,
+        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        bg_color: Optional[str] = None,
         text_color: Optional[str] = None,
-        container_bg_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        container: Optional[bool] = None,
     ):
         return IOComponent.style(
             self,
+            rounded=rounded,
+            bg_color=bg_color,
             text_color=text_color,
-            container_bg_color=container_bg_color,
+            margin=margin,
+            border=border,
+            container=container,
         )
 
 
@@ -1101,14 +1109,18 @@ class CheckboxGroup(Changeable, IOComponent):
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         bg_color: Optional[str] = None,
         text_color: Optional[str] = None,
-        container_bg_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        container: Optional[bool] = None,
     ):
         return IOComponent.style(
             self,
             rounded=rounded,
             bg_color=bg_color,
             text_color=text_color,
-            container_bg_color=container_bg_color,
+            margin=margin,
+            border=border,
+            container=container,
         )
 
 
@@ -1252,14 +1264,18 @@ class Radio(Changeable, IOComponent):
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         bg_color: Optional[str] = None,
         text_color: Optional[str] = None,
-        container_bg_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        container: Optional[bool] = None,
     ):
         return IOComponent.style(
             self,
             rounded=rounded,
             bg_color=bg_color,
             text_color=text_color,
-            container_bg_color=container_bg_color,
+            margin=margin,
+            border=border,
+            container=container,
         )
 
 
@@ -1634,15 +1650,11 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent):
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
-        container_bg_color: Optional[str] = None,
     ):
         return IOComponent.style(
             self,
             rounded=rounded,
             bg_color=bg_color,
-            text_color=text_color,
-            container_bg_color=container_bg_color,
         )
 
     def stream(
@@ -1804,6 +1816,19 @@ class Video(Changeable, Clearable, Playable, IOComponent):
 
     def deserialize(self, x):
         return processing_utils.decode_base64_to_file(x).name
+
+    def style(
+        self,
+        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        bg_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+    ):
+        return IOComponent.style(
+            self,
+            rounded=rounded,
+            bg_color=bg_color,
+            margin=margin,
+        )
 
 
 class Audio(Changeable, Clearable, Playable, Streamable, IOComponent):
@@ -2114,6 +2139,23 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent):
             )
         Streamable.stream(self, fn, inputs, outputs, _js)
 
+    def style(
+        self,
+        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        bg_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        container: Optional[bool] = None,
+    ):
+        return IOComponent.style(
+            self,
+            rounded=rounded,
+            bg_color=bg_color,
+            margin=margin,
+            border=border,
+            container=container,
+        )
+
 
 class File(Changeable, Clearable, IOComponent):
     """
@@ -2257,6 +2299,19 @@ class File(Changeable, Clearable, IOComponent):
             "size": os.path.getsize(y),
             "data": processing_utils.encode_file_to_base64(y),
         }
+
+    def style(
+        self,
+        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        bg_color: Optional[str] = None,
+        text_color: Optional[str] = None,
+    ):
+        return IOComponent.style(
+            self,
+            rounded=rounded,
+            bg_color=bg_color,
+            text_color=text_color,
+        )
 
 
 class Dataframe(Changeable, IOComponent):
@@ -2467,6 +2522,19 @@ class Dataframe(Changeable, IOComponent):
                 )
             )
 
+    def style(
+        self,
+        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        text_color: Optional[str] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+    ):
+        return IOComponent.style(
+            self,
+            rounded=rounded,
+            text_color=text_color,
+            border=border,
+        )
+
 
 class Timeseries(Changeable, IOComponent):
     """
@@ -2588,6 +2656,21 @@ class Timeseries(Changeable, IOComponent):
         (Dict[headers: List[str], data: List[List[Union[str, number]]]]): JSON object with key 'headers' for list of header names, 'data' for 2D array of string or numeric data
         """
         return {"headers": y.columns.values.tolist(), "data": y.values.tolist()}
+
+    def style(
+        self,
+        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        bg_color: Optional[str] = None,
+        text_color: Optional[str] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+    ):
+        return IOComponent.style(
+            self,
+            rounded=rounded,
+            bg_color=bg_color,
+            text_color=text_color,
+            border=border,
+        )
 
 
 class Variable(IOComponent):
@@ -2761,6 +2844,23 @@ class Label(Changeable, IOComponent):
             "__type__": "update",
         }
 
+    def style(
+        self,
+        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        bg_color: Optional[str] = None,
+        text_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+    ):
+        return IOComponent.style(
+            self,
+            rounded=rounded,
+            bg_color=bg_color,
+            text_color=text_color,
+            margin=margin,
+            border=border,
+        )
+
 
 class HighlightedText(Changeable, IOComponent):
     """
@@ -2775,7 +2875,6 @@ class HighlightedText(Changeable, IOComponent):
         self,
         value: str = "",
         *,
-        color_map: Dict[str, str] = None,
         show_legend: bool = False,
         combine_adjacent: bool = False,
         label: Optional[str] = None,
@@ -2787,14 +2886,12 @@ class HighlightedText(Changeable, IOComponent):
         """
         Parameters:
         value (str): Default value
-        color_map (Dict[str, str]): Map between category and respective colors
         show_legend (bool): whether to show span categories in a separate legend or inline.
         label (Optional[str]): component name in interface.
         show_label (bool): if True, will display label.
         visible (bool): If False, component will be hidden.
         """
         self.value = value
-        self.color_map = color_map
         self.show_legend = show_legend
         self.combine_adjacent = combine_adjacent
         IOComponent.__init__(
@@ -2808,7 +2905,6 @@ class HighlightedText(Changeable, IOComponent):
 
     def get_config(self):
         return {
-            "color_map": self.color_map,
             "show_legend": self.show_legend,
             "value": self.value,
             **IOComponent.get_config(self),
@@ -2817,14 +2913,12 @@ class HighlightedText(Changeable, IOComponent):
     @staticmethod
     def update(
         value: Optional[Any] = None,
-        color_map: Optional[Dict[str, str]] = None,
         show_legend: Optional[bool] = None,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
         return {
-            "color_map": color_map,
             "show_legend": show_legend,
             "label": label,
             "show_label": show_label,
@@ -2864,6 +2958,25 @@ class HighlightedText(Changeable, IOComponent):
 
     def restore_flagged(self, dir, data, encryption_key):
         return json.loads(data)
+
+    def style(
+        self,
+        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        bg_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        color_map: Optional[Dict[str, str]] = None,
+    ):
+        if color_map is not None:
+            self._style["color_map"] = color_map
+
+        return IOComponent.style(
+            self,
+            rounded=rounded,
+            bg_color=bg_color,
+            margin=margin,
+            border=border,
+        )
 
 
 class JSON(Changeable, IOComponent):
@@ -2941,6 +3054,21 @@ class JSON(Changeable, IOComponent):
     def restore_flagged(self, dir, data, encryption_key):
         return json.loads(data)
 
+    def style(
+        self,
+        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        bg_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+    ):
+        return IOComponent.style(
+            self,
+            rounded=rounded,
+            bg_color=bg_color,
+            margin=margin,
+            border=border,
+        )
+
 
 class HTML(Changeable, IOComponent):
     """
@@ -2998,6 +3126,17 @@ class HTML(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
+
+    def style(
+        self,
+        text_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+    ):
+        return IOComponent.style(
+            self,
+            text_color=text_color,
+            margin=margin,
+        )
 
 
 class Gallery(IOComponent):
@@ -3087,6 +3226,7 @@ class Gallery(IOComponent):
         margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         grid: Optional[int] = None,
         height: Optional[str] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
     ):
         if grid is not None:
             self._style["grid"] = grid
@@ -3099,6 +3239,7 @@ class Gallery(IOComponent):
             bg_color=bg_color,
             text_color=text_color,
             margin=margin,
+            border=border,
         )
 
 
@@ -3219,7 +3360,6 @@ class Chatbot(Changeable, IOComponent):
     def __init__(
         self,
         value="",
-        color_map: Tuple[str, str] = None,
         *,
         label: Optional[str] = None,
         show_label: bool = True,
@@ -3230,13 +3370,11 @@ class Chatbot(Changeable, IOComponent):
         """
         Parameters:
         value (str): Default value
-        color_map (Tuple[str, str]): Chat bubble color of input text and output text respectively.
         label (Optional[str]): component name in interface.
         show_label (bool): if True, will display label.
         visible (bool): If False, component will be hidden.
         """
         self.value = value
-        self.color_map = color_map
         IOComponent.__init__(
             self,
             label=label,
@@ -3249,20 +3387,17 @@ class Chatbot(Changeable, IOComponent):
     def get_config(self):
         return {
             "value": self.value,
-            "color_map": self.color_map,
             **IOComponent.get_config(self),
         }
 
     @staticmethod
     def update(
         value: Optional[Any] = None,
-        color_map: Optional[Tuple[str, str]] = None,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
         return {
-            "color_map": color_map,
             "label": label,
             "show_label": show_label,
             "visible": visible,
@@ -3279,6 +3414,29 @@ class Chatbot(Changeable, IOComponent):
 
         """
         return y
+
+    def style(
+        self,
+        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        bg_color: Optional[str] = None,
+        text_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        container: Optional[bool] = None,
+        color_map: Tuple[str, str] = None,
+    ):
+        if color_map is not None:
+            self._style["color_map"] = color_map
+
+        return IOComponent.style(
+            self,
+            rounded=rounded,
+            bg_color=bg_color,
+            text_color=text_color,
+            margin=margin,
+            border=border,
+            container=container,
+        )
 
 
 class Model3D(Changeable, Editable, Clearable, IOComponent):
@@ -3408,6 +3566,23 @@ class Model3D(Changeable, Editable, Clearable, IOComponent):
     def restore_flagged(self, dir, data, encryption_key):
         return self.restore_flagged_file(dir, data, encryption_key)
 
+    def style(
+        self,
+        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        bg_color: Optional[str] = None,
+        text_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+    ):
+        return IOComponent.style(
+            self,
+            rounded=rounded,
+            bg_color=bg_color,
+            text_color=text_color,
+            margin=margin,
+            border=border,
+        )
+
 
 class Plot(Changeable, Clearable, IOComponent):
     """
@@ -3533,6 +3708,17 @@ class Markdown(IOComponent, Changeable):
             "__type__": "update",
         }
 
+    def style(
+        self,
+        text_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+    ):
+        return IOComponent.style(
+            self,
+            text_color=text_color,
+            margin=margin,
+        )
+
 
 ############################
 # Static Components
@@ -3592,18 +3778,19 @@ class Button(Clickable, Component):
         text_color: Optional[str] = None,
         full_width: Optional[str] = None,
         margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
     ):
-        if rounded is not None:
-            self._style["rounded"] = rounded
-        if bg_color is not None:
-            self._style["bg_color"] = bg_color
-        if text_color is not None:
-            self._style["text_color"] = text_color
         if full_width is not None:
             self._style["full_width"] = full_width
-        if margin is not None:
-            self._style["margin"] = margin
-        return self
+
+        return IOComponent.style(
+            self,
+            rounded=rounded,
+            bg_color=bg_color,
+            text_color=text_color,
+            margin=margin,
+            border=border,
+        )
 
 
 class Dataset(Clickable, Component):
@@ -3663,6 +3850,21 @@ class Dataset(Clickable, Component):
             return x
         elif self.type == "values":
             return self.samples[x]
+
+    def style(
+        self,
+        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        text_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+    ):
+        return IOComponent.style(
+            self,
+            rounded=rounded,
+            text_color=text_color,
+            margin=margin,
+            border=border,
+        )
 
 
 class Interpretation(Component):

--- a/gradio/layouts.py
+++ b/gradio/layouts.py
@@ -44,7 +44,7 @@ class Row(BlockContext):
     def style(
         self,
         equal_height: Optional[bool] = None,
-        mobile_collapse: Optional[bool] = None,
+        mobile_collapse: Optional[bool] = True,
     ):
         if equal_height is not None:
             self._style["equal_height"] = equal_height
@@ -152,15 +152,11 @@ class Group(BlockContext):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
         margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
     ):
 
         if rounded is not None:
             self._style["rounded"] = rounded
-        if bg_color is not None:
-            assert bg_color in valid_colors
-            self._style["bg_color"] = bg_color
         if margin is not None:
             self._style["margin"] = margin
 
@@ -188,15 +184,11 @@ class Box(BlockContext):
     def style(
         self,
         rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
-        bg_color: Optional[str] = None,
         margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
         border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
     ):
         if rounded is not None:
             self._style["rounded"] = rounded
-        if bg_color is not None:
-            assert bg_color in valid_colors
-            self._style["bg_color"] = bg_color
         if margin is not None:
             self._style["margin"] = margin
         if border is not None:

--- a/gradio/layouts.py
+++ b/gradio/layouts.py
@@ -7,6 +7,22 @@ from gradio.blocks import BlockContext
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
     from gradio.components import Component
 
+valid_colors = [
+    "red",
+    "green",
+    "blue",
+    "yellow",
+    "purple",
+    "teal",
+    "orange",
+    "cyan",
+    "lime",
+    "pink",
+    "black",
+    "grey",
+    "gray",
+]
+
 
 class Row(BlockContext):
     """
@@ -133,6 +149,23 @@ class Group(BlockContext):
             "__type__": "update",
         }
 
+    def style(
+        self,
+        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        bg_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+    ):
+
+        if rounded is not None:
+            self._style["rounded"] = rounded
+        if bg_color is not None:
+            assert bg_color in valid_colors
+            self._style["bg_color"] = bg_color
+        if margin is not None:
+            self._style["margin"] = margin
+
+        return self
+
 
 class Box(BlockContext):
     """
@@ -151,3 +184,21 @@ class Box(BlockContext):
             "visible": visible,
             "__type__": "update",
         }
+
+    def style(
+        self,
+        rounded: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        bg_color: Optional[str] = None,
+        margin: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+        border: Optional[bool | Tuple[bool, bool, bool, bool]] = None,
+    ):
+        if rounded is not None:
+            self._style["rounded"] = rounded
+        if bg_color is not None:
+            assert bg_color in valid_colors
+            self._style["bg_color"] = bg_color
+        if margin is not None:
+            self._style["margin"] = margin
+        if border is not None:
+            self._style["border"] = border
+        return self

--- a/ui/package.json
+++ b/ui/package.json
@@ -50,7 +50,7 @@
 		"tailwindcss": "^3.0.23",
 		"tinyspy": "^0.3.0",
 		"vite": "^2.9.5",
-		"vitest": "^0.10.0"
+		"vitest": "^0.12.7"
 	},
 	"devDependencies": {
 		"@types/three": "^0.138.0"

--- a/ui/packages/app/src/components/Audio/Audio.svelte
+++ b/ui/packages/app/src/components/Audio/Audio.svelte
@@ -1,18 +1,22 @@
 <script lang="ts">
-	import { Audio, StaticAudio } from "@gradio/audio";
-	import type { FileData } from "@gradio/upload";
-	import { normalise_file } from "@gradio/upload";
-	import { Block } from "@gradio/atoms";
-
-	import StatusTracker from "../StatusTracker/StatusTracker.svelte";
-	import type { LoadingStatus } from "../StatusTracker/types";
 	import { createEventDispatcher } from "svelte";
-	const dispatch = createEventDispatcher<{
-		change;
-		stream;
-	}>();
-
 	import { _ } from "svelte-i18n";
+
+	import type { FileData } from "@gradio/upload";
+	import type { LoadingStatus } from "../StatusTracker/types";
+
+	import { Audio, StaticAudio } from "@gradio/audio";
+	import StatusTracker from "../StatusTracker/StatusTracker.svelte";
+	import { Block } from "@gradio/atoms";
+	import type { Styles } from "@gradio/utils";
+	export let style: Styles = {};
+
+	import { normalise_file } from "@gradio/upload";
+
+	const dispatch = createEventDispatcher<{
+		change: typeof value;
+		stream: typeof value;
+	}>();
 
 	export let elem_id: string = "";
 	export let mode: "static" | "dynamic";
@@ -41,6 +45,7 @@
 	color={dragging ? "green" : "grey"}
 	padding={false}
 	{elem_id}
+	style={{ rounded: style.rounded }}
 >
 	<StatusTracker {...loading_status} />
 

--- a/ui/packages/app/src/components/Box/Box.svelte
+++ b/ui/packages/app/src/components/Box/Box.svelte
@@ -9,6 +9,6 @@
 	}
 </script>
 
-<Block>
+<Block explicit_call>
 	<slot />
 </Block>

--- a/ui/packages/app/src/components/Button/Button.svelte
+++ b/ui/packages/app/src/components/Button/Button.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+	import type { Styles } from "@gradio/utils";
 	import { Button } from "@gradio/button";
 	import { _ } from "svelte-i18n";
-	export let style: Record<string, any> = {};
 
+	export let style: Styles = {};
 	export let elem_id: string = "";
 	export let value: string;
 	export let variant: "primary" | "secondary" = "primary";

--- a/ui/packages/app/src/components/Checkbox/Checkbox.svelte
+++ b/ui/packages/app/src/components/Checkbox/Checkbox.svelte
@@ -3,6 +3,7 @@
 	import { Block } from "@gradio/atoms";
 	import StatusTracker from "../StatusTracker/StatusTracker.svelte";
 	import type { LoadingStatus } from "../StatusTracker/types";
+	import type { Styles } from "@gradio/utils";
 
 	export let elem_id: string = "";
 	export let value: boolean = false;
@@ -10,12 +11,15 @@
 	export let mode: "static" | "dynamic";
 	export let form_position: "first" | "last" | "mid" | "single" = "single";
 	export let show_label: boolean;
-	export let style: Record<string, any> = {};
-
+	export let style: Styles = {};
 	export let loading_status: LoadingStatus;
 </script>
 
-<Block {form_position} {elem_id} {style}>
+<Block
+	{form_position}
+	{elem_id}
+	disable={typeof style.container === "boolean" && !style.container}
+>
 	<StatusTracker {...loading_status} />
 
 	<Checkbox

--- a/ui/packages/app/src/components/CheckboxGroup/CheckboxGroup.svelte
+++ b/ui/packages/app/src/components/CheckboxGroup/CheckboxGroup.svelte
@@ -3,12 +3,12 @@
 	import { Block } from "@gradio/atoms";
 	import StatusTracker from "../StatusTracker/StatusTracker.svelte";
 	import type { LoadingStatus } from "../StatusTracker/types";
+	import type { Styles } from "@gradio/utils";
 
 	export let elem_id: string = "";
 	export let value: Array<string> = [];
 	export let choices: Array<string>;
-	export let style: Record<string, any> = {};
-
+	export let style: Styles = {};
 	export let mode: "static" | "dynamic";
 	export let label: string = "Checkbox Group";
 	export let form_position: "first" | "last" | "mid" | "single" = "single";
@@ -17,7 +17,12 @@
 	export let loading_status: LoadingStatus;
 </script>
 
-<Block {form_position} {elem_id} {style} type="fieldset">
+<Block
+	{form_position}
+	{elem_id}
+	type="fieldset"
+	disable={typeof style.container === "boolean" && !style.container}
+>
 	<StatusTracker {...loading_status} />
 
 	<CheckboxGroup

--- a/ui/packages/app/src/components/Dropdown/Dropdown.svelte
+++ b/ui/packages/app/src/components/Dropdown/Dropdown.svelte
@@ -3,6 +3,7 @@
 	import { Block } from "@gradio/atoms";
 	import StatusTracker from "../StatusTracker/StatusTracker.svelte";
 	import type { LoadingStatus } from "../StatusTracker/types";
+	import type { Styles } from "@gradio/utils";
 
 	export let label: string = "Dropdown";
 	export let elem_id: string = "";
@@ -10,14 +11,17 @@
 	export let choices: Array<string>;
 	export let form_position: "first" | "last" | "mid" | "single" = "single";
 	export let show_label: boolean;
-	export let style: Record<string, any> = {};
-
+	export let style: Styles = {};
 	export let loading_status: LoadingStatus;
 
 	export let mode: "static" | "dynamic";
 </script>
 
-<Block {form_position} {elem_id} {style}>
+<Block
+	{form_position}
+	{elem_id}
+	disable={typeof style.container === "boolean" && !style.container}
+>
 	<StatusTracker {...loading_status} />
 
 	<Dropdown

--- a/ui/packages/app/src/components/File/File.svelte
+++ b/ui/packages/app/src/components/File/File.svelte
@@ -6,6 +6,8 @@
 
 	import StatusTracker from "../StatusTracker/StatusTracker.svelte";
 	import type { LoadingStatus } from "../StatusTracker/types";
+	import type { Styles } from "@gradio/utils";
+
 	import { _ } from "svelte-i18n";
 
 	export let elem_id: string = "";
@@ -14,6 +16,7 @@
 	export let root: string;
 	export let label: string;
 	export let show_label: boolean;
+	export let style: Styles = {};
 
 	export let loading_status: LoadingStatus;
 
@@ -28,6 +31,7 @@
 	color={dragging ? "green" : "grey"}
 	padding={false}
 	{elem_id}
+	style={{ rounded: style.rounded }}
 >
 	<StatusTracker {...loading_status} />
 

--- a/ui/packages/app/src/components/Image/Image.svelte
+++ b/ui/packages/app/src/components/Image/Image.svelte
@@ -4,6 +4,8 @@
 	import { Block } from "@gradio/atoms";
 	import { _ } from "svelte-i18n";
 	import { Component as StatusTracker } from "../StatusTracker/";
+	import type { LoadingStatus } from "../StatusTracker/types";
+	import type { Styles } from "@gradio/utils";
 
 	export let elem_id: string = "";
 	export let value: null | string = null;
@@ -13,6 +15,7 @@
 	export let show_label: boolean;
 	export let streaming: boolean;
 	export let pending: boolean;
+	export let style: Styles = {};
 
 	export let loading_status: LoadingStatus;
 
@@ -21,7 +24,6 @@
 	const dispatch = createEventDispatcher<{ change: undefined }>();
 
 	$: value, dispatch("change");
-
 	let dragging: boolean;
 </script>
 
@@ -32,6 +34,7 @@
 	color={dragging ? "green" : "grey"}
 	padding={false}
 	{elem_id}
+	style={{ rounded: style.rounded }}
 >
 	<StatusTracker {...loading_status} />
 	{#if mode === "static"}

--- a/ui/packages/app/src/components/Model3D/Model3D.svelte
+++ b/ui/packages/app/src/components/Model3D/Model3D.svelte
@@ -7,6 +7,8 @@
 	import StatusTracker from "../StatusTracker/StatusTracker.svelte";
 	import type { LoadingStatus } from "../StatusTracker/types";
 	import { _ } from "svelte-i18n";
+	import type { Styles } from "@gradio/utils";
+	export let style: Styles = {};
 
 	export let elem_id: string = "";
 	export let value: null | FileData = null;
@@ -29,6 +31,7 @@
 	color={dragging ? "green" : "grey"}
 	padding={false}
 	{elem_id}
+	style={{ rounded: style.rounded }}
 >
 	<StatusTracker {...loading_status} />
 

--- a/ui/packages/app/src/components/Number/Number.svelte
+++ b/ui/packages/app/src/components/Number/Number.svelte
@@ -3,10 +3,11 @@
 	import { Block } from "@gradio/atoms";
 	import StatusTracker from "../StatusTracker/StatusTracker.svelte";
 	import type { LoadingStatus } from "../StatusTracker/types";
+	import type { Styles } from "@gradio/utils";
 
 	export let label: string = "Number";
 	export let elem_id: string = "";
-	export let style: Record<string, any> = {};
+	export let style: Styles = {};
 	export let value: number = 0;
 	export let form_position: "first" | "last" | "mid" | "single" = "single";
 	export let show_label: boolean;
@@ -15,7 +16,11 @@
 	export let mode: "static" | "dynamic";
 </script>
 
-<Block {form_position} {elem_id} {style}>
+<Block
+	{form_position}
+	{elem_id}
+	disable={typeof style.container === "boolean" && !style.container}
+>
 	<StatusTracker {...loading_status} />
 
 	<Number

--- a/ui/packages/app/src/components/Radio/Radio.svelte
+++ b/ui/packages/app/src/components/Radio/Radio.svelte
@@ -3,6 +3,7 @@
 	import { Block } from "@gradio/atoms";
 	import StatusTracker from "../StatusTracker/StatusTracker.svelte";
 	import type { LoadingStatus } from "../StatusTracker/types";
+	import type { Styles } from "@gradio/utils";
 
 	export let label: string = "Radio";
 	export let elem_id: string = "";
@@ -11,12 +12,16 @@
 	export let mode: "static" | "dynamic";
 	export let form_position: "first" | "last" | "mid" | "single" = "single";
 	export let show_label: boolean;
-	export let style: Record<string, any> = {};
-
+	export let style: Styles = {};
 	export let loading_status: LoadingStatus;
 </script>
 
-<Block {form_position} type="fieldset" {elem_id} {style}>
+<Block
+	{form_position}
+	type="fieldset"
+	{elem_id}
+	disable={typeof style.container === "boolean" && !style.container}
+>
 	<StatusTracker {...loading_status} />
 
 	<Radio

--- a/ui/packages/app/src/components/Slider/Slider.svelte
+++ b/ui/packages/app/src/components/Slider/Slider.svelte
@@ -3,12 +3,12 @@
 	import { Block } from "@gradio/atoms";
 	import StatusTracker from "../StatusTracker/StatusTracker.svelte";
 	import type { LoadingStatus } from "../StatusTracker/types";
+	import type { Styles } from "@gradio/utils";
 
 	export let elem_id: string = "";
 	export let value: number = 0;
 	export let label: string = "Slider";
-	export let style: Record<string, any> = {};
-
+	export let style: Styles = {};
 	export let minimum: number;
 	export let maximum: number;
 	export let step: number;
@@ -19,7 +19,11 @@
 	export let loading_status: LoadingStatus;
 </script>
 
-<Block {form_position} {elem_id} {style}>
+<Block
+	{form_position}
+	{elem_id}
+	disable={typeof style.container === "boolean" && !style.container}
+>
 	<StatusTracker {...loading_status} />
 
 	<Range

--- a/ui/packages/app/src/components/TimeSeries/TimeSeries.svelte
+++ b/ui/packages/app/src/components/TimeSeries/TimeSeries.svelte
@@ -11,6 +11,9 @@
 
 	import { Chart as ChartIcon } from "@gradio/icons";
 
+	import type { Styles } from "@gradio/utils";
+	export let style: Styles = {};
+
 	function format_value(val: StaticData) {
 		return val.data.map((r) =>
 			r.reduce((acc, next, i) => ({ ...acc, [val.headers[i]]: next }), {})
@@ -118,6 +121,7 @@
 	color={"grey"}
 	padding={false}
 	{elem_id}
+	style={{ rounded: style.rounded }}
 >
 	<BlockLabel {show_label} Icon={ChartIcon} label={label || "TimeSeries"} />
 	<StatusTracker {...loading_status} />

--- a/ui/packages/app/src/components/Video/Video.svelte
+++ b/ui/packages/app/src/components/Video/Video.svelte
@@ -6,6 +6,7 @@
 
 	import StatusTracker from "../StatusTracker/StatusTracker.svelte";
 	import type { LoadingStatus } from "../StatusTracker/types";
+	import type { Styles } from "@gradio/utils";
 	import { _ } from "svelte-i18n";
 
 	export let elem_id: string = "";
@@ -15,6 +16,7 @@
 	export let root: string;
 	export let show_label: boolean;
 	export let loading_status: LoadingStatus;
+	export let style: Styles = {};
 
 	export let mode: "static" | "dynamic";
 
@@ -31,6 +33,7 @@
 	color={dragging ? "green" : "grey"}
 	padding={false}
 	{elem_id}
+	style={{ rounded: style.rounded }}
 >
 	<StatusTracker {...loading_status} />
 

--- a/ui/packages/app/tailwind.config.js
+++ b/ui/packages/app/tailwind.config.js
@@ -3,6 +3,22 @@ const colors = require("tailwindcss/colors");
 const defaultTheme = require("tailwindcss/defaultTheme");
 const production = !process.env.ROLLUP_WATCH;
 
+const allowed_colors = [
+	"red",
+	"green",
+	"blue",
+	"yellow",
+	"purple",
+	"teal",
+	"orange",
+	"cyan",
+	"lime",
+	"pink",
+	"black",
+	"grey",
+	"gray"
+];
+
 module.exports = {
 	content: [
 		"./src/**/*.{html,js,svelte,ts}",
@@ -42,6 +58,18 @@ module.exports = {
 	},
 	plugins: [require("@tailwindcss/forms")],
 	safelist: [
+		...allowed_colors.reduce(
+			(acc, col) => [
+				...acc,
+				`!text-${col}-500`,
+				`dark:!text-${col}-300`,
+				`!bg-${col}-200`,
+				`dark:!bg-${col}-700`
+			],
+			[]
+		),
+		"!text-gray-700",
+		"dark:!text-gray-50",
 		"min-h-[350px]",
 		"max-h-[55vh]",
 		"xl:min-h-[450px]",

--- a/ui/packages/atoms/package.json
+++ b/ui/packages/atoms/package.json
@@ -6,5 +6,8 @@
 	"main": "src/index.ts",
 	"author": "",
 	"license": "ISC",
-	"private": true
+	"private": true,
+	"dependencies": {
+		"@gradio/utils": "workspace:^0.0.1"
+	}
 }

--- a/ui/packages/atoms/src/Block.svelte
+++ b/ui/packages/atoms/src/Block.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import { create_classes } from "../../utils";
+	import { create_classes, get_styles } from "../../utils";
+	import type { Styles } from "@gradio/utils";
 
 	import { getContext } from "svelte";
-	import { BLOCK_KEY } from "./";
 
-	export let style: Record<string, any> = {};
+	export let style: Styles = {};
 	export let elem_id: string = "";
 	export let variant: "solid" | "dashed" | "none" = "solid";
 	export let color: "grey" | "green" = "grey";
@@ -14,6 +14,7 @@
 	export let type: "normal" | "fieldset" = "normal";
 	export let test_id: string | undefined = undefined;
 	export let disable: boolean = false;
+	export let explicit_call: boolean = false;
 
 	const styles = {
 		dashed: "border-dashed border border-gray-300",
@@ -47,28 +48,29 @@
 	$: form_class = form_position
 		? form_styles?.[(_parent as "column" | "row") || "column"][form_position]
 		: "";
+
+	const { classes } = explicit_call
+		? get_styles(style, ["container"])
+		: get_styles(style, ["rounded", "margin", "border"]);
+	$: console.log(style);
+	$: rounded =
+		typeof style.rounded !== "boolean" ||
+		(typeof style.rounded === "boolean" && style.rounded);
+
+	$: console.log(rounded);
 </script>
 
 <svelte:element
 	this={tag}
 	data-testid={test_id}
 	id={elem_id}
-	class={"w-full overflow-hidden " +
-		styles[variant] +
-		" " +
-		styles[color] +
-		" " +
-		form_class +
-		create_classes(style, "container")}
+	class="w-full overflow-hidden {styles[variant]} {rounded
+		? styles[color]
+		: ''} {form_class} {classes}"
 	class:gr-panel={padding}
 	class:form={form_position}
-	class:gr-box-unrounded={form_position}
+	class:gr-box-unrounded={!rounded && form_position}
 	class:gr-box={!form_position}
-	class:!p-0={disable}
-	class:!m-0={disable}
-	class:!border-0={disable}
-	class:!shadow-none={disable}
-	class:overflow-visible={disable}
 >
 	<slot />
 </svelte:element>

--- a/ui/packages/button/package.json
+++ b/ui/packages/button/package.json
@@ -6,5 +6,8 @@
 	"main": "src/index.ts",
 	"author": "",
 	"license": "ISC",
-	"private": true
+	"private": true,
+	"dependencies": {
+		"@gradio/utils": "workspace:^0.0.1"
+	}
 }

--- a/ui/packages/button/src/Button.svelte
+++ b/ui/packages/button/src/Button.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { create_classes } from "../../utils";
+	import type { Styles } from "@gradio/utils";
 
-	export let style: Record<string, any> = {};
+	export let style: Styles = {};
 	export let elem_id: string = "";
 	export let variant: "primary" | "secondary" = "secondary";
 	export let size: "sm" | "lg" = "lg";

--- a/ui/packages/file/src/FileUpload.svelte
+++ b/ui/packages/file/src/FileUpload.svelte
@@ -13,7 +13,6 @@
 	export let or_text: string = "or";
 	export let upload_text: string = "click to upload";
 	export let label: string = "";
-	export let style: string;
 	export let show_label: boolean;
 
 	async function handle_upload({ detail }: CustomEvent<FileData>) {

--- a/ui/packages/form/src/Checkbox.svelte
+++ b/ui/packages/form/src/Checkbox.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	import { create_classes } from "@gradio/utils";
+	import { create_classes, get_styles } from "@gradio/utils";
 	import { createEventDispatcher } from "svelte";
+	import type { Styles } from "@gradio/utils";
 
 	export let value: boolean;
-	export let style: Record<string, string> = {};
+	export let style: Styles = {};
 	export let disabled: boolean = false;
 	export let label: string;
 	export let show_label: boolean;
@@ -14,19 +15,25 @@
 		dispatch("change", !value);
 		value = !value;
 	}
+
+	const { margin, rounded, border } = get_styles(style, [
+		"margin",
+		"rounded",
+		"border"
+	]);
 </script>
 
 <!-- svelte-ignore a11y-label-has-associated-control -->
 <label
 	class:!cursor-not-allowed={disabled}
-	class="flex items-center text-gray-700 text-sm space-x-2 rounded-lg cursor-pointer bg-white dark:bg-transparent"
+	class="flex items-center text-gray-700 text-sm space-x-2 rounded-lg cursor-pointer dark:bg-transparent {margin}"
 >
 	<input
 		bind:checked={value}
 		{disabled}
 		type="checkbox"
 		name="test"
-		class="gr-check-radio gr-checkbox"
+		class="gr-check-radio gr-checkbox {rounded} {border}"
 	/>
-	<span class={"ml-2" + create_classes(style)}>{label}</span></label
+	<span class="ml-2">{label}</span></label
 >

--- a/ui/packages/form/src/CheckboxGroup.svelte
+++ b/ui/packages/form/src/CheckboxGroup.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
 	import { BlockTitle } from "@gradio/atoms";
-	import { create_classes } from "@gradio/utils";
+	import { get_styles } from "@gradio/utils";
+	import type { Styles } from "@gradio/utils";
 
 	export let value: Array<string> = [];
-	export let style: Record<string, string> = {};
+	export let style: Styles = {};
 	export let choices: Array<string>;
 	export let disabled: boolean = false;
 	export let label: string;
@@ -21,6 +22,12 @@
 		dispatch("change", value);
 		value = value;
 	};
+
+	const { margin, rounded, border } = get_styles(style, [
+		"margin",
+		"rounded",
+		"border"
+	]);
 </script>
 
 <BlockTitle {show_label}>{label}</BlockTitle>
@@ -29,8 +36,7 @@
 	{#each choices as choice, i}
 		<label
 			class:!cursor-not-allowed={disabled}
-			class={"flex items-center text-gray-700 text-sm space-x-2 border py-1.5 px-3 rounded-lg cursor-pointer bg-white shadow-sm checked:shadow-inner" +
-				create_classes(style)}
+			class="flex items-center text-gray-700 text-sm space-x-2 border py-1.5 px-3 rounded-lg cursor-pointer bg-white shadow-sm checked:shadow-inner {margin}"
 		>
 			<input
 				{disabled}
@@ -38,7 +44,7 @@
 				checked={value.includes(choice)}
 				type="checkbox"
 				name="test"
-				class="gr-check-radio gr-checkbox"
+				class="gr-check-radio gr-checkbox {rounded} {border}"
 			/> <span class="ml-2">{choice}</span></label
 		>
 	{/each}

--- a/ui/packages/form/src/Dropdown.svelte
+++ b/ui/packages/form/src/Dropdown.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
-	import { Block, BlockTitle } from "@gradio/atoms";
-	import { create_classes } from "@gradio/utils";
+	import { BlockTitle } from "@gradio/atoms";
+	import { get_styles } from "@gradio/utils";
+	import type { Styles } from "@gradio/utils";
 
 	export let label: string;
 	export let value: string | undefined = undefined;
-	export let style: Record<string, string> = {};
+	export let style: Styles = {};
 	export let choices: Array<string>;
 	export let disabled: boolean = false;
 	export let show_label: boolean;
@@ -13,13 +14,18 @@
 	const dispatch = createEventDispatcher<{ change: string }>();
 
 	$: dispatch("change", value);
+
+	const { rounded, margin, border } = get_styles(style, [
+		"rounded",
+		"margin",
+		"border"
+	]);
 </script>
 
-<label>
+<label class={margin}>
 	<BlockTitle {show_label}>{label}</BlockTitle>
 	<select
-		class={"gr-box gr-input w-full disabled:cursor-not-allowed" +
-			create_classes(style)}
+		class="gr-box gr-input w-full disabled:cursor-not-allowed {rounded} {border}"
 		bind:value
 		{disabled}
 	>

--- a/ui/packages/form/src/Number.svelte
+++ b/ui/packages/form/src/Number.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { createEventDispatcher, tick } from "svelte";
-	import { create_classes } from "@gradio/utils";
+	import { get_styles } from "@gradio/utils";
 	import { BlockTitle, Block } from "@gradio/atoms";
+	import type { Styles } from "@gradio/utils";
 
 	export let value: number = 0;
-	export let style: Record<string, string> = {};
+	export let style: Styles = {};
 	export let disabled: boolean = false;
 	export let label: string;
 	export let show_label: boolean;
@@ -30,6 +31,8 @@
 	}
 
 	$: handle_change(value);
+
+	const { classes } = get_styles(style, ["rounded", "margin", "border"]);
 </script>
 
 <!-- svelte-ignore a11y-label-has-associated-control -->
@@ -37,7 +40,7 @@
 	<BlockTitle {show_label}>{label}</BlockTitle>
 	<input
 		type="number"
-		class={"gr-box gr-input w-full gr-text-input" + create_classes(style)}
+		class="gr-box gr-input w-full gr-text-input {classes}"
 		bind:value
 		on:keypress={handle_keypress}
 		{disabled}

--- a/ui/packages/form/src/Radio.svelte
+++ b/ui/packages/form/src/Radio.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
 	import { BlockTitle } from "@gradio/atoms";
-	import { create_classes } from "@gradio/utils";
+	import { get_styles } from "@gradio/utils";
+	import type { Styles } from "@gradio/utils";
 
 	export let value: string;
-	export let style: Record<string, string> = {};
+	export let style: Styles = {};
 	export let choices: Array<string>;
 	export let disabled: boolean = false;
 	export let label: string;
@@ -14,6 +15,12 @@
 	const dispatch = createEventDispatcher();
 
 	$: dispatch("change", value);
+
+	const { margin, rounded, border } = get_styles(style, [
+		"margin",
+		"rounded",
+		"border"
+	]);
 </script>
 
 <BlockTitle {show_label}>{label}</BlockTitle>
@@ -22,15 +29,14 @@
 	{#each choices as choice, i (i)}
 		<label
 			class:!cursor-not-allowed={disabled}
-			class={"flex items-center text-gray-700 text-sm space-x-2 border py-1.5 px-3 rounded-lg cursor-pointer bg-white shadow-sm checked:shadow-inner" +
-				create_classes(style)}
+			class="flex items-center text-gray-700 text-sm space-x-2 border py-1.5 px-3 rounded-lg cursor-pointer bg-white shadow-sm checked:shadow-inner {margin}"
 		>
 			<input
 				{disabled}
 				bind:group={value}
 				type="radio"
 				name="radio-{elem_id}"
-				class="gr-check-radio gr-radio"
+				class="gr-check-radio gr-radio {border} {rounded}"
 				value={choice}
 			/> <span class="ml-2">{choice}</span></label
 		>

--- a/ui/packages/form/src/Range.svelte
+++ b/ui/packages/form/src/Range.svelte
@@ -4,11 +4,12 @@
 
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
-	import { Block, BlockTitle } from "@gradio/atoms";
-	import { create_classes } from "@gradio/utils";
+	import { BlockTitle } from "@gradio/atoms";
+	import { create_classes, get_styles } from "@gradio/utils";
+	import type { Styles } from "@gradio/utils";
 
 	export let value: number = 0;
-	export let style: Record<string, string> = {};
+	export let style: Styles = {};
 	export let minimum: number = 0;
 	export let maximum: number = 100;
 	export let step: number = 1;
@@ -21,9 +22,11 @@
 	const dispatch = createEventDispatcher<{ change: number }>();
 
 	$: dispatch("change", value);
+
+	const { margin } = get_styles(style, ["margin"]);
 </script>
 
-<div class="w-full flex flex-col">
+<div class="w-full flex flex-col {margin}">
 	<div class="flex justify-between">
 		<label for={id}>
 			<BlockTitle {show_label}>{label}</BlockTitle>

--- a/ui/packages/form/src/Textbox.svelte
+++ b/ui/packages/form/src/Textbox.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { createEventDispatcher, tick } from "svelte";
-	import { create_classes } from "@gradio/utils";
+	import { get_styles } from "@gradio/utils";
 	import { BlockTitle } from "@gradio/atoms";
 
 	export let value: string = "";
@@ -74,6 +74,8 @@
 			destroy: () => el.removeEventListener("input", resize)
 		};
 	}
+
+	const { classes } = get_styles(style, ["rounded", "margin", "border"]);
 </script>
 
 <!-- svelte-ignore a11y-label-has-associated-control -->
@@ -83,8 +85,7 @@
 	{#if lines === 1 && max_lines === 1}
 		<input
 			type="text"
-			class={"scroll-hide block gr-box gr-input w-full gr-text-input " +
-				create_classes(style)}
+			class="scroll-hide block gr-box gr-input w-full gr-text-input {classes}"
 			bind:value
 			bind:this={el}
 			{placeholder}
@@ -93,8 +94,7 @@
 	{:else}
 		<textarea
 			use:text_area_resize={value}
-			class={"scroll-hide block gr-box gr-input w-full gr-text-input " +
-				create_classes(style)}
+			class="scroll-hide block gr-box gr-input w-full gr-text-input {classes}"
 			bind:value
 			bind:this={el}
 			{placeholder}

--- a/ui/packages/label/package.json
+++ b/ui/packages/label/package.json
@@ -6,5 +6,8 @@
 	"main": "src/index.ts",
 	"author": "",
 	"license": "ISC",
-	"private": true
+	"private": true,
+	"dependencies": {
+		"@gradio/utils": "workspace:^0.0.1"
+	}
 }

--- a/ui/packages/model3D/src/Model3D.svelte
+++ b/ui/packages/model3D/src/Model3D.svelte
@@ -4,7 +4,6 @@
 	import { File } from "@gradio/icons";
 
 	export let value: FileData | null;
-	export let style: string;
 	export let clearColor: Array<number>;
 	export let label: string = "";
 	export let show_label: boolean;

--- a/ui/packages/model3D/src/Model3DUpload.svelte
+++ b/ui/packages/model3D/src/Model3DUpload.svelte
@@ -12,7 +12,6 @@
 	export let upload_text: string = "click to upload";
 	export let label: string = "";
 	export let show_label: boolean;
-	export let style: string;
 
 	afterUpdate(() => {
 		if (value != null && value.is_example) {

--- a/ui/packages/utils/src/styles.test.ts
+++ b/ui/packages/utils/src/styles.test.ts
@@ -1,0 +1,112 @@
+import { assert, describe, test } from "vitest";
+import { bool_to_tuple, tuple_to_class, get_styles } from "./styles";
+
+describe("bool_to_tuple", () => {
+	test("converts true to tuple of true", () => {
+		assert.deepEqual(bool_to_tuple(true), [true, true, true, true]);
+	});
+
+	test("converts true to tuple of true", () => {
+		assert.deepEqual(bool_to_tuple(false), [false, false, false, false]);
+	});
+});
+
+describe("tuple_to_class", () => {
+	test("adds correct classes when all are true", () => {
+		const output = tuple_to_class(
+			[true, true, true, true],
+			"!rounded-",
+			["tl", "tr", "br", "bl"],
+			["lg", "none"]
+		);
+
+		assert.equal(
+			output,
+			"!rounded-tl-lg !rounded-tr-lg !rounded-br-lg !rounded-bl-lg"
+		);
+	});
+
+	test("adds correct classes when all are false", () => {
+		const output = tuple_to_class(
+			[false, false, false, false],
+			"!rounded-",
+			["tl", "tr", "br", "bl"],
+			["lg", "none"]
+		);
+
+		assert.equal(
+			output,
+			"!rounded-tl-none !rounded-tr-none !rounded-br-none !rounded-bl-none"
+		);
+	});
+
+	test("adds correct classes with mix of booleans", () => {
+		const output = tuple_to_class(
+			[false, true, true, false],
+			"!rounded-",
+			["tl", "tr", "br", "bl"],
+			["lg", "none"]
+		);
+
+		assert.equal(
+			output,
+			"!rounded-tl-none !rounded-tr-lg !rounded-br-lg !rounded-bl-none"
+		);
+	});
+
+	test("does not add true class when no true suffix is given", () => {
+		const output = tuple_to_class(
+			[false, true, true, false],
+			"!m",
+			["t", "r", "b", "l"],
+			[false, "0"]
+		);
+
+		assert.equal(output, "!mt-0 !ml-0");
+	});
+
+	test("does not add false class when no false suffix is given", () => {
+		const output = tuple_to_class(
+			[false, true, true, false],
+			"!m",
+			["t", "r", "b", "l"],
+			["4", false]
+		);
+
+		assert.equal(output, "!mr-4 !mb-4");
+	});
+});
+
+describe("get_styles", () => {
+	test("only returns allowed styles", () => {
+		const styles = {
+			rounded: true,
+			margin: true
+		};
+
+		assert.deepEqual(get_styles(styles, ["rounded"]), {
+			rounded: " !rounded-tl-lg !rounded-tr-lg !rounded-br-lg !rounded-bl-lg ",
+			classes: " !rounded-tl-lg !rounded-tr-lg !rounded-br-lg !rounded-bl-lg "
+		});
+
+		assert.deepEqual(get_styles(styles, ["rounded", "margin"]), {
+			rounded: " !rounded-tl-lg !rounded-tr-lg !rounded-br-lg !rounded-bl-lg ",
+			margin: "  ",
+			classes: " !rounded-tl-lg !rounded-tr-lg !rounded-br-lg !rounded-bl-lg "
+		});
+	});
+
+	test("generates correct grid style", () => {
+		assert.deepEqual(get_styles({ grid: 3 }, ["grid"]), {
+			grid: " grid-cols-3 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-3 2xl:grid-cols-3 ",
+			classes:
+				" grid-cols-3 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-3 2xl:grid-cols-3 "
+		});
+
+		assert.deepEqual(get_styles({ grid: [3, 2, 1] }, ["grid"]), {
+			grid: " grid-cols-3 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-1 xl:grid-cols-1 2xl:grid-cols-1 ",
+			classes:
+				" grid-cols-3 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-1 xl:grid-cols-1 2xl:grid-cols-1 "
+		});
+	});
+});

--- a/ui/packages/utils/src/styles.ts
+++ b/ui/packages/utils/src/styles.ts
@@ -1,3 +1,153 @@
+type BoolTuple = [boolean, boolean, boolean, boolean];
+type BoolOrTuple = boolean | BoolTuple;
+
+export interface Styles {
+	rounded?: BoolOrTuple;
+	margin?: BoolOrTuple;
+	border?: BoolOrTuple;
+	container?: boolean;
+	grid?: number | Array<number>;
+	height?: "auto" | string;
+	full_width?: boolean;
+	equal_height?: boolean;
+	mobile_collapse?: boolean;
+	visible?: boolean;
+}
+
+type PartialRecord<K extends keyof any, T> = {
+	[P in K]?: T;
+};
+
+type ProcessedStyles = PartialRecord<keyof Styles, string> & {
+	classes: string;
+};
+
+const get_style = <T extends keyof Styles>(styles: Styles, key: T) => {
+	return style_handlers[key](styles[key]!);
+};
+
+export function get_styles(
+	styles: Styles,
+	allowed_styles: Array<keyof Styles>
+): ProcessedStyles {
+	const processed_styles = allowed_styles.reduce((acc, next) => {
+		if (styles[next] === undefined || !style_handlers[next]) acc[next] = " ";
+		else {
+			acc[next] = ` ${get_style(styles, next)} `;
+		}
+		return acc;
+	}, {} as ProcessedStyles);
+
+	processed_styles.classes = ` ${Object.values(processed_styles)
+		.join(" ")
+		.replace(/\s+/g, " ")
+		.trim()} `;
+
+	return processed_styles;
+}
+
+type StyleHandlers = {
+	[K in keyof Styles]: (style: Exclude<Styles[K], null | undefined>) => string;
+};
+
+const style_handlers: StyleHandlers = {
+	rounded(rounded) {
+		let _style: BoolTuple = Array.isArray(rounded)
+			? rounded
+			: bool_to_tuple(rounded);
+
+		return tuple_to_class(
+			_style,
+			"!rounded-",
+			["tl", "tr", "br", "bl"],
+			["lg", "none"]
+		);
+	},
+	margin(margin) {
+		let _style: BoolTuple = Array.isArray(margin)
+			? margin
+			: bool_to_tuple(margin);
+
+		return tuple_to_class(_style, "!m-", ["t", "r", "b", "l"], [false, "0"]);
+	},
+	border(border) {
+		let _style: BoolTuple = Array.isArray(border)
+			? border
+			: bool_to_tuple(border);
+
+		return tuple_to_class(
+			_style,
+			"!border-",
+			["t", "r", "b", "l"],
+			[false, "0"]
+		);
+	},
+	container(container_visible) {
+		return container_visible
+			? `!p-0 !m-0 !border-0 !shadow-none !overflow-visible`
+			: "";
+	},
+	grid(grid) {
+		let grid_map = ["", "sm:", "md:", "lg:", "xl:", "2xl:"];
+		let _grid = Array.isArray(grid) ? grid : [grid];
+
+		return [0, 0, 0, 0, 0, 0]
+			.map(
+				(_, i) =>
+					`${grid_map[i]}grid-cols-${_grid?.[i] || _grid?.[_grid?.length - 1]}`
+			)
+			.join(" ");
+	},
+	height(height) {
+		return height === "auto" ? "auto" : "";
+	},
+	full_width(full_width) {
+		return full_width ? "!w-full" : "";
+	},
+	equal_height(equal_height) {
+		return equal_height ? "" : "unequal-height";
+	},
+	mobile_collapse(mobile_collapse) {
+		return mobile_collapse ? "flex-col" : "mobile-row";
+	},
+	visible(visible) {
+		return visible ? "!hidden" : "";
+	}
+} as const;
+
+export function bool_to_tuple(bool: boolean): BoolTuple {
+	return !!bool ? [true, true, true, true] : [false, false, false, false];
+}
+
+export function tuple_to_class(
+	tuple: BoolTuple,
+	prefix: string = "",
+	position_map: [string, string, string, string],
+	condition_map: [string, string] | [false, string] | [string, false]
+) {
+	const [_true_class, _false_class] = condition_map;
+
+	return tuple
+		.map((condition, i) => {
+			if (!_true_class && condition) {
+				return "";
+			} else if (!_false_class && !condition) {
+				return "";
+			}
+
+			const suffix = !condition_map[0]
+				? condition_map[1]
+				: condition
+				? condition_map[0]
+				: condition_map[1];
+
+			return `${prefix}${position_map[i]}-${suffix}`;
+		})
+		.join(" ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
 export const create_classes = (
 	styles: Record<string, any>,
 	prefix: string = ""
@@ -13,26 +163,6 @@ export const create_classes = (
 				target_styles[propname] = styles[prop];
 			}
 		}
-	}
-
-	switch (target_styles.visible) {
-		case false:
-			classes.push("!hidden");
-			break;
-	}
-
-	if (target_styles.hasOwnProperty("rounded")) {
-		if (!Array.isArray(target_styles.rounded)) {
-			target_styles.rounded = !!target_styles.rounded
-				? [true, true, true, true]
-				: [false, false, false, false];
-		}
-
-		let rounded_map = ["tl", "tr", "br", "bl"];
-
-		(target_styles.rounded as boolean[]).forEach((rounded, i) => {
-			classes.push(`!rounded-${rounded_map[i]}-${!!rounded ? "lg" : "none"}`);
-		});
 	}
 
 	if (target_styles.hasOwnProperty("margin")) {

--- a/ui/packages/video/src/StaticVideo.svelte
+++ b/ui/packages/video/src/StaticVideo.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
-	import { Block, BlockLabel } from "@gradio/atoms";
+	import { BlockLabel } from "@gradio/atoms";
 	import type { FileData } from "@gradio/upload";
 	import { Video } from "@gradio/icons";
 

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
       tailwindcss: ^3.0.23
       tinyspy: ^0.3.0
       vite: ^2.9.5
-      vitest: ^0.10.0
+      vitest: ^0.12.7
     dependencies:
       '@gradio/tootils': link:packages/tootils
       '@playwright/test': 1.20.0
@@ -61,7 +61,7 @@ importers:
       tailwindcss: 3.0.23_autoprefixer@10.4.4
       tinyspy: 0.3.0
       vite: 2.9.5
-      vitest: 0.10.0_happy-dom@2.49.0
+      vitest: 0.12.7_happy-dom@2.49.0
     devDependencies:
       '@types/three': 0.138.0
 
@@ -120,7 +120,10 @@ importers:
       svelte-i18n: 3.3.13_svelte@3.47.0
 
   packages/atoms:
-    specifiers: {}
+    specifiers:
+      '@gradio/utils': workspace:^0.0.1
+    dependencies:
+      '@gradio/utils': link:../utils
 
   packages/audio:
     specifiers:
@@ -135,7 +138,10 @@ importers:
       svelte-range-slider-pips: 2.0.2
 
   packages/button:
-    specifiers: {}
+    specifiers:
+      '@gradio/utils': workspace:^0.0.1
+    dependencies:
+      '@gradio/utils': link:../utils
 
   packages/carousel:
     specifiers: {}
@@ -223,7 +229,10 @@ importers:
     specifiers: {}
 
   packages/label:
-    specifiers: {}
+    specifiers:
+      '@gradio/utils': workspace:^0.0.1
+    dependencies:
+      '@gradio/utils': link:../utils
 
   packages/markdown:
     specifiers: {}
@@ -290,11 +299,13 @@ importers:
       '@gradio/icons': workspace:^0.0.1
       '@gradio/image': workspace:^0.0.1
       '@gradio/upload': workspace:^0.0.1
+      '@gradio/utils': workspace:^0.0.1
     dependencies:
       '@gradio/atoms': link:../atoms
       '@gradio/icons': link:../icons
       '@gradio/image': link:../image
       '@gradio/upload': link:../upload
+      '@gradio/utils': link:../utils
 
   packages/workbench:
     specifiers:
@@ -1546,7 +1557,7 @@ packages:
       supports-color: 7.2.0
 
   /check-error/1.0.2:
-    resolution: {integrity: sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=}
+    resolution: {integrity: sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==}
     dev: false
 
   /chokidar/3.5.3:
@@ -2711,6 +2722,12 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  /nanoid/3.3.4:
+    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: false
+
   /nice-try/1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: false
@@ -2991,6 +3008,15 @@ packages:
       nanoid: 3.3.2
       picocolors: 1.0.0
       source-map-js: 1.0.2
+
+  /postcss/8.4.14:
+    resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.4
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: false
 
   /postcss/8.4.6:
     resolution: {integrity: sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==}
@@ -3768,8 +3794,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /tinypool/0.1.2:
-    resolution: {integrity: sha512-fvtYGXoui2RpeMILfkvGIgOVkzJEGediv8UJt7TxdAOY8pnvUkFg/fkvqTfXG9Acc9S17Cnn1S4osDc2164guA==}
+  /tinypool/0.1.3:
+    resolution: {integrity: sha512-2IfcQh7CP46XGWGGbdyO4pjcKqsmVqFAPcXfPxcPXmOWt9cYkTP9HcDmGgsfijYoAEc4z9qcpM/BaBz46Y9/CQ==}
     engines: {node: '>=14.0.0'}
     dev: false
 
@@ -3869,8 +3895,32 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
-  /vitest/0.10.0_happy-dom@2.49.0:
-    resolution: {integrity: sha512-8UXemUg9CA4QYppDTsDV76nH0e1p6C8lV9q+o9i0qMSK9AQ7vA2sjoxtkDP0M+pwNmc3ZGYetBXgSJx0M1D/gg==}
+  /vite/2.9.9:
+    resolution: {integrity: sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==}
+    engines: {node: '>=12.2.0'}
+    hasBin: true
+    peerDependencies:
+      less: '*'
+      sass: '*'
+      stylus: '*'
+    peerDependenciesMeta:
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+    dependencies:
+      esbuild: 0.14.31
+      postcss: 8.4.14
+      resolve: 1.22.0
+      rollup: 2.66.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
+
+  /vitest/0.12.7_happy-dom@2.49.0:
+    resolution: {integrity: sha512-rQsb9i/zEw+HtiTNr+5p+tOUMu0Ojp0jtZc/6FfE4T1xL2bhMq74tfUgu7hav3rFF9eGKpJeZBVlEszjdCuYQg==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     peerDependencies:
@@ -3891,15 +3941,17 @@ packages:
       '@types/chai': 4.3.1
       '@types/chai-subset': 1.3.3
       chai: 4.3.6
+      debug: 4.3.4
       happy-dom: 2.49.0
       local-pkg: 0.4.1
-      tinypool: 0.1.2
+      tinypool: 0.1.3
       tinyspy: 0.3.2
-      vite: 2.9.5
+      vite: 2.9.9
     transitivePeerDependencies:
       - less
       - sass
       - stylus
+      - supports-color
     dev: false
 
   /webidl-conversions/3.0.1:


### PR DESCRIPTION
This PR introduces some style changes to ensure that user can't completely break theirs app with the options that get passed in. There are also a few changes to Simplify how certain things are handled. Other changes are simply hooking

- Colors have been removed for now, I think colors should be handled via whatever theming mechanism we choose. In the case that users want a different color for a certain gradio block (so it stands out for example), I think we should allow `Box` to have a few variants, maybe `default`, `info`, `warning` and `error` each with their own background style but that works well for both luight and dark mode. The colors for these 'types' would be customisable with the themeing system (that doesn't yet exist).
- `color_map` still exists where it is used and is unchanged, i have moved this kwarg from the component to the style method. The rationale here is that anything that only affects the visuals should be a style kwarg. `show_label` is a bit of an anomaly here but it feels kindof logical. We could move it as well though.
- `container` is a style kwarg now, same logic as above.
- `container_bg_color` has been removed. Instead of allowing people to modify the container in this way (and end up with lots of `container_*` styles), we should encourage users to set `container=False` and use `gr.Box()` which they can pass some styles too.
- I'm really not sure where it makes sense to disable the container. In some cases it is fine but all of the upload components need the container for the dotted border + drop highlight functionality. Disabling that will break the ui pretty badly.
- I'm a bit confused about `margin`, only a few components actually have margins, most of the time the margins are actually paddings and i think we can remove them when the `container=False`. But that means we need a way to add them back, I'm not sure what that should be.
- `rounded` also gets a little confusing. I tried to make it so that the `round` is relating to whatever the main part of the component is but it is a little confusing. On form inputs (Textbox, Number, Checkbox, etc) it relates tot he input itself, this looks fine on most but terrible on checkbox + radio. Onfile upload components, this actually refers to the containing box which makes sense (ish) because that _is_ the component but is also slightly inconsistent with the fporm inputs. For table I'm not sure if this will break anything.

_note: there will probably be loads of conflicts when some of the current PRs go in. This PR is unfinished, I've been back and forth on a number of options and wanted to get other people's thoughts before I continued. There isn't much left to do in terms of hooking the last few styles up in the frontend_

**Tech stuff**

I also refactored the way in which styles are applied in the frontend but that is an implementation detail. Happy to go through it @aliabid94. Some inert code still needs removing.