### PR TITLE
Getting Interface.load() working for 2.x and 3.x models and Spaces

### DIFF
--- a/gradio/__init__.py
+++ b/gradio/__init__.py
@@ -41,7 +41,6 @@ from gradio.components import (
     component,
     update,
 )
-from gradio.external import load_interface
 from gradio.flagging import (
     CSVLogger,
     FlaggingCallback,

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -384,7 +384,7 @@ class Blocks(BlockContext):
         inputs: Optional[List[Component]] = None, 
         outputs: Optional[List[Component]] = None,
         *,
-        name: str,
+        name: Optional[str] = None,
         src: Optional[str] = None,
         api_key: Optional[str] = None,
         alias: Optional[str] = None, 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -251,15 +251,18 @@ class Blocks(BlockContext):
         self.auth = None
         self.dev_mode = True
         self.app_id = random.getrandbits(64)
-        self.loaded_externally: bool = False
-        self.external_config: str = None
+        self.loaded_from_config: bool = False
+        self.config: Optional[str] = None
 
     @classmethod
-    def from_config(cls, config: str) -> Blocks:
-        """Factory method that creates a Blocks object with only a config."""
+    def from_config(cls, config: str, fns: List[BlockFunction]) -> Blocks:
+        """Factory method that creates a Blocks object with only a config and a list of
+        BlockFunctions."""
         blocks = Blocks()
-        blocks.loaded_externally = True
-        blocks.external_config = config
+        blocks.loaded_from_config = True
+        blocks.config = config
+        blocks.fns = fns
+        blocks.dependencies = config["dependencies"]
         return blocks
 
     def render(self):
@@ -371,8 +374,9 @@ class Blocks(BlockContext):
         return {"type": "column"}
 
     def get_config_file(self):
-        if self.loaded_externally:
-            return self.external_config
+        if self.loaded_from_config:
+            self.config["enable_queue"] = False
+            return self.config
 
         config = {
             "version": routes.VERSION,

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -411,6 +411,8 @@ class Blocks(BlockContext):
         Returns: None
         """
         if isinstance(self_or_cls, type):
+            if name is None:
+                raise ValueError("Blocks.load() requires passing `name` as a keyword argument")
             if fn is not None:
                 kwargs["fn"] = fn
             if inputs is not None:

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -260,9 +260,20 @@ class Blocks(BlockContext):
         BlockFunctions."""
         blocks = Blocks()
         blocks.loaded_from_config = True
-        blocks.config = config
-        blocks.fns = fns
-        blocks.dependencies = config["dependencies"]
+        if Context.root_block is None:
+            blocks.config = config
+            blocks.fns = fns
+            blocks.dependencies = config["dependencies"]
+        else:
+            pass
+            # Each component ID needs to be offset by Context.id
+            # Each dependency's inputs, targets, and outputs needs to be offset by Context.id
+            # Each layout's id needs to be offset by Context.id
+            # Context.id needs to be incremented by the max component id
+            # Context.root_blocks.fns needs to be extended by fns
+            # Context.dependencies needs to be extended by dependencies
+            # Context.root_block.blocks needs be updated by blocks
+             
         return blocks
 
     def render(self):

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -287,24 +287,24 @@ class Blocks(BlockContext):
         with Blocks(theme=config["theme"], css=config["theme"]) as blocks:
             iterate_over_children(config["layout"]["children"])
 
-        # add the event triggers
-        for dependency, fn in zip(config["dependencies"], fns):
-            targets = dependency.pop("targets")
-            trigger = dependency.pop("trigger")
-            dependency.pop("backend_fn")
-            dependency["inputs"] = [original_mapping[i] for i in dependency["inputs"]]
-            dependency["outputs"] = [original_mapping[o] for o in dependency["outputs"]]
-            if dependency.get("status_tracker", None) is not None:
-                dependency["status_tracker"] = original_mapping[
-                    dependency["status_tracker"]
-                ]
-            dependency["_js"] = dependency.pop("js", None)
-            dependency["_preprocess"] = False
-            dependency["_postprocess"] = False
+            # add the event triggers
+            for dependency, fn in zip(config["dependencies"], fns):
+                targets = dependency.pop("targets")
+                trigger = dependency.pop("trigger")
+                dependency.pop("backend_fn")
+                dependency["inputs"] = [original_mapping[i] for i in dependency["inputs"]]
+                dependency["outputs"] = [original_mapping[o] for o in dependency["outputs"]]
+                if dependency.get("status_tracker", None) is not None:
+                    dependency["status_tracker"] = original_mapping[
+                        dependency["status_tracker"]
+                    ]
+                dependency["_js"] = dependency.pop("js", None)
+                dependency["_preprocess"] = False
+                dependency["_postprocess"] = False
 
-            for target in targets:
-                event_method = getattr(original_mapping[target], trigger)
-                event_method(fn=fn, **dependency)
+                for target in targets:
+                    event_method = getattr(original_mapping[target], trigger)
+                    event_method(fn=fn, **dependency)
 
         return blocks
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -171,7 +171,7 @@ class class_or_instancemethod(classmethod):
     def __get__(self, instance, type_):
         descr_get = super().__get__ if instance is None else self.__func__.__get__
         return descr_get(instance, type_)
-    
+
 
 def update(**kwargs) -> dict:
     """

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -292,8 +292,12 @@ class Blocks(BlockContext):
                 targets = dependency.pop("targets")
                 trigger = dependency.pop("trigger")
                 dependency.pop("backend_fn")
-                dependency["inputs"] = [original_mapping[i] for i in dependency["inputs"]]
-                dependency["outputs"] = [original_mapping[o] for o in dependency["outputs"]]
+                dependency["inputs"] = [
+                    original_mapping[i] for i in dependency["inputs"]
+                ]
+                dependency["outputs"] = [
+                    original_mapping[o] for o in dependency["outputs"]
+                ]
                 if dependency.get("status_tracker", None) is not None:
                     dependency["status_tracker"] = original_mapping[
                         dependency["status_tracker"]

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 from fastapi.concurrency import run_in_threadpool
 
-from gradio import encryptor, external, networking, queueing, strings, utils, routes
+from gradio import encryptor, external, networking, queueing, routes, strings, utils
 from gradio.context import Context
 from gradio.deprecation import check_deprecated_parameters
 from gradio.utils import delete_none
@@ -33,7 +33,7 @@ class Block:
         if render:
             self.render()
         check_deprecated_parameters(self.__class__.__name__, **kwargs)
-    
+
     def render(self):
         """
         Adds self into appropriate BlockContext
@@ -236,7 +236,7 @@ class Blocks(BlockContext):
         self.auth = None
         self.loaded_externally: bool = False
         self.external_config: str = None
-    
+
     @classmethod
     def from_config(cls, config: str) -> Blocks:
         """Factory method that creates a Blocks object with only a config."""
@@ -340,7 +340,7 @@ class Blocks(BlockContext):
     def get_config_file(self):
         if self.loaded_externally:
             return self.external_config
-        
+
         config = {
             "version": routes.VERSION,
             "mode": "blocks",
@@ -351,7 +351,7 @@ class Blocks(BlockContext):
                 self, "enable_queue", False
             ),  # attribute set at launch
         }
-        
+
         for _id, block in self.blocks.items():
             config["components"].append(
                 {
@@ -389,24 +389,24 @@ class Blocks(BlockContext):
         else:
             self.parent.children.extend(self.children)
         self.config = self.get_config_file()
-   
+
     @class_or_instancemethod
     def load(
-        self_or_cls, 
-        fn: Optional[Callable] = None, 
-        inputs: Optional[List[Component]] = None, 
+        self_or_cls,
+        fn: Optional[Callable] = None,
+        inputs: Optional[List[Component]] = None,
         outputs: Optional[List[Component]] = None,
         *,
         name: Optional[str] = None,
         src: Optional[str] = None,
         api_key: Optional[str] = None,
-        alias: Optional[str] = None, 
-        **kwargs,       
+        alias: Optional[str] = None,
+        **kwargs,
     ) -> Blocks | None:
         """
         For reverse compatibility reasons, this is both a class method and an instance
         method, the two of which, confusingly, do two completely different things.
-        
+
         Class method: loads a demo from a Hugging Face Spaces repo and creates it locally
         Parameters:
             name (str): the name of the model (e.g. "gpt2"), can include the `src` as prefix (e.g. "models/gpt2")
@@ -415,7 +415,7 @@ class Blocks(BlockContext):
             alias (str | None): optional string used as the name of the loaded model instead of the default name
             type (str): the type of the Blocks, either a standard `blocks` or `column`
         Returns: Blocks instance
-        
+
         Instance method: adds an event for when the demo loads in the browser.
         Parameters:
             fn: Callable function
@@ -425,7 +425,9 @@ class Blocks(BlockContext):
         """
         if isinstance(self_or_cls, type):
             if name is None:
-                raise ValueError("Blocks.load() requires passing `name` as a keyword argument")
+                raise ValueError(
+                    "Blocks.load() requires passing `name` as a keyword argument"
+                )
             if fn is not None:
                 kwargs["fn"] = fn
             if inputs is not None:

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 from fastapi.concurrency import run_in_threadpool
 
-from gradio import encryptor, networking, queueing, strings, utils
+from gradio import encryptor, networking, queueing, strings, utils, routes
 from gradio.context import Context
 from gradio.deprecation import check_deprecated_parameters
 from gradio.utils import delete_none
@@ -323,6 +323,7 @@ class Blocks(BlockContext):
 
     def get_config_file(self):
         config = {
+            "version": routes.VERSION,
             "mode": "blocks",
             "components": [],
             "theme": self.theme,

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -234,6 +234,16 @@ class Blocks(BlockContext):
         self.is_space = True if os.getenv("SYSTEM") == "spaces" else False
         self.favicon_path = None
         self.auth = None
+        self.loaded_externally: bool = False
+        self.external_config: str = None
+    
+    @classmethod
+    def from_config(cls, config: str) -> Blocks:
+        """Factory method that creates a Blocks object with only a config."""
+        blocks = Blocks()
+        blocks.loaded_externally = True
+        blocks.external_config = config
+        return blocks
 
     def render(self):
         if Context.root_block is not None:
@@ -328,6 +338,9 @@ class Blocks(BlockContext):
         return {"type": "column"}
 
     def get_config_file(self):
+        if self.loaded_externally:
+            return self.external_config
+        
         config = {
             "version": routes.VERSION,
             "mode": "blocks",
@@ -338,7 +351,7 @@ class Blocks(BlockContext):
                 self, "enable_queue", False
             ),  # attribute set at launch
         }
-
+        
         for _id, block in self.blocks.items():
             config["components"].append(
                 {

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -26,7 +26,7 @@ from ffmpy import FFmpeg
 from markdown_it import MarkdownIt
 
 from gradio import media_data, processing_utils
-from gradio.blocks import Block
+from gradio.blocks import Block, BlockContext
 from gradio.events import (
     Changeable,
     Clearable,
@@ -36,6 +36,7 @@ from gradio.events import (
     Streamable,
     Submittable,
 )
+from gradio.utils import component_or_layout_class
 
 
 class Component(Block):
@@ -3562,8 +3563,9 @@ class Dataset(Clickable, Component):
     def __init__(
         self,
         *,
-        components: List[Component],
+        components: List[Component] | List[str],
         samples: List[List[Any]],
+        headers: Optional[List[str]] = None,
         type: str = "values",
         visible: bool = True,
         elem_id: Optional[str] = None,
@@ -3571,15 +3573,16 @@ class Dataset(Clickable, Component):
     ):
         """
         Parameters:
-        components (List[Component]): Which component types to show in this dataset widget
+        components (List[Component]): Which component types to show in this dataset widget, can be passed in as a list of string names or Components instances
         samples (str): a nested list of samples. Each sublist within the outer list represents a data sample, and each element within the sublist represents an value for each component
+        headers (List[str]): Column headers in the Dataset widget, should be the same len as components. If not provided, inferred from component labels
         type (str): 'values' if clicking on a sample should pass the value of the sample, or "index" if it should pass the index of the sample
         visible (bool): If False, component will be hidden.
         """
         Component.__init__(self, visible=visible, elem_id=elem_id, **kwargs)
-        self.components = components
+        self.components = [get_component_instance(c).unrender() for c in components]
         self.type = type
-        self.headers = [c.label for c in components]
+        self.headers = headers or [c.label for c in self.components]
         self.samples = samples
 
     def get_config(self):
@@ -3684,41 +3687,17 @@ class StatusTracker(Component):
         }
 
 
-def component_class(cls_name: str) -> Type[Component]:
-    """
-    Returns the component class with the given class name, or raises a ValueError if not found.
-    @param cls_name: lower-case string class name of a component
-    @return cls: the component class
-    """
-    import gradio.templates
-
-    components = [
-        (name, cls)
-        for name, cls in sys.modules[__name__].__dict__.items()
-        if isinstance(cls, type)
-    ]
-    templates = [
-        (name, cls)
-        for name, cls in gradio.templates.__dict__.items()
-        if isinstance(cls, type)
-    ]
-    for name, cls in components + templates:
-        if name.lower() == cls_name.replace("_", "") and issubclass(cls, Component):
-            return cls
-    raise ValueError(f"No such Component: {cls_name}")
-
-
 def component(cls_name: str) -> Component:
-    obj = component_class(cls_name)()
+    obj = component_or_layout_class(cls_name)()
     return obj
 
 
-def get_component_instance(comp: str | dict | Component):
+def get_component_instance(comp: str | dict | Component) -> Component:
     if isinstance(comp, str):
         return component(comp)
     elif isinstance(comp, dict):
         name = comp.pop("name")
-        component_cls = component_class(name)
+        component_cls = component_or_layout_class(name)
         component_obj = component_cls(**comp)
         return component_obj
     elif isinstance(comp, Component):

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -15,7 +15,10 @@ class Changeable(Block):
         inputs: List[Component],
         outputs: List[Component],
         status_tracker: Optional[StatusTracker] = None,
+        queue: Optional[bool] = None,
         _js: Optional[str] = None,
+        _preprocess: bool = True,
+        _postprocess: bool = True,
     ):
         """
         Parameters:
@@ -27,7 +30,8 @@ class Changeable(Block):
         Returns: None
         """
         self.set_event_trigger(
-            "change", fn, inputs, outputs, status_tracker=status_tracker, js=_js
+            "change", fn, inputs, outputs, status_tracker=status_tracker, js=_js,
+            preprocess=_preprocess, postprocess=_postprocess, queue=queue
         )
 
 
@@ -74,7 +78,10 @@ class Submittable(Block):
         inputs: List[Component],
         outputs: List[Component],
         status_tracker: Optional[StatusTracker] = None,
+        queue: Optional[bool] = None,
         _js: Optional[str] = None,
+        _preprocess: bool = True,
+        _postprocess: bool = True,
     ):
         """
         Parameters:
@@ -86,7 +93,8 @@ class Submittable(Block):
         Returns: None
         """
         self.set_event_trigger(
-            "submit", fn, inputs, outputs, status_tracker=status_tracker, js=_js
+            "submit", fn, inputs, outputs, status_tracker=status_tracker, js=_js,
+            preprocess=_preprocess, postprocess=_postprocess, queue=queue            
         )
 
 
@@ -96,7 +104,10 @@ class Editable(Block):
         fn: Callable,
         inputs: List[Component],
         outputs: List[Component],
+        queue: Optional[bool] = None,
         _js: Optional[str] = None,
+        _preprocess: bool = True,
+        _postprocess: bool = True,
     ):
         """
         Parameters:
@@ -106,7 +117,8 @@ class Editable(Block):
             _js: Optional frontend js method to run before running 'fn'. Input arguments for js method are values of 'inputs' and 'outputs', return should be a list of values for output components.
         Returns: None
         """
-        self.set_event_trigger("edit", fn, inputs, outputs, js=_js)
+        self.set_event_trigger("edit", fn, inputs, outputs, js=_js,
+                               preprocess=_preprocess, postprocess=_postprocess, queue=queue)
 
 
 class Clearable(Block):
@@ -115,7 +127,10 @@ class Clearable(Block):
         fn: Callable,
         inputs: List[Component],
         outputs: List[Component],
+        queue: Optional[bool] = None,
         _js: Optional[str] = None,
+        _preprocess: bool = True,
+        _postprocess: bool = True,
     ):
         """
         Parameters:
@@ -125,7 +140,8 @@ class Clearable(Block):
             _js: Optional frontend js method to run before running 'fn'. Input arguments for js method are values of 'inputs' and 'outputs', return should be a list of values for output components.
         Returns: None
         """
-        self.set_event_trigger("submit", fn, inputs, outputs, js=_js)
+        self.set_event_trigger("submit", fn, inputs, outputs, js=_js,
+                                           preprocess=_preprocess, postprocess=_postprocess, queue=queue)
 
 
 class Playable(Block):
@@ -134,7 +150,10 @@ class Playable(Block):
         fn: Callable,
         inputs: List[Component],
         outputs: List[Component],
+        queue: Optional[bool] = None,
         _js: Optional[str] = None,
+        _preprocess: bool = True,
+        _postprocess: bool = True,
     ):
         """
         Parameters:
@@ -144,14 +163,18 @@ class Playable(Block):
             _js: Optional frontend js method to run before running 'fn'. Input arguments for js method are values of 'inputs' and 'outputs', return should be a list of values for output components.
         Returns: None
         """
-        self.set_event_trigger("play", fn, inputs, outputs, js=_js)
+        self.set_event_trigger("play", fn, inputs, outputs, js=_js,
+                                           preprocess=_preprocess, postprocess=_postprocess, queue=queue)
 
     def pause(
         self,
         fn: Callable,
         inputs: List[Component],
         outputs: List[Component],
+        queue: Optional[bool] = None,
         _js: Optional[str] = None,
+        _preprocess: bool = True,
+        _postprocess: bool = True,
     ):
         """
         Parameters:
@@ -161,14 +184,17 @@ class Playable(Block):
             _js: Optional frontend js method to run before running 'fn'. Input arguments for js method are values of 'inputs' and 'outputs', return should be a list of values for output components.
         Returns: None
         """
-        self.set_event_trigger("pause", fn, inputs, outputs, js=_js)
+        self.set_event_trigger("pause", fn, inputs, outputs, js=_js, preprocess=_preprocess, postprocess=_postprocess, queue=queue)
 
     def stop(
         self,
         fn: Callable,
         inputs: List[Component],
         outputs: List[Component],
+        queue: Optional[bool] = None,
         _js: Optional[str] = None,
+        _preprocess: bool = True,
+        _postprocess: bool = True,
     ):
         """
         Parameters:
@@ -178,7 +204,7 @@ class Playable(Block):
             _js: Optional frontend js method to run before running 'fn'. Input arguments for js method are values of 'inputs' and 'outputs', return should be a list of values for output components.
         Returns: None
         """
-        self.set_event_trigger("stop", fn, inputs, outputs, js=_js)
+        self.set_event_trigger("stop", fn, inputs, outputs, js=_js, preprocess=_preprocess, postprocess=_postprocess, queue=queue)
 
 
 class Streamable(Block):
@@ -187,7 +213,10 @@ class Streamable(Block):
         fn: Callable,
         inputs: List[Component],
         outputs: List[Component],
+        queue: Optional[bool] = None,
         _js: Optional[str] = None,
+        _preprocess: bool = True,
+        _postprocess: bool = True,
     ):
         """
         Parameters:
@@ -198,4 +227,4 @@ class Streamable(Block):
         Returns: None
         """
         self.streaming = True
-        self.set_event_trigger("stream", fn, inputs, outputs, js=_js)
+        self.set_event_trigger("stream", fn, inputs, outputs, js=_js, preprocess=_preprocess, postprocess=_postprocess, queue=queue)

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -30,8 +30,15 @@ class Changeable(Block):
         Returns: None
         """
         self.set_event_trigger(
-            "change", fn, inputs, outputs, status_tracker=status_tracker, js=_js,
-            preprocess=_preprocess, postprocess=_postprocess, queue=queue
+            "change",
+            fn,
+            inputs,
+            outputs,
+            status_tracker=status_tracker,
+            js=_js,
+            preprocess=_preprocess,
+            postprocess=_postprocess,
+            queue=queue,
         )
 
 
@@ -93,8 +100,15 @@ class Submittable(Block):
         Returns: None
         """
         self.set_event_trigger(
-            "submit", fn, inputs, outputs, status_tracker=status_tracker, js=_js,
-            preprocess=_preprocess, postprocess=_postprocess, queue=queue            
+            "submit",
+            fn,
+            inputs,
+            outputs,
+            status_tracker=status_tracker,
+            js=_js,
+            preprocess=_preprocess,
+            postprocess=_postprocess,
+            queue=queue,
         )
 
 
@@ -117,8 +131,16 @@ class Editable(Block):
             _js: Optional frontend js method to run before running 'fn'. Input arguments for js method are values of 'inputs' and 'outputs', return should be a list of values for output components.
         Returns: None
         """
-        self.set_event_trigger("edit", fn, inputs, outputs, js=_js,
-                               preprocess=_preprocess, postprocess=_postprocess, queue=queue)
+        self.set_event_trigger(
+            "edit",
+            fn,
+            inputs,
+            outputs,
+            js=_js,
+            preprocess=_preprocess,
+            postprocess=_postprocess,
+            queue=queue,
+        )
 
 
 class Clearable(Block):
@@ -140,8 +162,16 @@ class Clearable(Block):
             _js: Optional frontend js method to run before running 'fn'. Input arguments for js method are values of 'inputs' and 'outputs', return should be a list of values for output components.
         Returns: None
         """
-        self.set_event_trigger("submit", fn, inputs, outputs, js=_js,
-                                           preprocess=_preprocess, postprocess=_postprocess, queue=queue)
+        self.set_event_trigger(
+            "submit",
+            fn,
+            inputs,
+            outputs,
+            js=_js,
+            preprocess=_preprocess,
+            postprocess=_postprocess,
+            queue=queue,
+        )
 
 
 class Playable(Block):
@@ -163,8 +193,16 @@ class Playable(Block):
             _js: Optional frontend js method to run before running 'fn'. Input arguments for js method are values of 'inputs' and 'outputs', return should be a list of values for output components.
         Returns: None
         """
-        self.set_event_trigger("play", fn, inputs, outputs, js=_js,
-                                           preprocess=_preprocess, postprocess=_postprocess, queue=queue)
+        self.set_event_trigger(
+            "play",
+            fn,
+            inputs,
+            outputs,
+            js=_js,
+            preprocess=_preprocess,
+            postprocess=_postprocess,
+            queue=queue,
+        )
 
     def pause(
         self,
@@ -184,7 +222,16 @@ class Playable(Block):
             _js: Optional frontend js method to run before running 'fn'. Input arguments for js method are values of 'inputs' and 'outputs', return should be a list of values for output components.
         Returns: None
         """
-        self.set_event_trigger("pause", fn, inputs, outputs, js=_js, preprocess=_preprocess, postprocess=_postprocess, queue=queue)
+        self.set_event_trigger(
+            "pause",
+            fn,
+            inputs,
+            outputs,
+            js=_js,
+            preprocess=_preprocess,
+            postprocess=_postprocess,
+            queue=queue,
+        )
 
     def stop(
         self,
@@ -204,7 +251,16 @@ class Playable(Block):
             _js: Optional frontend js method to run before running 'fn'. Input arguments for js method are values of 'inputs' and 'outputs', return should be a list of values for output components.
         Returns: None
         """
-        self.set_event_trigger("stop", fn, inputs, outputs, js=_js, preprocess=_preprocess, postprocess=_postprocess, queue=queue)
+        self.set_event_trigger(
+            "stop",
+            fn,
+            inputs,
+            outputs,
+            js=_js,
+            preprocess=_preprocess,
+            postprocess=_postprocess,
+            queue=queue,
+        )
 
 
 class Streamable(Block):
@@ -227,4 +283,13 @@ class Streamable(Block):
         Returns: None
         """
         self.streaming = True
-        self.set_event_trigger("stream", fn, inputs, outputs, js=_js, preprocess=_preprocess, postprocess=_postprocess, queue=queue)
+        self.set_event_trigger(
+            "stream",
+            fn,
+            inputs,
+            outputs,
+            js=_js,
+            preprocess=_preprocess,
+            postprocess=_postprocess,
+            queue=queue,
+        )

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -1,3 +1,6 @@
+"""This module should not be used directly as its API is subject to change. Instead, 
+use the `gr.Blocks.load()` or `gr.Interface.load()` functions."""
+
 import base64
 import json
 import re

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -1,4 +1,4 @@
-"""This module should not be used directly as its API is subject to change. Instead, 
+"""This module should not be used directly as its API is subject to change. Instead,
 use the `gr.Blocks.load()` or `gr.Interface.load()` functions."""
 
 import base64

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -330,7 +330,7 @@ def get_spaces(model_name, api_key, alias, **kwargs):
     if "allow_flagging" in config:  # Create an Interface for Gradio 2.x Spaces
         return get_spaces_interface(model_name, config, alias, **kwargs)      
     else: # Create a Blcoks for Gradio 3.x Spaces
-        raise NotImplementedError("Gradio 3.x Spaces are not yet supported.")
+        return gradio.Blocks.from_config(config)
 
 def get_spaces_interface(model_name, config, alias, **kwargs):
     config = streamline_interface_config(config)

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -331,7 +331,10 @@ def get_spaces_blocks(model_name, config):
                     data = json.dumps({"data": data})
                     response = requests.post(api_url, headers=headers, data=data)
                     result = json.loads(response.content.decode("utf-8"))
-                    output = result["data"]
+                    try:
+                        output = result["data"]
+                    except KeyError:
+                        raise KeyError(f"Could not find 'data' key in response from external Space. Response received: {result}")
                     if len(dependency["outputs"]) == 1:
                         output = output[0]
                     if len(dependency["outputs"]) == 1 and isinstance(output, list):

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -12,10 +12,6 @@ import requests
 import gradio
 from gradio import components, utils
 
-####################################################
-# Create a Blocks or Interface from a HF Repo
-####################################################
-
 
 def load_blocks_from_repo(name, src=None, api_key=None, alias=None, **kwargs):
     """Creates and returns a Blocks instance from several kinds of Hugging Face repos:
@@ -382,7 +378,10 @@ def get_spaces_interface(model_name, config, alias, **kwargs):
         data = json.dumps({"data": data})
         response = requests.post(api_url, headers=headers, data=data)
         result = json.loads(response.content.decode("utf-8"))
-        output = result["data"]
+        try:
+            output = result["data"]
+        except KeyError:
+            raise KeyError(f"Could not find 'data' key in response from external Space. Response received: {result}")
         if (
             len(config["outputs"]) == 1
         ):  # if the fn is supposed to return a single value, pop it
@@ -408,11 +407,6 @@ factory_methods: Dict[str, Callable] = {
     "models": get_models_interface,
     "spaces": get_spaces,
 }
-
-
-####################################################
-# Create an Interface from a transformers.pipeline
-####################################################
 
 
 def load_from_pipeline(pipeline):

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -334,7 +334,9 @@ def get_spaces_blocks(model_name, config):
                     try:
                         output = result["data"]
                     except KeyError:
-                        raise KeyError(f"Could not find 'data' key in response from external Space. Response received: {result}")
+                        raise KeyError(
+                            f"Could not find 'data' key in response from external Space. Response received: {result}"
+                        )
                     if len(dependency["outputs"]) == 1:
                         output = output[0]
                     return output
@@ -382,7 +384,9 @@ def get_spaces_interface(model_name, config, alias, **kwargs):
         try:
             output = result["data"]
         except KeyError:
-            raise KeyError(f"Could not find 'data' key in response from external Space. Response received: {result}")
+            raise KeyError(
+                f"Could not find 'data' key in response from external Space. Response received: {result}"
+            )
         if (
             len(config["outputs"]) == 1
         ):  # if the fn is supposed to return a single value, pop it

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -1,13 +1,39 @@
 import base64
 import json
 import re
+from typing import Callable, Dict
 
 import requests
 
+import gradio
 from gradio import components, utils
 
 
-def get_huggingface_interface(model_name, api_key, alias):
+####################################################
+# Create a Blocks or Interface from a HF Repo 
+####################################################
+
+def load_blocks_from_repo(name, src=None, api_key=None, alias=None, **kwargs):
+    """ Creates and returns a Blocks instance from several kinds of Hugging Face repos:
+    1) A model repo
+    2) A Spaces repo running Gradio 2.x
+    3) A Spaces repo running Gradio 3.x
+    """
+    if src is None:
+        tokens = name.split(
+            "/"
+        )  # Separate the source (e.g. "huggingface") from the repo name (e.g. "google/vit-base-patch16-224")
+        assert (
+            len(tokens) > 1
+        ), "Either `src` parameter must be provided, or `name` must be formatted as {src}/{repo name}"
+        src = tokens[0]
+        name = "/".join(tokens[1:])
+    assert src.lower() in factory_methods, "parameter: src must be one of {}".format(factory_methods.keys())
+    blocks: gradio.Blocks = factory_methods[src](name, api_key, alias, **kwargs)
+    return blocks
+
+
+def get_models_interface(model_name, api_key, alias, **kwargs):
     model_url = "https://huggingface.co/{}".format(model_name)
     api_url = "https://api-inference.huggingface.co/models/{}".format(model_name)
     print("Fetching model from: {}".format(model_url))
@@ -256,26 +282,14 @@ def get_huggingface_interface(model_name, api_key, alias):
         "title": model_name,
     }
 
-    return interface_info
+    kwargs = dict(interface_info, **kwargs)
+    interface = gradio.Interface(**kwargs)
+    interface.api_mode = True  # So interface doesn't run pre/postprocess.
+    return interface
 
 
-def load_interface(name, src=None, api_key=None, alias=None):
-    if src is None:
-        tokens = name.split(
-            "/"
-        )  # Separate the source (e.g. "huggingface") from the repo name (e.g. "google/vit-base-patch16-224")
-        assert (
-            len(tokens) > 1
-        ), "Either `src` parameter must be provided, or `name` must be formatted as {src}/{repo name}"
-        src = tokens[0]
-        name = "/".join(tokens[1:])
-    assert src.lower() in repos, "parameter: src must be one of {}".format(repos.keys())
-    interface_info = repos[src](name, api_key, alias)
-    return interface_info
-
-
-def interface_params_from_config(config_dict):
-    # instantiate input component and output component
+def streamline_interface_config(config_dict):
+    """Streamlines the interface config dictionary to remove unnecessary keys."""
     config_dict["inputs"] = [
         components.get_component_instance(component)
         for component in config_dict["input_components"]
@@ -285,15 +299,11 @@ def interface_params_from_config(config_dict):
         for component in config_dict["output_components"]
     ]
     parameters = {
-        "allow_flagging",
-        "allow_screenshot",
         "article",
         "description",
         "flagging_options",
         "inputs",
         "outputs",
-        "show_input",
-        "show_output",
         "theme",
         "title",
     }
@@ -301,12 +311,10 @@ def interface_params_from_config(config_dict):
     return config_dict
 
 
-def get_spaces_interface(model_name, api_key, alias):
+def get_spaces(model_name, api_key, alias, **kwargs):
     space_url = "https://huggingface.co/spaces/{}".format(model_name)
     print("Fetching interface from: {}".format(space_url))
     iframe_url = "https://hf.space/embed/{}/+".format(model_name)
-    api_url = "https://hf.space/embed/{}/api/predict/".format(model_name)
-    headers = {"Content-Type": "application/json"}
 
     r = requests.get(iframe_url)
     result = re.search(
@@ -316,7 +324,15 @@ def get_spaces_interface(model_name, api_key, alias):
         config = json.loads(result.group(1))
     except AttributeError:
         raise ValueError("Could not load the Space: {}".format(model_name))
-    interface_info = interface_params_from_config(config)
+    if "allow_flagging" in config:  # Create an Interface for Gradio 2.x Spaces
+        return get_spaces_interface(model_name, config, alias, **kwargs)      
+    else: # Create a Blcoks for Gradio 3.x Spaces
+        raise NotImplementedError("Gradio 3.x Spaces are not yet supported.")
+
+def get_spaces_interface(model_name, config, alias, **kwargs):
+    config = streamline_interface_config(config)
+    api_url = "https://hf.space/embed/{}/api/predict/".format(model_name)
+    headers = {"Content-Type": "application/json"}
 
     # The function should call the API with preprocessed data
     def fn(*data):
@@ -325,28 +341,35 @@ def get_spaces_interface(model_name, api_key, alias):
         result = json.loads(response.content.decode("utf-8"))
         output = result["data"]
         if (
-            len(interface_info["outputs"]) == 1
+            len(config["outputs"]) == 1
         ):  # if the fn is supposed to return a single value, pop it
             output = output[0]
-        if len(interface_info["outputs"]) == 1 and isinstance(
+        if len(config["outputs"]) == 1 and isinstance(
             output, list
         ):  # Needed to support Output.Image() returning bounding boxes as well (TODO: handle different versions of gradio since they have slightly different APIs)
             output = output[0]
         return output
 
     fn.__name__ = alias if (alias is not None) else model_name
-    interface_info["fn"] = fn
+    config["fn"] = fn
 
-    return interface_info
+    kwargs = dict(config, **kwargs)
+    interface = gradio.Interface(**kwargs)
+    interface.api_mode = True  # So interface doesn't run pre/postprocess.
+    return interface
 
 
-repos = {
-    # for each repo, we have a method that returns the Interface given the model name & optionally an api_key
-    "huggingface": get_huggingface_interface,
-    "models": get_huggingface_interface,
-    "spaces": get_spaces_interface,
+factory_methods: Dict[str, Callable] = {
+    # for each repo type, we have a method that returns the Interface given the model name & optionally an api_key
+    "huggingface": get_models_interface,
+    "models": get_models_interface,
+    "spaces": get_spaces,
 }
 
+
+####################################################
+# Create an Interface from a transformers.pipeline 
+####################################################
 
 def load_from_pipeline(pipeline):
     """

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -337,8 +337,6 @@ def get_spaces_blocks(model_name, config):
                         raise KeyError(f"Could not find 'data' key in response from external Space. Response received: {result}")
                     if len(dependency["outputs"]) == 1:
                         output = output[0]
-                    if len(dependency["outputs"]) == 1 and isinstance(output, list):
-                        output = output[0]
                     return output
 
                 return fn

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -2,9 +2,9 @@
 use the `gr.Blocks.load()` or `gr.Interface.load()` functions."""
 
 import base64
-from copy import deepcopy
 import json
 import re
+from copy import deepcopy
 from typing import Callable, Dict
 
 import requests
@@ -329,7 +329,7 @@ def get_spaces_blocks(model_name, config):
     fns = []
     for _dependency in config["dependencies"]:
         if _dependency["backend_fn"]:
-                        
+
             def get_fn(dependency):
                 def fn(*data):
                     data = json.dumps({"data": data})
@@ -341,8 +341,9 @@ def get_spaces_blocks(model_name, config):
                     if len(dependency["outputs"]) == 1 and isinstance(output, list):
                         output = output[0]
                     return output
+
                 return fn
-            
+
             fns.append(get_fn(deepcopy(_dependency)))
         else:
             fns.append(None)

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -11,13 +11,13 @@ import requests
 import gradio
 from gradio import components, utils
 
+####################################################
+# Create a Blocks or Interface from a HF Repo
+####################################################
 
-####################################################
-# Create a Blocks or Interface from a HF Repo 
-####################################################
 
 def load_blocks_from_repo(name, src=None, api_key=None, alias=None, **kwargs):
-    """ Creates and returns a Blocks instance from several kinds of Hugging Face repos:
+    """Creates and returns a Blocks instance from several kinds of Hugging Face repos:
     1) A model repo
     2) A Spaces repo running Gradio 2.x
     3) A Spaces repo running Gradio 3.x
@@ -31,7 +31,9 @@ def load_blocks_from_repo(name, src=None, api_key=None, alias=None, **kwargs):
         ), "Either `src` parameter must be provided, or `name` must be formatted as {src}/{repo name}"
         src = tokens[0]
         name = "/".join(tokens[1:])
-    assert src.lower() in factory_methods, "parameter: src must be one of {}".format(factory_methods.keys())
+    assert src.lower() in factory_methods, "parameter: src must be one of {}".format(
+        factory_methods.keys()
+    )
     blocks: gradio.Blocks = factory_methods[src](name, api_key, alias, **kwargs)
     return blocks
 
@@ -328,9 +330,10 @@ def get_spaces(model_name, api_key, alias, **kwargs):
     except AttributeError:
         raise ValueError("Could not load the Space: {}".format(model_name))
     if "allow_flagging" in config:  # Create an Interface for Gradio 2.x Spaces
-        return get_spaces_interface(model_name, config, alias, **kwargs)      
-    else: # Create a Blcoks for Gradio 3.x Spaces
+        return get_spaces_interface(model_name, config, alias, **kwargs)
+    else:  # Create a Blcoks for Gradio 3.x Spaces
         return gradio.Blocks.from_config(config)
+
 
 def get_spaces_interface(model_name, config, alias, **kwargs):
     config = streamline_interface_config(config)
@@ -371,8 +374,9 @@ factory_methods: Dict[str, Callable] = {
 
 
 ####################################################
-# Create an Interface from a transformers.pipeline 
+# Create an Interface from a transformers.pipeline
 ####################################################
+
 
 def load_from_pipeline(pipeline):
     """

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -343,10 +343,9 @@ def get_spaces_blocks(model_name, config):
                     return output
                 return fn
             
-            fn = get_fn(deepcopy(_dependency))
-            fns.append(gradio.blocks.BlockFunction(fn, False, False))
+            fns.append(get_fn(deepcopy(_dependency)))
         else:
-            fns.append(gradio.blocks.BlockFunction(None, False, False))
+            fns.append(None)
     return gradio.Blocks.from_config(config, fns)
 
 

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -34,7 +34,7 @@ from gradio.components import (
     get_component_instance,
 )
 from gradio.events import Changeable, Streamable
-from gradio.external import load_from_pipeline, load_interface  # type: ignore
+from gradio.external import load_from_pipeline  # type: ignore
 from gradio.flagging import CSVLogger, FlaggingCallback  # type: ignore
 from gradio.layouts import Column, Row, TabItem, Tabs
 from gradio.process_examples import cache_interface_examples, load_from_cache
@@ -87,11 +87,7 @@ class Interface(Blocks):
         Returns:
         (gradio.Interface): a Gradio Interface object for the given model
         """
-        interface_info = load_interface(name, src, api_key, alias)
-        kwargs = dict(interface_info, **kwargs)
-        interface = cls(**kwargs)
-        interface.api_mode = True  # So interface doesn't run pre/postprocess.
-        return interface
+        return super().load(name=name, src=src, api_key=api_key, alias=alias, **kwargs)
 
     @classmethod
     def from_pipeline(cls, pipeline: transformers.Pipeline, **kwargs) -> Interface:

--- a/gradio/test_data/blocks_configs.py
+++ b/gradio/test_data/blocks_configs.py
@@ -1,4 +1,4 @@
-import gradio 
+import gradio
 
 XRAY_CONFIG = {
     "mode": "blocks",

--- a/gradio/test_data/blocks_configs.py
+++ b/gradio/test_data/blocks_configs.py
@@ -1,3 +1,5 @@
+import gradio 
+
 XRAY_CONFIG = {
     "mode": "blocks",
     "components": [

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -23,7 +23,7 @@ import requests
 import gradio
 
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
-    from gradio import Interface, Blocks
+    from gradio import Blocks, Interface
     from gradio.blocks import BlockContext
     from gradio.components import Component
 
@@ -277,15 +277,17 @@ def resolve_singleton(_list):
 
 def component_or_layout_class(cls_name: str) -> Component | BlockContext:
     """
-    Returns the component, template, or layout class with the given class name, or 
+    Returns the component, template, or layout class with the given class name, or
     raises a ValueError if not found.
-    
+
     Parameters:
     cls_name (str): lower-case string class name of a component
-    Returns: 
+    Returns:
     cls: the component class
     """
-    import gradio.components, gradio.templates, gradio.layouts
+    import gradio.components
+    import gradio.layouts
+    import gradio.templates
 
     components = [
         (name, cls)
@@ -304,8 +306,8 @@ def component_or_layout_class(cls_name: str) -> Component | BlockContext:
     ]
     for name, cls in components + templates + layouts:
         if name.lower() == cls_name.replace("_", "") and (
-            issubclass(cls, gradio.components.Component) or issubclass(cls, gradio.blocks.BlockContext)):
+            issubclass(cls, gradio.components.Component)
+            or issubclass(cls, gradio.blocks.BlockContext)
+        ):
             return cls
     raise ValueError(f"No such component or layout: {cls_name}")
-
-

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -9,6 +9,7 @@ import json
 import json.decoder
 import os
 import random
+import sys
 import warnings
 from copy import deepcopy
 from distutils.version import StrictVersion
@@ -22,7 +23,9 @@ import requests
 import gradio
 
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
-    from gradio import Interface
+    from gradio import Interface, Blocks
+    from gradio.blocks import BlockContext
+    from gradio.components import Component
 
 analytics_url = "https://api.gradio.app/"
 PKG_VERSION_URL = "https://api.gradio.app/pkg-version"
@@ -270,3 +273,39 @@ def resolve_singleton(_list):
         return _list[0]
     else:
         return _list
+
+
+def component_or_layout_class(cls_name: str) -> Component | BlockContext:
+    """
+    Returns the component, template, or layout class with the given class name, or 
+    raises a ValueError if not found.
+    
+    Parameters:
+    cls_name (str): lower-case string class name of a component
+    Returns: 
+    cls: the component class
+    """
+    import gradio.components, gradio.templates, gradio.layouts
+
+    components = [
+        (name, cls)
+        for name, cls in gradio.components.__dict__.items()
+        if isinstance(cls, type)
+    ]
+    templates = [
+        (name, cls)
+        for name, cls in gradio.templates.__dict__.items()
+        if isinstance(cls, type)
+    ]
+    layouts = [
+        (name, cls)
+        for name, cls in gradio.layouts.__dict__.items()
+        if isinstance(cls, type)
+    ]
+    for name, cls in components + templates + layouts:
+        if name.lower() == cls_name.replace("_", "") and (
+            issubclass(cls, gradio.components.Component) or issubclass(cls, gradio.blocks.BlockContext)):
+            return cls
+    raise ValueError(f"No such component or layout: {cls_name}")
+
+

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -57,9 +57,9 @@ class TestBlocks(unittest.TestCase):
                     )
             textbox = gr.components.Textbox()
             demo.load(fake_func, [], [textbox])
-            print(XRAY_CONFIG)
-            print(demo.get_config_file())
-        self.assertDictEqual(XRAY_CONFIG, demo.get_config_file())
+            config = demo.get_config_file()
+            config.pop("version")  # remove version key
+        self.assertDictEqual(XRAY_CONFIG, config)
 
     @pytest.mark.asyncio
     async def test_async_function(self):

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -2,9 +2,10 @@ import os
 import pathlib
 import unittest
 
+import gradio as gr
+
 # import transformers
 
-import gradio as gr
 
 """
 WARNING: These tests have an external dependency: namely that Hugging Face's
@@ -33,9 +34,7 @@ class TestLoadInterface(unittest.TestCase):
     def test_question_answering(self):
         model_type = "image-classification"
         interface = gr.Blocks.load(
-            name="lysandre/tiny-vit-random",
-            src="models",
-            alias=model_type
+            name="lysandre/tiny-vit-random", src="models", alias=model_type
         )
         self.assertEqual(interface.predict[0].__name__, model_type)
         self.assertIsInstance(interface.input_components[0], gr.components.Image)
@@ -43,10 +42,7 @@ class TestLoadInterface(unittest.TestCase):
 
     def test_text_generation(self):
         model_type = "text_generation"
-        interface = gr.Interface.load(
-            "models/gpt2", 
-            alias=model_type
-        )
+        interface = gr.Interface.load("models/gpt2", alias=model_type)
         self.assertEqual(interface.predict[0].__name__, model_type)
         self.assertIsInstance(interface.input_components[0], gr.components.Textbox)
         self.assertIsInstance(interface.output_components[0], gr.components.Textbox)
@@ -195,16 +191,12 @@ class TestLoadInterface(unittest.TestCase):
         self.assertLess(output["Survives"], 0.5)
 
     def test_speech_recognition_model(self):
-        io = gr.Interface.load(
-            "models/facebook/wav2vec2-base-960h"
-        )
+        io = gr.Interface.load("models/facebook/wav2vec2-base-960h")
         output = io("gradio/test_data/test_audio.wav")
         self.assertIsNotNone(output)
 
     def test_text_to_image_model(self):
-        io = gr.Interface.load(
-            "models/osanseviero/BigGAN-deep-128"
-        )
+        io = gr.Interface.load("models/osanseviero/BigGAN-deep-128")
         filename = io("chest")
         self.assertTrue(filename.endswith(".jpg") or filename.endswith(".jpeg"))
 

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -2,10 +2,9 @@ import os
 import pathlib
 import unittest
 
-import gradio as gr
-
 import transformers
 
+import gradio as gr
 
 """
 WARNING: These tests have an external dependency: namely that Hugging Face's

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 import unittest
 
-import transformers
+# import transformers
 
 import gradio as gr
 
@@ -10,223 +10,201 @@ import gradio as gr
 WARNING: These tests have an external dependency: namely that Hugging Face's
 Hub and Space APIs do not change, and they keep their most famous models up.
 So if, e.g. Spaces is down, then these test will not pass.
+
+These tests actually test gr.Interface.load() and gr.Blocks.load() but are 
+included in a separate file because of the above-mentioned dependency.
 """
 
 os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
 
 
-class TestHuggingFaceModelAPI(unittest.TestCase):
+class TestLoadInterface(unittest.TestCase):
     def test_audio_to_audio(self):
         model_type = "audio-to-audio"
-        interface_info = gr.external.get_huggingface_interface(
-            "speechbrain/mtl-mimic-voicebank",
-            api_key=None,
+        interface = gr.Interface.load(
+            name="speechbrain/mtl-mimic-voicebank",
+            src="models",
             alias=model_type,
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"], gr.components.Audio)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Audio)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Audio)
+        self.assertIsInstance(interface.output_components[0], gr.components.Audio)
 
     def test_question_answering(self):
-        model_type = "question-answering"
-        interface_info = gr.external.get_huggingface_interface(
-            "lysandre/tiny-vit-random", api_key=None, alias=model_type
+        model_type = "image-classification"
+        interface = gr.Blocks.load(
+            name="lysandre/tiny-vit-random",
+            src="models",
+            alias=model_type
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"], gr.components.Image)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Label)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Image)
+        self.assertIsInstance(interface.output_components[0], gr.components.Label)
 
     def test_text_generation(self):
         model_type = "text_generation"
-        interface_info = gr.external.get_huggingface_interface(
-            "gpt2", api_key=None, alias=model_type
+        interface = gr.Interface.load(
+            "models/gpt2", 
+            alias=model_type
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"], gr.components.Textbox)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Textbox)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Textbox)
+        self.assertIsInstance(interface.output_components[0], gr.components.Textbox)
 
     def test_summarization(self):
         model_type = "summarization"
-        interface_info = gr.external.get_huggingface_interface(
-            "facebook/bart-large-cnn", api_key=None, alias=model_type
+        interface = gr.Interface.load(
+            "models/facebook/bart-large-cnn", api_key=None, alias=model_type
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"], gr.components.Textbox)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Textbox)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Textbox)
+        self.assertIsInstance(interface.output_components[0], gr.components.Textbox)
 
     def test_translation(self):
         model_type = "translation"
-        interface_info = gr.external.get_huggingface_interface(
-            "facebook/bart-large-cnn", api_key=None, alias=model_type
+        interface = gr.Interface.load(
+            "models/facebook/bart-large-cnn", api_key=None, alias=model_type
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"], gr.components.Textbox)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Textbox)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Textbox)
+        self.assertIsInstance(interface.output_components[0], gr.components.Textbox)
 
     def test_text2text_generation(self):
         model_type = "text2text-generation"
-        interface_info = gr.external.get_huggingface_interface(
-            "sshleifer/tiny-mbart", api_key=None, alias=model_type
+        interface = gr.Interface.load(
+            "models/sshleifer/tiny-mbart", api_key=None, alias=model_type
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"], gr.components.Textbox)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Textbox)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Textbox)
+        self.assertIsInstance(interface.output_components[0], gr.components.Textbox)
 
     def test_text_classification(self):
         model_type = "text-classification"
-        interface_info = gr.external.get_huggingface_interface(
-            "distilbert-base-uncased-finetuned-sst-2-english",
+        interface = gr.Interface.load(
+            "models/distilbert-base-uncased-finetuned-sst-2-english",
             api_key=None,
             alias=model_type,
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"], gr.components.Textbox)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Label)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Textbox)
+        self.assertIsInstance(interface.output_components[0], gr.components.Label)
 
     def test_fill_mask(self):
         model_type = "fill-mask"
-        interface_info = gr.external.get_huggingface_interface(
-            "bert-base-uncased", api_key=None, alias=model_type
+        interface = gr.Interface.load(
+            "models/bert-base-uncased", api_key=None, alias=model_type
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"], gr.components.Textbox)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Label)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Textbox)
+        self.assertIsInstance(interface.output_components[0], gr.components.Label)
 
     def test_zero_shot_classification(self):
         model_type = "zero-shot-classification"
-        interface_info = gr.external.get_huggingface_interface(
-            "facebook/bart-large-mnli", api_key=None, alias=model_type
+        interface = gr.Interface.load(
+            "models/facebook/bart-large-mnli", api_key=None, alias=model_type
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"][0], gr.components.Textbox)
-        self.assertIsInstance(interface_info["inputs"][1], gr.components.Textbox)
-        self.assertIsInstance(interface_info["inputs"][2], gr.components.Checkbox)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Label)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Textbox)
+        self.assertIsInstance(interface.input_components[1], gr.components.Textbox)
+        self.assertIsInstance(interface.input_components[2], gr.components.Checkbox)
+        self.assertIsInstance(interface.output_components[0], gr.components.Label)
 
     def test_automatic_speech_recognition(self):
         model_type = "automatic-speech-recognition"
-        interface_info = gr.external.get_huggingface_interface(
-            "facebook/wav2vec2-base-960h", api_key=None, alias=model_type
+        interface = gr.Interface.load(
+            "models/facebook/wav2vec2-base-960h", api_key=None, alias=model_type
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"], gr.components.Audio)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Textbox)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Audio)
+        self.assertIsInstance(interface.output_components[0], gr.components.Textbox)
 
     def test_image_classification(self):
         model_type = "image-classification"
-        interface_info = gr.external.get_huggingface_interface(
-            "google/vit-base-patch16-224", api_key=None, alias=model_type
+        interface = gr.Interface.load(
+            "models/google/vit-base-patch16-224", api_key=None, alias=model_type
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"], gr.components.Image)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Label)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Image)
+        self.assertIsInstance(interface.output_components[0], gr.components.Label)
 
     def test_feature_extraction(self):
         model_type = "feature-extraction"
-        interface_info = gr.external.get_huggingface_interface(
-            "sentence-transformers/distilbert-base-nli-mean-tokens",
+        interface = gr.Interface.load(
+            "models/sentence-transformers/distilbert-base-nli-mean-tokens",
             api_key=None,
             alias=model_type,
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"], gr.components.Textbox)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Dataframe)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Textbox)
+        self.assertIsInstance(interface.output_components[0], gr.components.Dataframe)
 
     def test_sentence_similarity(self):
         model_type = "text-to-speech"
-        interface_info = gr.external.get_huggingface_interface(
-            "julien-c/ljspeech_tts_train_tacotron2_raw_phn_tacotron_g2p_en_no_space_train",
+        interface = gr.Interface.load(
+            "models/julien-c/ljspeech_tts_train_tacotron2_raw_phn_tacotron_g2p_en_no_space_train",
             api_key=None,
             alias=model_type,
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"], gr.components.Textbox)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Audio)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Textbox)
+        self.assertIsInstance(interface.output_components[0], gr.components.Audio)
 
     def test_text_to_speech(self):
         model_type = "text-to-speech"
-        interface_info = gr.external.get_huggingface_interface(
-            "julien-c/ljspeech_tts_train_tacotron2_raw_phn_tacotron_g2p_en_no_space_train",
+        interface = gr.Interface.load(
+            "models/julien-c/ljspeech_tts_train_tacotron2_raw_phn_tacotron_g2p_en_no_space_train",
             api_key=None,
             alias=model_type,
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"], gr.components.Textbox)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Audio)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Textbox)
+        self.assertIsInstance(interface.output_components[0], gr.components.Audio)
 
     def test_text_to_image(self):
         model_type = "text-to-image"
-        interface_info = gr.external.get_huggingface_interface(
-            "osanseviero/BigGAN-deep-128", api_key=None, alias=model_type
+        interface = gr.Interface.load(
+            "models/osanseviero/BigGAN-deep-128", api_key=None, alias=model_type
         )
-        self.assertEqual(interface_info["fn"].__name__, model_type)
-        self.assertIsInstance(interface_info["inputs"], gr.components.Textbox)
-        self.assertIsInstance(interface_info["outputs"], gr.components.Image)
+        self.assertEqual(interface.predict[0].__name__, model_type)
+        self.assertIsInstance(interface.input_components[0], gr.components.Textbox)
+        self.assertIsInstance(interface.output_components[0], gr.components.Image)
 
     def test_english_to_spanish(self):
-        interface_info = gr.external.get_spaces_interface(
-            "abidlabs/english_to_spanish", api_key=None, alias=None
-        )
-        self.assertIsInstance(interface_info["inputs"][0], gr.components.Textbox)
-        self.assertIsInstance(interface_info["outputs"][0], gr.components.Textbox)
-
-
-class TestLoadInterface(unittest.TestCase):
-    def test_english_to_spanish(self):
-        interface_info = gr.external.load_interface(
-            "spaces/abidlabs/english_to_spanish"
-        )
-        self.assertIsInstance(interface_info["inputs"][0], gr.components.Textbox)
-        self.assertIsInstance(interface_info["outputs"][0], gr.components.Textbox)
+        interface = gr.Interface.load("spaces/abidlabs/english_to_spanish")
+        self.assertIsInstance(interface.input_components[0], gr.components.Textbox)
+        self.assertIsInstance(interface.output_components[0], gr.components.Textbox)
 
     def test_sentiment_model(self):
-        interface_info = gr.external.load_interface(
-            "models/distilbert-base-uncased-finetuned-sst-2-english",
-            alias="sentiment_classifier",
-        )
-        io = gr.Interface(**interface_info)
-        io.api_mode = True
+        io = gr.Interface.load("models/distilbert-base-uncased-finetuned-sst-2-english")
         output = io("I am happy, I love you.")
         self.assertGreater(output["POSITIVE"], 0.5)
 
     def test_image_classification_model(self):
-        interface_info = gr.external.load_interface(
-            "models/google/vit-base-patch16-224"
-        )
-        io = gr.Interface(**interface_info)
-        io.api_mode = True
+        io = gr.Blocks.load(name="models/google/vit-base-patch16-224")
         output = io("gradio/test_data/lion.jpg")
         self.assertGreater(output["lion"], 0.5)
 
     def test_translation_model(self):
-        interface_info = gr.external.load_interface("models/t5-base")
-        io = gr.Interface(**interface_info)
-        io.api_mode = True
+        io = gr.Blocks.load(name="models/t5-base")
         output = io("My name is Sarah and I live in London")
         self.assertEqual(output, "Mein Name ist Sarah und ich lebe in London")
 
     def test_numerical_to_label_space(self):
-        interface_info = gr.load_interface("spaces/abidlabs/titanic-survival")
-        io = gr.Interface(**interface_info)
-        io.api_mode = True
+        io = gr.Interface.load("spaces/abidlabs/titanic-survival")
         output = io("male", 77, 10)
         self.assertLess(output["Survives"], 0.5)
 
     def test_speech_recognition_model(self):
-        interface_info = gr.external.load_interface(
+        io = gr.Interface.load(
             "models/facebook/wav2vec2-base-960h"
         )
-        io = gr.Interface(**interface_info)
-        io.api_mode = True
         output = io("gradio/test_data/test_audio.wav")
         self.assertIsNotNone(output)
 
     def test_text_to_image_model(self):
-        interface_info = gr.external.load_interface(
+        io = gr.Interface.load(
             "models/osanseviero/BigGAN-deep-128"
         )
-        io = gr.Interface(**interface_info)
-        io.api_mode = True
         filename = io("chest")
         self.assertTrue(filename.endswith(".jpg") or filename.endswith(".jpeg"))
 
@@ -235,9 +213,7 @@ class TestLoadInterface(unittest.TestCase):
             if not pathlib.Path(path).resolve().is_file():
                 raise AssertionError("File does not exist: %s" % str(path))
 
-        interface_info = gr.external.load_interface("spaces/abidlabs/image-identity")
-        io = gr.Interface(**interface_info)
-        io.api_mode = True
+        io = gr.Interface.load("spaces/abidlabs/image-identity")
         output = io("gradio/test_data/lion.jpg")
         assertIsFile(output)
 

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -4,7 +4,7 @@ import unittest
 
 import gradio as gr
 
-# import transformers
+import transformers
 
 
 """
@@ -12,7 +12,7 @@ WARNING: These tests have an external dependency: namely that Hugging Face's
 Hub and Space APIs do not change, and they keep their most famous models up.
 So if, e.g. Spaces is down, then these test will not pass.
 
-These tests actually test gr.Interface.load() and gr.Blocks.load() but are 
+These tests actually test gr.Interface.load() and gr.Blocks.load() but are
 included in a separate file because of the above-mentioned dependency.
 """
 


### PR DESCRIPTION
Took waaay longer than I thought, but there were a lot of cases to cover. We can now load any model, 2.x space, or 3.x space using `gr.Interface.load()` or basically its alias `gr.Blocks.load()`. The basic idea here is:

- When loading a `model`, it creates an `Interface` based on the type of `model`
- When loading a 2.x Space, it creates an `Interface` based on the config (very easy mapping as the config is just basically the keyword arguments needed to instantiate the `Interface`)
- When loading a 3.x Space, it reads the config and recreates the Blocks and components locally. Of course the backend functions are a little different -- instead of calling the local function, it instead calls the remote /api/predict appropriately

Touches a lot of the backend code, so happy to explain anything

You can test in different scenarios:

- Loading a **model** from the Hub

```py
gr.Interface.load("models/gpt2", title="GPT 2", description="a completion model").launch()
```

```py
gr.Interface.load("models/facebook/wav2vec2-base-960h", inputs="mic").launch()
```

- Loading a **Gradio 2.x Space** from the Hub

```py
gr.Interface.load("spaces/abidlabs/test5").launch()
```

- Loading a **Gradio 3.x Space** from the Hub

```py
gr.Interface.load("spaces/gradio/pictionary").launch()
```

- Loading a **Gradio 3.x Space** from the Hub within a Blocks

```py
with gr.Blocks() as demo:
    with gr.Tabs():
        with gr.TabItem("Pictionary"):
            gr.Interface.load("spaces/gradio/pictionary")

demo.launch()
```

- Creating a Blocks that loads both a **Gradio 3.x Space** and a **Gradio 2.x Space**

```py
with gr.Blocks() as demo:
    with gr.Tabs():
        with gr.TabItem("Pictionary"):
            gr.Interface.load("spaces/gradio/pictionary")
        with gr.TabItem("Hello World"):
            gr.Interface.load("spaces/abidlabs/test5")

demo.launch()
```

 
Closes: #1248 cc @apolinario