### PR TITLE
Mute examples videos

### DIFF
--- a/ui/packages/app/src/components/Dataset/ExampleComponents/Video.svelte
+++ b/ui/packages/app/src/components/Dataset/ExampleComponents/Video.svelte
@@ -1,9 +1,19 @@
 <script lang="ts">
 	import { playable } from "../../utils/helpers";
+	import { onMount } from "svelte";
 
 	export let value: string;
 	export let samples_dir: string;
 	let video: HTMLVideoElement;
+
+	onMount(() => {
+		video.muted = true;
+		video.playsInline = true;
+		video.controls = false;
+		video.setAttribute("muted", "");
+		video.play();
+		video.pause();
+	});
 </script>
 
 <!-- svelte-ignore a11y-media-has-caption -->
@@ -11,6 +21,7 @@
 {#if playable(value)}
 	<video
 		muted
+		playsinline
 		bind:this={video}
 		on:mouseover={video.play}
 		on:mouseout={video.pause}

--- a/ui/packages/app/src/components/Dataset/ExampleComponents/Video.svelte
+++ b/ui/packages/app/src/components/Dataset/ExampleComponents/Video.svelte
@@ -10,6 +10,7 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 {#if playable(value)}
 	<video
+		muted
 		bind:this={video}
 		on:mouseover={video.play}
 		on:mouseout={video.pause}


### PR DESCRIPTION
Videos examples autoplay on mouseover but maybe we want to mute them by default? (I got jump scared)
No super strong opinion on it open to discussions.
example: https://huggingface.co/spaces/radames/edit-video-by-editing-text
