### PR TITLE
Minor cosmetic changes

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3497,7 +3497,7 @@ class Button(Clickable, Component):
         self,
         value: str = "Run",
         *,
-        variant: str = "primary",
+        variant: str = "secondary",
         visible: bool = True,
         elem_id: Optional[str] = None,
         **kwargs,

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -465,14 +465,14 @@ class Interface(Blocks):
                                 self.InterfaceTypes.STANDARD,
                                 self.InterfaceTypes.INPUT_ONLY,
                             ]:
-                                clear_btn = Button("Clear", variant="secondary")
+                                clear_btn = Button("Clear")
                                 if not self.live:
-                                    submit_btn = Button("Submit")
+                                    submit_btn = Button("Submit", variant="primary")
                             elif self.interface_type == self.InterfaceTypes.UNIFIED:
-                                clear_btn = Button("Clear", variant="secondary")
-                                submit_btn = Button("Submit")
+                                clear_btn = Button("Clear")
+                                submit_btn = Button("Submit", variant="primary")
                                 if self.allow_flagging == "manual":
-                                    flag_btn = Button("Flag", variant="secondary")
+                                    flag_btn = Button("Flag")
 
                 if self.interface_type in [
                     self.InterfaceTypes.STANDARD,
@@ -485,14 +485,12 @@ class Interface(Blocks):
                             component.render()
                         with Row().style(mobile_collapse=False):
                             if self.interface_type == self.InterfaceTypes.OUTPUT_ONLY:
-                                clear_btn = Button("Clear", variant="secondary")
-                                submit_btn = Button("Generate")
+                                clear_btn = Button("Clear")
+                                submit_btn = Button("Generate", variant="primary")
                             if self.allow_flagging == "manual":
-                                flag_btn = Button("Flag", variant="secondary")
+                                flag_btn = Button("Flag")
                             if self.interpretation:
-                                interpretation_btn = Button(
-                                    "Interpret", variant="secondary"
-                                )
+                                interpretation_btn = Button("Interpret")
             submit_fn = (
                 lambda *args: self.run_prediction(args)[0]
                 if len(self.output_components) == 1

--- a/gradio/test_data/blocks_configs.py
+++ b/gradio/test_data/blocks_configs.py
@@ -53,19 +53,14 @@ XRAY_CONFIG = {
         {
             "id": 7,
             "type": "json",
-            "props": {
-                "show_label": True,
-                "name": "json",
-                "visible": True,
-                "style": {},
-            },
+            "props": {"show_label": True, "name": "json", "visible": True, "style": {}},
         },
         {
             "id": 8,
             "type": "button",
             "props": {
                 "value": "Run",
-                "variant": "primary",
+                "variant": "secondary",
                 "name": "button",
                 "visible": True,
                 "style": {},
@@ -98,19 +93,14 @@ XRAY_CONFIG = {
         {
             "id": 12,
             "type": "json",
-            "props": {
-                "show_label": True,
-                "name": "json",
-                "visible": True,
-                "style": {},
-            },
+            "props": {"show_label": True, "name": "json", "visible": True, "style": {}},
         },
         {
             "id": 13,
             "type": "button",
             "props": {
                 "value": "Run",
-                "variant": "primary",
+                "variant": "secondary",
                 "name": "button",
                 "visible": True,
                 "style": {},
@@ -261,7 +251,7 @@ XRAY_CONFIG_DIFF_IDS = {
             "type": "button",
             "props": {
                 "value": "Run",
-                "variant": "primary",
+                "variant": "secondary",
                 "name": "button",
                 "visible": True,
                 "style": {},
@@ -306,7 +296,7 @@ XRAY_CONFIG_DIFF_IDS = {
             "type": "button",
             "props": {
                 "value": "Run",
-                "variant": "primary",
+                "variant": "secondary",
                 "name": "button",
                 "visible": True,
                 "style": {},
@@ -462,7 +452,7 @@ XRAY_CONFIG_WITH_MISTAKE = {
                 "value": "Run",
                 "name": "button",
                 "css": {"background-color": "red", "--hover-color": "orange"},
-                "variant": "primary",
+                "variant": "secondary",
             },
         },
         {
@@ -508,7 +498,7 @@ XRAY_CONFIG_WITH_MISTAKE = {
                 "value": "Run",
                 "name": "button",
                 "style": {},
-                "variant": "primary",
+                "variant": "secondary",
             },
         },
         {

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -57,7 +57,7 @@ class TestBlocks(unittest.TestCase):
                     )
             textbox = gr.Textbox()
             demo.load(fake_func, [], [textbox])
-            
+
         config = demo.get_config_file()
         config.pop("version")  # remove version key
         self.assertDictEqual(XRAY_CONFIG, config)

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -57,8 +57,6 @@ class TestBlocks(unittest.TestCase):
                     )
             textbox = gr.Textbox()
             demo.load(fake_func, [], [textbox])
-            print(XRAY_CONFIG)
-            print(demo.get_config_file())
         self.assertDictEqual(XRAY_CONFIG, demo.get_config_file())
 
     @pytest.mark.asyncio

--- a/ui/packages/app/index.html
+++ b/ui/packages/app/index.html
@@ -54,7 +54,11 @@
 			crossorigin="anonymous"
 		/>
 		<link
-			href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600&family=IBM+Plex+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=IBM+Plex+Serif:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap"
+			href="https://fonts.googleapis.com/css?family=Source Sans Pro"
+			rel="stylesheet"
+		/>
+		<link
+			href="https://fonts.googleapis.com/css?family=IBM Plex Mono"
 			rel="stylesheet"
 		/>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js"></script>

--- a/ui/packages/app/src/Blocks.svelte
+++ b/ui/packages/app/src/Blocks.svelte
@@ -381,8 +381,11 @@
 			src="https://www.googletagmanager.com/gtag/js?id=UA-156449732-1"></script>
 	{/if}
 </svelte:head>
-<div class="w-full h-full min-h-screen {mode}">
-	<div class="mx-auto container px-4 py-6 dark:bg-gray-950">
+<div class="w-full h-full min-h-screen {mode} flex flex-col">
+	<div
+		class="mx-auto container px-4 py-6 dark:bg-gray-950"
+		class:flex-grow={(window.__gradio_mode__ = "app")}
+	>
 		{#if ready}
 			<Render
 				component={rootNode.component}
@@ -398,20 +401,19 @@
 			/>
 		{/if}
 	</div>
-	<div
-		class="gradio-page container mx-auto flex flex-col box-border flex-grow text-gray-700 dark:text-gray-50"
-	>
-		<div
-			class="footer flex-shrink-0 inline-flex gap-2.5 items-center text-gray-600 dark:text-gray-300 justify-center py-2"
+	<footer class="flex justify-center pb-6">
+		<a
+			href="https://gradio.app"
+			target="_blank"
+			rel="noreferrer"
+			class="group text-gray-300 dark:text-gray-500 hover:text-gray-400 dark:hover:text-gray-400 transition-colors font-semibold text-sm"
 		>
-			<a href="https://gradio.app" target="_blank" rel="noreferrer">
-				{$_("interface.built_with_Gradio")}
-				<img
-					class="h-5 inline-block pb-0.5"
-					src="{static_src}/static/img/logo.svg"
-					alt="logo"
-				/>
-			</a>
-		</div>
-	</div>
+			{$_("interface.built_with_Gradio")}
+			<img
+				class="h-[22px] ml-0.5 inline-block pb-0.5 filter grayscale opacity-50 group-hover:grayscale-0 group-hover:opacity-100 transition"
+				src="{static_src}/static/img/logo.svg"
+				alt="logo"
+			/>
+		</a>
+	</footer>
 </div>

--- a/ui/packages/app/tailwind.config.js
+++ b/ui/packages/app/tailwind.config.js
@@ -12,7 +12,7 @@ module.exports = {
 	theme: {
 		extend: {
 			fontFamily: {
-				sans: ["Source Sans Pro", ...defaultTheme.fontFamily.sans],
+				sans: ["IBM Plex Sans", ...defaultTheme.fontFamily.sans],
 				mono: ["IBM Plex Mono", ...defaultTheme.fontFamily.mono]
 			},
 			colors: {

--- a/ui/packages/app/tailwind.config.js
+++ b/ui/packages/app/tailwind.config.js
@@ -12,7 +12,7 @@ module.exports = {
 	theme: {
 		extend: {
 			fontFamily: {
-				sans: ["IBM Plex Sans", ...defaultTheme.fontFamily.sans],
+				sans: ["Source Sans Pro", ...defaultTheme.fontFamily.sans],
 				mono: ["IBM Plex Mono", ...defaultTheme.fontFamily.mono]
 			},
 			colors: {

--- a/ui/packages/atoms/src/BlockTitle.svelte
+++ b/ui/packages/atoms/src/BlockTitle.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <span
-	class="text-gray-600 text-[0.855rem] mb-2 block dark:text-gray-200 relative z-40"
+	class="text-gray-500 text-[0.855rem] mb-2 block dark:text-gray-200 relative z-40"
 	class:sr-only={!show_label}
 	class:h-0={!show_label}
 	class:!m-0={!show_label}

--- a/ui/packages/form/src/CheckboxGroup.svelte
+++ b/ui/packages/form/src/CheckboxGroup.svelte
@@ -29,7 +29,7 @@
 	{#each choices as choice, i}
 		<label
 			class:!cursor-not-allowed={disabled}
-			class={"flex items-center text-gray-700 text-sm space-x-2 border py-1.5 px-3 rounded-lg cursor-pointer bg-white shadow-sm checked:shadow-inner" +
+			class={"gr-input-label flex items-center text-gray-700 text-sm space-x-2 border py-1.5 px-3 rounded-lg cursor-pointer shadow-sm checked:shadow-inner" +
 				create_classes(style)}
 		>
 			<input

--- a/ui/packages/form/src/Radio.svelte
+++ b/ui/packages/form/src/Radio.svelte
@@ -22,7 +22,7 @@
 	{#each choices as choice, i (i)}
 		<label
 			class:!cursor-not-allowed={disabled}
-			class={"flex items-center text-gray-700 text-sm space-x-2 border py-1.5 px-3 rounded-lg cursor-pointer bg-white shadow-sm checked:shadow-inner" +
+			class={"gr-input-label flex items-center text-gray-700 text-sm space-x-2 border py-1.5 px-3 rounded-lg cursor-pointer shadow-sm checked:shadow-inner" +
 				create_classes(style)}
 		>
 			<input

--- a/ui/packages/theme/src/tokens.css
+++ b/ui/packages/theme/src/tokens.css
@@ -45,7 +45,7 @@
 }
 
 .gr-text-input {
-	@apply p-2.5;
+	@apply p-2.5 shadow-inner disabled:shadow-none;
 }
 
 .gr-check-radio {
@@ -54,6 +54,10 @@
 
 .gr-checkbox {
 	@apply rounded;
+}
+
+.gr-input-label {
+	@apply bg-gradient-to-t from-gray-50 to-white hover:from-gray-100 dark:from-gray-900 dark:to-gray-800 transition;
 }
 
 .gr-radio {
@@ -65,7 +69,7 @@
 }
 
 .gr-button-primary {
-	@apply from-orange-100/70 to-orange-200/80 hover:to-orange-100/90 text-orange-600 border-orange-200
+	@apply from-orange-200/70 to-orange-300/80 hover:from-orange-200/90 text-orange-600 border-orange-200
 	  	 dark:from-orange-700 dark:to-orange-700 dark:hover:to-orange-500 dark:text-white dark:border-orange-600;
 }
 


### PR DESCRIPTION
Introduced some minor cosmetic changes:
- Footer stays at the bottom, is grayed out except on hover
- Button variant is "secondary" (gray) by default
- Font was never loaded properly, fell back on system fonts because index.html loaded IBM Plex, and tailwind.config required Source Sans Pro. Made both refer to IMB Plex (though we could also point both to Source Sans Pro if desired)
- Introduced minor gradient to form buttons (radio / checkboxgroup), and inner shadow to input text. This was done because the UI looked quite "flat", especially when using Blocks instead of Interface since there was no gray panel background when using Blocks. These gradients/shadows were introduced in the original Huggingface theme created by victor/julien in gradio 2.x, but were removed in Gradio 3.0 design. I believe they add a lot of visual cues to what is clickable / enterable and also help breakup the white monotony.
-  Made submit button slightly darker orange. Open to discussion on this.

BEFORE:
![Screen Shot 2022-05-25 at 1 54 39 PM](https://user-images.githubusercontent.com/7870876/170365686-1fbb5219-37ff-4c16-aedf-9fff3c4f8cef.png)

AFTER:
![Screen Shot 2022-05-25 at 1 55 13 PM](https://user-images.githubusercontent.com/7870876/170365711-783e3db0-6daa-440c-a594-5be3befc7a17.png)

BEFORE GIF:
![Recording 2022-05-25 at 13 58 02](https://user-images.githubusercontent.com/7870876/170366390-0af7a825-32b4-40f8-9cf5-3be854ad7668.gif)

AFTER GIF:
![Recording 2022-05-25 at 13 58 49](https://user-images.githubusercontent.com/7870876/170366414-0ce7f77c-e995-47c9-8ded-3203fe1e077e.gif)


Further improvements:
- I would like to suggest we also override the default slider to use a custom slider that can be styled with colors instead of using the browser default. Same for radio and checkboxes