### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ if __name__ == "__main__":
 ![blocks_flipper interface](demo/blocks_flipper/screenshot.gif)
 
 
-If you are interested in how Blocks works, [read its dedicated Guide](introduction_to_blocks).
+If you are interested in how Blocks works, [read its dedicated Guide](https://gradio.app/introduction_to_blocks/).
 
 ### Sharing Demos 🌎
 


### PR DESCRIPTION
Introduction to Blocks in line 372: The previous link does not exist in the repo, new link points to a gradio.app website page about the topic.