### PR TITLE
Fix broken link in guides/getting_started

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ if __name__ == "__main__":
 ![blocks_flipper interface](demo/blocks_flipper/screenshot.gif)
 
 
-If you are interested in how Blocks works, [read its dedicated Guide](introduction_to_blocks).
+If you are interested in how Blocks works, [read its dedicated Guide](https://gradio.app/introduction_to_blocks/).
 
 ### Sharing Demos 🌎
 

--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -151,7 +151,7 @@ As an example, Blocks uses nested `with` statements in Python to lay out compone
 {{ demos["blocks_flipper"] }}
 
 
-If you are interested in how Blocks works, [read its dedicated Guide](introduction_to_blocks).
+If you are interested in how Blocks works, [read its dedicated Guide](https://gradio.app/introduction_to_blocks/).
 
 ### Sharing Demos 🌎
 


### PR DESCRIPTION
This is the main README.md file and a link is written as a reference inside the `guide` folder, this leads to a 404 error. I changed the file to gradio.app website link to fix the issue.

- [x] I modified `guide/getting_started.md`
- [x] I ran `python render_readme.py`
- [x] This changed the `README.md` as I originally intended

Thanks @abidlabs for the help.