### PR TITLE
set iframe policy to enable camera and audio

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -683,17 +683,21 @@ class Blocks(BlockContext):
                     "click the link to access the interface in a new tab."
                 )
             try:
-                from IPython.display import IFrame, display  # type: ignore
+                from IPython.display import HTML, display  # type: ignore
 
                 if share:
                     while not networking.url_ok(self.share_url):
                         time.sleep(1)
                     display(
-                        IFrame(self.share_url, width=self.width, height=self.height)
+                        HTML(
+                            f'<div><iframe src="{self.share_url}" width="{self.width}" height="{self.height}" allow="autoplay; camera; microphone;" frameborder="0" allowfullscreen></iframe></div>'
+                        )
                     )
                 else:
                     display(
-                        IFrame(self.local_url, width=self.width, height=self.height)
+                        HTML(
+                            f'<div><iframe src="{self.local_url}" width="{self.width}" height="{self.height}" allow="autoplay; camera; microphone;" frameborder="0" allowfullscreen></iframe></div>'
+                        )
                     )
             except ImportError:
                 pass


### PR DESCRIPTION
This PR fixes #1406. I also enable iframe features via local jupyter dev.

Notes:
* While `IPython.display.IFrame` is a better method to generate the HTML, temporary `IPython.display.HTML` address the fact google colab is using an outdated IPython https://github.com/googlecolab/colabtools/issues/1582

* The `<div>` wrapping `<iframe>` is a hack to disable the  IPython`HTML` [iframe warning](https://github.com/ipython/ipython/blob/c97f6d2ebb9a2eee5bc6531ecaf96dcb0649dadd/IPython/core/display.py#L416-L419)

