### PR TITLE
set camera icon to be always text-white

### DIFF
--- a/ui/packages/image/src/Webcam.svelte
+++ b/ui/packages/image/src/Webcam.svelte
@@ -119,7 +119,7 @@
 					</div>
 				{/if}
 			{:else}
-				<div class="w-2/4 h-2/4 dark:text-white opacity-80">
+				<div class="w-2/4 h-2/4 text-white opacity-80">
 					<Camera />
 				</div>
 			{/if}


### PR DESCRIPTION
Quick CSS fix for camera icon, set it to be always `text-white` as icon always has a dark background

**Before:**
<img width="392" alt="Screen Shot 2022-05-31 at 13 45 56" src="https://user-images.githubusercontent.com/102277/171281764-fb594613-6d76-4cff-8c1e-a896f18b2509.png">
<img width="404" alt="Screen Shot 2022-05-31 at 13 46 04" src="https://user-images.githubusercontent.com/102277/171281766-04b78bbf-6c15-4fb7-821e-785da60fac12.png">

**After:**

<img width="403" alt="Screen Shot 2022-05-31 at 13 45 02" src="https://user-images.githubusercontent.com/102277/171281754-78615787-0b3d-4deb-b732-18da9cbe52fe.png">
<img width="416" alt="Screen Shot 2022-05-31 at 13 45 16" src="https://user-images.githubusercontent.com/102277/171281760-da669a49-4812-4eb5-800f-86bb183284f6.png">