### PR TITLE
Fixes `gr.Interface.load()`

### DIFF
--- a/gradio.egg-info/PKG-INFO
+++ b/gradio.egg-info/PKG-INFO
@@ -382,7 +382,7 @@ if __name__ == "__main__":
 ![blocks_flipper interface](demo/blocks_flipper/screenshot.gif)
 
 
-If you are interested in how Blocks works, [read its dedicated Guide](introduction_to_blocks).
+If you are interested in how Blocks works, [read its dedicated Guide](https://gradio.app/introduction_to_blocks/).
 
 ### Sharing Demos 🌎
 

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3580,9 +3580,7 @@ class Dataset(Clickable, Component):
         visible (bool): If False, component will be hidden.
         """
         Component.__init__(self, visible=visible, elem_id=elem_id, **kwargs)
-        self.components = (
-            components  # [get_component_instance(c).unrender() for c in components]
-        )
+        self.components = [get_component_instance(c, render=False) for c in components]
         self.type = type
         self.headers = headers or [c.label for c in self.components]
         self.samples = samples
@@ -3694,13 +3692,18 @@ def component(cls_name: str) -> Component:
     return obj
 
 
-def get_component_instance(comp: str | dict | Component) -> Component:
+def get_component_instance(comp: str | dict | Component, render=True) -> Component:
     if isinstance(comp, str):
-        return component(comp)
+        component_obj = component(comp)
+        if not (render):
+            component_obj.unrender()
+        return component_obj
     elif isinstance(comp, dict):
         name = comp.pop("name")
         component_cls = component_or_layout_class(name)
         component_obj = component_cls(**comp)
+        if not (render):
+            component_obj.unrender()
         return component_obj
     elif isinstance(comp, Component):
         return comp

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -201,8 +201,12 @@ class Interface(Blocks):
                 )
             self.cache_examples = False
 
-        self.input_components = [get_component_instance(i).unrender() for i in inputs]
-        self.output_components = [get_component_instance(o).unrender() for o in outputs]
+        self.input_components = [
+            get_component_instance(i, render=False) for i in inputs
+        ]
+        self.output_components = [
+            get_component_instance(o, render=False) for o in outputs
+        ]
 
         for component in self.input_components + self.output_components:
             if not (

--- a/ui/packages/app/src/Blocks.svelte
+++ b/ui/packages/app/src/Blocks.svelte
@@ -114,7 +114,6 @@
 		acc[next.id] = next;
 		return acc;
 	}, {} as { [id: number]: Component });
-	console.log(instance_map);
 
 	function load_component<T extends keyof typeof component_map>(
 		name: T
@@ -132,7 +131,6 @@
 
 	async function walk_layout(node: LayoutNode) {
 		let instance = instance_map[node.id];
-		console.log(node.id, instance);
 		const _component = (await _component_map.get(instance.type)).component;
 		instance.component = _component.Component;
 		if (_component.modes.length > 1) {


### PR DESCRIPTION
As identified in #1417 and in other places, there was an issue with `gr.Interface.load()` not handling the `Dataset` component correctly, which was making it unable to load Spaces that were running 3.x.  This should fix it.

Now, there is a separate issue in the example with #1417, which is that when 3.x Interfaces are loaded, they are created as regular Blocks and not Interfaces, so they cannot be used with Parallel/Series. Will work on that next, along with making Blocks callable, like what @apolinario has suggested.