### PR TITLE
Increase max parallel requests

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -7,12 +7,12 @@ import random
 import sys
 import time
 import webbrowser
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
-from anyio import CapacityLimiter
-import anyio
-
-from fastapi.concurrency import run_in_threadpool
 from functools import partial
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+
+import anyio
+from anyio import CapacityLimiter
+from fastapi.concurrency import run_in_threadpool
 
 from gradio import encryptor, external, networking, queueing, routes, strings, utils
 from gradio.context import Context

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -263,8 +263,7 @@ class Blocks(BlockContext):
         if self.max_threads is None:
             return
         limiter = CapacityLimiter(total_tokens=self.max_threads)
-        prev_run_in_thread = anyio.to_thread.run_sync
-        anyio.to_thread.run_sync = partial(prev_run_in_thread, limiter=limiter)
+        anyio.to_thread.run_sync = partial(anyio.to_thread.run_sync, limiter=limiter)
 
     @classmethod
     def from_config(cls, config: dict, fns: List[Callable]) -> Blocks:


### PR DESCRIPTION
Please, see #1442.

So far I haven't found a better way to deal with this than monkey-patching
`anyio.to_thread.run_sync` to use a custom `CapacityLimiter`. I did try
to obtain the predictions inside a context handler instead:

```
async with self.limiter:
    predictions = await run_in_threadpool(block_fn.fn, *processed_input)
```

However, that approach didn't seem to work.

Please include: 
* relevant motivation
* a summary of the change 
* which issue is fixed. 
* any additional dependencies that are required for this change.

Closes: #1442

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
