### PR TITLE
Lower bound Python version to 3.7

### DIFF
--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -16,7 +16,7 @@ Gradio allows you to **build demos and share them, all in Python.** And usually 
 
 To get Gradio running with a simple "Hello, World" example, follow these three steps:
 
-<span>1.</span> Install Gradio from pip.
+<span>1.</span> Install Gradio from pip. Note, the minimal supported Python version is 3.7.
 
 ```bash
 pip install gradio

--- a/setup.py
+++ b/setup.py
@@ -42,4 +42,5 @@ setup(
     entry_points={
         'console_scripts': ['gradio=gradio.reload:run_in_reload_mode']
     },
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
# Description

Gradio no longer works on Python 3.6 becauses it calls `from __future__ import annotations`. Using [python_requires](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#python-requires) can help the package to be no longer pip installable on 3.6. 

Closes: #1016

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
