### PR TITLE
replace call to huggingface api-inference by call to huggingface api

### DIFF
--- a/gradio/external.py
+++ b/gradio/external.py
@@ -37,7 +37,7 @@ def load_blocks_from_repo(name, src=None, api_key=None, alias=None, **kwargs):
 
 def get_models_interface(model_name, api_key, alias, **kwargs):
     model_url = "https://huggingface.co/{}".format(model_name)
-    api_url = "https://api-inference.huggingface.co/models/{}".format(model_name)
+    api_url = "https://huggingface.co/api/models/{}".format(model_name)
     print("Fetching model from: {}".format(model_url))
 
     if api_key is not None:


### PR DESCRIPTION
# Description

To get a Hugging Face interface model details a call is made to the `api-inference` which simply proxies the call to the Hugging Face api.
This fix replace the call by a direct call to the Hugging Face api.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code follows the style guidelines of this project
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
