### PR TITLE
Fix checkbox default value

### DIFF
--- a/ui/packages/form/src/Checkbox.svelte
+++ b/ui/packages/form/src/Checkbox.svelte
@@ -27,6 +27,7 @@
 	<input
 		on:change={(evt) => handle_change(evt)}
 		{disabled}
+		checked={value}
 		type="checkbox"
 		name="test"
 		class="gr-check-radio gr-checkbox {rounded} {border}"


### PR DESCRIPTION
Fixes: #1507 

test:
```
with gr.Blocks() as demo:
  cbox = gr.Checkbox(value=True)
  textbox = gr.Textbox("Hey There")
  cbox.change(lambda v: gr.update(visible=v), cbox, textbox)
```