### PR TITLE
`live=True` for input-less Interfaces

### DIFF
--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -518,7 +518,9 @@ class Interface(Blocks):
                         if isinstance(component, Streamable):
                             if component.streaming:
                                 component.stream(
-                                    submit_fn, self.input_components, self.output_components
+                                    submit_fn,
+                                    self.input_components,
+                                    self.output_components,
                                 )
                                 continue
                             else:

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -499,8 +499,7 @@ class Interface(Blocks):
                         with Row().style(mobile_collapse=False):
                             if self.interface_type == self.InterfaceTypes.OUTPUT_ONLY:
                                 clear_btn = Button("Clear")
-                                if not self.live:
-                                    submit_btn = Button("Generate", variant="primary")
+                                submit_btn = Button("Generate", variant="primary")
                             if self.allow_flagging == "manual":
                                 flag_btns = render_flag_btns(self.flagging_options)
                             if self.interpretation:
@@ -513,6 +512,13 @@ class Interface(Blocks):
             if self.live:
                 if self.interface_type == self.InterfaceTypes.OUTPUT_ONLY:
                     super().load(submit_fn, None, self.output_components)
+                    submit_btn.click(
+                        submit_fn,
+                        None,
+                        self.output_components,
+                        api_name="predict",
+                        status_tracker=status_tracker,
+                    )
                 else:
                     for component in self.input_components:
                         if isinstance(component, Streamable):


### PR DESCRIPTION
* Implements `live=True` for input-less interfaces (closes: #1469)

Test code:

```py
import gradio as gr

def func3():
    return "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80"

demo = gr.Interface(func3, None, "image", live=True)
demo.launch()
```

Or a more sophisticated example:

```py
import gradio as gr

def func3():
    return "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80"

def f2(x):
    return x

demo = gr.Interface(func3, None, "image", live=True)
demo2 = gr.Interface(f2, "text", "text")


gr.TabbedInterface([demo, demo2]).launch()
```