### PR TITLE
Matplotlib max-h fix so that plots are not cut off

### DIFF
--- a/ui/packages/plot/src/Plot.svelte
+++ b/ui/packages/plot/src/Plot.svelte
@@ -67,11 +67,11 @@
 	<div id="bokehDiv"/>
 {:else if value && value["type"] == "matplotlib"}
 	<div
-		class="output-image w-full max-h-80 flex justify-center items-center  relative"
+		class="output-image w-full flex justify-center items-center  relative"
 		{theme}
 	>
 		<!-- svelte-ignore a11y-missing-attribute -->
-		<img  class="w-full h-full object-contain" src={value["plot"]} />
+		<img  class="w-full max-h-[30rem] object-contain" src={value["plot"]} />
 	</div>
 {:else}
 	<div class="h-full min-h-[15rem] flex justify-center items-center">


### PR DESCRIPTION
`object-fit:contain` only works with `max-h` if they are set on the same element. I moved `max-h` to `img` and also increased the height a bit such that the plot has enough space and can adapt to the container height.

Fixes #1546

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
