### PR TITLE
Stop audio tracks of user media on the stop callback for the Audio component

### DIFF
--- a/ui/packages/audio/src/Audio.svelte
+++ b/ui/packages/audio/src/Audio.svelte
@@ -74,6 +74,8 @@
 				name
 			};
 			dispatch(streaming ? "stream" : "change", value);
+			const audioTracks = stream.getAudioTracks();
+			audioTracks.forEach((track) => track.stop());
 		});
 	}
 


### PR DESCRIPTION
# Description

Please include: 
This PR fixes the issue #1548 . The problem was caused by not stoping the audio tracks of the stream as part of the stop callback.

A more detailed explanation can be found in [this SO link](https://stackoverflow.com/questions/44274410/mediarecorder-stop-doesnt-clear-the-recording-icon-in-the-tab).

Now it behaves in this way:

![gradio-recording-bugfix](https://user-images.githubusercontent.com/24900688/173495046-c0eee6b1-3772-4a77-9c04-54edf4153b59.gif)

Closes: #1548

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
