### PR TITLE
Fix plotly rendering in the Plot component

### DIFF
--- a/ui/packages/plot/src/Plot.svelte
+++ b/ui/packages/plot/src/Plot.svelte
@@ -14,10 +14,13 @@
 	import Plotly from "plotly.js-dist-min";
 	import { Plot as PlotIcon } from "@gradio/icons";
 	
-	import { afterUpdate, onMount } from "svelte";
+	import { afterUpdate } from "svelte";
 
 	export let value: null | string;
 	export let theme: string;
+
+	// Plotly
+	let plotDiv;
 
 	// Bokeh
 	let bokehLoaded = false
@@ -50,7 +53,6 @@
 	afterUpdate(() => {
 		if (value && value["type"] == "plotly") {
 			let plotObj = JSON.parse(value["plot"]);
-			let plotDiv = document.getElementById("plotlyDiv");
 			Plotly.newPlot(plotDiv, plotObj["data"], plotObj["layout"]);
 		} else if (value && value["type"] == "bokeh") {
 			document.getElementById("bokehDiv").innerHTML = "";
@@ -61,16 +63,16 @@
 </script>
 
 {#if value && value["type"] == "plotly"}
-	<div id="plotlyDiv"/>
+	<div bind:this={plotDiv}/>
 {:else if value && value["type"] == "bokeh"}
 	<div id="bokehDiv"/>
 {:else if value && value["type"] == "matplotlib"}
 	<div
-		class="output-image w-full flex justify-center items-center  relative"
+		class="output-image w-full flex justify-center items-center relative"
 		{theme}
 	>
 		<!-- svelte-ignore a11y-missing-attribute -->
-		<img  class="w-full max-h-[30rem] object-contain" src={value["plot"]} />
+		<img class="w-full max-h-[30rem] object-contain" src={value["plot"]} />
 	</div>
 {:else}
 	<div class="h-full min-h-[15rem] flex justify-center items-center">


### PR DESCRIPTION
# Description

Please include: 
The issue was reported on #1544 . Seems like something is making Svelte not work properly with some document functions like `getElementById`. Anyhow, it also seems like the more Svelte-like way of doing DOM manipulations is via bindings, so I changed the plot div to use bindings and it now works.

![plotly-working](https://user-images.githubusercontent.com/24900688/173703905-ef6f1df4-90cc-4929-b75b-e8432c2b279a.gif)

Unfortunately, the Bokeh plots also face the same problem and this solution does not work for that case. Bokeh internally uses the div id to render with `embed_item` as it is done [here](https://github.com/gradio-app/gradio/blob/d455baca4ed982846e17b5f27b5a9429b9944f1a/ui/packages/plot/src/Plot.svelte#L58). To solve that I think either a bigger debugging to see what is messing up with the document functions or another way to render Bokeh (maybe using [components](https://docs.bokeh.org/en/latest/docs/reference/embed.html#bokeh.embed.components)?) is needed.

Closes: #1544 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
