### PR TITLE
Update blocks in memory after prediction

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -507,6 +507,13 @@ class Blocks(BlockContext):
                                 if prediction_value["value"] is not None
                                 else None
                             )
+                        if prediction_value["__type__"] == "update":
+                            keys_to_update = [
+                                key for key in prediction_value if key != "__type__"
+                            ]
+                            for key in keys_to_update:
+                                setattr(block, key, prediction_value[key])
+
                         output_value = prediction_value
                     else:
                         output_value = (


### PR DESCRIPTION
# Description 

The dependencies are being updated in the front-end, but not on the server-side. This causes some issues with certain components, such as the Radio component (see #1566).

This PR adds a small step for each non-stateful dependency in `postprocess_data`, so that any prediction of type `update` will have all of its attributes copied over to the relevant block. I've tested this manually with a few components.

Note that this PR is being opened as a draft to get feedback the approach. Let me know if this seems like an appropriate solution!

Also, the only tests that I can see that hit `postprocess_data` are:

```
test.test_external.TestLoadInterface.test_numerical_to_label_space
test.test_routes.TestRoutes.test_predict_route
test.test_routes.TestRoutes.test_predict_route_without_fn_index
test.test_routes.TestRoutes.test_state
```

But these all do it through either `.load` or the API routes. Any recommendations on good ways to test this? I was thinking of doing it in `test.test_blocks.TestBlocks`.

@abidlabs @aliabd

Closes: #1566

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
