### PR TITLE
Allows updating `interactive` property for components

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -337,6 +337,7 @@ class Textbox(Changeable, Submittable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
+        interactive: Optional[bool] = None,
     ):
         return {
             "lines": lines,
@@ -546,7 +547,7 @@ class Number(Changeable, Submittable, IOComponent):
             "show_label": show_label,
             "visible": visible,
             "value": value,
-            "interactive": interactive,
+            "mode": "dynamic" if interactive else "static",
             "__type__": "update",
         }
 

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -267,7 +267,12 @@ class IOComponent(Component):
             return None
         else:
             raise ValueError("Invalid doumentation target.")
-
+    
+    @staticmethod
+    def add_interactive_to_config(config, interactive):
+        if interactive is not None:
+            config["mode"] = "dynamic" if interactive else "static"
+        return config
 
 class Textbox(Changeable, Submittable, IOComponent):
     """
@@ -337,8 +342,9 @@ class Textbox(Changeable, Submittable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
+        interactive: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "lines": lines,
             "max_lines": max_lines,
             "placeholder": placeholder,
@@ -348,6 +354,7 @@ class Textbox(Changeable, Submittable, IOComponent):
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     # Input Functionalities
     def preprocess(self, x: str | None) -> Any:
@@ -548,9 +555,7 @@ class Number(Changeable, Submittable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        if interactive is not None:
-            updated_config["mode"] = "dynamic" if interactive else "static"
-        return updated_config
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def preprocess(self, x: float | None) -> float | None:
         """
@@ -717,7 +722,7 @@ class Slider(Changeable, IOComponent):
         interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "minimum": minimum,
             "maximum": maximum,
             "step": step,
@@ -728,6 +733,7 @@ class Slider(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def preprocess(self, x: float) -> float:
         """
@@ -854,7 +860,7 @@ class Checkbox(Changeable, IOComponent):
         interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "label": label,
             "show_label": show_label,
             "interactive": interactive,
@@ -862,6 +868,7 @@ class Checkbox(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def preprocess(self, x: bool) -> bool:
         """
@@ -982,7 +989,7 @@ class CheckboxGroup(Changeable, IOComponent):
         interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "choices": choices,
             "label": label,
             "show_label": show_label,
@@ -991,6 +998,7 @@ class CheckboxGroup(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def preprocess(self, x: List[str]) -> List[str] | List[int]:
         """
@@ -1149,7 +1157,7 @@ class Radio(Changeable, IOComponent):
         interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "choices": choices,
             "label": label,
             "show_label": show_label,
@@ -1158,6 +1166,7 @@ class Radio(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def preprocess(self, x: str) -> str | int:
         """
@@ -1375,7 +1384,7 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent):
         interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "label": label,
             "show_label": show_label,
             "interactive": interactive,
@@ -1383,6 +1392,7 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent):
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def preprocess(self, x: Optional[str]) -> np.array | PIL.Image | str | None:
         """
@@ -1688,7 +1698,7 @@ class Video(Changeable, Clearable, Playable, IOComponent):
         interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "source": source,
             "label": label,
             "show_label": show_label,
@@ -1697,6 +1707,7 @@ class Video(Changeable, Clearable, Playable, IOComponent):
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def preprocess_example(self, x):
         return {"name": x, "data": None, "is_example": True}
@@ -1859,7 +1870,7 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent):
         interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "source": source,
             "label": label,
             "show_label": show_label,
@@ -1868,6 +1879,7 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent):
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def preprocess_example(self, x):
         return {"name": x, "data": None, "is_example": True}
@@ -2160,7 +2172,7 @@ class File(Changeable, Clearable, IOComponent):
         interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "label": label,
             "show_label": show_label,
             "interactive": interactive,
@@ -2168,6 +2180,7 @@ class File(Changeable, Clearable, IOComponent):
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def preprocess_example(self, x):
         if isinstance(x, list):
@@ -2395,7 +2408,7 @@ class Dataframe(Changeable, IOComponent):
         interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "max_rows": max_rows,
             "max_cols": max_cols,
             "label": label,
@@ -2405,6 +2418,7 @@ class Dataframe(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def preprocess(self, x: List[List[str | Number | bool]]):
         """
@@ -2565,7 +2579,7 @@ class Timeseries(Changeable, IOComponent):
         interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "colors": colors,
             "label": label,
             "show_label": show_label,
@@ -2574,6 +2588,7 @@ class Timeseries(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def preprocess_example(self, x):
         return {"name": x, "is_example": True}
@@ -2793,14 +2808,16 @@ class Label(Changeable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
+        interactive: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "label": label,
             "show_label": show_label,
             "visible": visible,
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def style(
         self,
@@ -2877,8 +2894,9 @@ class HighlightedText(Changeable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
+        interactive: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "color_map": color_map,
             "show_legend": show_legend,
             "label": label,
@@ -2887,6 +2905,7 @@ class HighlightedText(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def postprocess(self, y):
         """
@@ -2988,14 +3007,16 @@ class JSON(Changeable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
+        interactive: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "label": label,
             "show_label": show_label,
             "visible": visible,
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def postprocess(self, y):
         """
@@ -3067,14 +3088,16 @@ class HTML(Changeable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
+        interactive: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "label": label,
             "show_label": show_label,
             "visible": visible,
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def style(self):
         return self
@@ -3121,14 +3144,16 @@ class Gallery(IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
+        interactive: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "label": label,
             "show_label": show_label,
             "visible": visible,
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def postprocess(self, y):
         """
@@ -3224,14 +3249,16 @@ class Carousel(IOComponent, Changeable):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
+        interactive: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "label": label,
             "show_label": show_label,
             "visible": visible,
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def postprocess(self, y):
         """
@@ -3335,8 +3362,9 @@ class Chatbot(Changeable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
+        interactive: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "color_map": color_map,
             "label": label,
             "show_label": show_label,
@@ -3344,6 +3372,7 @@ class Chatbot(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def postprocess(self, y):
         """
@@ -3420,14 +3449,16 @@ class Model3D(Changeable, Editable, Clearable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
+        interactive: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "label": label,
             "show_label": show_label,
             "visible": visible,
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def preprocess_example(self, x):
         return {"name": x, "data": None, "is_example": True}
@@ -3548,14 +3579,16 @@ class Plot(Changeable, Clearable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
+        interactive: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "label": label,
             "show_label": show_label,
             "visible": visible,
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def postprocess(self, y):
         """
@@ -3623,12 +3656,14 @@ class Markdown(IOComponent, Changeable):
     def update(
         value: Optional[Any] = None,
         visible: Optional[bool] = None,
+        interactive: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "visible": visible,
             "value": value,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)      
 
     def style(self):
         return self

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -337,7 +337,6 @@ class Textbox(Changeable, Submittable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = None,
     ):
         return {
             "lines": lines,

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -549,7 +549,7 @@ class Number(Changeable, Submittable, IOComponent):
             "__type__": "update",
         }
         if interactive is not None:
-            updated_config["mode"] = "dynamic" if interactive else "static", 
+            updated_config["mode"] = "dynamic" if interactive else "static"
         return updated_config
 
     def preprocess(self, x: float | None) -> float | None:

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2809,7 +2809,6 @@ class Label(Changeable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = None,
     ):
         updated_config = {
             "label": label,
@@ -2818,7 +2817,7 @@ class Label(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)
+        return updated_config
 
     def style(
         self,
@@ -2895,7 +2894,6 @@ class HighlightedText(Changeable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = None,
     ):
         updated_config = {
             "color_map": color_map,
@@ -2906,7 +2904,7 @@ class HighlightedText(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)
+        return updated_config
 
     def postprocess(self, y):
         """
@@ -3017,7 +3015,7 @@ class JSON(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)
+        return updated_config
 
     def postprocess(self, y):
         """
@@ -3089,7 +3087,6 @@ class HTML(Changeable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = None,
     ):
         updated_config = {
             "label": label,
@@ -3098,7 +3095,7 @@ class HTML(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)
+        return updated_config
 
     def style(self):
         return self
@@ -3145,7 +3142,6 @@ class Gallery(IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = None,
     ):
         updated_config = {
             "label": label,
@@ -3154,7 +3150,7 @@ class Gallery(IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)
+        return updated_config
 
     def postprocess(self, y):
         """
@@ -3250,7 +3246,6 @@ class Carousel(IOComponent, Changeable):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = None,
     ):
         updated_config = {
             "label": label,
@@ -3259,7 +3254,7 @@ class Carousel(IOComponent, Changeable):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)
+        return updated_config
 
     def postprocess(self, y):
         """
@@ -3363,7 +3358,6 @@ class Chatbot(Changeable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = None,
     ):
         updated_config = {
             "color_map": color_map,
@@ -3373,7 +3367,7 @@ class Chatbot(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)
+        return updated_config
 
     def postprocess(self, y):
         """
@@ -3450,7 +3444,6 @@ class Model3D(Changeable, Editable, Clearable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = None,
     ):
         updated_config = {
             "label": label,
@@ -3459,7 +3452,7 @@ class Model3D(Changeable, Editable, Clearable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)
+        return updated_config
 
     def preprocess_example(self, x):
         return {"name": x, "data": None, "is_example": True}
@@ -3580,7 +3573,6 @@ class Plot(Changeable, Clearable, IOComponent):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = None,
     ):
         updated_config = {
             "label": label,
@@ -3589,7 +3581,7 @@ class Plot(Changeable, Clearable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)
+        return updated_config
 
     def postprocess(self, y):
         """
@@ -3657,14 +3649,13 @@ class Markdown(IOComponent, Changeable):
     def update(
         value: Optional[Any] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = None,
     ):
         updated_config = {
             "visible": visible,
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)
+        return updated_config
 
     def style(self):
         return self

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -541,14 +541,16 @@ class Number(Changeable, Submittable, IOComponent):
         interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
-        return {
+        updated_config = {
             "label": label,
             "show_label": show_label,
             "visible": visible,
             "value": value,
-            "mode": "dynamic" if interactive else "static",
             "__type__": "update",
         }
+        if interactive is not None:
+            updated_config["mode"] = "dynamic" if interactive else "static", 
+        return updated_config
 
     def preprocess(self, x: float | None) -> float | None:
         """

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -267,12 +267,13 @@ class IOComponent(Component):
             return None
         else:
             raise ValueError("Invalid doumentation target.")
-    
+
     @staticmethod
     def add_interactive_to_config(config, interactive):
         if interactive is not None:
             config["mode"] = "dynamic" if interactive else "static"
         return config
+
 
 class Textbox(Changeable, Submittable, IOComponent):
     """
@@ -733,7 +734,7 @@ class Slider(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def preprocess(self, x: float) -> float:
         """
@@ -868,7 +869,7 @@ class Checkbox(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def preprocess(self, x: bool) -> bool:
         """
@@ -998,7 +999,7 @@ class CheckboxGroup(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def preprocess(self, x: List[str]) -> List[str] | List[int]:
         """
@@ -1166,7 +1167,7 @@ class Radio(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def preprocess(self, x: str) -> str | int:
         """
@@ -1392,7 +1393,7 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def preprocess(self, x: Optional[str]) -> np.array | PIL.Image | str | None:
         """
@@ -1707,7 +1708,7 @@ class Video(Changeable, Clearable, Playable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def preprocess_example(self, x):
         return {"name": x, "data": None, "is_example": True}
@@ -1879,7 +1880,7 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def preprocess_example(self, x):
         return {"name": x, "data": None, "is_example": True}
@@ -2180,7 +2181,7 @@ class File(Changeable, Clearable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def preprocess_example(self, x):
         if isinstance(x, list):
@@ -2418,7 +2419,7 @@ class Dataframe(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def preprocess(self, x: List[List[str | Number | bool]]):
         """
@@ -2588,7 +2589,7 @@ class Timeseries(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def preprocess_example(self, x):
         return {"name": x, "is_example": True}
@@ -2817,7 +2818,7 @@ class Label(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def style(
         self,
@@ -2905,7 +2906,7 @@ class HighlightedText(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def postprocess(self, y):
         """
@@ -3016,7 +3017,7 @@ class JSON(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def postprocess(self, y):
         """
@@ -3097,7 +3098,7 @@ class HTML(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def style(self):
         return self
@@ -3153,7 +3154,7 @@ class Gallery(IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def postprocess(self, y):
         """
@@ -3258,7 +3259,7 @@ class Carousel(IOComponent, Changeable):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def postprocess(self, y):
         """
@@ -3372,7 +3373,7 @@ class Chatbot(Changeable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def postprocess(self, y):
         """
@@ -3458,7 +3459,7 @@ class Model3D(Changeable, Editable, Clearable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def preprocess_example(self, x):
         return {"name": x, "data": None, "is_example": True}
@@ -3588,7 +3589,7 @@ class Plot(Changeable, Clearable, IOComponent):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def postprocess(self, y):
         """
@@ -3663,7 +3664,7 @@ class Markdown(IOComponent, Changeable):
             "value": value,
             "__type__": "update",
         }
-        return IOComponent.add_interactive_to_config(updated_config, interactive)      
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def style(self):
         return self

--- a/ui/packages/plot/src/Plot.svelte
+++ b/ui/packages/plot/src/Plot.svelte
@@ -14,10 +14,13 @@
 	import Plotly from "plotly.js-dist-min";
 	import { Plot as PlotIcon } from "@gradio/icons";
 	
-	import { afterUpdate, onMount } from "svelte";
+	import { afterUpdate } from "svelte";
 
 	export let value: null | string;
 	export let theme: string;
+
+	// Plotly
+	let plotDiv;
 
 	// Bokeh
 	let bokehLoaded = false
@@ -50,7 +53,6 @@
 	afterUpdate(() => {
 		if (value && value["type"] == "plotly") {
 			let plotObj = JSON.parse(value["plot"]);
-			let plotDiv = document.getElementById("plotlyDiv");
 			Plotly.newPlot(plotDiv, plotObj["data"], plotObj["layout"]);
 		} else if (value && value["type"] == "bokeh") {
 			document.getElementById("bokehDiv").innerHTML = "";
@@ -61,16 +63,16 @@
 </script>
 
 {#if value && value["type"] == "plotly"}
-	<div id="plotlyDiv"/>
+	<div bind:this={plotDiv}/>
 {:else if value && value["type"] == "bokeh"}
 	<div id="bokehDiv"/>
 {:else if value && value["type"] == "matplotlib"}
 	<div
-		class="output-image w-full flex justify-center items-center  relative"
+		class="output-image w-full flex justify-center items-center relative"
 		{theme}
 	>
 		<!-- svelte-ignore a11y-missing-attribute -->
-		<img  class="w-full max-h-[30rem] object-contain" src={value["plot"]} />
+		<img class="w-full max-h-[30rem] object-contain" src={value["plot"]} />
 	</div>
 {:else}
 	<div class="h-full min-h-[15rem] flex justify-center items-center">


### PR DESCRIPTION
Right now, you cannot update a component's "interactivity" using the standard `gr.component.update()` method: some components like `Number` actually accept `interactive` as a parameter to their `update()` method, but it has no effect, while others like `Textbox` don't accept it at all and error out.

In this PR, I'm working on fixing that. Note that the `interactive` parameter is a little different than others because it is used indirectly to set a component's `mode` property, which is what actually reflects whether a component is static or dynamic. Because "mode" is only used in the frontend, we shouldn't ask backend users to change "mode" but instead update the "mode" ourselves based on what users pass in for `interactive`. 

So I've done that in this draft PR for the `Number` component. Does this look like a reasonable approach @pngwn? If so, I'll implement it for the other components as well. 

You can test with code like this:

```py
import gradio as gr

with gr.Blocks() as demo:
    a = gr.Checkbox()
    c = gr.Textbox()
    b = gr.Number()
    a.change(lambda x:(x, gr.Number.update(interactive=x)), a, [c, b])
    
demo.launch()
```

Closes: #1574 