### PR TITLE
Remove query parameter from API docs url

### DIFF
--- a/ui/packages/app/src/ApiDocs.svelte
+++ b/ui/packages/app/src/ApiDocs.svelte
@@ -17,7 +17,10 @@
 	export let root: string;
 
 	if (root === "") {
-		root = window.location.href;
+		root = location.protocol + "//" + location.host + location.pathname;
+	}
+	if (!root.endsWith("/")) {
+		root += "/";
 	}
 
 	let just_copied = -1;


### PR DESCRIPTION
The API url displayed in the api docs is incorrent, should not include url parameter. Removed. Fixes #1572 