### PR TITLE
Manage a null value update on Dataframe

### DIFF
--- a/ui/packages/app/src/components/DataFrame/DataFrame.svelte
+++ b/ui/packages/app/src/components/DataFrame/DataFrame.svelte
@@ -19,10 +19,12 @@
 	export let label: string | null = null;
 
 	$: {
-		if (!Array.isArray(value)) {
+		if (value && !Array.isArray(value)) {
 			if (Array.isArray(value.headers)) headers = value.headers;
 			value =
 				value.data.length === 0 ? [Array(headers.length).fill("")] : value.data;
+		} else if (value === null) {
+			value = [Array(headers.length).fill("")];
 		} else {
 			value = value;
 		}


### PR DESCRIPTION
# Description

The Dataframe as output update was crashing when clearing due to the value being null. With these changes, when clearing the Dataframe will default to three empty rows and the column number of the headers.

![dataframe-clear](https://user-images.githubusercontent.com/24900688/173995363-e8f68d46-acfe-4c4b-86c1-0b7084281be2.gif)

Closes: #1579

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
