### PR TITLE
Attempt to find workaround to fix bokeh plots

### DIFF
--- a/ui/packages/app/index.html
+++ b/ui/packages/app/index.html
@@ -59,8 +59,11 @@
 			><div
 				id="root"
 				style="display: flex; flex-direction: column; flex-grow: 1"
-			></div
-		></gradio-app>
+			></div>
+			<div id="bokeh-helper">
+				<div id="bokeh-plot-helper"></div>
+			</div>
+		</gradio-app>
 
 		<script>
 			const ce = document.getElementsByTagName("gradio-app");
@@ -68,7 +71,6 @@
 				ce[0].addEventListener("domchange", () => {
 					document.body.style.padding = "0";
 				});
-				console.log("hello");
 				document.body.style.padding = "0";
 			}
 		</script>


### PR DESCRIPTION
# Description

The Bokeh plots are currently broken. The reason for this is that bokehJS internally uses `getElementById` to get the container of the plot and render it. Since Gradio UI is using the shadow DOM to render, this step fails.

I have tried here a workaround where I added a new hidden div in the index.html file to use as a helper to render the plot, once it is rendered, then the content is appended to the actual div that should have the plot. This part is all working, unfortunately although I can see the div with the expected content, the plot is still not showing.

Closes: # (issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
