### PR TITLE
Restore get_config function for Gallery component

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3156,6 +3156,12 @@ class Gallery(IOComponent):
         }
         return updated_config
 
+    def get_config(self):
+        return {
+            "value": self.value,
+            **IOComponent.get_config(self),
+        }
+
     def postprocess(self, y):
         """
         Parameters:


### PR DESCRIPTION
# Description

The `get_config` function from the Gallery component had been erased, causing the default images set to not be shown.

Closes: #1587 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
