### PR TITLE
Fix text color for bold and code on dark theme

### DIFF
--- a/ui/packages/app/index.html
+++ b/ui/packages/app/index.html
@@ -68,7 +68,6 @@
 				ce[0].addEventListener("domchange", () => {
 					document.body.style.padding = "0";
 				});
-				console.log("hello");
 				document.body.style.padding = "0";
 			}
 		</script>

--- a/ui/packages/markdown/src/typography.css
+++ b/ui/packages/markdown/src/typography.css
@@ -1081,6 +1081,12 @@
 .dark .gr-prose a {
 	color: #ffffff;
 }
+.dark .gr-prose strong {
+	color: #daddd8;
+}
+.dark .gr-prose code {
+	color: #daddd8;
+}
 .dark :is(h1, h2, h3, h4) {
 	color: #ffffff;
 }


### PR DESCRIPTION
# Description

Fixes the issue where **bold** and `code` formatting on Markdown was not white on the dark theme. Changes were just to include relevant classes for dark theme on the typography CSS file.

<img width="225" alt="Screen Shot 2022-06-20 at 22 23 04" src="https://user-images.githubusercontent.com/24900688/174710155-94dec7c9-85a5-4735-a675-c417934e4273.png">

Closes: #1346 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
