### PR TITLE
Deprecation error if multiple functions are passed into `fn` parameter in `Interface`

### DIFF
--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -106,7 +106,7 @@ class Interface(Blocks):
 
     def __init__(
         self,
-        fn: Callable | List[Callable],
+        fn: Callable,
         inputs: Optional[str | Component | List[str | Component]],
         outputs: Optional[str | Component | List[str | Component]],
         examples: Optional[List[Any] | List[List[Any]] | str] = None,
@@ -172,6 +172,11 @@ class Interface(Blocks):
 
         if not isinstance(fn, list):
             fn = [fn]
+        else:
+            raise DeprecationWarning("The `fn` parameter only accepts a single function" 
+                                     ", support for a list of functions has been "
+                                     "deprecated. Please use gradio.mix.Parallel "
+                                     "instead.")
         if not isinstance(inputs, list):
             inputs = [inputs]
         if not isinstance(outputs, list):

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -173,10 +173,11 @@ class Interface(Blocks):
         if not isinstance(fn, list):
             fn = [fn]
         else:
-            raise DeprecationWarning("The `fn` parameter only accepts a single function" 
-                                     ", support for a list of functions has been "
-                                     "deprecated. Please use gradio.mix.Parallel "
-                                     "instead.")
+            raise DeprecationWarning(
+                "The `fn` parameter only accepts a single function, support for a list "
+                "of functions has been deprecated. Please use gradio.mix.Parallel "
+                "instead."
+            )
         if not isinstance(inputs, list):
             inputs = [inputs]
         if not isinstance(outputs, list):

--- a/gradio/mix.py
+++ b/gradio/mix.py
@@ -30,9 +30,19 @@ class Parallel(gradio.Interface):
                 )
             fns.extend(io.predict)
             outputs.extend(io.output_components)
+            
+        def parallel_fn(*args):
+            return_values = []
+            for fn in fns:
+                value = fn(*args)
+                if isinstance(value, tuple): 
+                    return_values.extend(value)
+                else:
+                    return_values.append(value)
+            return return_values
 
         kwargs = {
-            "fn": fns,
+            "fn": parallel_fn,
             "inputs": interfaces[0].input_components,
             "outputs": outputs,
             "_repeat_outputs_per_model": False,

--- a/gradio/mix.py
+++ b/gradio/mix.py
@@ -30,12 +30,12 @@ class Parallel(gradio.Interface):
                 )
             fns.extend(io.predict)
             outputs.extend(io.output_components)
-            
+
         def parallel_fn(*args):
             return_values = []
             for fn in fns:
                 value = fn(*args)
-                if isinstance(value, tuple): 
+                if isinstance(value, tuple):
                     return_values.extend(value)
                 else:
                     return_values.append(value)

--- a/test/test_mix.py
+++ b/test/test_mix.py
@@ -41,7 +41,9 @@ class TestParallel(unittest.TestCase):
         )
 
     def test_multiple_return_in_interface(self):
-        io1 = gr.Interface(lambda x: (x, x+x), "textbox", [gr.Textbox(), gr.Textbox()])
+        io1 = gr.Interface(
+            lambda x: (x, x + x), "textbox", [gr.Textbox(), gr.Textbox()]
+        )
         io2 = gr.Interface(lambda x: x + " World 2!", "textbox", gr.Textbox())
         parallel = mix.Parallel(io1, io2)
         self.assertEqual(

--- a/test/test_mix.py
+++ b/test/test_mix.py
@@ -15,8 +15,8 @@ os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
 
 class TestSeries(unittest.TestCase):
     def test_in_interface(self):
-        io1 = gr.Interface(lambda x: x + " World", "textbox", gr.outputs.Textbox())
-        io2 = gr.Interface(lambda x: x + "!", "textbox", gr.outputs.Textbox())
+        io1 = gr.Interface(lambda x: x + " World", "textbox", gr.Textbox())
+        io2 = gr.Interface(lambda x: x + "!", "textbox", gr.Textbox())
         series = mix.Series(io1, io2)
         self.assertEqual(series.process(["Hello"]), ["Hello World!"])
 
@@ -33,11 +33,19 @@ class TestSeries(unittest.TestCase):
 
 class TestParallel(unittest.TestCase):
     def test_in_interface(self):
-        io1 = gr.Interface(lambda x: x + " World 1!", "textbox", gr.outputs.Textbox())
-        io2 = gr.Interface(lambda x: x + " World 2!", "textbox", gr.outputs.Textbox())
+        io1 = gr.Interface(lambda x: x + " World 1!", "textbox", gr.Textbox())
+        io2 = gr.Interface(lambda x: x + " World 2!", "textbox", gr.Textbox())
         parallel = mix.Parallel(io1, io2)
         self.assertEqual(
             parallel.process(["Hello"]), ["Hello World 1!", "Hello World 2!"]
+        )
+
+    def test_multiple_return_in_interface(self):
+        io1 = gr.Interface(lambda x: (x, x+x), "textbox", [gr.Textbox(), gr.Textbox()])
+        io2 = gr.Interface(lambda x: x + " World 2!", "textbox", gr.Textbox())
+        parallel = mix.Parallel(io1, io2)
+        self.assertEqual(
+            parallel.process(["Hello"]), ["Hello", "HelloHello", "Hello World 2!"]
         )
 
     def test_with_external(self):


### PR DESCRIPTION
Raises deprecation warning and rewrite gr.mix.Parallel to not use stack of functions.

Closes: #1605 