### PR TITLE
Add type hint to provide autocompletion for the Request class

### DIFF
--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -13,7 +13,7 @@ import warnings
 from copy import deepcopy
 from distutils.version import StrictVersion
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, NewType, Type
+from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, NewType, Type
 
 import aiohttp
 import analytics
@@ -424,7 +424,7 @@ class Request:
         # Create request
         self._request = self._create_request(method, url, **kwargs)
 
-    def __await__(self):
+    def __await__(self) -> Generator[None, Any, "Request"]:
         """
         Wrap Request's __await__ magic function to create request calls which are executed in one line.
         """

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -200,7 +200,7 @@ async def client():
 class TestRequest:
     @pytest.mark.asyncio
     async def test_get(self):
-        client_response: Request = await Request(
+        client_response = await Request(
             method=Request.Method.GET,
             url="http://headers.jsontest.com/",
         )
@@ -210,7 +210,7 @@ class TestRequest:
 
     @pytest.mark.asyncio
     async def test_post(self):
-        client_response: Request = await Request(
+        client_response = await Request(
             method=Request.Method.POST,
             url="https://reqres.in/api/users",
             json={"name": "morpheus", "job": "leader"},
@@ -228,7 +228,7 @@ class TestRequest:
             id: str
             createdAt: str
 
-        client_response: Request = await Request(
+        client_response = await Request(
             method=Request.Method.POST,
             url="https://reqres.in/api/users",
             json={"name": "morpheus", "job": "leader"},
@@ -242,7 +242,7 @@ class TestRequest:
             name: Literal[str] = "John"
             job: str
 
-        client_response: Request = await Request(
+        client_response = await Request(
             method=Request.Method.POST,
             url="https://reqres.in/api/users",
             json={"name": "morpheus", "job": "leader"},
@@ -261,7 +261,7 @@ class TestRequest:
 
         validate_response_data.side_effect = Exception()
 
-        client_response: Request = await Request(
+        client_response = await Request(
             method=Request.Method.GET,
             url="https://reqres.in/api/users",
             exception_type=ResponseValidationException,
@@ -275,7 +275,7 @@ class TestRequest:
                 return response
             raise Exception
 
-        client_response: Request = await Request(
+        client_response = await Request(
             method=Request.Method.POST,
             url="https://reqres.in/api/users",
             json={"name": "morpheus", "job": "leader"},
@@ -294,7 +294,7 @@ class TestRequest:
                     return response
             raise Exception
 
-        client_response: Request = await Request(
+        client_response = await Request(
             method=Request.Method.POST,
             url="https://reqres.in/api/users",
             json={"name": "morpheus", "job": "leader"},


### PR DESCRIPTION
# Description
@FarukOzderim realized we don't have auto-completion for the `Request` class. To provide auto-completion, I added the missing type hints to the `__await__`function. 

```python
def __await__(self) -> Generator[None, Any, "Request"]:
     # Since our generator uses only ReturnType, we set the YieldValue to None and SendType to Any
     # For a quick reference: Generator[YieldType, SendType, ReturnType]
     ...
```
# Summary o the change
- Added missing type hints to `Request.__await__` function
- Revised test `Request` instance usages, removed redundant type hints.

# References
-  [typing.Generator documentation](https://docs.python.org/3/library/typing.html?highlight=generator#typing.Generator) 


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
