### PR TITLE
fix interactivity

### DIFF
--- a/ui/packages/app/src/Blocks.svelte
+++ b/ui/packages/app/src/Blocks.svelte
@@ -118,8 +118,8 @@
 	const dynamic_ids = components.reduce((acc, { id, props }) => {
 		const is_input = is_dep(id, "inputs", dependencies);
 		const is_output = is_dep(id, "outputs", dependencies);
-
-		if (!is_input && !is_output && !props.value) acc.add(id); // default dynamic
+		console.log(props.value, is_input, is_output);
+		if (!is_input && !is_output) acc.add(id); // default dynamic
 		if (is_input) acc.add(id);
 
 		return acc;

--- a/ui/packages/app/src/Blocks.svelte
+++ b/ui/packages/app/src/Blocks.svelte
@@ -118,7 +118,7 @@
 	const dynamic_ids = components.reduce((acc, { id, props }) => {
 		const is_input = is_dep(id, "inputs", dependencies);
 		const is_output = is_dep(id, "outputs", dependencies);
-		console.log(props.value, is_input, is_output);
+
 		if (!is_input && !is_output) acc.add(id); // default dynamic
 		if (is_input) acc.add(id);
 

--- a/ui/packages/app/src/Render.svelte
+++ b/ui/packages/app/src/Render.svelte
@@ -23,6 +23,7 @@
 
 	const dispatch = createEventDispatcher<{ mount: number; destroy: number }>();
 
+	console.log(props.interactive);
 	if (has_modes) {
 		if (props.interactive === false) {
 			props.mode = "static";

--- a/ui/packages/app/src/Render.svelte
+++ b/ui/packages/app/src/Render.svelte
@@ -23,7 +23,6 @@
 
 	const dispatch = createEventDispatcher<{ mount: number; destroy: number }>();
 
-	console.log(props.interactive);
 	if (has_modes) {
 		if (props.interactive === false) {
 			props.mode = "static";


### PR DESCRIPTION
Closes #1569.

Previously there were some issues with interactivity auto-detection. It was actually working as intended for the most part but it was a little confusing. The important factor here was that components needed to have no default_value in order to appear as dynamic. As soon as you gave them a default_value, the logic determined that if they have no inputs or outputs they are static. This makes sense in general but is slightly confusing when developing the application before all events have been hooked up.

This PR is more of a proposal. It essentially means that components which act only as an output will rename static, everything else is dynamic regardless of whether there is a default value. It is less magical but much easier to understand. _Most_ of the time the component will be dynamic, users will always have the `interactive=False` kwarg for those times when they need to go against the very simple auto behaviour.