### PR TITLE
Fix Audio deserialize method

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2119,7 +2119,7 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent):
         return processing_utils.encode_url_or_file_to_base64(y)
 
     def deserialize(self, x):
-        file = processing_utils.decode_base64_to_file(x["data"])
+        file = processing_utils.decode_base64_to_file(x)
         return file.name
 
     def stream(

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -843,7 +843,9 @@ class TestAudio(unittest.TestCase):
             },
         )
         self.assertTrue(
-            audio_output.deserialize(deepcopy(media_data.BASE64_AUDIO)).endswith(".wav")
+            audio_output.deserialize(
+                deepcopy(media_data.BASE64_AUDIO)["data"]
+            ).endswith(".wav")
         )
         with tempfile.TemporaryDirectory() as tmpdirname:
             to_save = audio_output.save_flagged(


### PR DESCRIPTION
# Description

Fixes #1663

The [postprocess function](https://github.com/gradio-app/gradio/blob/main/gradio/external.py#L234) for text-to-speech models already converts the response from the inference api to a base64 blob (and so does postprocess) so the deserialize method should not have to read from a dict.

Tested on the original repro as well as series and parallel interfaces since I know those also use `api_mode`. 

![image](https://user-images.githubusercontent.com/41651716/176494232-7e83dd75-3b6f-4fef-b259-014e30301c63.png)

![image](https://user-images.githubusercontent.com/41651716/176494299-19492e28-4791-4649-bec2-79fd26465666.png)

Opting not to unit test this for now as that could introduce further flakes but filed #1665 to track discussion about how to do that in the future.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
