### PR TITLE
add markdown and html support to dataframe

### DIFF
--- a/demo/blocks_outputs/run.py
+++ b/demo/blocks_outputs/run.py
@@ -1,5 +1,26 @@
 import gradio as gr
 
+
+def make_markdown():
+    return [
+        [
+            "# hello again",
+            "Hello my name is frank, I am liking the small turtle you have there. It would be a shame if it went missing.",
+            '<img src="https://images.unsplash.com/photo-1574613362884-f79513a5128c?fit=crop&w=500&q=80"/>',
+        ],
+        [
+            "## hello again again",
+            "Hello my name is frank, I am liking the small turtle you have there. It would be a shame if it went missing.",
+            '<img src="https://images.unsplash.com/photo-1574613362884-f79513a5128c?fit=crop&w=500&q=80"/>',
+        ],
+        [
+            "### hello thrice",
+            "Hello my name is frank, I am liking the small turtle you have there. It would be a shame if it went missing.",
+            '<img src="https://images.unsplash.com/photo-1574613362884-f79513a5128c?fit=crop&w=500&q=80"/>',
+        ],
+    ]
+
+
 with gr.Blocks() as demo:
     with gr.Column():
         txt = gr.Textbox(label="Small Textbox", lines=1, show_label=False)
@@ -43,27 +64,31 @@ with gr.Blocks() as demo:
         gr.Dataframe(
             interactive=True, headers=["One", "Two", "Three", "Four"], col_count=4
         )
-        gr.DataFrame(
+        df = gr.DataFrame(
             [
                 [
+                    "# hello",
                     "Hello my name is frank, I am liking the small turtle you have there. It would be a shame if it went missing.",
-                    "Hello my name is frank, I am liking the small turtle you have there. It would be a shame if it went missing.",
-                    "Hello my name is frank, I am liking the small turtle you have there. It would be a shame if it went missing.",
+                    '<img src="https://images.unsplash.com/photo-1574613362884-f79513a5128c?fit=crop&w=500&q=80"/>',
                 ],
                 [
+                    "## hello",
                     "Hello my name is frank, I am liking the small turtle you have there. It would be a shame if it went missing.",
-                    "Hello my name is frank, I am liking the small turtle you have there. It would be a shame if it went missing.",
-                    "Hello my name is frank, I am liking the small turtle you have there. It would be a shame if it went missing.",
+                    '<img src="https://images.unsplash.com/photo-1574613362884-f79513a5128c?fit=crop&w=500&q=80"/>',
                 ],
                 [
+                    "### hello",
                     "Hello my name is frank, I am liking the small turtle you have there. It would be a shame if it went missing.",
-                    "Hello my name is frank, I am liking the small turtle you have there. It would be a shame if it went missing.",
-                    "Hello my name is frank, I am liking the small turtle you have there. It would be a shame if it went missing.",
+                    '<img src="https://images.unsplash.com/photo-1574613362884-f79513a5128c?fit=crop&w=500&q=80"/>',
                 ],
             ],
             headers=["One", "Two", "Three"],
             wrap=True,
+            datatype=["markdown", "str", "html"],
+            interactive=True,
         )
+        btn = gr.Button("Run")
+        btn.click(fn=make_markdown, inputs=None, outputs=df)
 
 
 if __name__ == "__main__":

--- a/demo/blocks_outputs/run.py
+++ b/demo/blocks_outputs/run.py
@@ -84,7 +84,7 @@ with gr.Blocks() as demo:
             ],
             headers=["One", "Two", "Three"],
             wrap=True,
-            datatype=["markdown", "str", "html"],
+            datatype=["markdown", "markdown", "html"],
             interactive=True,
         )
         btn = gr.Button("Run")

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2356,7 +2356,7 @@ class Dataframe(Changeable, IOComponent):
     Demos: filter_records, matrix_transpose, tax_calculator
     """
 
-    md = None
+    markdown_parser = None
 
     def __init__(
         self,
@@ -2572,13 +2572,13 @@ class Dataframe(Changeable, IOComponent):
         if "markdown" not in datatype:
             return data
 
-        if cls.md is None:
-            cls.md = MarkdownIt()
+        if cls.markdown_parser is None:
+            cls.markdown_parser = MarkdownIt()
 
         for i in range(len(data)):
             for j in range(len(data[i])):
                 if datatype[j] == "markdown":
-                    data[i][j] = Dataframe.md.render(data[i][j])
+                    data[i][j] = Dataframe.markdown_parser.render(data[i][j])
 
         return data
 

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2407,7 +2407,9 @@ class Dataframe(Changeable, IOComponent):
         self.__validate_headers(headers, self.col_count[0])
 
         self.headers = headers
-        self.datatype = datatype
+        self.datatype = (
+            datatype if isinstance(datatype, list) else [datatype] * self.col_count[0]
+        )
         self.type = type
         values = {
             "str": "",
@@ -2527,7 +2529,7 @@ class Dataframe(Changeable, IOComponent):
         if y is None:
             return y
         if isinstance(y, str):
-            y = pd.read_csv(str)
+            y = pd.read_csv(y)
             return {
                 "headers": list(y.columns),
                 "data": Dataframe.__process_markdown(y.values.tolist(), self.datatype),
@@ -2565,21 +2567,17 @@ class Dataframe(Changeable, IOComponent):
                 )
             )
 
-    @staticmethod
-    def __process_markdown(data: List[List[Any]], datatype: str | List[str]):
-        if (
-            type(datatype) is list and "markdown" not in datatype
-        ) or datatype != "markdown":
+    @classmethod
+    def __process_markdown(cls, data: List[List[Any]], datatype: List[str]):
+        if "markdown" not in datatype:
             return data
 
-        if Dataframe.md is None:
-            Dataframe.md = MarkdownIt()
+        if cls.md is None:
+            cls.md = MarkdownIt()
 
         for i in range(len(data)):
             for j in range(len(data[i])):
-                if (
-                    type(datatype) is list and datatype[j] == "markdown"
-                ) or datatype == "markdown":
+                if datatype[j] == "markdown":
                     data[i][j] = Dataframe.md.render(data[i][j])
 
         return data

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1022,7 +1022,7 @@ class TestDataframe(unittest.TestCase):
             dataframe_input.get_config(),
             {
                 "headers": ["Name", "Age", "Member"],
-                "datatype": "str",
+                "datatype": ["str", "str", "str"],
                 "row_count": (3, "dynamic"),
                 "col_count": (3, "dynamic"),
                 "value": [

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1079,7 +1079,7 @@ class TestDataframe(unittest.TestCase):
                 "style": {},
                 "elem_id": None,
                 "visible": True,
-                "datatype": "str",
+                "datatype": ["str", "str", "str"],
                 "row_count": (3, "dynamic"),
                 "col_count": (3, "dynamic"),
                 "value": [

--- a/ui/packages/app/src/components/DataFrame/DataFrame.svelte
+++ b/ui/packages/app/src/components/DataFrame/DataFrame.svelte
@@ -7,6 +7,7 @@
 
 	type Headers = Array<string>;
 	type Data = Array<Array<string | number>>;
+	type Datatype = "str" | "markdown" | "html" | "number" | "bool" | "date";
 
 	export let headers: Headers = [];
 	export let elem_id: string = "";
@@ -19,6 +20,7 @@
 	export let style: Styles = {};
 	export let label: string | null = null;
 	export let wrap: boolean;
+	export let datatype: Datatype | Array<Datatype>;
 
 	$: {
 		if (value && !Array.isArray(value)) {
@@ -60,5 +62,6 @@
 		editable={mode === "dynamic"}
 		{style}
 		{wrap}
+		{datatype}
 	/>
 </div>

--- a/ui/packages/table/src/EditableCell.svelte
+++ b/ui/packages/table/src/EditableCell.svelte
@@ -3,6 +3,7 @@
 	export let value: string | number = "";
 	export let el: HTMLInputElement | null;
 	export let header: boolean = false;
+	export let datatype: "str" | "markdown" | "html" | "number" | "bool" | "date";
 </script>
 
 {#if edit}
@@ -24,5 +25,11 @@
 	role="button"
 	class:opacity-0={edit}
 	class:pointer-events-none={edit}
-	class="p-2  outline-none border-0 flex-1">{value}</span
+	class="p-2  outline-none border-0 flex-1"
 >
+	{#if datatype === "markdown" || datatype === "html"}
+		{@html value}
+	{:else}
+		{value}
+	{/if}
+</span>

--- a/ui/packages/table/src/Table.svelte
+++ b/ui/packages/table/src/Table.svelte
@@ -9,6 +9,9 @@
 	import { Upload } from "@gradio/upload";
 	import EditableCell from "./EditableCell.svelte";
 
+	type Datatype = "str" | "markdown" | "html" | "number" | "bool" | "date";
+
+	export let datatype: Datatype | Array<Datatype>;
 	export let label: string | null = null;
 	export let headers: Array<string> = [];
 	export let values: Array<Array<string | number>> = [[]];
@@ -567,6 +570,9 @@
 											bind:value
 											bind:el={els[id].input}
 											edit={editing === id}
+											datatype={Array.isArray(datatype)
+												? datatype[j]
+												: datatype}
 										/>
 									</div>
 								</td>


### PR DESCRIPTION
Allows dataframe cells to contain markdown or html.

- markdown will be processed in the same way that markdown in the `Markdown` component is (using `MarkdownIt`)
- Supports both default values and generated values (via predict function)
- If the table is interactive, the 'editable' value is the resulting HTML. This feels like a niche usecase but it is supported. We could optionally disable editing for html + markdown fields. Allowing the original source markdown to be the editable value is technically possible but introduces a degree of complexity I did not want to introduce in this PR, it would require significant changes to the implementation.

Closes #1364.

cc @radames 