### PR TITLE
detect all types of null default value

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -1233,9 +1233,7 @@ class Radio(Changeable, IOComponent):
         Returns:
         (str): string of choice
         """
-        return (
-            y if y is not None else self.choices[0] if len(self.choices) > 0 else None
-        )
+        return y if y is not None else None
 
     def deserialize(self, x):
         """

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -1233,7 +1233,7 @@ class Radio(Changeable, IOComponent):
         Returns:
         (str): string of choice
         """
-        return y if y is not None else None
+        return y
 
     def deserialize(self, x):
         """

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -537,7 +537,7 @@ class TestRadio(unittest.TestCase):
             radio_input.get_config(),
             {
                 "choices": ["a", "b", "c"],
-                "value": "a",
+                "value": None,
                 "name": "radio",
                 "show_label": True,
                 "label": "Pick Your One Input",

--- a/ui/packages/app/src/Blocks.svelte
+++ b/ui/packages/app/src/Blocks.svelte
@@ -119,11 +119,21 @@
 		const is_input = is_dep(id, "inputs", dependencies);
 		const is_output = is_dep(id, "outputs", dependencies);
 
-		if (!is_input && !is_output && !props.value) acc.add(id); // default dynamic
+		if (!is_input && !is_output && has_no_default_value(props.value))
+			acc.add(id); // default dynamic
 		if (is_input) acc.add(id);
 
 		return acc;
 	}, new Set());
+
+	function has_no_default_value(value: any) {
+		return (
+			(Array.isArray(value) && value.length === 0) ||
+			value === "" ||
+			value === 0 ||
+			!value
+		);
+	}
 
 	let instance_map = components.reduce((acc, next) => {
 		acc[next.id] = next;


### PR DESCRIPTION
ALternative to #1645.

- This PR checks for all types of 'null' default value (i.e. the value we get when no default value is provided), fixing the interactive/ non-interactive autodetection when no default value is given.
- I had to modify the preprocessing for Radio (which Dropdown inherits) as it was selecting the first value for the user even when none was given. I can kind of understand the reasoning but if we do this we have no way of knowing whether or a not a default value is being passed or not. I don't think we should be selecting a value for the user if they have not provided a valid one.

Closes #1569.

