### PR TITLE
Allows setting custom <title>

### DIFF
--- a/demo/blocks_neural_instrument_coding/run.py
+++ b/demo/blocks_neural_instrument_coding/run.py
@@ -61,7 +61,7 @@ io4 = gr.Interface(
     gr.Audio(),
 )
 
-demo = gr.Blocks()
+demo = gr.Blocks(title="Neural Instrument Cloning")
 
 with demo.clear():
     m(

--- a/demo/blocks_style/run.py
+++ b/demo/blocks_style/run.py
@@ -1,6 +1,6 @@
 import gradio as gr
 
-with gr.Blocks() as demo:
+with gr.Blocks(title="Styling Examples") as demo:
     with gr.Column():
         txt = gr.Textbox(label="Small Textbox", lines=1).style(
             rounded=False,

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -226,6 +226,7 @@ class Blocks(BlockContext):
         theme: str = "default",
         analytics_enabled: Optional[bool] = None,
         mode: str = "blocks",
+        title: str = "Gradio",
         css: Optional[str] = None,
         **kwargs,
     ):
@@ -272,6 +273,7 @@ class Blocks(BlockContext):
         self.auth = None
         self.dev_mode = True
         self.app_id = random.getrandbits(64)
+        self.title = title
 
     @property
     def share(self):
@@ -573,6 +575,7 @@ class Blocks(BlockContext):
             "components": [],
             "theme": self.theme,
             "css": self.css,
+            "title": self.title or "Gradio",
             "enable_queue": getattr(
                 self, "enable_queue", False
             ),  # attribute set at launch

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -235,6 +235,8 @@ class Blocks(BlockContext):
         theme (str): which theme to use - right now, only "default" is supported.
         analytics_enabled (bool | None): whether to allow basic telemetry. If None, will use GRADIO_ANALYTICS_ENABLED environment variable or default to True.
         mode (str): a human-friendly name for the kind of Blocks interface being created.
+        title (str): The tab title to display when this is opened in a browser window.
+        css (str | None): custom css or path to custom css file to apply to entire Blocks
         """
         # Cleanup shared parameters with Interface #TODO: is this part still necessary after Interface with Blocks?
         self.limiter = None

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -153,8 +153,11 @@ class Interface(Blocks):
         analytics_enabled (bool | None): Whether to allow basic telemetry. If None, will use GRADIO_ANALYTICS_ENABLED environment variable if defined, or default to True.
         """
         super().__init__(
-            analytics_enabled=analytics_enabled, mode="interface", css=css, 
-            title=title, **kwargs
+            analytics_enabled=analytics_enabled,
+            mode="interface",
+            css=css,
+            title=title,
+            **kwargs,
         )
 
         if inspect.iscoroutinefunction(fn):

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -153,7 +153,8 @@ class Interface(Blocks):
         analytics_enabled (bool | None): Whether to allow basic telemetry. If None, will use GRADIO_ANALYTICS_ENABLED environment variable if defined, or default to True.
         """
         super().__init__(
-            analytics_enabled=analytics_enabled, mode="interface", css=css, **kwargs
+            analytics_enabled=analytics_enabled, mode="interface", css=css, 
+            title=title, **kwargs
         )
 
         if inspect.iscoroutinefunction(fn):

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -140,7 +140,7 @@ class Interface(Blocks):
         live (bool): whether the interface should automatically rerun if any of the inputs change.
         interpretation (Callable | str): function that provides interpretation explaining prediction output. Pass "default" to use simple built-in interpreter, "shap" to use a built-in shapley-based interpreter, or your own custom interpretation function.
         num_shap (float): a multiplier that determines how many examples are computed for shap-based interpretation. Increasing this value will increase shap runtime, but improve results. Only applies if interpretation is "shap".
-        title (str | None): a title for the interface; if provided, appears above the input and output components in large font.
+        title (str | None): a title for the interface; if provided, appears above the input and output components in large font. Also used as the tab title when opened in a browser window.
         description (str | None): a description for the interface; if provided, appears above the input and output components and beneath the title in regular font. Accepts Markdown and HTML content.
         article (str | None): an expanded article explaining the interface; if provided, appears below the input and output components in regular font. Accepts Markdown and HTML content.
         thumbnail (str | None): path or url to image to use as display image when the web demo is shared on social media.


### PR DESCRIPTION
Allows users to provide a custom title which shows up on the browser tab. For an `Interface`, simply uses the existing `title` kwarg. For Blocks, there is a new `title` kwarg that has been added to the constructor.

Closes #1691 