### PR TITLE
Add background-color and text-color options to the Textbox component

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -297,6 +297,8 @@ class Textbox(Changeable, Submittable, IOComponent):
         interactive: Optional[bool] = None,
         visible: bool = True,
         elem_id: Optional[str] = None,
+        background_color: Optional[str] = None,
+        text_color: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -310,6 +312,8 @@ class Textbox(Changeable, Submittable, IOComponent):
         interactive (Optional[bool]): if True, will be rendered as an editable textbox; if False, editing will be disabled. If not provided, this is inferred based on whether the component is used as an input or output.
         visible (bool): If False, component will be hidden.
         elem_id (Optional[str]): An optional string that is assigned as the id of this component in the HTML DOM. Can be used for targeting CSS styles.
+        background_color (Optional[str]): An optional string that determines the background color of the Textbox. If set, will override the theme color.
+        text_color (Optional[str]): An optional string that determines the text color of the Textbox. If set, will override the theme color.
         """
         self.lines = lines
         self.max_lines = max_lines
@@ -318,6 +322,9 @@ class Textbox(Changeable, Submittable, IOComponent):
         self.cleared_value = ""
         self.test_input = value
         self.interpret_by_tokens = True
+        self.background_color = background_color
+        self.text_color = text_color
+
         IOComponent.__init__(
             self,
             label=label,
@@ -334,6 +341,8 @@ class Textbox(Changeable, Submittable, IOComponent):
             "max_lines": self.max_lines,
             "placeholder": self.placeholder,
             "value": self.value,
+            "background_color": self.background_color,
+            "text_color": self.text_color,
             **IOComponent.get_config(self),
         }
 
@@ -347,6 +356,8 @@ class Textbox(Changeable, Submittable, IOComponent):
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
         interactive: Optional[bool] = None,
+        background_color: Optional[str] = None,
+        text_color: Optional[str] = None
     ):
         updated_config = {
             "lines": lines,
@@ -356,6 +367,8 @@ class Textbox(Changeable, Submittable, IOComponent):
             "show_label": show_label,
             "visible": visible,
             "value": value,
+            "background_color": background_color,
+            "text_color": text_color,
             "__type__": "update",
         }
         return IOComponent.add_interactive_to_config(updated_config, interactive)

--- a/ui/packages/app/src/components/Textbox/Textbox.svelte
+++ b/ui/packages/app/src/components/Textbox/Textbox.svelte
@@ -12,6 +12,8 @@
 	export let value: string = "";
 	export let lines: number;
 	export let placeholder: string = "";
+	export let background_color: string | null = null;
+	export let text_color: string | null = null;
 	export let form_position: "first" | "last" | "mid" | "single" = "single";
 	export let show_label: boolean;
 	export let max_lines: number | false;
@@ -39,6 +41,8 @@
 		{lines}
 		max_lines={!max_lines && mode === "static" ? lines + 1 : max_lines}
 		{placeholder}
+		{background_color}
+		{text_color}
 		on:change
 		on:submit
 		disabled={mode === "static"}

--- a/ui/packages/form/src/Textbox.svelte
+++ b/ui/packages/form/src/Textbox.svelte
@@ -7,6 +7,8 @@
 	export let style: Record<string, unknown> = {};
 	export let lines: number = 1;
 	export let placeholder: string = "Type here...";
+	export let background_color: string | null = null;
+	export let text_color: string | null = null;
 	export let label: string;
 	export let disabled = false;
 	export let show_label: boolean = true;
@@ -77,7 +79,22 @@
 		};
 	}
 
+	function get_additional_styles(background_color: string | null, text_color: string | null) {
+		let styles = "";
+
+		if (background_color) {
+			styles = `background-color: ${background_color};`;
+		}
+
+		if(text_color) {
+			styles = `${styles} color: ${text_color};`;
+		}
+
+		return styles;
+	}
+
 	$: ({ classes } = get_styles(style, ["rounded", "border"]));
+	$: additional_styles = get_additional_styles(background_color, text_color);
 </script>
 
 <!-- svelte-ignore a11y-label-has-associated-control -->
@@ -89,6 +106,7 @@
 			data-testid="textbox"
 			type="text"
 			class="scroll-hide block gr-box gr-input w-full gr-text-input {classes}"
+			style="{additional_styles}"
 			bind:value
 			bind:this={el}
 			{placeholder}
@@ -100,6 +118,7 @@
 			data-testid="textbox"
 			use:text_area_resize={value}
 			class="scroll-hide block gr-box gr-input w-full gr-text-input {classes}"
+			style="{additional_styles}"
 			bind:value
 			bind:this={el}
 			{placeholder}


### PR DESCRIPTION
# Description

Please include: 

This PR adds the ability to set a specific background-color and text-color in the Textbox component from the server side.

Still a draft PR since it is missing tests.

Closes: #1698 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
