### PR TITLE
Mark tests as flaky and run in separate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run:
           command: |
             . venv/bin/activate
-            coverage run -m pytest -m << parameters.test-type >>
+            coverage run -m pytest -m "<< parameters.test-type >>"
             coverage xml
       - codecov/upload:
           file: "coverage.xml"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,6 @@ orbs:
   codecov: codecov/codecov@3.2.2
   node: circleci/node@5.0.2
 
-workflows:
-  backend:
-    jobs:
-      - build:
-          matrix:
-            parameters:
-              test-type: ["not flaky", "flaky"]
-
-
 jobs:
   build:
     environment:
@@ -79,3 +70,11 @@ jobs:
           destination: screenshots
       - store_test_results:
           path: test-reports/
+
+workflows:
+  backend:
+    jobs:
+      - build:
+          matrix:
+            parameters:
+              test-type: ["not flaky", "flaky"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   node: circleci/node@5.0.2
 
 jobs:
-  build:
+  test:
     parameters:
       test-type:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@ orbs:
 
 jobs:
   build:
+    parameters:
+      test-type:
+        type: string
     environment:
       NODE_OPTIONS: --max-old-space-size=4096
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,16 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@3.2.2
   node: circleci/node@5.0.2
+
+workflows:
+  backend:
+    jobs:
+      - build:
+          matrix:
+            parameters:
+              test-type: ["not flaky", "flaky"]
+
+
 jobs:
   build:
     environment:
@@ -60,7 +70,7 @@ jobs:
       - run:
           command: |
             . venv/bin/activate
-            coverage run -m pytest
+            coverage run -m pytest -m <<<< parameters.test-type >>
             coverage xml
       - codecov/upload:
           file: "coverage.xml"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
 workflows:
   backend:
     jobs:
-      - build:
+      - test:
           matrix:
             parameters:
               test-type: ["not flaky", "flaky"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - run:
           command: |
             . venv/bin/activate
-            coverage run -m pytest -m <<<< parameters.test-type >>
+            coverage run -m pytest -m << parameters.test-type >>
             coverage xml
       - codecov/upload:
           file: "coverage.xml"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,4 @@
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "flaky: mark test as flaky. Failure will not cause te"
+    )

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -1,7 +1,7 @@
 import os
-import pathlib
 import unittest
 
+import pytest
 import transformers
 
 import gradio as gr
@@ -17,6 +17,9 @@ included in a separate file because of the above-mentioned dependency.
 """
 
 os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
+
+# Mark the whole module as flaky
+pytestmark = pytest.mark.flaky
 
 
 class TestLoadInterface(unittest.TestCase):

--- a/test/test_mix.py
+++ b/test/test_mix.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+import pytest
+
 import gradio as gr
 from gradio import mix
 from gradio.external import TooManyRequestsError
@@ -20,6 +22,7 @@ class TestSeries(unittest.TestCase):
         series = mix.Series(io1, io2)
         self.assertEqual(series.process(["Hello"]), ["Hello World!"])
 
+    @pytest.mark.flaky
     def test_with_external(self):
         io1 = gr.Interface.load("spaces/abidlabs/image-identity")
         io2 = gr.Interface.load("spaces/abidlabs/image-classifier")
@@ -50,6 +53,7 @@ class TestParallel(unittest.TestCase):
             parallel.process(["Hello"]), ["Hello", "HelloHello", "Hello World 2!"]
         )
 
+    @pytest.mark.flaky
     def test_with_external(self):
         io1 = gr.Interface.load("spaces/abidlabs/english_to_spanish")
         io2 = gr.Interface.load("spaces/abidlabs/english2german")


### PR DESCRIPTION
# Description

Mark flaky tests and run them in a separate job. My hope is that we make the "not flaky" tests as required. We should still look into failures in the flaky tests but not prevent people from merging because of them. 

Curious what people think. Certainly we can also make some modifications to `test_external.py` so that all exceptions are ignored but I think it's still valuable to run the tests in separate jobs. 


Tests properly selected:
![image](https://user-images.githubusercontent.com/41651716/178036197-7d1c6f0d-c748-41d4-9200-31785ed8ae77.png)

![image](https://user-images.githubusercontent.com/41651716/178036252-efbbfedf-564b-4c2e-bb7c-b6293a2ccfcb.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
