### PR TITLE
Add back component-specific info to docs

### DIFF
--- a/website/homepage/src/docs/template.html
+++ b/website/homepage/src/docs/template.html
@@ -95,7 +95,7 @@
             <img src="/assets/img/dataflow.svg" class="mt-4">
           </div>
           {% for component in docs["component"] %}
-            {% with obj=component, is_class=True, parent="gradio" %}
+            {% with obj=component, is_component=True, is_class=True, parent="gradio" %}
               {% include "docs/obj_doc_template.html" %}
             {% endwith %}
           {% endfor %}


### PR DESCRIPTION
# Description

I accidentally removed the component preprocessing/postprocessing, and supported events from the docs page in #1729 

![image](https://user-images.githubusercontent.com/41651716/178073249-8ad25a0d-531a-41c5-8f88-d5535a6cf6bc.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
