### PR TITLE
Fixes multiple people using `HuggingFaceDatasetSaver` simultaneously

### DIFF
--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -279,7 +279,7 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
     ) -> int:
         is_new = not os.path.exists(self.log_file)
         infos = {"flagged": {"features": {}}}
-        
+
         self.repo.git_pull(lfs=True)
 
         with open(self.log_file, "a", newline="") as csvfile:

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -277,10 +277,10 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
         flag_index: Optional[int] = None,
         username: Optional[str] = None,
     ) -> int:
+        self.repo.git_pull(lfs=True)
+        
         is_new = not os.path.exists(self.log_file)
         infos = {"flagged": {"features": {}}}
-
-        self.repo.git_pull(lfs=True)
 
         with open(self.log_file, "a", newline="") as csvfile:
             writer = csv.writer(csvfile)

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -278,7 +278,7 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
         username: Optional[str] = None,
     ) -> int:
         self.repo.git_pull(lfs=True)
-        
+
         is_new = not os.path.exists(self.log_file)
         infos = {"flagged": {"features": {}}}
 

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -279,6 +279,8 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
     ) -> int:
         is_new = not os.path.exists(self.log_file)
         infos = {"flagged": {"features": {}}}
+        
+        self.repo.git_pull(lfs=True)
 
         with open(self.log_file, "a", newline="") as csvfile:
             writer = csv.writer(csvfile)


### PR DESCRIPTION
If multiple people were simultaneously flagging a demo using `HuggingFaceDatasetSaver`, it would error out because we didn't pull the dataset repo before changing it and trying to push the changes. This fixes and that and closes: #1727 