### PR TITLE
Add data format expected for examples to Docs page

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -284,6 +284,7 @@ class Textbox(Changeable, Submittable, IOComponent):
     Creates a textarea for user to enter string input or display string output.
     Preprocessing: passes textarea value as a {str} into the function.
     Postprocessing: expects a {str} returned from function and sets textarea value to it.
+    Examples-format: {str} representing the textbox input.
 
     Demos: hello_world, diff_texts, sentence_builder
     """
@@ -480,7 +481,7 @@ class Number(Changeable, Submittable, IOComponent):
     Creates a numeric field for user to enter numbers as input or display numeric output.
     Preprocessing: passes field value as a {float} or {int} into the function, depending on `precision`.
     Postprocessing: expects an {int} or {float} returned from the function and sets field value to it.
-    Examples: Float or int representing value.
+    Examples-format: {float} or {int} representing value.
 
     Demos: tax_calculator, titanic_survival, blocks_simple_squares
     """
@@ -665,7 +666,7 @@ class Slider(Changeable, IOComponent):
     Creates a slider that ranges from `minimum` to `maximum` with a step size of `step`.
     Preprocessing: passes slider value as a {float} into the function.
     Postprocessing: expects an {int} or {float} returned from function and sets slider value to it as long as it is within range.
-    Examples: Float or int representing slider value.
+    Examples-format: {float} or {int} representing slider value.
 
     Demos: sentence_builder, generate_tone, titanic_survival
     """
@@ -828,7 +829,7 @@ class Checkbox(Changeable, IOComponent):
 
     Preprocessing: passes the status of the checkbox as a {bool} into the function.
     Postprocessing: expects a {bool} returned from the function and, if it is True, checks the checkbox.
-    Examples: Boolean representing whether box is checked.
+    Examples-format: {bool} representing whether box is checked.
     Demos: sentence_builder, titanic_survival
     """
 
@@ -951,7 +952,7 @@ class CheckboxGroup(Changeable, IOComponent):
     Creates a set of checkboxes of which a subset can be checked.
     Preprocessing: passes the list of checked checkboxes as a {List[str]} or their indices as a {List[int]} into the function, depending on `type`.
     Postprocessing: expects a {List[str]}, each element of which becomes a checked checkbox.
-    Examples: List of strings representing values to be checked.
+    Examples-format: {List[str]} representing values to be checked.
     Demos: sentence_builder, titanic_survival
     """
 
@@ -1122,7 +1123,7 @@ class Radio(Changeable, IOComponent):
     Creates a set of radio buttons of which only one can be selected.
     Preprocessing: passes the value of the selected radio button as a {str} or its index as an {int} into the function, depending on `type`.
     Postprocessing: expects a {str} corresponding to the value of the radio button to be selected.
-    Examples: String representing radio option to select.
+    Examples-format: {str} representing radio option to select.
 
     Demos: sentence_builder, titanic_survival, blocks_essay
     """
@@ -1274,7 +1275,7 @@ class Dropdown(Radio):
     Creates a dropdown of which only one entry can be selected.
     Preprocessing: passes the value of the selected dropdown entry as a {str} or its index as an {int} into the function, depending on `type`.
     Postprocessing: expects a {str} corresponding to the value of the dropdown entry to be selected.
-    Examples: String representing drop down value to select.
+    Examples-format: {str} representing drop down value to select.
     Demos: sentence_builder, titanic_survival
     """
 
@@ -1332,7 +1333,7 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent):
     Creates an image component that can be used to upload/draw images (as an input) or display images (as an output).
     Preprocessing: passes the uploaded image as a {numpy.array}, {PIL.Image} or {str} filepath depending on `type` -- unless `tool` is `sketch`. In the special case, a {dict} with keys `image` and `mask` is passed, and the format of the corresponding values depends on `type`.
     Postprocessing: expects a {numpy.array}, {PIL.Image} or {str} filepath to an image and displays the image.
-    Examples: Filepath of image.
+    Examples-format: {str} filepath to an image.
     Demos: image_mod
     """
 
@@ -1702,7 +1703,7 @@ class Video(Changeable, Clearable, Playable, IOComponent):
     Creates an video component that can be used to upload/record videos (as an input) or display videos (as an output).
     Preprocessing: passes the uploaded video as a {str} filepath whose extension can be set by `format`.
     Postprocessing: expects a {str} filepath to a video which is displayed.
-    Examples: Filepath of video.
+    Examples-format: {str) filepath to a video.
     Demos: video_identity
     """
 
@@ -1881,7 +1882,7 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent):
     Creates an audio component that can be used to upload/record audio (as an input) or display audio (as an output).
     Preprocessing: passes the uploaded audio as a {Tuple(int, numpy.array)} corresponding to (sample rate, data) or as a {str} filepath, depending on `type`
     Postprocessing: expects a {Tuple(int, numpy.array)} corresponding to (sample rate, data) or as a {str} filepath to an audio file, which gets displayed
-    Examples: Filepath of audio.
+    Examples-format: {str} filepath of audio.
     Demos: main_note, generate_tone, reverse_audio
     """
 
@@ -2202,7 +2203,7 @@ class File(Changeable, Clearable, IOComponent):
     Creates a file component that allows uploading generic file (when used as an input) and or displaying generic files (output).
     Preprocessing: passes the uploaded file as a {file-object} or {List[file-object]} depending on `file_count` (or a {bytes}/{List{bytes}} depending on `type`)
     Postprocessing: expects function to return a {str} path to a file, or {List[str]} consisting of paths to files.
-    Examples: Filepath.
+    Examples-format: {str} Filepath.
     Demos: zip_to_json, zip_two_files
     """
 
@@ -2647,7 +2648,7 @@ class Timeseries(Changeable, IOComponent):
     Creates a component that can be used to upload/preview timeseries csv files or display a dataframe consisting of a time series graphically.
     Preprocessing: passes the uploaded timeseries data as a {pandas.DataFrame} into the function
     Postprocessing: expects a {pandas.DataFrame} or {str} path to a csv to be returned, which is then displayed as a timeseries graph
-    Examples: Filepath of csv data with time series.
+    Examples-format: {str} Filepath of csv data with time series.
     Demos: fraud_detector
     """
 
@@ -2889,7 +2890,7 @@ class ColorPicker(Changeable, Submittable, IOComponent):
     Creates a color picker for user to select a color as string input.
     Preprocessing: passes selected color value as a {str} into the function.
     Postprocessing: expects a {str} returned from function and sets color picker value to it.
-    Examples: A string with a hexadecimal representation of a color.
+    Examples-format: {str} with a hexadecimal representation of a color.
     Demos: color_picker
     """
 

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -284,7 +284,7 @@ class Textbox(Changeable, Submittable, IOComponent):
     Creates a textarea for user to enter string input or display string output.
     Preprocessing: passes textarea value as a {str} into the function.
     Postprocessing: expects a {str} returned from function and sets textarea value to it.
-    Examples-format: {str} representing the textbox input.
+    Examples-format: a {str} representing the textbox input.
 
     Demos: hello_world, diff_texts, sentence_builder
     """
@@ -481,7 +481,7 @@ class Number(Changeable, Submittable, IOComponent):
     Creates a numeric field for user to enter numbers as input or display numeric output.
     Preprocessing: passes field value as a {float} or {int} into the function, depending on `precision`.
     Postprocessing: expects an {int} or {float} returned from the function and sets field value to it.
-    Examples-format: {float} or {int} representing value.
+    Examples-format: a {float} or {int} representing the number's value.
 
     Demos: tax_calculator, titanic_survival, blocks_simple_squares
     """
@@ -666,7 +666,7 @@ class Slider(Changeable, IOComponent):
     Creates a slider that ranges from `minimum` to `maximum` with a step size of `step`.
     Preprocessing: passes slider value as a {float} into the function.
     Postprocessing: expects an {int} or {float} returned from function and sets slider value to it as long as it is within range.
-    Examples-format: {float} or {int} representing slider value.
+    Examples-format: A {float} or {int} representing the slider's value.
 
     Demos: sentence_builder, generate_tone, titanic_survival
     """
@@ -829,7 +829,7 @@ class Checkbox(Changeable, IOComponent):
 
     Preprocessing: passes the status of the checkbox as a {bool} into the function.
     Postprocessing: expects a {bool} returned from the function and, if it is True, checks the checkbox.
-    Examples-format: {bool} representing whether box is checked.
+    Examples-format: a {bool} representing whether the box is checked.
     Demos: sentence_builder, titanic_survival
     """
 
@@ -952,7 +952,7 @@ class CheckboxGroup(Changeable, IOComponent):
     Creates a set of checkboxes of which a subset can be checked.
     Preprocessing: passes the list of checked checkboxes as a {List[str]} or their indices as a {List[int]} into the function, depending on `type`.
     Postprocessing: expects a {List[str]}, each element of which becomes a checked checkbox.
-    Examples-format: {List[str]} representing values to be checked.
+    Examples-format: a {List[str]} representing the values to be checked.
     Demos: sentence_builder, titanic_survival
     """
 
@@ -1123,7 +1123,7 @@ class Radio(Changeable, IOComponent):
     Creates a set of radio buttons of which only one can be selected.
     Preprocessing: passes the value of the selected radio button as a {str} or its index as an {int} into the function, depending on `type`.
     Postprocessing: expects a {str} corresponding to the value of the radio button to be selected.
-    Examples-format: {str} representing radio option to select.
+    Examples-format: a {str} representing the radio option to select.
 
     Demos: sentence_builder, titanic_survival, blocks_essay
     """
@@ -1275,7 +1275,7 @@ class Dropdown(Radio):
     Creates a dropdown of which only one entry can be selected.
     Preprocessing: passes the value of the selected dropdown entry as a {str} or its index as an {int} into the function, depending on `type`.
     Postprocessing: expects a {str} corresponding to the value of the dropdown entry to be selected.
-    Examples-format: {str} representing drop down value to select.
+    Examples-format: a {str} representing the drop down value to select.
     Demos: sentence_builder, titanic_survival
     """
 
@@ -1333,7 +1333,7 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent):
     Creates an image component that can be used to upload/draw images (as an input) or display images (as an output).
     Preprocessing: passes the uploaded image as a {numpy.array}, {PIL.Image} or {str} filepath depending on `type` -- unless `tool` is `sketch`. In the special case, a {dict} with keys `image` and `mask` is passed, and the format of the corresponding values depends on `type`.
     Postprocessing: expects a {numpy.array}, {PIL.Image} or {str} filepath to an image and displays the image.
-    Examples-format: {str} filepath to an image.
+    Examples-format: a {str} filepath to a local file that contains the image.
     Demos: image_mod
     """
 
@@ -1703,7 +1703,7 @@ class Video(Changeable, Clearable, Playable, IOComponent):
     Creates an video component that can be used to upload/record videos (as an input) or display videos (as an output).
     Preprocessing: passes the uploaded video as a {str} filepath whose extension can be set by `format`.
     Postprocessing: expects a {str} filepath to a video which is displayed.
-    Examples-format: {str) filepath to a video.
+    Examples-format: a {str} filepath to a local file that contains the video.
     Demos: video_identity
     """
 
@@ -1882,7 +1882,7 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent):
     Creates an audio component that can be used to upload/record audio (as an input) or display audio (as an output).
     Preprocessing: passes the uploaded audio as a {Tuple(int, numpy.array)} corresponding to (sample rate, data) or as a {str} filepath, depending on `type`
     Postprocessing: expects a {Tuple(int, numpy.array)} corresponding to (sample rate, data) or as a {str} filepath to an audio file, which gets displayed
-    Examples-format: {str} filepath of audio.
+    Examples-format: a {str} filepath to a local file that contains audio.
     Demos: main_note, generate_tone, reverse_audio
     """
 
@@ -2203,7 +2203,7 @@ class File(Changeable, Clearable, IOComponent):
     Creates a file component that allows uploading generic file (when used as an input) and or displaying generic files (output).
     Preprocessing: passes the uploaded file as a {file-object} or {List[file-object]} depending on `file_count` (or a {bytes}/{List{bytes}} depending on `type`)
     Postprocessing: expects function to return a {str} path to a file, or {List[str]} consisting of paths to files.
-    Examples-format: {str} Filepath.
+    Examples-format: a {str} path to a local file that populates the component.
     Demos: zip_to_json, zip_two_files
     """
 
@@ -2648,7 +2648,7 @@ class Timeseries(Changeable, IOComponent):
     Creates a component that can be used to upload/preview timeseries csv files or display a dataframe consisting of a time series graphically.
     Preprocessing: passes the uploaded timeseries data as a {pandas.DataFrame} into the function
     Postprocessing: expects a {pandas.DataFrame} or {str} path to a csv to be returned, which is then displayed as a timeseries graph
-    Examples-format: {str} Filepath of csv data with time series.
+    Examples-format: a {str} filepath of csv data with time series data.
     Demos: fraud_detector
     """
 
@@ -2890,7 +2890,7 @@ class ColorPicker(Changeable, Submittable, IOComponent):
     Creates a color picker for user to select a color as string input.
     Preprocessing: passes selected color value as a {str} into the function.
     Postprocessing: expects a {str} returned from function and sets color picker value to it.
-    Examples-format: {str} with a hexadecimal representation of a color.
+    Examples-format: a {str} with a hexadecimal representation of a color, e.g. "#ff0000" for red.
     Demos: color_picker
     """
 

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2647,7 +2647,7 @@ class Timeseries(Changeable, IOComponent):
     Creates a component that can be used to upload/preview timeseries csv files or display a dataframe consisting of a time series graphically.
     Preprocessing: passes the uploaded timeseries data as a {pandas.DataFrame} into the function
     Postprocessing: expects a {pandas.DataFrame} or {str} path to a csv to be returned, which is then displayed as a timeseries graph
-    Examples: Filepath of csv data with  time series.
+    Examples: Filepath of csv data with time series.
     Demos: fraud_detector
     """
 
@@ -2889,6 +2889,7 @@ class ColorPicker(Changeable, Submittable, IOComponent):
     Creates a color picker for user to select a color as string input.
     Preprocessing: passes selected color value as a {str} into the function.
     Postprocessing: expects a {str} returned from function and sets color picker value to it.
+    Examples: A string with a hexadecimal representation of a color.
     Demos: color_picker
     """
 

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -480,6 +480,7 @@ class Number(Changeable, Submittable, IOComponent):
     Creates a numeric field for user to enter numbers as input or display numeric output.
     Preprocessing: passes field value as a {float} or {int} into the function, depending on `precision`.
     Postprocessing: expects an {int} or {float} returned from the function and sets field value to it.
+    Examples: Float or int representing value.
 
     Demos: tax_calculator, titanic_survival, blocks_simple_squares
     """
@@ -664,6 +665,7 @@ class Slider(Changeable, IOComponent):
     Creates a slider that ranges from `minimum` to `maximum` with a step size of `step`.
     Preprocessing: passes slider value as a {float} into the function.
     Postprocessing: expects an {int} or {float} returned from function and sets slider value to it as long as it is within range.
+    Examples: Float or int representing slider value.
 
     Demos: sentence_builder, generate_tone, titanic_survival
     """
@@ -826,6 +828,7 @@ class Checkbox(Changeable, IOComponent):
 
     Preprocessing: passes the status of the checkbox as a {bool} into the function.
     Postprocessing: expects a {bool} returned from the function and, if it is True, checks the checkbox.
+    Examples: Boolean representing whether box is checked.
     Demos: sentence_builder, titanic_survival
     """
 
@@ -948,7 +951,7 @@ class CheckboxGroup(Changeable, IOComponent):
     Creates a set of checkboxes of which a subset can be checked.
     Preprocessing: passes the list of checked checkboxes as a {List[str]} or their indices as a {List[int]} into the function, depending on `type`.
     Postprocessing: expects a {List[str]}, each element of which becomes a checked checkbox.
-
+    Examples: List of strings representing values to be checked.
     Demos: sentence_builder, titanic_survival
     """
 
@@ -1119,6 +1122,7 @@ class Radio(Changeable, IOComponent):
     Creates a set of radio buttons of which only one can be selected.
     Preprocessing: passes the value of the selected radio button as a {str} or its index as an {int} into the function, depending on `type`.
     Postprocessing: expects a {str} corresponding to the value of the radio button to be selected.
+    Examples: String representing radio option to select.
 
     Demos: sentence_builder, titanic_survival, blocks_essay
     """
@@ -1270,7 +1274,7 @@ class Dropdown(Radio):
     Creates a dropdown of which only one entry can be selected.
     Preprocessing: passes the value of the selected dropdown entry as a {str} or its index as an {int} into the function, depending on `type`.
     Postprocessing: expects a {str} corresponding to the value of the dropdown entry to be selected.
-
+    Examples: String representing drop down value to select.
     Demos: sentence_builder, titanic_survival
     """
 
@@ -1328,7 +1332,7 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent):
     Creates an image component that can be used to upload/draw images (as an input) or display images (as an output).
     Preprocessing: passes the uploaded image as a {numpy.array}, {PIL.Image} or {str} filepath depending on `type` -- unless `tool` is `sketch`. In the special case, a {dict} with keys `image` and `mask` is passed, and the format of the corresponding values depends on `type`.
     Postprocessing: expects a {numpy.array}, {PIL.Image} or {str} filepath to an image and displays the image.
-
+    Examples: Filepath of image.
     Demos: image_mod
     """
 
@@ -1698,7 +1702,7 @@ class Video(Changeable, Clearable, Playable, IOComponent):
     Creates an video component that can be used to upload/record videos (as an input) or display videos (as an output).
     Preprocessing: passes the uploaded video as a {str} filepath whose extension can be set by `format`.
     Postprocessing: expects a {str} filepath to a video which is displayed.
-
+    Examples: Filepath of video.
     Demos: video_identity
     """
 
@@ -1877,7 +1881,7 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent):
     Creates an audio component that can be used to upload/record audio (as an input) or display audio (as an output).
     Preprocessing: passes the uploaded audio as a {Tuple(int, numpy.array)} corresponding to (sample rate, data) or as a {str} filepath, depending on `type`
     Postprocessing: expects a {Tuple(int, numpy.array)} corresponding to (sample rate, data) or as a {str} filepath to an audio file, which gets displayed
-
+    Examples: Filepath of audio.
     Demos: main_note, generate_tone, reverse_audio
     """
 
@@ -2198,7 +2202,7 @@ class File(Changeable, Clearable, IOComponent):
     Creates a file component that allows uploading generic file (when used as an input) and or displaying generic files (output).
     Preprocessing: passes the uploaded file as a {file-object} or {List[file-object]} depending on `file_count` (or a {bytes}/{List{bytes}} depending on `type`)
     Postprocessing: expects function to return a {str} path to a file, or {List[str]} consisting of paths to files.
-
+    Examples: Filepath.
     Demos: zip_to_json, zip_two_files
     """
 
@@ -2643,7 +2647,7 @@ class Timeseries(Changeable, IOComponent):
     Creates a component that can be used to upload/preview timeseries csv files or display a dataframe consisting of a time series graphically.
     Preprocessing: passes the uploaded timeseries data as a {pandas.DataFrame} into the function
     Postprocessing: expects a {pandas.DataFrame} or {str} path to a csv to be returned, which is then displayed as a timeseries graph
-
+    Examples: Filepath of csv data with  time series.
     Demos: fraud_detector
     """
 

--- a/website/homepage/src/docs/obj_doc_template.html
+++ b/website/homepage/src/docs/obj_doc_template.html
@@ -48,6 +48,9 @@
   {% if is_component %}
   <p class="mb-2 text-lg text-gray-500">As input, {{ obj["tags"]["preprocessing"] }}</p>
   <p class="mb-2 text-lg text-gray-500">As output, {{ obj["tags"]["postprocessing"] }}</p>
+  {% if "examples" in obj["tags"]  %}
+  <p class="text-lg text-gray-500">Format expected for examples: <em>{{ obj["tags"]["examples"] }}</em></p>
+  {% endif %}
   <p class="text-lg text-gray-500">Supported events: <em>{{ obj["events"] }}</em></p>
   {% endif %}
   

--- a/website/homepage/src/docs/obj_doc_template.html
+++ b/website/homepage/src/docs/obj_doc_template.html
@@ -49,7 +49,7 @@
   <p class="mb-2 text-lg text-gray-500">As input, {{ obj["tags"]["preprocessing"] }}</p>
   <p class="mb-2 text-lg text-gray-500">As output, {{ obj["tags"]["postprocessing"] }}</p>
   {% if "examples-format" in obj["tags"]  %}
-  <p class="text-lg text-gray-500">Format expected for examples: <em>{{ obj["tags"]["examples-format"] }}</em></p>
+  <p class="text-lg text-gray-500">Format expected for examples: {{ obj["tags"]["examples-format"] }}</p>
   {% endif %}
   <p class="text-lg text-gray-500">Supported events: <em>{{ obj["events"] }}</em></p>
   {% endif %}

--- a/website/homepage/src/docs/obj_doc_template.html
+++ b/website/homepage/src/docs/obj_doc_template.html
@@ -48,8 +48,8 @@
   {% if is_component %}
   <p class="mb-2 text-lg text-gray-500">As input, {{ obj["tags"]["preprocessing"] }}</p>
   <p class="mb-2 text-lg text-gray-500">As output, {{ obj["tags"]["postprocessing"] }}</p>
-  {% if "examples" in obj["tags"]  %}
-  <p class="text-lg text-gray-500">Format expected for examples: <em>{{ obj["tags"]["examples"] }}</em></p>
+  {% if "examples-format" in obj["tags"]  %}
+  <p class="text-lg text-gray-500">Format expected for examples: <em>{{ obj["tags"]["examples-format"] }}</em></p>
   {% endif %}
   <p class="text-lg text-gray-500">Supported events: <em>{{ obj["events"] }}</em></p>
   {% endif %}


### PR DESCRIPTION
# Description
Fixes #1737 

You'll see a "Format expected for examples" if the docstring has a line that starts with `Examples` 

![image](https://user-images.githubusercontent.com/41651716/178364200-edb42108-af24-4e10-89b6-ba5512ce6f40.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
