### PR TITLE
Remove example methods from docs

### DIFF
--- a/gradio/examples.py
+++ b/gradio/examples.py
@@ -21,7 +21,7 @@ CACHED_FOLDER = "gradio_cached_examples"
 set_documentation_group("component-helpers")
 
 
-@document("cache_interface_examples", "load_from_cache", "process_example")
+@document()
 class Examples:
     """
     This class is a wrapper over the Dataset component and can be used to create Examples


### PR DESCRIPTION
# Description

Removes public but not intended to be user facing methods from Examples docs

Closes: # (issue)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
