### PR TITLE
reuse port without waiting to leave TIME-WAIT state

### DIFF
--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -57,6 +57,7 @@ def get_first_available_port(initial: int, final: int) -> int:
     for port in range(initial, final):
         try:
             s = socket.socket()  # create a socket object
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.bind((LOCALHOST_NAME, port))  # Bind to the port
             s.close()
             return port

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -45,7 +45,7 @@ class Server(uvicorn.Server):
         self.thread.join()
 
 
-def get_first_available_port(initial: int, final: int) -> int:
+def get_first_available_port(initial: int, final: int, reuse_port: bool = False) -> int:
     """
     Gets the first open port in a specified range of port numbers
     Parameters:
@@ -57,7 +57,8 @@ def get_first_available_port(initial: int, final: int) -> int:
     for port in range(initial, final):
         try:
             s = socket.socket()  # create a socket object
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            if reuse_port:
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.bind((LOCALHOST_NAME, port))  # Bind to the port
             s.close()
             return port

--- a/gradio/reload.py
+++ b/gradio/reload.py
@@ -34,6 +34,7 @@ def run_in_reload_mode():
     port = networking.get_first_available_port(
         networking.INITIAL_PORT_VALUE,
         networking.INITIAL_PORT_VALUE + networking.TRY_NUM_PORTS,
+        True,
     )
     print(
         f"\nLaunching in *reload mode* on: http://{networking.LOCALHOST_NAME}:{port} (Press CTRL+C to quit)\n"


### PR DESCRIPTION
If you close and restart a gradio app, it won't reuse the expected port because the endpoint is in the `TIME_WAIT` state. 

This is a state that basically exists to remove ambiguity because there could still be packages sent back over the network intended for what is now a dead connection (just how TCP works). Typically, this state lasts quite a while, 60-120 seconds which is why there needs to be such a large delay between hitting the server, killing the server, and restarting the on the same port.

We can reuse the port by setting the socket options. That is what this PR does.