### PR TITLE
Run all demos in website, not just components

### DIFF
--- a/gradio/inputs.py
+++ b/gradio/inputs.py
@@ -42,7 +42,6 @@ class Number(components.Number):
     """
     Component creates a field for user to enter numeric input. Provides a number as an argument to the wrapped function.
     Input type: float
-    Demos: tax_calculator, titanic_survival
     """
 
     def __init__(
@@ -68,7 +67,6 @@ class Slider(components.Slider):
     """
     Component creates a slider that ranges from `minimum` to `maximum`. Provides number as an argument to the wrapped function.
     Input type: float
-    Demos: sentence_builder, generate_tone, titanic_survival
     """
 
     def __init__(
@@ -108,7 +106,6 @@ class Checkbox(components.Checkbox):
     """
     Component creates a checkbox that can be set to `True` or `False`. Provides a boolean as an argument to the wrapped function.
     Input type: bool
-    Demos: sentence_builder, titanic_survival
     """
 
     def __init__(
@@ -134,7 +131,6 @@ class CheckboxGroup(components.CheckboxGroup):
     """
     Component creates a set of checkboxes of which a subset can be selected. Provides a list of strings representing the selected choices as an argument to the wrapped function.
     Input type: Union[List[str], List[int]]
-    Demos: sentence_builder, titanic_survival, fraud_detector
     """
 
     def __init__(
@@ -170,7 +166,6 @@ class Radio(components.Radio):
     """
     Component creates a set of radio buttons of which only one can be selected. Provides string representing selected choice as an argument to the wrapped function.
     Input type: Union[str, int]
-    Demos: sentence_builder, tax_calculator, titanic_survival
     """
 
     def __init__(
@@ -206,7 +201,6 @@ class Dropdown(components.Dropdown):
     """
     Component creates a dropdown of which only one can be selected. Provides string representing selected choice as an argument to the wrapped function.
     Input type: Union[str, int]
-    Demos: sentence_builder, filter_records, titanic_survival
     """
 
     def __init__(
@@ -242,7 +236,6 @@ class Image(components.Image):
     """
     Component creates an image upload box with editing capabilities.
     Input type: Union[numpy.array, PIL.Image, file-object]
-    Demos: image_classifier, image_mod, webcam, digit_classifier
     """
 
     def __init__(
@@ -288,7 +281,6 @@ class Video(components.Video):
     Component creates a video file upload that is converted to a file path.
 
     Input type: filepath
-    Demos: video_flip
     """
 
     def __init__(
@@ -316,7 +308,6 @@ class Audio(components.Audio):
     """
     Component accepts audio input files.
     Input type: Union[Tuple[int, numpy.array], file-object, numpy.array]
-    Demos: main_note, reverse_audio, spectogram
     """
 
     def __init__(
@@ -344,7 +335,6 @@ class File(components.File):
     """
     Component accepts generic file uploads.
     Input type: Union[file-object, bytes, List[Union[file-object, bytes]]]
-    Demos: zip_to_json, zip_two_files
     """
 
     def __init__(
@@ -380,7 +370,6 @@ class Dataframe(components.Dataframe):
     """
     Component accepts 2D input through a spreadsheet interface.
     Input type: Union[pandas.DataFrame, numpy.array, List[Union[str, float]], List[List[Union[str, float]]]]
-    Demos: filter_records, matrix_transpose, tax_calculator
     """
 
     def __init__(
@@ -428,7 +417,6 @@ class Timeseries(components.Timeseries):
     """
     Component accepts pandas.DataFrame uploaded as a timeseries csv file.
     Input type: pandas.DataFrame
-    Demos: fraud_detector
     """
 
     def __init__(
@@ -456,7 +444,6 @@ class State(components.Variable):
     """
     Special hidden component that stores state across runs of the interface.
     Input type: Any
-    Demos: chatbot
     """
 
     def __init__(
@@ -481,7 +468,6 @@ class Image3D(components.Model3D):
     """
     Used for 3D image model output.
     Input type: File object of type (.obj, glb, or .gltf)
-    Demos: Image3D
     """
 
     def __init__(

--- a/gradio/outputs.py
+++ b/gradio/outputs.py
@@ -29,7 +29,6 @@ class Image(components.Image):
     """
     Component displays an output image.
     Output type: Union[numpy.array, PIL.Image, str, matplotlib.pyplot, Tuple[Union[numpy.array, PIL.Image, str], List[Tuple[str, float, float, float, float]]]]
-    Demos: image_mod, webcam
     """
 
     def __init__(
@@ -54,7 +53,6 @@ class Video(components.Video):
     """
     Used for video output.
     Output type: filepath
-    Demos: video_flip
     """
 
     def __init__(self, type: Optional[str] = None, label: Optional[str] = None):
@@ -74,7 +72,6 @@ class Audio(components.Audio):
     """
     Creates an audio player that plays the output audio.
     Output type: Union[Tuple[int, numpy.array], str]
-    Demos: generate_tone, reverse_audio
     """
 
     def __init__(self, type: str = "auto", label: Optional[str] = None):
@@ -94,7 +91,6 @@ class File(components.File):
     """
     Used for file output.
     Output type: Union[file-like, str]
-    Demos: zip_two_files
     """
 
     def __init__(self, label: Optional[str] = None):
@@ -113,7 +109,6 @@ class Dataframe(components.Dataframe):
     """
     Component displays 2D output through a spreadsheet interface.
     Output type: Union[pandas.DataFrame, numpy.array, List[Union[str, float]], List[List[Union[str, float]]]]
-    Demos: filter_records, matrix_transpose, fraud_detector
     """
 
     def __init__(
@@ -152,7 +147,6 @@ class Timeseries(components.Timeseries):
     """
     Component accepts pandas.DataFrame.
     Output type: pandas.DataFrame
-    Demos: fraud_detector
     """
 
     def __init__(
@@ -175,7 +169,6 @@ class State(components.Variable):
     """
     Special hidden component that stores state across runs of the interface.
     Output type: Any
-    Demos: chatbot
     """
 
     def __init__(self, label: Optional[str] = None):
@@ -194,7 +187,6 @@ class Label(components.Label):
     """
     Component outputs a classification label, along with confidence scores of top categories if provided. Confidence scores are represented as a dictionary mapping labels to scores between 0 and 1.
     Output type: Union[Dict[str, float], str, int, float]
-    Demos: image_classifier, main_note, titanic_survival
     """
 
     def __init__(
@@ -220,7 +212,6 @@ class KeyValues:
     """
     Component displays a table representing values for multiple fields.
     Output type: Union[Dict, List[Tuple[str, Union[str, int, float]]]]
-    Demos: text_analysis
     """
 
     def __init__(self, value: str = " ", *, label: Optional[str] = None, **kwargs):
@@ -240,7 +231,6 @@ class HighlightedText(components.HighlightedText):
     Component creates text that contains spans that are highlighted by category or numerical value.
     Output is represent as a list of Tuple pairs, where the first element represents the span of text represented by the tuple, and the second element represents the category or value of the text.
     Output type: List[Tuple[str, Union[float, str]]]
-    Demos: diff_texts, text_analysis
     """
 
     def __init__(
@@ -266,7 +256,6 @@ class JSON(components.JSON):
     """
     Used for JSON output. Expects a JSON string or a Python object that is JSON serializable.
     Output type: Union[str, Any]
-    Demos: zip_to_json
     """
 
     def __init__(self, label: Optional[str] = None):
@@ -285,7 +274,6 @@ class HTML(components.HTML):
     """
     Used for HTML output. Expects an HTML valid string.
     Output type: str
-    Demos: text_analysis
     """
 
     def __init__(self, label: Optional[str] = None):
@@ -299,7 +287,6 @@ class HTML(components.HTML):
 class Carousel(components.Carousel):
     """
     Component displays a set of output components that can be scrolled through.
-    Output type: List[List[Any]]
     """
 
     def __init__(
@@ -323,7 +310,6 @@ class Chatbot(components.Chatbot):
     """
     Component displays a chatbot output showing both user submitted messages and responses
     Output type: List[Tuple[str, str]]
-    Demos: chatbot
     """
 
     def __init__(self, label: Optional[str] = None):
@@ -342,7 +328,6 @@ class Image3D(components.Model3D):
     """
     Used for 3D image model output.
     Input type: File object of type (.obj, glb, or .gltf)
-    Demos: Image3D
     """
 
     def __init__(

--- a/website/demos/map_demos.py
+++ b/website/demos/map_demos.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 import sys
+import pathlib
 
 from jinja2 import Template
 
@@ -13,11 +14,16 @@ sys.path.insert(0, GRADIO_DEMO_DIR)
 port = 7860
 
 demos_to_run = []
-GRADIO_COMPONENTS_FILE = os.path.join(GRADIO_DIR, "gradio", "components.py")
-with open(GRADIO_COMPONENTS_FILE) as comp_file:
-    comp_text = comp_file.read()
-for demostr in re.findall(r'Demos:(.*)', comp_text):
-  demos_to_run += re.findall(r'([a-zA-Z0-9_]+)', demostr)
+for root, _, files in os.walk(pathlib.Path(GRADIO_DIR) / "gradio"):
+    for filename in files:
+        source_file = pathlib.Path(root) / filename
+        if source_file.suffix != ".py":
+            continue
+        with open(source_file, "r") as comp_file:
+            comp_text = comp_file.read()
+        for demostr in re.findall(r'Demos:(.*)', comp_text):
+            demos_to_run += re.findall(r'([a-zA-Z0-9_]+)', demostr)
+
 DEMO_PATTERN = r'\$demo_([A-Za-z0-9_]+)'
 for guide_filename in os.listdir(GRADIO_GUIDES_DIR):
     if not os.path.isfile(os.path.join(GRADIO_GUIDES_DIR, guide_filename)):


### PR DESCRIPTION
# Description

This PR makes it so that all demos tagged in docstrings are run on the website. Previously, we only ran demos for components if they were not listed in the guides. As we add more apis to our docs I think it will be important to automatically run the demos beyond just the components.

### Screenshot of demos run prior to this change
![Screen Shot 2022-07-12 at 12 11 51 PM](https://user-images.githubusercontent.com/41651716/178548072-a30655f5-c095-4074-93d0-ff635c879710.png)

### Screenshot of demos after this change
Note that `interface_series` and `interface_parallel` are now in the list

![image](https://user-images.githubusercontent.com/41651716/178548565-6879da35-dc0f-4db3-8b17-3bebb6632dba.png)



# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
