### PR TITLE
`integrate()` method moved to `Blocks`

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -13,7 +13,6 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, AnyStr, Callable, Dict, List, Optional, Tuple
 
 import anyio
-import comet_ml
 from anyio import CapacityLimiter
 
 from gradio import encryptor, external, networking, queueing, routes, strings, utils
@@ -25,10 +24,12 @@ from gradio.utils import component_or_layout_class, delete_none
 set_documentation_group("blocks")
 
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
+    import comet_ml
+    import mlflow
+    import wandb
     from fastapi.applications import FastAPI
 
     from gradio.components import Component, StatusTracker
-    from gradio.routes import PredictBody
 
 
 class Block:
@@ -923,15 +924,11 @@ class Blocks(BlockContext):
         mlflow: ModuleType("mlflow") = None,
     ) -> None:
         """
-        A catch-all method for integrating with other libraries.
-        This method should be run after launch()
+        A catch-all method for integrating with other libraries. This method should be run after launch()
         Parameters:
-            comet_ml: If a comet_ml Experiment object is provided,
-            will integrate with the experiment and appear on Comet dashboard
-            wandb: If the wandb module is provided, will integrate
-            with it and appear on WandB dashboard
-            mlflow: If the mlflow module  is provided, will integrate
-            with the experiment and appear on ML Flow dashboard
+            comet_ml: If a comet_ml Experiment object is provided, will integrate with the experiment and appear on Comet dashboard
+            wandb: If the wandb module is provided, will integrate with it and appear on WandB dashboard
+            mlflow: If the mlflow module  is provided, will integrate with the experiment and appear on ML Flow dashboard
         """
         analytics_integration = ""
         if comet_ml is not None:

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -286,7 +286,10 @@ class Blocks(BlockContext):
         self.mode = mode
 
         self.is_running = False
+        self.local_url = None
         self.share_url = None
+        self.width = None
+        self.height = None
 
         self.ip_address = utils.get_local_ip_address()
         self.is_space = True if os.getenv("SYSTEM") == "spaces" else False

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -9,9 +9,11 @@ import random
 import sys
 import time
 import webbrowser
+from types import ModuleType
 from typing import TYPE_CHECKING, Any, AnyStr, Callable, Dict, List, Optional, Tuple
 
 import anyio
+import comet_ml
 from anyio import CapacityLimiter
 
 from gradio import encryptor, external, networking, queueing, routes, strings, utils
@@ -914,16 +916,21 @@ class Blocks(BlockContext):
 
         return self.server_app, self.local_url, self.share_url
 
-    def integrate(self, comet_ml=None, wandb=None, mlflow=None) -> None:
+    def integrate(
+        self,
+        comet_ml: comet_ml.Experiment = None,
+        wandb: ModuleType("wandb") = None,
+        mlflow: ModuleType("mlflow") = None,
+    ) -> None:
         """
         A catch-all method for integrating with other libraries.
-        Should be run after launch()
+        This method should be run after launch()
         Parameters:
-            comet_ml (Experiment): If a comet_ml Experiment object is provided,
+            comet_ml: If a comet_ml Experiment object is provided,
             will integrate with the experiment and appear on Comet dashboard
-            wandb (module): If the wandb module is provided, will integrate
+            wandb: If the wandb module is provided, will integrate
             with it and appear on WandB dashboard
-            mlflow (module): If the mlflow module  is provided, will integrate
+            mlflow: If the mlflow module  is provided, will integrate
             with the experiment and appear on ML Flow dashboard
         """
         analytics_integration = ""

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import copy
 import getpass
 import inspect

--- a/gradio/documentation.py
+++ b/gradio/documentation.py
@@ -12,6 +12,15 @@ def set_documentation_group(m):
 
 
 def document(*fns):
+    """
+    Defines the @document decorator which adds classes or functions to the Gradio
+    documentation at www.gradio.app/docs.
+
+    Usage examples:
+    - Put @document() above a class to document the class and its constructor.
+    - Put @document(fn1, fn2) above a class to also document the class methods fn1 and fn2.
+    """
+
     def inner_doc(cls):
         global documentation_group
         classes_to_document[documentation_group].append((cls, fns))

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -5,12 +5,9 @@ including various methods for constructing an interface and then launching it.
 
 from __future__ import annotations
 
-import copy
-import csv
 import inspect
 import json
 import os
-import random
 import re
 import warnings
 import weakref
@@ -721,59 +718,6 @@ class Interface(Blocks):
         else:
             self.process(raw_input)
             print("PASSED")
-
-    def integrate(self, comet_ml=None, wandb=None, mlflow=None) -> None:
-        """
-        A catch-all method for integrating with other libraries.
-        Should be run after launch()
-        Parameters:
-            comet_ml (Experiment): If a comet_ml Experiment object is provided,
-            will integrate with the experiment and appear on Comet dashboard
-            wandb (module): If the wandb module is provided, will integrate
-            with it and appear on WandB dashboard
-            mlflow (module): If the mlflow module  is provided, will integrate
-            with the experiment and appear on ML Flow dashboard
-        """
-        analytics_integration = ""
-        if comet_ml is not None:
-            analytics_integration = "CometML"
-            comet_ml.log_other("Created from", "Gradio")
-            if self.share_url is not None:
-                comet_ml.log_text("gradio: " + self.share_url)
-                comet_ml.end()
-            else:
-                comet_ml.log_text("gradio: " + self.local_url)
-                comet_ml.end()
-        if wandb is not None:
-            analytics_integration = "WandB"
-            if self.share_url is not None:
-                wandb.log(
-                    {
-                        "Gradio panel": wandb.Html(
-                            '<iframe src="'
-                            + self.share_url
-                            + '" width="'
-                            + str(self.width)
-                            + '" height="'
-                            + str(self.height)
-                            + '" frameBorder="0"></iframe>'
-                        )
-                    }
-                )
-            else:
-                print(
-                    "The WandB integration requires you to "
-                    "`launch(share=True)` first."
-                )
-        if mlflow is not None:
-            analytics_integration = "MLFlow"
-            if self.share_url is not None:
-                mlflow.log_param("Gradio Interface Share Link", self.share_url)
-            else:
-                mlflow.log_param("Gradio Interface Local Link", self.local_url)
-        if self.analytics_enabled and analytics_integration:
-            data = {"integration": analytics_integration}
-            utils.integration_analytics(data)
 
 
 @document()

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
     import transformers
 
 
-@document("launch", "load", "from_pipeline")
+@document("launch", "load", "from_pipeline", "integrate")
 class Interface(Blocks):
     """
     The Interface class is a high-level abstraction that allows you to create a

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -169,10 +169,10 @@ class TestBlocks(unittest.TestCase):
                 
         demo.launch(prevent_thread_lock=True)
         demo.integrate(comet_ml=experiment)
-        experiment.log_text.assert_called_with("gradio: " + interface.local_url)
+        experiment.log_text.assert_called_with("gradio: " + demo.local_url)
         demo.share_url = "tmp"  # used to avoid creating real share links.
         demo.integrate(comet_ml=experiment)
-        experiment.log_text.assert_called_with("gradio: " + interface.share_url)
+        experiment.log_text.assert_called_with("gradio: " + demo.share_url)
         self.assertEqual(experiment.log_other.call_count, 2)
         demo.share_url = None
         demo.close()

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 import wandb
+import mlflow
 
 import gradio as gr
 from gradio.routes import PredictBody
@@ -155,6 +156,46 @@ class TestBlocks(unittest.TestCase):
             demo.share_url = "tmp"
             demo.integrate(wandb=wandb)
             wandb.log.assert_called_once()
+            
+    @mock.patch("comet_ml.Experiment")
+    def test_integration_comet(self, mock_experiment):
+        experiment = mock_experiment()
+        experiment.log_text = mock.MagicMock()
+        experiment.log_other = mock.MagicMock()
+
+        demo = gr.Blocks()
+        with demo:
+            gr.Textbox("Hi there!")
+                
+        demo.launch(prevent_thread_lock=True)
+        demo.integrate(comet_ml=experiment)
+        experiment.log_text.assert_called_with("gradio: " + interface.local_url)
+        demo.share_url = "tmp"  # used to avoid creating real share links.
+        demo.integrate(comet_ml=experiment)
+        experiment.log_text.assert_called_with("gradio: " + interface.share_url)
+        self.assertEqual(experiment.log_other.call_count, 2)
+        demo.share_url = None
+        demo.close()
+
+    def test_integration_mlflow(self):
+        mlflow.log_param = mock.MagicMock()
+        demo = gr.Blocks()
+        with demo:
+            gr.Textbox("Hi there!")
+        
+        demo.launch(prevent_thread_lock=True)
+        demo.integrate(mlflow=mlflow)
+        mlflow.log_param.assert_called_with(
+            "Gradio Interface Local Link", demo.local_url
+        )
+        demo.share_url = "tmp"  # used to avoid creating real share links.
+        demo.integrate(mlflow=mlflow)
+        mlflow.log_param.assert_called_with(
+            "Gradio Interface Share Link", demo.share_url
+        )
+        demo.share_url = None
+        demo.close()
+            
 
 
 if __name__ == "__main__":

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1,12 +1,12 @@
 import asyncio
 import io
-import sys
 import random
+import sys
 import time
 import unittest
-from unittest.mock import patch
 import unittest.mock as mock
 from contextlib import contextmanager
+from unittest.mock import patch
 
 import pytest
 import wandb
@@ -138,7 +138,7 @@ class TestBlocks(unittest.TestCase):
             difference = end - start
             assert difference >= 0.01
             assert result
-            
+
     def test_integration_wandb(self):
         with captured_output() as (out, err):
             wandb.log = mock.MagicMock()
@@ -155,7 +155,6 @@ class TestBlocks(unittest.TestCase):
             demo.share_url = "tmp"
             demo.integrate(wandb=wandb)
             wandb.log.assert_called_once()
-            
 
 
 if __name__ == "__main__":

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -8,9 +8,9 @@ import unittest.mock as mock
 from contextlib import contextmanager
 from unittest.mock import patch
 
+import mlflow
 import pytest
 import wandb
-import mlflow
 
 import gradio as gr
 from gradio.routes import PredictBody
@@ -156,7 +156,7 @@ class TestBlocks(unittest.TestCase):
             demo.share_url = "tmp"
             demo.integrate(wandb=wandb)
             wandb.log.assert_called_once()
-            
+
     @mock.patch("comet_ml.Experiment")
     def test_integration_comet(self, mock_experiment):
         experiment = mock_experiment()
@@ -166,7 +166,7 @@ class TestBlocks(unittest.TestCase):
         demo = gr.Blocks()
         with demo:
             gr.Textbox("Hi there!")
-                
+
         demo.launch(prevent_thread_lock=True)
         demo.integrate(comet_ml=experiment)
         experiment.log_text.assert_called_with("gradio: " + demo.local_url)
@@ -182,7 +182,7 @@ class TestBlocks(unittest.TestCase):
         demo = gr.Blocks()
         with demo:
             gr.Textbox("Hi there!")
-        
+
         demo.launch(prevent_thread_lock=True)
         demo.integrate(mlflow=mlflow)
         mlflow.log_param.assert_called_with(
@@ -195,7 +195,6 @@ class TestBlocks(unittest.TestCase):
         )
         demo.share_url = None
         demo.close()
-            
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As pointed out by @AK391, we currently only support integrating with 3rd party libraries (e.g. W&B or Comet) for `Interface` and not for `Blocks`. This PR moves the `integrate()` method to `Blocks` and adds a quick test to confirm that it is working as expected.