### PR TITLE
Raise warning when using gr.inputs or gr.outputs

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -1448,7 +1448,6 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent):
             if self.type == "file":
                 warnings.warn(
                     "The 'file' type has been deprecated. Set parameter 'type' to 'filepath' instead.",
-                    DeprecationWarning,
                 )
                 return file_obj
             else:
@@ -1996,7 +1995,6 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent):
         if self.type == "file":
             warnings.warn(
                 "The 'file' type has been deprecated. Set parameter 'type' to 'filepath' instead.",
-                DeprecationWarning,
             )
             return file_obj
         elif self.type == "filepath":
@@ -2018,7 +2016,6 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent):
         elif self.type == "file":
             warnings.warn(
                 "The 'file' type has been deprecated. Set parameter 'type' to 'filepath' instead.",
-                DeprecationWarning,
             )
             name = x.name
         elif self.type == "numpy":
@@ -3177,7 +3174,6 @@ class HighlightedText(Changeable, IOComponent):
         if color_map is not None:
             warnings.warn(
                 "The 'color_map' parameter has been moved from the constructor to `HighlightedText.style()` ",
-                DeprecationWarning,
             )
         self.show_legend = show_legend
         self.combine_adjacent = combine_adjacent
@@ -3546,7 +3542,6 @@ class Carousel(IOComponent, Changeable):
         """
         warnings.warn(
             "The Carousel component is partially deprecated. It may not behave as expected.",
-            DeprecationWarning,
         )
         if not isinstance(components, list):
             components = [components]
@@ -3659,7 +3654,6 @@ class Chatbot(Changeable, IOComponent):
         if color_map is not None:
             warnings.warn(
                 "The 'color_map' parameter has been moved from the constructor to `Chatbot.style()` ",
-                DeprecationWarning,
             )
 
         self.value = self.postprocess(value)

--- a/gradio/inputs.py
+++ b/gradio/inputs.py
@@ -25,7 +25,6 @@ class Textbox(components.Textbox):
     ):
         warnings.warn(
             "Usage of gradio.inputs is deprecated, and will not be supported in the future, please import your component from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(
             value=default,
@@ -58,7 +57,6 @@ class Number(components.Number):
         """
         warnings.warn(
             "Usage of gradio.inputs is deprecated, and will not be supported in the future, please import your component from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(value=default, label=label, optional=optional)
 
@@ -89,7 +87,6 @@ class Slider(components.Slider):
         """
         warnings.warn(
             "Usage of gradio.inputs is deprecated, and will not be supported in the future, please import your component from gradio.components",
-            DeprecationWarning,
         )
 
         super().__init__(
@@ -122,7 +119,6 @@ class Checkbox(components.Checkbox):
         """
         warnings.warn(
             "Usage of gradio.inputs is deprecated, and will not be supported in the future, please import your component from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(value=default, label=label, optional=optional)
 
@@ -151,7 +147,6 @@ class CheckboxGroup(components.CheckboxGroup):
         """
         warnings.warn(
             "Usage of gradio.inputs is deprecated, and will not be supported in the future, please import your component from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(
             value=default,
@@ -186,7 +181,6 @@ class Radio(components.Radio):
         """
         warnings.warn(
             "Usage of gradio.inputs is deprecated, and will not be supported in the future, please import your component from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(
             choices=choices,
@@ -221,7 +215,6 @@ class Dropdown(components.Dropdown):
         """
         warnings.warn(
             "Usage of gradio.inputs is deprecated, and will not be supported in the future, please import your component from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(
             choices=choices,
@@ -262,7 +255,6 @@ class Image(components.Image):
         """
         warnings.warn(
             "Usage of gradio.inputs is deprecated, and will not be supported in the future, please import your component from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(
             shape=shape,
@@ -299,7 +291,6 @@ class Video(components.Video):
         """
         warnings.warn(
             "Usage of gradio.inputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(format=type, source=source, label=label, optional=optional)
 
@@ -326,7 +317,6 @@ class Audio(components.Audio):
         """
         warnings.warn(
             "Usage of gradio.inputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(source=source, type=type, label=label, optional=optional)
 
@@ -355,7 +345,6 @@ class File(components.File):
         """
         warnings.warn(
             "Usage of gradio.inputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(
             file_count=file_count,
@@ -398,7 +387,6 @@ class Dataframe(components.Dataframe):
         """
         warnings.warn(
             "Usage of gradio.inputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(
             value=default,
@@ -435,7 +423,6 @@ class Timeseries(components.Timeseries):
         """
         warnings.warn(
             "Usage of gradio.inputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(x=x, y=y, label=label, optional=optional)
 
@@ -459,7 +446,6 @@ class State(components.Variable):
         """
         warnings.warn(
             "Usage of gradio.inputs is deprecated, and will not be supported in the future, please import this component as gr.Variable from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(value=default, label=label)
 
@@ -482,6 +468,5 @@ class Image3D(components.Model3D):
         """
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(label=label, optional=optional)

--- a/gradio/outputs.py
+++ b/gradio/outputs.py
@@ -20,7 +20,6 @@ class Textbox(components.Textbox):
     ):
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(label=label, type=type)
 
@@ -42,7 +41,6 @@ class Image(components.Image):
         """
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         if plot:
             type = "plot"
@@ -63,7 +61,6 @@ class Video(components.Video):
         """
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(format=type, label=label)
 
@@ -82,7 +79,6 @@ class Audio(components.Audio):
         """
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(type=type, label=label)
 
@@ -100,7 +96,6 @@ class File(components.File):
         """
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(label=label)
 
@@ -131,7 +126,6 @@ class Dataframe(components.Dataframe):
         """
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(
             headers=headers,
@@ -160,7 +154,6 @@ class Timeseries(components.Timeseries):
         """
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(x=x, y=y, label=label)
 
@@ -178,7 +171,6 @@ class State(components.Variable):
         """
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(label=label)
 
@@ -203,7 +195,6 @@ class Label(components.Label):
         """
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(num_top_classes=num_top_classes, type=type, label=label)
 
@@ -247,7 +238,6 @@ class HighlightedText(components.HighlightedText):
         """
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(color_map=color_map, label=label, show_legend=show_legend)
 
@@ -265,7 +255,6 @@ class JSON(components.JSON):
         """
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(label=label)
 
@@ -301,7 +290,6 @@ class Carousel(components.Carousel):
         """
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(components=components, label=label)
 
@@ -319,7 +307,6 @@ class Chatbot(components.Chatbot):
         """
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(label=label)
 
@@ -342,6 +329,5 @@ class Image3D(components.Model3D):
         """
         warnings.warn(
             "Usage of gradio.outputs is deprecated, and will not be supported in the future, please import your components from gradio.components",
-            DeprecationWarning,
         )
         super().__init__(clear_color=clear_color, label=label)

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -4,12 +4,12 @@ import tempfile
 import unittest
 from copy import deepcopy
 from difflib import SequenceMatcher
-import pytest
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import PIL
+import pytest
 
 import gradio as gr
 from gradio import media_data
@@ -32,8 +32,9 @@ class TestComponent(unittest.TestCase):
 
 
 def test_raise_warnings():
-    for c_type, component in zip(["inputs"] * 2 + ["outputs"] * 2,
-                                 [gr.inputs.Textbox, gr.inputs.Video, gr.outputs.Label, gr.outputs.Image]):
+    for c_type, component in zip(
+        ["inputs", "outputs"], [gr.inputs.Textbox, gr.outputs.Label]
+    ):
         with pytest.warns(UserWarning, match=f"Usage of gradio.{c_type}"):
             component()
 

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from copy import deepcopy
 from difflib import SequenceMatcher
+import pytest
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -28,6 +29,13 @@ class TestComponent(unittest.TestCase):
         component
         """
         assert isinstance(gr.components.component("text"), gr.templates.Text)
+
+
+def test_raise_warnings():
+    for c_type, component in zip(["inputs"] * 2 + ["outputs"] * 2,
+                                 [gr.inputs.Textbox, gr.inputs.Video, gr.outputs.Label, gr.outputs.Image]):
+        with pytest.warns(UserWarning, match=f"Usage of gradio.{c_type}"):
+            component()
 
 
 class TestTextbox(unittest.TestCase):

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -812,7 +812,7 @@ class TestAudio(unittest.TestCase):
         x_wav["is_example"] = True
         x_wav["crop_min"], x_wav["crop_max"] = 1, 4
         self.assertIsNotNone(audio_input.preprocess(x_wav))
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarns(UserWarning):
             audio_input = gr.Audio(type="file")
             audio_input.preprocess(x_wav)
             with open("test/test_files/audio_sample.wav") as f:


### PR DESCRIPTION
# Description

Fixes #1778

Raising a `UserWarning` instead because the default warnings filter filters out deprecation warnings lol

https://docs.python.org/3/library/warnings.html#default-warning-filter

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
