### PR TITLE
Fix missing TypedDict on python 3.7

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -12,11 +12,17 @@ import operator
 import os
 import pathlib
 import shutil
+import sys
 import tempfile
 import warnings
 from copy import deepcopy
 from types import ModuleType
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+if sys.version_info[0] == 3 and sys.version_info[1] >= 8:
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 import matplotlib.figure
 import numpy as np

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -14,7 +14,6 @@ import warnings
 from copy import deepcopy
 from distutils.version import StrictVersion
 from enum import Enum
-from importlib.metadata import version
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, NewType, Tuple, Type
 
 import aiohttp


### PR DESCRIPTION
Attempt to import TypedDict from typing_extensions
if running on python 3.7.
Remove unused importlib.metadata.

# Description
Fixes import issue on 3.7 as TypedDict was introduced in python 3.8
Should get gradio working on default colab again.
This change attempts to import TypedDict from typing_extensions when required so 3.7 users can add the new dependency as required.
This doesn't require 3.8+ users to install typing_extensions.

@pngwn @abidlabs 

Closes: #1801
