### PR TITLE
Add requirements.txt and test_files to source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
 recursive-include gradio/templates *
 recursive-include gradio/test_data *
+recursive-include test/test_files *
 include gradio/version.txt
+include requirements.txt
+include test/requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author="Abubakar Abid, Ali Abid, Ali Abdalla, Dawood Khan, Ahsen Khaliq, Pete Allen, Ömer Faruk Özdemir",
     author_email="team@gradio.app",
     url="https://github.com/gradio-app/gradio",
-    packages=["gradio", "gradio.test_data"],
+    packages=["gradio", "gradio.test_data", "test.test_files"],
     license="Apache License 2.0",
     keywords=["machine learning", "visualization", "reproducibility"],
     install_requires=requirements,


### PR DESCRIPTION
# Description

Fixes #1812

## How to test

1. Clone this branch
2. python setup.py sdist
3. In a fresh env, `pip install dist/gradio-3.0.26.tar.gz` should install gradio + all dependencies
4. Unpack the source distribution. `test/test_files` and `test/requirements.txt` should be included.
![image](https://user-images.githubusercontent.com/41651716/179548370-91942341-2fc7-4d41-b8d0-9643976aa10c.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
