### PR TITLE
Fix Underscore Bug in Demo Names

### DIFF
--- a/website/homepage/src/guides/__init__.py
+++ b/website/homepage/src/guides/__init__.py
@@ -12,6 +12,7 @@ GUIDE_ASSETS_DIR = os.path.join(GUIDES_DIR, "assets", "guides")
 DEMOS_DIR = os.path.join(GRADIO_DIR, "demo")
 
 TEMP_TEMPLATE = os.path.join(DIR, "temporary_template.html")
+UNDERSCORE_TOKEN = "!UNDERSCORE!"
 
 demos = {}
 for demo_folder in os.listdir(DEMOS_DIR):
@@ -80,7 +81,7 @@ for guide in guide_list:
     )
     guide_content = re.sub(
         r"\$demo_([a-z _\-0-9]+)",
-        lambda x: f"<gradio-app src='/demo/{x.group(1)}' />",
+        lambda x: f"<gradio-app src='/demo/{x.group(1).replace('_', UNDERSCORE_TOKEN)}' />",
         guide_content
     )
 
@@ -108,7 +109,7 @@ def build_guides(output_dir, jinja_env):
                 markdown2.markdown(
                     guide["content"],
                     extras=["target-blank-links", "header-ids", "tables", "fenced-code-blocks"],
-                )
+                ).replace(UNDERSCORE_TOKEN, "_")
             )
         template = jinja_env.get_template("guides/template.html")
         output_folder = os.path.join(output_dir, guide["name"])


### PR DESCRIPTION
When a demo in a guide has two underscores in the title (for example `hello_world_2.py` in `getting_started.md`) the markdown to HTML generator converts what's between the underscores into italic, which breaks the demo logic. This is causing demos to go missing on guides. 

This was fixed but lost in one of the big website PRs. This PR brings back the fix which is just to replace the underscores with a special token during the HTML rendering process.