### PR TITLE
Make supported events and other sections of component doc stand out

### DIFF
--- a/website/homepage/src/docs/obj_doc_template.html
+++ b/website/homepage/src/docs/obj_doc_template.html
@@ -50,14 +50,15 @@
     </div>
   {% endif %}
   <p class="mt-8 mb-2 text-lg">{{ obj["description"] }}</p>
+  <br>
   {% if is_component %}
-  <p class="mb-2 text-lg text-gray-500">As input, {{ obj["tags"]["preprocessing"] }}</p>
-  <p class="mb-2 text-lg text-gray-500">As output, {{ obj["tags"]["postprocessing"] }}</p>
+  <p class="mb-2 text-lg text-gray-500"> <span class="text-orange-500">As input: </span> {{ obj["tags"]["preprocessing"] }}</p>
+  <p class="mb-2 text-lg text-gray-500"> <span class="text-orange-500">As output:</span> {{ obj["tags"]["postprocessing"] }}</p>
   {% if "examples-format" in obj["tags"]  %}
-  <p class="text-lg text-gray-500">Format expected for examples: {{ obj["tags"]["examples-format"] }}</p>
+  <p class="text-lg text-gray-500"> <span class="text-orange-500">Format expected for examples:</span> {{ obj["tags"]["examples-format"] }}</p>
   {% endif %}
   {% if obj["events"]|length > 0 %}
-  <p class="text-lg text-gray-500">Supported events: <em>{{ obj["events"] }}</em></p>
+  <p class="text-lg text-gray-500"><span class="text-orange-500">Supported events:</span> <em>{{ obj["events"] }}</em></p>
   {% endif %}
   {% endif %}
   


### PR DESCRIPTION
# Description

Fixes #1678

I think changing the font color for the supported events (preprocessing/postprocessing) sections + line break is sufficient

![image](https://user-images.githubusercontent.com/41651716/180869236-87163c4a-fafa-4c01-be2d-47d2477c6278.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
