### PR TITLE
Move gr update to helpers

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -202,7 +202,7 @@ class class_or_instancemethod(classmethod):
 @document()
 def update(**kwargs) -> dict:
     """
-    Updates component parameters.
+    Updates component properties.
     This is a shorthand for using the update method on a component.
     For example, rather than using gr.Number.update(...) you can just use gr.update(...).
     Note that your editor's autocompletion will suggest proper parameters

--- a/website/homepage/src/docs/template.html
+++ b/website/homepage/src/docs/template.html
@@ -149,8 +149,7 @@
         </section>
         <section id="update" class="pt-2 flex flex-col gap-10">
             <h3 class="text-3xl font-light my-4" id="update-section-header">Update</h3>
-            <p class="mb-12">Within Gradio, various functions exist to make it easier
-              to define events and data flows.
+            <p class="mb-12">The update function updates component properties. Works for both Interface and Blocks demos.
             </p>
             <div class="flex flex-col gap-10">
               {% with obj=find_cls("update"), parent="gradio" %}

--- a/website/homepage/src/docs/template.html
+++ b/website/homepage/src/docs/template.html
@@ -17,7 +17,6 @@
         <a class="thin-link px-4 block" href="#flagging">Flagging</a>
         <a class="thin-link px-4 block" href="#combining_interfaces">Combining Interfaces</a>
         <a class="thin-link px-4 block" href="#blocks">Blocks<sup class="text-orange-500">NEW</sup></a>
-        <a class="thin-link px-4 block" href="#blocks-utils">Blocks Utilities</a>
         <a class="link px-4 my-2 block" href="#components">Components
         </h4>
         {% for component in docs["component"] %}
@@ -27,6 +26,7 @@
         {% for component in docs["component-helpers"] %}
           <a class="px-4 block thin-link" href="#{{ component['name'].lower() }}">{{ component['name'] }}</a>
         {% endfor %}
+        <a class="thin-link px-4 block" href="#update">Update</a>
       </div>
       <div class="flex flex-col">
         <p class="bg-gradient-to-r from-orange-100 to-orange-50 border border-orange-200 px-4 py-1 rounded-full text-orange-800 mb-1">
@@ -107,17 +107,6 @@
               {% endfor %}
             </div>
           </section>
-          <section id="blocks-utils" class="pt-2 flex flex-col gap-10">
-            <h3 class="text-3xl font-light my-4" id="blocks-utils-header">Blocks Utilities</h3>
-            <p class="mb-12">Within Gradio Blocks, various functions exist to make it easier
-              to define events and data flows.
-            </p>
-            <div class="flex flex-col gap-10">
-              {% with obj=find_cls("update"), parent="gradio" %}
-                {% include "docs/obj_doc_template.html" %}
-              {% endwith %}
-            </div>
-          </section>
         </section>
         <section id="components" class="pt-2 flex flex-col gap-10">
           <div>
@@ -158,6 +147,17 @@
             {% endwith %}
           {% endfor %}
         </section>
+        <section id="update" class="pt-2 flex flex-col gap-10">
+            <h3 class="text-3xl font-light my-4" id="update-section-header">Update</h3>
+            <p class="mb-12">Within Gradio, various functions exist to make it easier
+              to define events and data flows.
+            </p>
+            <div class="flex flex-col gap-10">
+              {% with obj=find_cls("update"), parent="gradio" %}
+                {% include "docs/obj_doc_template.html" %}
+              {% endwith %}
+            </div>
+          </section>
       </div>
     </main>
     <script src="/assets/prism.js"></script>


### PR DESCRIPTION
# Description

Move gr.update to helpers as it works for both interfaces and blocks so "blocks utilities" may confuse users.

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/41651716/181060827-11f4abbe-e048-4f3d-a9e1-4c940de7b142.png">

<img width="205" alt="image" src="https://user-images.githubusercontent.com/41651716/181060934-5bbd6c20-48e2-41ad-897a-8deb487eb3b1.png">



# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
