### PR TITLE
Always return headers from postprocess

### DIFF
--- a/demo/fake_gan_2/run.py
+++ b/demo/fake_gan_2/run.py
@@ -38,4 +38,4 @@ demo = gr.Interface(
 )
 
 if __name__ == "__main__":
-    demo.launch()
+    demo.launch(enable_queue=True)

--- a/demo/fake_gan_2/run.py
+++ b/demo/fake_gan_2/run.py
@@ -1,41 +1,17 @@
-# This demo needs to be run from the repo folder.
-# python demo/fake_gan/run.py
-import os
-import random
-import time
-
 import gradio as gr
-
-
-def fake_gan(*args):
-    time.sleep(1)
-    image = random.choice(
-        [
-            "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80",
-            "https://images.unsplash.com/photo-1554151228-14d9def656e4?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=386&q=80",
-            "https://images.unsplash.com/photo-1542909168-82c3e7fdca5c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8aHVtYW4lMjBmYWNlfGVufDB8fDB8fA%3D%3D&w=1000&q=80",
-            "https://images.unsplash.com/photo-1546456073-92b9f0a8d413?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80",
-            "https://images.unsplash.com/photo-1601412436009-d964bd02edbc?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=464&q=80",
-        ]
-    )
-    return image
-
+import pandas as pd
 
 demo = gr.Interface(
-    fn=fake_gan,
-    inputs=[
-        gr.Image(label="Initial Image (optional)"),
-    ],
-    outputs=gr.Image(label="Generated Image"),
-    title="FD-GAN",
-    description="This is a fake demo of a GAN. In reality, the images are randomly chosen from Unsplash.",
-    examples=[
-        [os.path.join(os.path.dirname(__file__), "files/cheetah1.jpg")],
-        [os.path.join(os.path.dirname(__file__), "files/elephant.jpg")],
-        [os.path.join(os.path.dirname(__file__), "files/tiger.jpg")],
-        [os.path.join(os.path.dirname(__file__), "files/zebra.jpg")],
-    ],
+    fn=lambda: [["x1", "y1"], ["x2", "y2"], ["x3", "y3"]],
+    inputs=None,
+    outputs=gr.DataFrame(
+        col_count=2,
+        row_count=3,
+        type="array",
+        headers=["A", "B"],
+        interactive=False,
+    ),
 )
 
 if __name__ == "__main__":
-    demo.launch()
+    demo.launch(debug=True)

--- a/demo/fake_gan_2/run.py
+++ b/demo/fake_gan_2/run.py
@@ -1,17 +1,41 @@
+# This demo needs to be run from the repo folder.
+# python demo/fake_gan/run.py
+import os
+import random
+import time
+
 import gradio as gr
-import pandas as pd
+
+
+def fake_gan(*args):
+    time.sleep(1)
+    image = random.choice(
+        [
+            "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80",
+            "https://images.unsplash.com/photo-1554151228-14d9def656e4?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=386&q=80",
+            "https://images.unsplash.com/photo-1542909168-82c3e7fdca5c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8aHVtYW4lMjBmYWNlfGVufDB8fDB8fA%3D%3D&w=1000&q=80",
+            "https://images.unsplash.com/photo-1546456073-92b9f0a8d413?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80",
+            "https://images.unsplash.com/photo-1601412436009-d964bd02edbc?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=464&q=80",
+        ]
+    )
+    return image
+
 
 demo = gr.Interface(
-    fn=lambda: [["x1", "y1"], ["x2", "y2"], ["x3", "y3"]],
-    inputs=None,
-    outputs=gr.DataFrame(
-        col_count=2,
-        row_count=3,
-        type="array",
-        headers=["A", "B"],
-        interactive=False,
-    ),
+    fn=fake_gan,
+    inputs=[
+        gr.Image(label="Initial Image (optional)"),
+    ],
+    outputs=gr.Image(label="Generated Image"),
+    title="FD-GAN",
+    description="This is a fake demo of a GAN. In reality, the images are randomly chosen from Unsplash.",
+    examples=[
+        [os.path.join(os.path.dirname(__file__), "files/cheetah1.jpg")],
+        [os.path.join(os.path.dirname(__file__), "files/elephant.jpg")],
+        [os.path.join(os.path.dirname(__file__), "files/tiger.jpg")],
+        [os.path.join(os.path.dirname(__file__), "files/zebra.jpg")],
+    ],
 )
 
 if __name__ == "__main__":
-    demo.launch(debug=True)
+    demo.launch()

--- a/demo/fake_gan_2/run.py
+++ b/demo/fake_gan_2/run.py
@@ -38,4 +38,4 @@ demo = gr.Interface(
 )
 
 if __name__ == "__main__":
-    demo.launch(enable_queue=True)
+    demo.launch()

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2462,7 +2462,9 @@ class Dataframe(Changeable, IOComponent):
 
         self.__validate_headers(headers, self.col_count[0])
 
-        self.headers = headers
+        self.headers = (
+            headers if headers is not None else list(range(1, self.col_count[0] + 1))
+        )
         self.datatype = (
             datatype if isinstance(datatype, list) else [datatype] * self.col_count[0]
         )
@@ -2482,8 +2484,11 @@ class Dataframe(Changeable, IOComponent):
             [values[c] for c in column_dtypes] for _ in range(self.row_count[0])
         ]
 
-        self.value = value if value is not None else self.test_input
-        self.value = self.__process_markdown(self.value, datatype)
+        self.value = (
+            self.postprocess(value)
+            if value is not None
+            else self.postprocess(self.test_input)
+        )
 
         self.max_rows = max_rows
         self.max_cols = max_cols
@@ -2597,6 +2602,7 @@ class Dataframe(Changeable, IOComponent):
             if isinstance(y, np.ndarray):
                 y = y.tolist()
             return {
+                "headers": self.headers,
                 "data": Dataframe.__process_markdown(y, self.datatype),
             }
         raise ValueError("Cannot process value as a Dataframe")

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2601,8 +2601,19 @@ class Dataframe(Changeable, IOComponent):
         if isinstance(y, (np.ndarray, list)):
             if isinstance(y, np.ndarray):
                 y = y.tolist()
+
+            _headers = self.headers
+
+            if len(self.headers) < len(y[0]):
+                _headers = [
+                    *self.headers,
+                    *list(range(len(self.headers) + 1, len(y[0]) + 1)),
+                ]
+            elif len(self.headers) > len(y[0]):
+                _headers = self.headers[0 : len(y[0])]
+            print(_headers)
             return {
-                "headers": self.headers,
+                "headers": _headers,
                 "data": Dataframe.__process_markdown(y, self.datatype),
             }
         raise ValueError("Cannot process value as a Dataframe")

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2611,7 +2611,7 @@ class Dataframe(Changeable, IOComponent):
                 ]
             elif len(self.headers) > len(y[0]):
                 _headers = self.headers[0 : len(y[0])]
-            print(_headers)
+
             return {
                 "headers": _headers,
                 "data": Dataframe.__process_markdown(y, self.datatype),

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1038,11 +1038,14 @@ class TestDataframe(unittest.TestCase):
                 "datatype": ["str", "str", "str"],
                 "row_count": (3, "dynamic"),
                 "col_count": (3, "dynamic"),
-                "value": [
-                    ["", "", ""],
-                    ["", "", ""],
-                    ["", "", ""],
-                ],
+                "value": {
+                    "data": [
+                        ["", "", ""],
+                        ["", "", ""],
+                        ["", "", ""],
+                    ],
+                    "headers": ["Name", "Age", "Member"],
+                },
                 "name": "dataframe",
                 "show_label": True,
                 "label": "Dataframe Input",
@@ -1066,9 +1069,9 @@ class TestDataframe(unittest.TestCase):
         # Output functionalities
         dataframe_output = gr.Dataframe()
         output = dataframe_output.postprocess(np.zeros((2, 2)))
-        self.assertDictEqual(output, {"data": [[0, 0], [0, 0]]})
+        self.assertDictEqual(output, {"data": [[0, 0], [0, 0]], "headers": [1, 2]})
         output = dataframe_output.postprocess([[1, 3, 5]])
-        self.assertDictEqual(output, {"data": [[1, 3, 5]]})
+        self.assertDictEqual(output, {"data": [[1, 3, 5]], "headers": [1, 2, 3]})
         output = dataframe_output.postprocess(
             pd.DataFrame([[2, True], [3, True], [4, False]], columns=["num", "prime"])
         )
@@ -1082,7 +1085,7 @@ class TestDataframe(unittest.TestCase):
         self.assertEqual(
             dataframe_output.get_config(),
             {
-                "headers": None,
+                "headers": [1, 2, 3],
                 "max_rows": 20,
                 "max_cols": None,
                 "overflow_row_behaviour": "paginate",
@@ -1095,11 +1098,14 @@ class TestDataframe(unittest.TestCase):
                 "datatype": ["str", "str", "str"],
                 "row_count": (3, "dynamic"),
                 "col_count": (3, "dynamic"),
-                "value": [
-                    ["", "", ""],
-                    ["", "", ""],
-                    ["", "", ""],
-                ],
+                "value": {
+                    "data": [
+                        ["", "", ""],
+                        ["", "", ""],
+                        ["", "", ""],
+                    ],
+                    "headers": [1, 2, 3],
+                },
                 "interactive": None,
                 "wrap": False,
             },
@@ -1135,7 +1141,7 @@ class TestDataframe(unittest.TestCase):
         x_data = {"data": [[1, 2, 3], [4, 5, 6]]}
         iface = gr.Interface(np.max, "numpy", "number")
         self.assertEqual(iface.process([x_data]), [6])
-        x_data = {"data": [["Tim"], ["Jon"], ["Sal"]]}
+        x_data = {"data": [["Tim"], ["Jon"], ["Sal"]], "headers": [1, 2, 3]}
 
         def get_last(my_list):
             return my_list[-1][-1]
@@ -1153,7 +1159,8 @@ class TestDataframe(unittest.TestCase):
 
         iface = gr.Interface(check_odd, "numpy", "numpy")
         self.assertEqual(
-            iface.process([{"data": [[2, 3, 4]]}])[0], {"data": [[True, False, True]]}
+            iface.process([{"data": [[2, 3, 4]]}])[0],
+            {"data": [[True, False, True]], "headers": [1, 2, 3]},
         )
 
 

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1096,11 +1096,11 @@ class TestDataframe(unittest.TestCase):
                 "wrap": False,
             },
         )
-            
+
     def test_postprocess(self):
         """
         postprocess
-        """        
+        """
         dataframe_output = gr.Dataframe()
         output = dataframe_output.postprocess(np.zeros((2, 2)))
         self.assertDictEqual(output, {"data": [[0, 0], [0, 0]], "headers": [1, 2]})
@@ -1139,7 +1139,7 @@ class TestDataframe(unittest.TestCase):
                     "data": [[2, True], [3, True], [4, False]],
                 },
             )
-            
+
         # When the headers don't match the data
         dataframe_output = gr.Dataframe(headers=["one", "two", "three"])
         output = dataframe_output.postprocess([[2, True], [3, True]])
@@ -1159,8 +1159,6 @@ class TestDataframe(unittest.TestCase):
                 "data": [[2, True, "ab", 4], [3, True, "cd", 5]],
             },
         )
-        
-        
 
     def test_in_interface_as_input(self):
         """

--- a/ui/packages/app/src/components/DataFrame/DataFrame.svelte
+++ b/ui/packages/app/src/components/DataFrame/DataFrame.svelte
@@ -12,7 +12,10 @@
 	export let headers: Headers = [];
 	export let elem_id: string = "";
 	export let visible: boolean = true;
-	export let value: Data | { data: Data; headers: Headers } = [["", "", ""]];
+	export let value: { data: Data; headers: Headers } = {
+		data: [["", "", ""]],
+		headers: ["1", "2", "3"]
+	};
 	export let mode: "static" | "dynamic";
 	export let col_count: [number, "fixed" | "dynamic"];
 	export let row_count: [number, "fixed" | "dynamic"];


### PR DESCRIPTION
Closes #1887.

This PR ensures that Dataframe's postprocess method always returns headers along with the data, this means the frontend does not need to decide what to do with the headers. I've also moved the automatic generation of headers (when none are given, we use the list index + 1) to the backend.

I have also added some additional logic to generate a new compound set of headers for the following case:

- users set headers: `["A", "B"]`
- User returns new dataframe as a list that has more than 2 columns

In this case the existing headers will be used for the first two columns, any subsequent headers will be the list index +1. So in the above case the initial headers would be: `["A", "B"]` and after returning the new list `["A", "B", "3", "4"]`.

This PR modifies the API payload a little but doesn't change anything user facing.
