### PR TITLE
Embedding the spaces on the landing page using web components

### DIFF
--- a/website/homepage/src/index/demos_template.html
+++ b/website/homepage/src/index/demos_template.html
@@ -24,7 +24,7 @@
 </div>
 <div class="container mx-auto mb-6 px-4 grid grid-cols-1">
     <div class="demo space-y-2 md:col-span-3" demo="1">
-        <div class="rounded-lg bg-gray-50 shadow-inner text-sm md:text-base mx-auto max-w-5xl">
+        <div class="codeblock rounded-lg bg-gray-50 shadow-inner text-sm md:text-base mx-auto max-w-5xl">
             <pre class="language-python"><code class="language-python"><span class="token keyword">import</span> gradio <span class="token keyword">as</span> gr
 <span class="token keyword">def</span> <span class="token function">sketch_recognition</span><span class="token punctuation">(</span>img<span class="token punctuation">)</span><span class="token punctuation">:</span>
     <span class="token keyword">pass</span><span class="token comment"># Implement your sketch recognition model here...</span>
@@ -37,7 +37,7 @@ gr<span class="token punctuation">.</span>Interface<span class="token punctuatio
         </div>
     </div>
     <div class="demo space-y-2 md:col-span-3 hidden" demo="2">
-        <div class="rounded-lg bg-gray-50 shadow-inner text-sm md:text-base mx-auto max-w-5xl">
+        <div class="codeblock rounded-lg bg-gray-50 shadow-inner text-sm md:text-base mx-auto max-w-5xl">
             <pre class="language-python"><code class="language-python"><span class="token keyword">import</span> gradio <span class="token keyword">as</span> gr
 <span class="token keyword">def</span> <span class="token function">question_answer</span><span class="token punctuation">(</span>context<span class="token punctuation">,</span> question<span class="token punctuation">)</span><span class="token punctuation">:</span>
     <span class="token keyword">pass </span><span class="token comment"> # Implement your question-answering model here...</span>
@@ -50,7 +50,7 @@ gr<span class="token punctuation">.</span>Interface<span class="token punctuatio
         </div>
     </div>
     <div class="demo space-y-2 md:col-span-3 hidden" demo="3">
-        <div class="rounded-lg bg-gray-50 shadow-inner text-sm md:text-base mx-auto max-w-5xl">
+        <div class="codeblock rounded-lg bg-gray-50 shadow-inner text-sm md:text-base mx-auto max-w-5xl">
             <pre class="language-python"><code class="language-python"><span class="token keyword">import</span> gradio <span class="token keyword">as</span> gr
 <span class="token keyword">def</span> <span class="token function">segment</span><span class="token punctuation">(</span>image<span class="token punctuation">)</span><span class="token punctuation">:</span>
     <span class="token keyword">pass </span><span class="token comment"> # Implement your image segmentation model here...</span>
@@ -63,7 +63,7 @@ gr<span class="token punctuation">.</span>Interface<span class="token punctuatio
         </div>
     </div>
     <div class="demo space-y-2 md:col-span-3 hidden" demo="4">
-        <div class="rounded-lg bg-gray-50 shadow-inner text-sm md:text-base mx-auto max-w-5xl">
+        <div class="codeblock rounded-lg bg-gray-50 shadow-inner text-sm md:text-base mx-auto max-w-5xl">
             <pre class="language-python"><code class="language-python"><span class="token keyword">import</span> gradio <span class="token keyword">as</span> gr
 <span class="token keyword">def</span> <span class="token function">same_or_different</span><span class="token punctuation">(</span>audio1<span class="token punctuation">,</span> audio2<span class="token punctuation">)</span><span class="token punctuation">:</span>
     <span class="token keyword">pass </span><span class="token comment"> # Generate a response depending on if audio1 and audio2 are spoken by same person or not</span>
@@ -77,6 +77,7 @@ gr<span class="token punctuation">.</span>Interface<span class="token punctuatio
 </div>
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.1.1/gradio.js"></script>
+<script src="/assets/add_copy.js"></script>
 <script>
     let load_demo = demo_id => {
         document.querySelectorAll(".demo-tab").forEach(e => {

--- a/website/homepage/src/index/demos_template.html
+++ b/website/homepage/src/index/demos_template.html
@@ -32,12 +32,9 @@
 gr<span class="token punctuation">.</span>Interface<span class="token punctuation">(</span>fn<span class="token operator">=</span>sketch_recognition<span class="token punctuation">,</span> inputs<span class="token operator">=</span><span class="token string">"sketchpad"</span><span class="token punctuation">,</span> outputs<span class="token operator">=</span><span class="token string">"label"</span><span class="token punctuation">).</span>launch<span class="token punctuation">(</span><span class="token punctuation">)</span>
 </code></pre>
         </div>
-        <iframe src="https://hf.space/embed/gradio/pictionary/+?__theme=light"
-                frameBorder="0"
-                height="425"
-                scrolling="yes"
-                title="Gradio app"
-                class="container p-0 flex-grow m-0"></iframe>
+        <div class="mx-auto max-w-5xl">
+        <gradio-app space="gradio/pictionary"> </gradio-app>
+        </div>
     </div>
     <div class="demo space-y-2 md:col-span-3 hidden" demo="2">
         <div class="rounded-lg bg-gray-50 shadow-inner text-sm md:text-base mx-auto max-w-5xl">
@@ -48,12 +45,9 @@ gr<span class="token punctuation">.</span>Interface<span class="token punctuatio
 gr<span class="token punctuation">.</span>Interface<span class="token punctuation">(</span>fn<span class="token operator">=</span>question_answer<span class="token punctuation">,</span> inputs<span class="token operator">=</span><span class="token punctuation">[</span><span class="token string">"text"</span><span class="token punctuation">,</span> <span class="token string">"text"</span><span class="token punctuation">],</span> outputs<span class="token operator">=</span>[</span><span class="token string">"textbox"</span><span class="token punctuation">,</span> <span class="token string">"text"</span><span class="token punctuation">]).</span>launch<span class="token punctuation">(</span><span class="token punctuation">)</span>
 </code></pre>
         </div>
-        <iframe src="https://hf.space/embed/gradio/question-answering/+?__theme=light"
-                frameBorder="0"
-                height="425"
-                scrolling="yes"
-                title="Gradio app"
-                class="container p-0 flex-grow m-0"></iframe>
+        <div class="mx-auto max-w-5xl">
+        <gradio-app space="gradio/question-answering"> </gradio-app>
+        </div>
     </div>
     <div class="demo space-y-2 md:col-span-3 hidden" demo="3">
         <div class="rounded-lg bg-gray-50 shadow-inner text-sm md:text-base mx-auto max-w-5xl">
@@ -64,12 +58,9 @@ gr<span class="token punctuation">.</span>Interface<span class="token punctuatio
 gr<span class="token punctuation">.</span>Interface<span class="token punctuation">(</span>fn<span class="token operator">=</span>segment<span class="token punctuation">,</span> inputs<span class="token operator">=</span><span class="token string">"image"</span><span class="token punctuation">,</span> outputs<span class="token operator">=</span><span class="token string">"image"</span><span class="token punctuation">).</span>launch<span class="token punctuation">(</span><span class="token punctuation">)</span>
 </code></pre>
         </div>
-        <iframe src="https://hf.space/embed/gradio/Echocardiogram-Segmentation/+?__theme=light"
-                frameBorder="0"
-                height="425"
-                scrolling="yes"
-                title="Gradio app"
-                class="container p-0 flex-grow m-0"></iframe>
+        <div class="mx-auto max-w-5xl">
+        <gradio-app space="gradio/Echocardiogram-Segmentation"> </gradio-app>
+        </div>
     </div>
     <div class="demo space-y-2 md:col-span-3 hidden" demo="4">
         <div class="rounded-lg bg-gray-50 shadow-inner text-sm md:text-base mx-auto max-w-5xl">
@@ -79,14 +70,13 @@ gr<span class="token punctuation">.</span>Interface<span class="token punctuatio
 
 gr<span class="token punctuation">.</span>Interface<span class="token punctuation">(</span>fn<span class="token operator">=</span>same_or_different<span class="token punctuation">,</span> inputs<span class="token operator">=</span><span class="token punctuation">[</span><span class="token string">"audio"</span><span class="token punctuation">,</span> <span class="token string">"audio"</span><span class="token punctuation">]</span><span class="token punctuation">,</span> outputs<span class="token operator">=</span><span class="token string">"html"</span><span class="token punctuation">)</span><span class="token punctuation">.</span>launch<span class="token punctuation">(</span><span class="token punctuation">)</span></code></pre>
         </div>
-        <iframe src="https://hf.space/embed/gradio/same-person-or-different/+?__theme=light"
-                frameBorder="0"
-                height="425"
-                scrolling="yes"
-                title="Gradio app"
-                class="container p-0 flex-grow m-0"></iframe>
+        <div class="mx-auto max-w-5xl">
+            <gradio-app space="gradio/same-person-or-different"> </gradio-app>
+        </div>
     </div>
 </div>
+
+<script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.1.1/gradio.js"></script>
 <script>
     let load_demo = demo_id => {
         document.querySelectorAll(".demo-tab").forEach(e => {


### PR DESCRIPTION
Removes the iframes on the landing page, replacing them with web component embeddings. Much better for styling and alignment. Both the spaces (sdk_version) and the landing page (gradio.js) are now pinned to the same version of gradio (v3.1.1). We can update this for major releases but this will insure the demos never break. Also added copy buttons to the codeblocks like we have in docs and guides.