### PR TITLE
Fix default value in docs for objects

### DIFF
--- a/gradio/documentation.py
+++ b/gradio/documentation.py
@@ -82,6 +82,8 @@ def document_fn(fn):
             default = param.default
             if type(default) == str:
                 default = '"' + default + '"'
+            if default.__class__.__module__ != 'builtins':
+                default = f"{default.__class__.__name__}()"
             parameter_doc["default"] = default
         elif parameter_doc["doc"] is not None and "kwargs" in parameter_doc["doc"]:
             parameter_doc["kwargs"] = True

--- a/gradio/documentation.py
+++ b/gradio/documentation.py
@@ -82,7 +82,7 @@ def document_fn(fn):
             default = param.default
             if type(default) == str:
                 default = '"' + default + '"'
-            if default.__class__.__module__ != 'builtins':
+            if default.__class__.__module__ != "builtins":
                 default = f"{default.__class__.__name__}()"
             parameter_doc["default"] = default
         elif parameter_doc["doc"] is not None and "kwargs" in parameter_doc["doc"]:


### PR DESCRIPTION
Issue is the default value in docs parameter tables gets thrown off for objects that aren't builtin types (eg `flagging_callback = CSVLogger()`). This fixes that by detecting them and using the class name instead.