### PR TITLE
Fix dark mode with apps smaller than window size

### DIFF
--- a/ui/packages/app/index.html
+++ b/ui/packages/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" style="margin: 0; padding: 0">
+<html lang="en" style="margin: 0; padding: 0; min-height: 100%">
 	<head>
 		<meta charset="utf-8" />
 		<meta
@@ -54,14 +54,8 @@
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js"></script>
 	</head>
 
-	<body style="width: 100%; margin: 0; padding: 0">
-		<gradio-app
-			><div
-				id="root"
-				style="display: flex; flex-direction: column; flex-grow: 1"
-			></div
-		></gradio-app>
-
+	<body style="width: 100%; margin: 0; padding: 0; height: 100%">
+		<gradio-app></gradio-app>
 		<script>
 			const ce = document.getElementsByTagName("gradio-app");
 			if (ce[0]) {

--- a/ui/packages/app/src/Blocks.svelte
+++ b/ui/packages/app/src/Blocks.svelte
@@ -31,6 +31,7 @@
 	export let target: HTMLElement;
 	export let id: number = 0;
 	export let autoscroll: boolean = false;
+	let app_mode = window.__gradio_mode__ === "app";
 
 	$: app_state.update((s) => ({ ...s, autoscroll }));
 
@@ -407,10 +408,10 @@
 	{/if}
 </svelte:head>
 
-<div class="w-full flex flex-col">
+<div class="w-full flex flex-col" class:min-h-screen={app_mode}>
 	<div
 		class="mx-auto container px-4 py-6 dark:bg-gray-950"
-		class:flex-grow={window.__gradio_mode__ === "app"}
+		class:flex-grow={app_mode}
 	>
 		{#if api_docs_visible}
 			<ApiDocs {components} {dependencies} {root} />

--- a/ui/packages/app/src/Blocks.svelte
+++ b/ui/packages/app/src/Blocks.svelte
@@ -367,13 +367,13 @@
 
 		if (color_mode !== null) {
 			if (color_mode === "dark") {
-				target.classList.add("dark");
+				darkmode();
 			} else if (color_mode === "system") {
 				use_system_theme();
 			}
 			// light is default, so we don't need to do anything else
 		} else if (url.searchParams.get("__dark-theme") === "true") {
-			target.classList.add("dark");
+			darkmode();
 		} else {
 			use_system_theme();
 		}
@@ -389,7 +389,16 @@
 			const is_dark =
 				window?.matchMedia?.("(prefers-color-scheme: dark)").matches ?? null;
 
-			if (is_dark) target.classList.add("dark");
+			if (is_dark) {
+				darkmode();
+			}
+		}
+	}
+
+	function darkmode() {
+		target.classList.add("dark");
+		if (app_mode) {
+			document.body.style.backgroundColor = "rgb(11, 15, 25)"; // bg-gray-950 for scrolling outside the body
 		}
 	}
 


### PR DESCRIPTION
These is white-space at the bottom of any dark mode app thats not long enough for the whole page (most apps). 

![Screen Shot 2022-08-01 at 4 00 40 PM](https://user-images.githubusercontent.com/7870876/182259522-0aca5602-c039-4248-9538-f74e022c0d2c.png)

Looks very gross. Fixed now. 
![Screen Shot 2022-08-01 at 4 02 41 PM](https://user-images.githubusercontent.com/7870876/182259681-39f5eaed-348b-474d-83fb-ec4ccec9dc19.png)

Also added the dark bg color to the body, so on chrome when you scroll past the body, it doesn't show white.

Fixes #1772 