### PR TITLE
Enable flagging/caching examples for Gallery

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3637,7 +3637,8 @@ class Gallery(IOComponent):
     def restore_flagged(self, dir, data, encryption_key):
         files = []
         gallery_path = os.path.join(dir, data)
-        for file in os.listdir():
+        # Sort to preserve order
+        for file in sorted(os.listdir(gallery_path)):
             file_path = os.path.join(gallery_path, file)
             img = processing_utils.encode_file_to_base64(
                 file_path, encryption_key=encryption_key

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -13,6 +13,7 @@ import os
 import pathlib
 import shutil
 import tempfile
+import uuid
 import warnings
 from copy import deepcopy
 from types import ModuleType
@@ -122,7 +123,7 @@ class IOComponent(Component):
         """
         Saved flagged file and returns filepath
         """
-        label = "".join([char for char in label if char.isalnum() or char in "._- "])
+        label = processing_utils.strip_invalid_filename_characters(label)
         old_file_name = file.name
         output_dir = os.path.join(dir, label)
         if os.path.exists(output_dir):
@@ -3617,6 +3618,32 @@ class Gallery(IOComponent):
             self._style["height"] = height
 
         return IOComponent.style(self, rounded=rounded, container=container)
+
+    def save_flagged(
+        self, dir: str, label: Optional[str], data: List[str], encryption_key: bool
+    ) -> None | str:
+        if data is None:
+            return None
+
+        label = processing_utils.strip_invalid_filename_characters(label)
+        # Save all the files belonging to this gallery at gallery_path
+        gallery_path = f"{label}_{str(uuid.uuid4())}"
+        for img_data in data:
+            self.save_flagged_file(dir, gallery_path, img_data, encryption_key)
+        # In the csv file, the row corresponding to this sample will list
+        # the path where all sub-images are stored.
+        return gallery_path
+
+    def restore_flagged(self, dir, data, encryption_key):
+        files = []
+        gallery_path = os.path.join(dir, data)
+        for file in os.listdir():
+            file_path = os.path.join(gallery_path, file)
+            img = processing_utils.encode_file_to_base64(
+                file_path, encryption_key=encryption_key
+            )
+            files.append(img)
+        return files
 
 
 class Carousel(IOComponent, Changeable):

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3626,13 +3626,19 @@ class Gallery(IOComponent):
             return None
 
         label = processing_utils.strip_invalid_filename_characters(label)
-        # Save all the files belonging to this gallery at gallery_path
-        gallery_path = f"{label}_{str(uuid.uuid4())}"
+        # join the label with the dir so that one directory stores all gallery
+        # outputs, e.g. <dir>/<component-label>
+        dir = os.path.join(dir, label)
+
+        # Save all the files belonging to this gallery in the gallery_path directory
+        gallery_path = str(uuid.uuid4())
+
         for img_data in data:
             self.save_flagged_file(dir, gallery_path, img_data, encryption_key)
+
         # In the csv file, the row corresponding to this sample will list
-        # the path where all sub-images are stored.
-        return gallery_path
+        # the path where all sub-images are stored, e.g. <component-label>/<uuid>
+        return os.path.join(label, gallery_path)
 
     def restore_flagged(self, dir, data, encryption_key):
         files = []

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -514,3 +514,7 @@ def _convert(image, dtype, force_copy=False, uniform=False):
     image = _scale(image, 8 * itemsize_in, 8 * itemsize_out, copy=False)
     image += imin_out
     return image.astype(dtype_out)
+
+
+def strip_invalid_filename_characters(filename: str) -> str:
+    return "".join([char for char in filename if char.isalnum() or char in "._- "])

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1,16 +1,17 @@
 import json
 import os
+import pathlib
 import tempfile
 import unittest
 from copy import deepcopy
 from difflib import SequenceMatcher
+from unittest.mock import patch
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import PIL
 import pytest
-from requests import head
 
 import gradio as gr
 from gradio import media_data
@@ -1805,6 +1806,27 @@ class TestColorPicker(unittest.TestCase):
         """
         component = gr.ColorPicker("#000000")
         self.assertEqual(component.get_config().get("value"), "#000000")
+
+
+@patch("uuid.uuid4", return_value="my-uuid")
+def test_gallery_save_and_restore_flagged(my_uuid, tmp_path):
+    gallery = gr.Gallery()
+    test_file_dir = pathlib.Path(pathlib.Path(__file__).parent, "test_files")
+    data = [
+        gr.processing_utils.encode_file_to_base64(
+            pathlib.Path(test_file_dir, "bus.png")
+        ),
+        gr.processing_utils.encode_file_to_base64(
+            pathlib.Path(test_file_dir, "cheetah1.jpg")
+        ),
+    ]
+    label = "Gallery, 1"
+    path = gallery.save_flagged(str(tmp_path), label, data, encryption_key=None)
+    assert path == "Gallery 1_my-uuid"
+    assert sorted(os.listdir(os.path.join(tmp_path, path))) == ["0.png", "1.jpg"]
+
+    data_restored = gallery.restore_flagged(tmp_path, path, encryption_key=None)
+    assert data == data_restored
 
 
 if __name__ == "__main__":

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1822,7 +1822,7 @@ def test_gallery_save_and_restore_flagged(my_uuid, tmp_path):
     ]
     label = "Gallery, 1"
     path = gallery.save_flagged(str(tmp_path), label, data, encryption_key=None)
-    assert path == "Gallery 1_my-uuid"
+    assert path == os.path.join("Gallery 1", "my-uuid")
     assert sorted(os.listdir(os.path.join(tmp_path, path))) == ["0.png", "1.jpg"]
 
     data_restored = gallery.restore_flagged(tmp_path, path, encryption_key=None)


### PR DESCRIPTION
# Description

Fixes #1867
Fixes #1533

To test, run `fake_gan` with `cache_examples=True`

### Example of the csv
```
'Generated Images','flag','username','timestamp'
'Generated Images_68533214-ea69-4e01-a557-94a714440a03','','','2022-08-02 17:02:47.356494'
'Generated Images_5e542cf3-bf6f-42f3-b0de-62dbbd214219','','','2022-08-02 17:02:48.707235'
'Generated Images_4882b0bb-e967-414a-a0e2-38ca5bb278a4','','','2022-08-02 17:02:51.111492'
'Generated Images_ccde2db1-4106-4b14-9c73-d0e5cf86d7db','','','2022-08-02 17:02:54.028124'
'Generated Images_7f8327f8-41b8-454c-990d-a04be1e3d661','','','2022-08-02 17:02:56.513317'
'Generated Images_0e50cc01-9a67-4f0a-8419-636e2d26b99f','','','2022-08-02 17:02:58.628534'
```

### Directory structure
![image](https://user-images.githubusercontent.com/41651716/182476347-0408dd88-7bd0-4e5e-8050-9377d037eade.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
