### PR TITLE
Fix add_copy.js on landing page

### DIFF
--- a/website/homepage/src/index/demos_template.html
+++ b/website/homepage/src/index/demos_template.html
@@ -77,7 +77,7 @@ gr<span class="token punctuation">.</span>Interface<span class="token punctuatio
 </div>
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.1.1/gradio.js"></script>
-<script src="/assets/add_copy.js"></script>
+<script>{% include 'templates/add_copy.js' %}</script>
 <script>
     let load_demo = demo_id => {
         document.querySelectorAll(".demo-tab").forEach(e => {


### PR DESCRIPTION
Simple fix to load the correct script for adding copy buttons on the landing page.
