### PR TITLE
Remove broken audio demo from landing page

### DIFF
--- a/website/homepage/src/index/demos_template.html
+++ b/website/homepage/src/index/demos_template.html
@@ -15,11 +15,6 @@
              onclick="load_demo(3)">
             Image Segmentation
         </div>
-        <div class="demo-tab hover:text-gray-800 cursor-pointer px-3 py-1"
-             demo="4"
-             onclick="load_demo(4)">
-            Speech Verification
-        </div>
     </nav>
 </div>
 <div class="container mx-auto mb-6 px-4 grid grid-cols-1">
@@ -60,18 +55,6 @@ gr<span class="token punctuation">.</span>Interface<span class="token punctuatio
         </div>
         <div class="mx-auto max-w-5xl">
         <gradio-app space="gradio/Echocardiogram-Segmentation"> </gradio-app>
-        </div>
-    </div>
-    <div class="demo space-y-2 md:col-span-3 hidden" demo="4">
-        <div class="codeblock rounded-lg bg-gray-50 shadow-inner text-sm md:text-base mx-auto max-w-5xl">
-            <pre class="language-python"><code class="language-python"><span class="token keyword">import</span> gradio <span class="token keyword">as</span> gr
-<span class="token keyword">def</span> <span class="token function">same_or_different</span><span class="token punctuation">(</span>audio1<span class="token punctuation">,</span> audio2<span class="token punctuation">)</span><span class="token punctuation">:</span>
-    <span class="token keyword">pass </span><span class="token comment"> # Generate a response depending on if audio1 and audio2 are spoken by same person or not</span>
-
-gr<span class="token punctuation">.</span>Interface<span class="token punctuation">(</span>fn<span class="token operator">=</span>same_or_different<span class="token punctuation">,</span> inputs<span class="token operator">=</span><span class="token punctuation">[</span><span class="token string">"audio"</span><span class="token punctuation">,</span> <span class="token string">"audio"</span><span class="token punctuation">]</span><span class="token punctuation">,</span> outputs<span class="token operator">=</span><span class="token string">"html"</span><span class="token punctuation">)</span><span class="token punctuation">.</span>launch<span class="token punctuation">(</span><span class="token punctuation">)</span></code></pre>
-        </div>
-        <div class="mx-auto max-w-5xl">
-            <gradio-app space="gradio/same-person-or-different"> </gradio-app>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Removes the audio demo from the landing page since it isn't working. We should bring it back when #1962 is resolved or this [space](https://huggingface.co/spaces/gradio/same-person-or-different) works.