### PR TITLE
Cleaning up the way data is processed for components

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -201,12 +201,6 @@ class IOComponent(Component):
         """
         return x
 
-    def preprocess_example(self, x: Any) -> Any:
-        """
-        Any preprocessing needed to be performed on an example before being passed to the main function.
-        """
-        return x
-
     def set_interpret_parameters(self):
         """
         Set any parameters for interpretation.
@@ -405,15 +399,6 @@ class Textbox(Changeable, Submittable, IOComponent):
             called_directly: if True, the interface was called(), otherwise, it is being used via the GUI
         """
         return x
-
-    def preprocess_example(self, x: str | None) -> Any:
-        """
-        Any preprocessing needed to be performed on an example before being passed to the main function.
-        """
-        if x is None:
-            return None
-        else:
-            return str(x)
 
     def set_interpret_parameters(
         self, separator: str = " ", replacement: Optional[str] = None

--- a/gradio/examples.py
+++ b/gradio/examples.py
@@ -15,7 +15,7 @@ from gradio.flagging import CSVLogger
 
 if TYPE_CHECKING:  # Only import for type checking (to avoid circular imports).
     from gradio import Interface
-    from gradio.components import Component
+    from gradio.components import IOComponent
 
 CACHED_FOLDER = "gradio_cached_examples"
 
@@ -37,8 +37,8 @@ class Examples:
     def __init__(
         self,
         examples: List[Any] | List[List[Any]] | str,
-        inputs: Component | List[Component],
-        outputs: Optional[Component | List[Component]] = None,
+        inputs: IOComponent | List[IOComponent],
+        outputs: Optional[IOComponent | List[IOComponent]] = None,
         fn: Optional[Callable] = None,
         cache_examples: bool = False,
         examples_per_page: int = 10,
@@ -143,7 +143,7 @@ class Examples:
 
         self.processed_examples = [
             [
-                component.preprocess_example(sample)
+                component.postprocess(sample)
                 for component, sample in zip(inputs_with_examples, example)
             ]
             for example in non_none_examples


### PR DESCRIPTION
There is a lot of redundant data processing code for each `Component` (more details below), which is problematic because: (1) bugs are introduced when some parts of the code are updated, but other parts are not (2) it's hard to understand how the data is preprocessed / postprocessed, thereby making it harder to understand the existing codebase as well as to contribute new components.

This PR eliminates the following redundancies and along the ways, fixes: #1194, #1721 

1. `preprocess_example()` being a special case of `postprocess()` for most components -- both functions takes a Python object (e.g. PIL image or path to image file) and serializes it (e.g. to base64 representation) so that it can be viewed in the browser. However, for file-based components, we do not serialize examples, but rather just include a reference to them, so this special case needs to be handled. 
2. `serialize()` and `deserialize()` being part of `postprocess()` and `preprocess()` respectively.