### PR TITLE
Automatically deploy kitchen sink to spaces on release

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -56,3 +56,30 @@ jobs:
         with:
           name: ${{ env.INPUT_NAME }}
           tag_name: ${{ env.INPUT_NAME }}
+  spaces-test-release:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - name: Install Hub Client Library
+        run: pip install huggingface-hub==0.8.1
+      - name: get release name
+        run: echo "GRADIO_VERSION=$(cat gradio/version.txt)" >> $GITHUB_ENV
+      - name: Upload kitchen sink to spaces
+        run: |
+          python scripts/upload_demo_to_space.py kitchen_sink \
+          gradio-test-deploys/${{ env.GRADIO_VERSION }}_kitchen_sink \
+          ${{ secrets.SPACES_DEPLOY_TOKEN }} \
+          --gradio-version  ${{ env.GRADIO_VERSION }} > url.txt
+          echo "SPACE_URL=$(cat url.txt)" >> $GITHUB_ENV
+      - name: Comment On Release PR
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: |
+            Deployed a demo with this version at ${{ env.SPACE_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -82,4 +82,12 @@ jobs:
           message: |
             Deployed a demo with this version at ${{ env.SPACE_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      - name: Comment on Slack
+        uses: slackapi/slack-github-action@v1.21.0
+        with:
+          payload: |
+            {
+              "text": "@here Checkout out the deploy for ${{ env.GRADIO_VERSION }} at ${{ env.SPACE_URL }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/demo/kitchen_sink/run.py
+++ b/demo/kitchen_sink/run.py
@@ -152,6 +152,7 @@ demo = gr.Interface(
     * 3,
     theme="default",
     title="Kitchen Sink",
+    cache_examples=False,
     description="Try out all the components!",
     article="Learn more about [Gradio](http://gradio.app)",
 )

--- a/scripts/upload_demo_to_space.py
+++ b/scripts/upload_demo_to_space.py
@@ -1,10 +1,11 @@
-import huggingface_hub
-import pathlib
-import tempfile
-import shutil
 import argparse
-from typing import Optional
+import pathlib
+import shutil
+import tempfile
 import textwrap
+from typing import Optional
+
+import huggingface_hub
 
 
 def upload_demo_to_space(

--- a/scripts/upload_demo_to_space.py
+++ b/scripts/upload_demo_to_space.py
@@ -1,0 +1,77 @@
+from huggingface_hub import create_repo, HfApi
+import pathlib
+import tempfile
+import shutil
+import argparse
+from typing import Optional
+import textwrap
+
+
+def upload_demo_to_space(
+    demo_name: str, space_id: str, hf_token: str, gradio_version: Optional[str]
+):
+    """Upload a demo in the demo directory to a huggingface space.
+    Args:
+        demo_name: The name of the demo to upload.
+        space_id: The id of the space to upload the demo to.
+        hf_token: HF api token. Need to have permission to write to space_id for this to work.
+        gradio_version: If not None, will set the gradio version in the created space to the given version.
+    """
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        demo_path = pathlib.Path(pathlib.Path().absolute(), f"demo/{demo_name}")
+        shutil.copytree(demo_path, tmpdir, dirs_exist_ok=True)
+        app_file = pathlib.Path(tmpdir, "run.py")
+        # Rename the app file to be app.py
+        app_file.rename(app_file.with_stem("app"))
+        if gradio_version:
+            readme = pathlib.Path(tmpdir, "README.md")
+            readme_content = f"""
+                                ---
+                                title: {space_id.split("/")[-1]} 
+                                emoji: 💩
+                                colorFrom: indigo
+                                colorTo: indigo
+                                sdk: gradio
+                                sdk_version: {gradio_version}
+                                app_file: app.py
+                                pinned: false
+                                ---
+                                """
+            readme.open("w").write(textwrap.dedent(readme_content))
+
+        api = HfApi()
+        create_repo(
+            space_id,
+            space_sdk="gradio",
+            repo_type="space",
+            token=hf_token,
+            exist_ok=True,
+        )
+        api.upload_folder(
+            token=hf_token,
+            repo_id=space_id,
+            repo_type="space",
+            folder_path=tmpdir,
+            path_in_repo="",
+        )
+    return f"https://huggingface.co/spaces/{space_id}"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Upload a demo to a space")
+    parser.add_argument("demo_name", type=str, help="Name of demo to upload")
+    parser.add_argument(
+        "space_id", type=str, help="Name of the space to upload the demo to"
+    )
+    parser.add_argument("hf_token", type=str, help="HF API token")
+    parser.add_argument(
+        "--gradio-version",
+        type=str,
+        help="If not None, will set the gradio version in the created space to the given version.",
+    )
+    args = parser.parse_args()
+    new_space = upload_demo_to_space(
+        args.demo_name, args.space_id, args.hf_token, args.gradio_version
+    )
+    print(new_space)

--- a/scripts/upload_demo_to_space.py
+++ b/scripts/upload_demo_to_space.py
@@ -1,4 +1,4 @@
-from huggingface_hub import create_repo, HfApi
+import huggingface_hub
 import pathlib
 import tempfile
 import shutil
@@ -40,8 +40,8 @@ def upload_demo_to_space(
                                 """
             readme.open("w").write(textwrap.dedent(readme_content))
 
-        api = HfApi()
-        create_repo(
+        api = huggingface_hub.HfApi()
+        huggingface_hub.create_repo(
             space_id,
             space_sdk="gradio",
             repo_type="space",


### PR DESCRIPTION
# Description

Fixes #1934

Once a new version is uploaded to pypi, we'll automatically upload the kitchen sink to the [gradio-test-deploys-organization](https://huggingface.co/gradio-test-deploys)

Eventually I want to do this on every PR but we'd need to push the assets to the cdn on every commit

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
