### PR TITLE
Sanitize for CSV

### DIFF
--- a/demo/kitchen_sink/run.py
+++ b/demo/kitchen_sink/run.py
@@ -151,7 +151,6 @@ demo = gr.Interface(
     * 3,
     theme="default",
     title="Kitchen Sink",
-    cache_examples=False,
     description="Try out all the components!",
     article="Learn more about [Gradio](http://gradio.app)",
     cache_examples=True

--- a/demo/kitchen_sink/run.py
+++ b/demo/kitchen_sink/run.py
@@ -153,7 +153,7 @@ demo = gr.Interface(
     title="Kitchen Sink",
     description="Try out all the components!",
     article="Learn more about [Gradio](http://gradio.app)",
-    cache_examples=True
+    cache_examples=False
 )
 
 if __name__ == "__main__":

--- a/gradio/examples.py
+++ b/gradio/examples.py
@@ -256,7 +256,7 @@ class Examples:
             example_id: The id of the example to process (zero-indexed).
         """
         with open(self.cached_file) as cache:
-            examples = list(csv.reader(cache, quotechar="'"))
+            examples = list(csv.reader(cache))
         example = examples[example_id + 1]  # +1 to adjust for header
         output = []
         for component, value in zip(self.outputs, example):

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -612,3 +612,9 @@ def set_directory(path: Path):
 
 def strip_invalid_filename_characters(filename: str) -> str:
     return "".join([char for char in filename if char.isalnum() or char in "._- "])
+
+
+def sanitize_for_csv(value: str) -> str:
+    value = value.replace("\"", "\"\"")
+    return "\"'" + value + "\""
+

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from distutils.version import StrictVersion
 from enum import Enum
+from numbers import Number
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -614,7 +615,35 @@ def strip_invalid_filename_characters(filename: str) -> str:
     return "".join([char for char in filename if char.isalnum() or char in "._- "])
 
 
-def sanitize_for_csv(value: str) -> str:
-    value = value.replace("\"", "\"\"")
-    return "\"'" + value + "\""
+def sanitize_value_for_csv(value: str | Number) -> str | Number:
+    """
+    Sanitizes a value that is being written to a CSV file to prevent CSV injection attacks.
+    Reference: https://owasp.org/www-community/attacks/CSV_Injection
+    """
+    if isinstance(value, Number):
+        return value
+    unsafe_prefixes = ["=", "+", "-", "@", "\t", "\n"]
+    unsafe_sequences = [",=", ",+", ",-", ",@", ",\t", ",\n"]
+    if any(value.startswith(prefix) for prefix in unsafe_prefixes) or any(
+        sequence in value for sequence in unsafe_sequences
+    ):
+        value = "'" + value
+    return value
 
+
+def sanitize_list_for_csv(
+    values: List[str | Number] | List[List[str | Number]],
+) -> List[str | Number] | List[List[str | Number]]:
+    """
+    Sanitizes a list of values (or a list of list of values) that is being written to a
+    CSV file to prevent CSV injection attacks.
+    """
+    sanitized_values = []
+    for value in values:
+        if isinstance(value, list):
+            sanitized_value = sanitize_list_for_csv(value)
+            sanitized_values.append(sanitized_value)
+        else:
+            sanitized_value = sanitize_value_for_csv(value)
+            sanitized_values.append(sanitized_value)
+    return sanitized_values

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import os
 import unittest
 import unittest.mock as mock
@@ -25,10 +26,10 @@ from gradio.utils import (
     format_ner_list,
     get_local_ip_address,
     ipython_check,
-    json,
     launch_analytics,
     readme_to_html,
     version_check,
+    sanitize_for_csv    
 )
 
 os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
@@ -409,6 +410,13 @@ async def test_validate_and_fail_with_function(respx_mock):
         client_response.is_valid(raise_exceptions=True)
     assert client_response.exception is not None
 
+
+class TestSanitizeForCSV():
+    def test_unsafe():
+        assert sanitize_for_csv('=1+2";=1+2') == '"\'=1+2"";=1+2"'
+
+    def test_safe():
+        assert sanitize_for_csv("1aaa2") == '"\'1aaa2"'
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I went back and forth on how to best implement this, but I decided on the following approach:
* If any unsafe characters are detected in the cell value, prepend it with a single quotation mark, which prevents it from being run as a formula in Excel / LibreOffice
* Otherwise, the value in unchanged

I'm hoping that for 99% of the users, this means they can read the flagged data like a regular CSV file and not worry about any changes introduced by this quotation.

The reason I went with this approach:
* instead of quoting everything with double and single quotes ([the 2nd solution here](https://owasp.org/www-community/attacks/CSV_Injection)) is because this approach allows the data to be read in a regular CSV format (99% of the time)
* instead of not sanitizing anything: was to prevent CSV injection (which this PR should do, in fact better than how things were before) 
* instead of leaving things as they were before on `main`: was to fix issues like #1811 

Fixes: #1811