### PR TITLE
Better empty state for the gr.Gallery component

### DIFF
--- a/ui/packages/app/src/components/Gallery/Gallery.svelte
+++ b/ui/packages/app/src/components/Gallery/Gallery.svelte
@@ -149,7 +149,7 @@
 			class:xl:min-h-[450px]={style.height !== "auto"}
 		>
 			{#if value.length === 0}
-				<div class="h-full flex justify-center items-center">
+				<div class="h-full min-h-[15rem] flex justify-center items-center">
 					<div class="h-5 dark:text-white opacity-50"><Image /></div>
 				</div>
 			{:else}

--- a/ui/packages/app/src/components/Gallery/Gallery.svelte
+++ b/ui/packages/app/src/components/Gallery/Gallery.svelte
@@ -148,22 +148,26 @@
 			class:max-h-[55vh]={style.height !== "auto"}
 			class:xl:min-h-[450px]={style.height !== "auto"}
 		>
-			<div class=" grid  gap-2 {classes}" class:pt-6={show_label}>
-				{#each value as image, i}
-					<button
-						class="gallery-item"
-						on:click={() => (selected_image = can_zoom ? i : selected_image)}
-					>
-						<img
-							alt=""
-							class="h-full w-full overflow-hidden object-contain"
-							src={image}
-						/>
-					</button>
-				{:else}
-					<p>{$_("interface.empty")}</p>
-				{/each}
-			</div>
+			{#if value.length === 0}
+				<div class="h-full flex justify-center items-center">
+					<div class="h-5 dark:text-white opacity-50"><Image /></div>
+				</div>
+			{:else}
+				<div class=" grid  gap-2 {classes}" class:pt-6={show_label}>
+					{#each value as image, i}
+						<button
+							class="gallery-item"
+							on:click={() => (selected_image = can_zoom ? i : selected_image)}
+						>
+							<img
+								alt=""
+								class="h-full w-full overflow-hidden object-contain"
+								src={image}
+							/>
+						</button>
+					{/each}
+				</div>
+			{/if}
 		</div>
 	{/if}
 </Block>


### PR DESCRIPTION
# Description
Add empty image icon to gallery when there are no images to show

<img width="997" alt="Screen Shot 2022-08-16 at 2 00 29 PM" src="https://user-images.githubusercontent.com/12725292/184947803-28ee2f8e-b845-4924-900c-c005146d7d94.png">



Please include: 
* relevant motivation
* a summary of the change 
* which issue is fixed. 
* any additional dependencies that are required for this change.

Closes: # (issue)
#2013

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
