### PR TITLE
Max thread tweaks

### DIFF
--- a/demo/concurrency_with_queue/run.py
+++ b/demo/concurrency_with_queue/run.py
@@ -1,9 +1,9 @@
 import gradio as gr
-import asyncio
+import time
 
 
-async def say_hello(name):
-  await asyncio.sleep(5)
+def say_hello(name):
+  time.sleep(5)
   return f"Hello {name}!"
 
 
@@ -13,4 +13,4 @@ with gr.Blocks() as demo:
   button = gr.Button()
   button.click(say_hello, inp, outp)
 
-  demo.configure_queue(concurrency_count=5).launch(enable_queue=True)
+  demo.queue(concurrency_count=41).launch()

--- a/demo/concurrency_without_queue/run.py
+++ b/demo/concurrency_without_queue/run.py
@@ -1,0 +1,16 @@
+import gradio as gr
+import time
+
+
+def say_hello(name):
+  time.sleep(5)
+  return f"Hello {name}!"
+
+
+with gr.Blocks() as demo:
+  inp = gr.Textbox()
+  outp = gr.Textbox()
+  button = gr.Button()
+  button.click(say_hello, inp, outp)
+
+  demo.launch(max_threads=41)

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -299,13 +299,16 @@ class App(FastAPI):
             return Queue.get_estimation()
 
         @app.get(
-            "/queue/start",
+            "/startup-events",
             dependencies=[Depends(login_check)],
         )
-        async def start_queue():
+        async def startup_events():
             from gradio.utils import run_coro_in_background
 
-            gradio.utils.run_coro_in_background(Queue.init)
+            if app.blocks.enable_queue:
+                gradio.utils.run_coro_in_background(Queue.init)
+            gradio.utils.run_coro_in_background(app.blocks.create_limiter)
+
             return True
 
         return app

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -339,6 +339,8 @@ def synchronize_async(func: Callable, *args, **kwargs):
     """
     Runs async functions in sync scopes.
 
+    Can be used in any scope. See run_coro_in_background for more details.
+
     Example:
         if inspect.iscoroutinefunction(block_fn.fn):
             predictions = utils.synchronize_async(block_fn.fn, *processed_input)
@@ -354,6 +356,15 @@ def synchronize_async(func: Callable, *args, **kwargs):
 def run_coro_in_background(func: Callable, *args, **kwargs):
     """
     Runs coroutines in background.
+
+    Warning, be careful to not use this function in other than FastAPI scope, because the event_loop has not started yet.
+    You can use it in any scope reached by FastAPI app.
+
+    correct scope examples: endpoints in routes, Blocks.process_api
+    incorrect scope examples: Blocks.launch
+
+    Use startup_events in routes.py if you need to run a coro in background in Blocks.launch().
+
 
     Example:
         utils.run_coro_in_background(fn, *args, **kwargs)


### PR DESCRIPTION
# Description
1. move creation of limiter to fastapi endpoint since run_coro_in_background works only in there
2. make max_threads compatible with queue concurrency count
3. add warning to run_coro_in_background

Tested limiter creation with putting a print into `Blocks.predict_api` and tested both queue and nonqueue demos, both works alright!
