### PR TITLE
Add data science demos to landing page

### DIFF
--- a/website/homepage/src/index/demos_template.html
+++ b/website/homepage/src/index/demos_template.html
@@ -15,6 +15,16 @@
              onclick="load_demo(3)">
             Image Segmentation
         </div>
+        <div class="demo-tab hover:text-gray-800 cursor-pointer px-3 py-1"
+             demo="4"
+             onclick="load_demo(4)">
+            Time Series Forecasting With Prophet
+        </div>
+        <div class="demo-tab hover:text-gray-800 cursor-pointer px-3 py-1"
+             demo="5"
+             onclick="load_demo(5)">
+            XGBoost Classification with Explainability
+        </div>
     </nav>
 </div>
 <div class="container mx-auto mb-6 px-4 grid grid-cols-1">
@@ -55,6 +65,16 @@ gr<span class="token punctuation">.</span>Interface<span class="token punctuatio
         </div>
         <div class="mx-auto max-w-5xl">
         <gradio-app space="gradio/Echocardiogram-Segmentation"> </gradio-app>
+        </div>
+    </div>
+    <div class="demo space-y-2 md:col-span-3" demo="4">
+        <div class="mx-auto max-w-5xl">
+        <gradio-app space="gradio/timeseries-forecasting-with-prophet"> </gradio-app>
+        </div>
+    </div>
+    <div class="demo space-y-2 md:col-span-3" demo="5">
+        <div class="mx-auto max-w-5xl">
+        <gradio-app space="gradio/xgboost-income-prediction-with-explainability"> </gradio-app>
         </div>
     </div>
 </div>

--- a/website/homepage/src/index/demos_template.html
+++ b/website/homepage/src/index/demos_template.html
@@ -18,12 +18,12 @@
         <div class="demo-tab hover:text-gray-800 cursor-pointer px-3 py-1"
              demo="4"
              onclick="load_demo(4)">
-            Time Series Forecasting With Prophet
+            Time Series Forecasting
         </div>
         <div class="demo-tab hover:text-gray-800 cursor-pointer px-3 py-1"
              demo="5"
              onclick="load_demo(5)">
-            XGBoost Classification with Explainability
+            XGBoost with Explainability
         </div>
     </nav>
 </div>


### PR DESCRIPTION
# Description
Fixes #2048 

Added two demos:
- [Time series forecasting with Prophet](https://huggingface.co/spaces/gradio/timeseries-forecasting-with-prophet)
- [XGBoost Classification with Explainability](https://huggingface.co/spaces/gradio/xgboost-income-prediction-with-explainability)

Forecasting, Prophet, Tabular datasets, and Prediction Explainability are all concepts that have come up in our conversations with data scientists (both internal and external) and these demos cover those concepts. 

My hope is that putting them in the front page will catch the eyes of prospective data science users. The xgboost example is a sneak peek of what we want to be able to automate for skops models.

![image](https://user-images.githubusercontent.com/41651716/186252351-fb6a7952-7a30-42f5-a206-6e2fca9c77e1.png)

![image](https://user-images.githubusercontent.com/41651716/186252441-96dda2c0-ff35-468e-ad9f-fa55c559a53e.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
