### PR TITLE
Hide time series + xgboost demos by default

### DIFF
--- a/website/homepage/src/index/demos_template.html
+++ b/website/homepage/src/index/demos_template.html
@@ -67,12 +67,12 @@ gr<span class="token punctuation">.</span>Interface<span class="token punctuatio
         <gradio-app space="gradio/Echocardiogram-Segmentation"> </gradio-app>
         </div>
     </div>
-    <div class="demo space-y-2 md:col-span-3" demo="4">
+    <div class="demo space-y-2 md:col-span-3 hidden" demo="4">
         <div class="mx-auto max-w-5xl">
         <gradio-app space="gradio/timeseries-forecasting-with-prophet"> </gradio-app>
         </div>
     </div>
-    <div class="demo space-y-2 md:col-span-3" demo="5">
+    <div class="demo space-y-2 md:col-span-3 hidden" demo="5">
         <div class="mx-auto max-w-5xl">
         <gradio-app space="gradio/xgboost-income-prediction-with-explainability"> </gradio-app>
         </div>


### PR DESCRIPTION
# Description

Fix a mistake I made in #2067 where I didn't hide the new demos by default

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
