### PR TITLE
Updated our analytics on creation of Blocks/Interface

### DIFF
--- a/demo/all_demos/run.py
+++ b/demo/all_demos/run.py
@@ -5,6 +5,7 @@ import sys
 import copy
 import pathlib
 
+os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
 
 demo_dir = pathlib.Path(__file__).parent / "demos"
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -4,6 +4,7 @@ import copy
 import getpass
 import inspect
 import os
+import pkgutil
 import random
 import sys
 import tempfile
@@ -382,6 +383,16 @@ class Blocks(BlockContext):
         self.app_id = random.getrandbits(64)
         self.temp_dirs = set()
         self.title = title
+
+        data = {
+            "mode": self.mode,
+            "ip_address": self.ip_address,
+            "custom_css": self.css is not None,
+            "theme": self.theme,
+            "version": pkgutil.get_data(__name__, "version.txt").decode("ascii").strip()
+        }
+        if self.analytics_enabled:
+            utils.initiated_analytics(data)
 
     @property
     def share(self):

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -389,7 +389,9 @@ class Blocks(BlockContext):
             "ip_address": self.ip_address,
             "custom_css": self.css is not None,
             "theme": self.theme,
-            "version": pkgutil.get_data(__name__, "version.txt").decode("ascii").strip()
+            "version": pkgutil.get_data(__name__, "version.txt")
+            .decode("ascii")
+            .strip(),
         }
         if self.analytics_enabled:
             utils.initiated_analytics(data)

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import inspect
 import json
 import os
+import pkgutil
 import re
 import warnings
 import weakref
@@ -372,6 +373,7 @@ class Interface(Blocks):
         self.favicon_path = None
 
         data = {
+            "mode": self.mode,
             "fn": fn,
             "inputs": inputs,
             "outputs": outputs,
@@ -381,6 +383,7 @@ class Interface(Blocks):
             "allow_flagging": allow_flagging,
             "custom_css": self.css is not None,
             "theme": self.theme,
+            "version": pkgutil.get_data(__name__, "version.txt").decode("ascii").strip()
         }
 
         if self.analytics_enabled:

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -383,7 +383,9 @@ class Interface(Blocks):
             "allow_flagging": allow_flagging,
             "custom_css": self.css is not None,
             "theme": self.theme,
-            "version": pkgutil.get_data(__name__, "version.txt").decode("ascii").strip()
+            "version": pkgutil.get_data(__name__, "version.txt")
+            .decode("ascii")
+            .strip(),
         }
 
         if self.analytics_enabled:

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -199,7 +199,7 @@ class TestBlocks(unittest.TestCase):
 
     @mock.patch("requests.post")
     def test_initiated_analytics(self, mock_post):
-        with gr.Blocks(analytics_enabled=True) as demo:
+        with gr.Blocks(analytics_enabled=True):
             pass
         mock_post.assert_called_once()
 

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1,5 +1,5 @@
 import asyncio
-import inspect
+import os
 import io
 import random
 import sys
@@ -19,6 +19,8 @@ from gradio.test_data.blocks_configs import XRAY_CONFIG
 from gradio.utils import assert_configs_are_equivalent_besides_ids
 
 pytest_plugins = ("pytest_asyncio",)
+
+os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
 
 
 @contextmanager

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1,6 +1,6 @@
 import asyncio
-import os
 import io
+import os
 import random
 import sys
 import time

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -197,6 +197,12 @@ class TestBlocks(unittest.TestCase):
         demo.share_url = None
         demo.close()
 
+    @mock.patch("requests.post")
+    def test_initiated_analytics(self, mock_post):
+        with gr.Blocks(analytics_enabled=True) as demo:
+            pass
+        mock_post.assert_called_once()
+
 
 def test_slider_random_value_config():
     with gr.Blocks() as demo:

--- a/test/test_documentation.py
+++ b/test/test_documentation.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import unittest
 
@@ -5,6 +6,7 @@ import pytest
 
 import gradio as gr
 
+os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
 
 class TestDocumentation(unittest.TestCase):
     @pytest.mark.skipif(

--- a/test/test_documentation.py
+++ b/test/test_documentation.py
@@ -8,6 +8,7 @@ import gradio as gr
 
 os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
 
+
 class TestDocumentation(unittest.TestCase):
     @pytest.mark.skipif(
         sys.version_info < (3, 8),

--- a/test/test_event_queue.py
+++ b/test/test_event_queue.py
@@ -6,8 +6,8 @@ from fastapi.testclient import TestClient
 
 import gradio as gr
 
-
 os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
+
 
 class TestQueue:
     @pytest.mark.asyncio

--- a/test/test_event_queue.py
+++ b/test/test_event_queue.py
@@ -1,10 +1,13 @@
 import asyncio
+import os
 
 import pytest
 from fastapi.testclient import TestClient
 
 import gradio as gr
 
+
+os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
 
 class TestQueue:
     @pytest.mark.asyncio

--- a/test/test_flagging.py
+++ b/test/test_flagging.py
@@ -8,6 +8,8 @@ import huggingface_hub
 import gradio as gr
 from gradio import flagging
 
+os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
+
 
 class TestDefaultFlagging(unittest.TestCase):
     def test_default_flagging_callback(self):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,5 @@
 import copy
+import ipaddress
 import json
 import os
 import unittest
@@ -101,12 +102,13 @@ class TestUtils(unittest.TestCase):
 
 
 class TestIPAddress(unittest.TestCase):
-    # def test_get_ip(self): # Removed test because internet is flaky on circleci
-    #     ip = get_local_ip_address()
-    #     try:  # check whether ip is valid
-    #         ipaddress.ip_address(ip)
-    #     except ValueError:
-    #         self.fail("Invalid IP address")
+    @pytest.mark.flaky
+    def test_get_ip(self):
+        ip = get_local_ip_address()
+        try:  # check whether ip is valid
+            ipaddress.ip_address(ip)
+        except ValueError:
+            self.fail("Invalid IP address")
 
     @mock.patch("requests.get")
     def test_get_ip_without_internet(self, mock_get):

--- a/website/homepage/src/index/demos_template.html
+++ b/website/homepage/src/index/demos_template.html
@@ -67,12 +67,12 @@ gr<span class="token punctuation">.</span>Interface<span class="token punctuatio
         <gradio-app space="gradio/Echocardiogram-Segmentation"> </gradio-app>
         </div>
     </div>
-    <div class="demo space-y-2 md:col-span-3" demo="4">
+    <div class="demo space-y-2 md:col-span-3 hidden" demo="4">
         <div class="mx-auto max-w-5xl">
         <gradio-app space="gradio/timeseries-forecasting-with-prophet"> </gradio-app>
         </div>
     </div>
-    <div class="demo space-y-2 md:col-span-3" demo="5">
+    <div class="demo space-y-2 md:col-span-3 hidden" demo="5">
         <div class="mx-auto max-w-5xl">
         <gradio-app space="gradio/xgboost-income-prediction-with-explainability"> </gradio-app>
         </div>


### PR DESCRIPTION
Three quick changes to our analytics on creation of Blocks/Interface:

* We actually fire the analytics when Blocks are created (previously, it was only when Interface was created)
* We record whether it was a Blocks or Interface that was created (using "mode")
* We also record which Gradio version they are running

I've also updated the `gradio-api-server` running to accept these analytics. We should keep in mind that we'll see an artificial bump in the "initiation" analytics as a result of this. For retrospective analysis, we should stick to launch analytics, which correctly record whenever Blocks are launched