### PR TITLE
`Label` component now accepts file paths to `.json` files 

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2753,7 +2753,7 @@ class Label(Changeable, IOComponent, JSONSerializable):
     """
     Displays a classification label, along with confidence scores of top categories, if provided.
     Preprocessing: this component does *not* accept input.
-    Postprocessing: expects a {Dict[str, float]} of classes and confidences, or {str} with just the class or an {int}/{float} for regression outputs.
+    Postprocessing: expects a {Dict[str, float]} of classes and confidences, or {str} with just the class or an {int}/{float} for regression outputs, or a {str} path to a .json file containing a json dictionary in the structure produced by Label.postprocess().
 
     Demos: main_note, titanic_survival
     Guides: Gradio_and_ONNX_on_Hugging_Face, image_classification_in_pytorch, image_classification_in_tensorflow, image_classification_with_vision_transformers, building_a_pictionary_app
@@ -2808,6 +2808,8 @@ class Label(Changeable, IOComponent, JSONSerializable):
         """
         if y is None or y == {}:
             return None
+        if isinstance(y, str) and y.endswith(".json") and os.path.exists(y):
+            return self.serialize(y)
         if isinstance(y, (str, numbers.Number)):
             return {"label": str(y)}
         if isinstance(y, dict):

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1289,7 +1289,7 @@ class TestLabel(unittest.TestCase):
         )
         label_output = gr.Label(num_top_classes=2)
         label = label_output.postprocess(y)
-        
+
         self.assertDictEqual(
             label,
             {
@@ -1302,12 +1302,12 @@ class TestLabel(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             label_output.postprocess([1, 2, 3])
-            
+
         test_file_dir = pathlib.Path(pathlib.Path(__file__).parent, "test_files")
         path = str(pathlib.Path(test_file_dir, "test_label_json.json"))
         label = label_output.postprocess(path)
         self.assertEqual(label["label"], "web site")
-        
+
         self.assertEqual(
             label_output.get_config(),
             {

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1289,6 +1289,7 @@ class TestLabel(unittest.TestCase):
         )
         label_output = gr.Label(num_top_classes=2)
         label = label_output.postprocess(y)
+        
         self.assertDictEqual(
             label,
             {
@@ -1301,7 +1302,12 @@ class TestLabel(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             label_output.postprocess([1, 2, 3])
-
+            
+        test_file_dir = pathlib.Path(pathlib.Path(__file__).parent, "test_files")
+        path = str(pathlib.Path(test_file_dir, "test_label_json.json"))
+        label = label_output.postprocess(path)
+        self.assertEqual(label["label"], "web site")
+        
         self.assertEqual(
             label_output.get_config(),
             {

--- a/test/test_files/test_label_json.json
+++ b/test/test_files/test_label_json.json
@@ -1,0 +1,1 @@
+{"label": "web site", "confidences": [{"label": "web site", "confidence": 0.6625185608863831}, {"label": "envelope", "confidence": 0.02277352288365364}, {"label": "menu", "confidence": 0.012591145932674408}, {"label": "monitor", "confidence": 0.012062293477356434}, {"label": "washer", "confidence": 0.008587697520852089}]}


### PR DESCRIPTION
This PR adds support for filepaths to the `Label` component. Specifically, if you pass in a filepath to a ".json" file that exists, the Label component will read it and display its contents instead of just displaying the string filepath.

This fixes: #2080