### PR TITLE
Accept deprecated `file` route as well

### DIFF
--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -236,6 +236,10 @@ class App(FastAPI):
                     f"it is not in any of {app.blocks.temp_dirs}"
                 )
 
+        @app.get("/file/{path:path}", dependencies=[Depends(login_check)])
+        def file_deprecated(path: str):
+            return file(path)
+
         async def run_predict(
             body: PredictBody, username: str = Depends(get_current_user)
         ):

--- a/guides/2)building_interfaces/4)advanced_interface_features.md
+++ b/guides/2)building_interfaces/4)advanced_interface_features.md
@@ -25,7 +25,17 @@ $code_gender_sentence_custom_interpretation
 
 ## Custom Styling
 
-If you'd like to have more fine-grained control over any aspect of your demo, you can also write your own css or pass in a css file, with the `css` parameter of the `Interface` class.
+If you'd like to have more fine-grained control over any aspect of your demo, you can also write your own css or pass in a filepath to a css file, with the `css` parameter of the `Interface` class.
+
+```python
+gr.Interface(..., css="body {background-color: red}")
+```
+
+If you'd like to reference external files in your css, preface the file path (which can be a relative or absolute path) with "file=", for example:
+
+```python
+gr.Interface(..., css="body {background-image: url('file=clouds.jpg')}")
+```
 
 ## Loading Hugging Face Models and Spaces
 

--- a/guides/2)building_interfaces/4)advanced_interface_features.md
+++ b/guides/2)building_interfaces/4)advanced_interface_features.md
@@ -31,7 +31,7 @@ If you'd like to have more fine-grained control over any aspect of your demo, yo
 gr.Interface(..., css="body {background-color: red}")
 ```
 
-If you'd like to reference external files in your css, preface the file path (which can be a relative or absolute path) with "file=", for example:
+If you'd like to reference external files in your css, preface the file path (which can be a relative or absolute path) with `"file="`, for example:
 
 ```python
 gr.Interface(..., css="body {background-image: url('file=clouds.jpg')}")

--- a/guides/3)building_with_blocks/4)custom_CSS_and_JS.md
+++ b/guides/3)building_with_blocks/4)custom_CSS_and_JS.md
@@ -9,7 +9,7 @@ with gr.Blocks(css="body {background-color: red}") as demo:
     ...
 ```
 
-If you'd like to reference external files in your css, preface the file path (which can be a relative or absolute path) with "file=", for example:
+If you'd like to reference external files in your css, preface the file path (which can be a relative or absolute path) with `"file="`, for example:
 
 ```python
 with gr.Blocks(css="body {background-image: url('file=clouds.jpg')}") as demo:

--- a/guides/3)building_with_blocks/4)custom_CSS_and_JS.md
+++ b/guides/3)building_with_blocks/4)custom_CSS_and_JS.md
@@ -9,7 +9,14 @@ with gr.Blocks(css="body {background-color: red}") as demo:
     ...
 ```
 
-You can also pass the filepath to a CSS file to this argument.
+If you'd like to reference external files in your css, preface the file path (which can be a relative or absolute path) with "file=", for example:
+
+```python
+with gr.Blocks(css="body {background-image: url('file=clouds.jpg')}") as demo:
+    ...
+```
+
+You can also pass the filepath to a CSS file to the `css` argument.
 
 ## The `elem_id` Argument
 


### PR DESCRIPTION
This PR does two things:

* As part of #2086, I changed the route corresponding to serving files from `/file/` to `/file=`. However, I realized that this might break demos if people are providing file paths themselves, for example as part of custom css, as in #2074. So this PR restores the deprecated file path as well. 

* Added documentation about providing files as part of CSS to address questions that have popped up about it (including #2074). So this fixes: #2074