### PR TITLE
Allow frontend method execution on Block.load event

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -745,6 +745,7 @@ class Blocks(BlockContext):
         src: Optional[str] = None,
         api_key: Optional[str] = None,
         alias: Optional[str] = None,
+        _js: Optional[str] = None,
         **kwargs,
     ) -> Blocks | None:
         """
@@ -765,6 +766,7 @@ class Blocks(BlockContext):
             inputs: Instance Method - input list
             outputs: Instance Method - output list
         """
+        # _js: Optional frontend js method to run before running 'fn'. Input arguments for js method are values of 'inputs' and 'outputs', return should be a list of values for output components.
         if isinstance(self_or_cls, type):
             if name is None:
                 raise ValueError(
@@ -779,7 +781,7 @@ class Blocks(BlockContext):
             return external.load_blocks_from_repo(name, src, api_key, alias, **kwargs)
         else:
             self_or_cls.set_event_trigger(
-                event_name="load", fn=fn, inputs=inputs, outputs=outputs, no_target=True
+                event_name="load", fn=fn, inputs=inputs, outputs=outputs, no_target=True, js=_js
             )
 
     def clear(self):


### PR DESCRIPTION
# Description

Please include: 
Adds `_js` as an optional parameter to the `load` event similar to other events

Closes: #2105

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
