### PR TITLE
feat(samples table/gallery): Crop thumbs to square

### DIFF
--- a/ui/packages/theme/src/tokens.css
+++ b/ui/packages/theme/src/tokens.css
@@ -91,7 +91,7 @@
 
 	img.gr-sample-image,
 	video.gr-sample-video {
-		@apply object-contain h-20 w-20;
+		@apply object-cover h-20 w-20;
 	}
 }
 
@@ -100,7 +100,7 @@
 
 	img.gr-sample-image,
 	video.gr-sample-video {
-		@apply max-h-20;
+		@apply object-cover max-h-20;
 	}
 
 	.gr-sample-textbox,


### PR DESCRIPTION
Crops image/video thumbnails in Examples section so they look neater. [Slack thread on pros/cons](https://huggingface.slack.com/archives/C02QZLG8GMN/p1661502226400639)

### Before
<img width="351" alt="image" src="https://user-images.githubusercontent.com/5785323/187132939-cffe45b6-f4c3-4a2c-b242-485d0d220b0d.png">
<img width="207" alt="image" src="https://user-images.githubusercontent.com/5785323/187132957-60769eca-d17b-488e-b3b9-85cc4aeed021.png">

### After
<img width="353" alt="image" src="https://user-images.githubusercontent.com/5785323/187132985-4295a62f-876b-4a98-b2bd-863766462c5d.png">
<img width="209" alt="image" src="https://user-images.githubusercontent.com/5785323/187132999-b4265773-f410-4a8e-adf5-ac3a7a8586a6.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes