### PR TITLE
Catch IndexError, KeyError in video_is_playable

### DIFF
--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -605,7 +605,7 @@ def video_is_playable(video_filepath: str) -> bool:
             (".webm", "vp9"),
         ]
     # If anything goes wrong, assume the video can be played to not convert downstream
-    except FFRuntimeError:
+    except (FFRuntimeError, IndexError, KeyError):
         return True
 
 


### PR DESCRIPTION
# Description

The goal of this PR is to make the `video_is_playable` catch more exceptions to better account for the unpredictability of the data being returned from the inference function. Noted in this PR [comment](https://github.com/gradio-app/gradio/pull/2003#discussion_r956530287)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
