### PR TITLE
2092 df ex

### DIFF
--- a/ui/packages/app/package.json
+++ b/ui/packages/app/package.json
@@ -35,6 +35,7 @@
 		"@gradio/upload": "workspace:^0.0.1",
 		"@gradio/utils": "workspace:^0.0.1",
 		"@gradio/video": "workspace:^0.0.1",
+		"d3-dsv": "^3.0.1",
 		"mime-types": "^2.1.34",
 		"playwright": "^1.22.2",
 		"svelte-i18n": "^3.3.13"

--- a/ui/packages/app/src/components/Dataset/Dataset.svelte
+++ b/ui/packages/app/src/components/Dataset/Dataset.svelte
@@ -23,6 +23,7 @@
 	let selected_samples: Array<Array<any>>;
 	let page_count: number;
 	let visible_pages: Array<number> = [];
+
 	$: {
 		if (paginate) {
 			visible_pages = [];

--- a/ui/packages/app/src/components/Dataset/ExampleComponents/Dataframe.svelte
+++ b/ui/packages/app/src/components/Dataset/ExampleComponents/Dataframe.svelte
@@ -1,23 +1,60 @@
 <script lang="ts">
-	export let value: Array<Array<string | number>>;
+	//@ts-ignore
+	import { csvParseRows } from "d3-dsv";
+	export let value: Array<Array<string | number>> | string;
+	export let samples_dir: string;
+	let hovered = false;
+	let loaded = Array.isArray(value);
+
+	$: if (!loaded && typeof value === "string" && /\.[a-zA-Z]+$/.test(value)) {
+		fetch(samples_dir + value)
+			.then((v) => v.text())
+			.then((v) => {
+				try {
+					value = csvParseRows(v);
+					loaded = true;
+				} catch (e) {
+					console.error(e);
+				}
+			});
+	}
 </script>
 
-<table class="gr-sample-dataframe">
-	{#each value.slice(0, 3) as row}
-		<tr>
-			{#each row.slice(0, 3) as cell}
-				<td class="p-2">{cell}</td>
+{#if loaded}
+	<div
+		class="gr-sample-dataframe"
+		on:mouseenter={() => (hovered = true)}
+		on:mouseleave={() => (hovered = false)}
+	>
+		<table class="gr-sample-dataframe relative">
+			{#each value.slice(0, 3) as row, i}
+				<tr>
+					{#each row.slice(0, 3) as cell, j}
+						<td
+							class="p-2 {i < 3 ? 'border-b border-b-slate-700' : ''} 
+							{j < 3 ? 'border-r border-r-slate-700 ' : ''}">{cell}</td
+						>
+					{/each}
+					{#if row.length > 3}
+						<td
+							class="p-2  border-r border-b border-r-slate-700 border-b-slate-700"
+							>…</td
+						>
+					{/if}
+				</tr>
 			{/each}
-			{#if row.length > 3}
-				<td class="p-2">...</td>
+			{#if value.length > 3}
+				<div
+					class="absolute w-full h-[50%] bottom-0 bg-gradient-to-b from-transparent to-slate-900"
+					class:to-slate-800={hovered}
+				/>
 			{/if}
-		</tr>
-	{/each}
-	{#if value.length > 3}
-		<tr>
-			{#each Array(Math.min(4, value[0].length)) as _}
-				<td class="p-2">...</td>
-			{/each}
-		</tr>
-	{/if}
-</table>
+			<!--	{#if value[0].length > 3}
+			<div
+				class="absolute h-full w-[50%] right-0 top-0 bg-gradient-to-r from-transparent to-slate-900"
+				class:to-slate-800={hovered}
+			/>
+		{/if} -->
+		</table>
+	</div>
+{/if}

--- a/ui/packages/app/src/components/Dataset/ExampleComponents/Dataframe.svelte
+++ b/ui/packages/app/src/components/Dataset/ExampleComponents/Dataframe.svelte
@@ -12,9 +12,21 @@
 			.then((v) => {
 				try {
 					if ((value as string).endsWith("csv")) {
-						value = csvParseRows(v);
+						const small_df = v
+							.split("\n")
+							.slice(0, 4)
+							.map((v) => v.split(",").slice(0, 4).join(","))
+							.join("\n");
+
+						value = csvParseRows(small_df);
 					} else if ((value as string).endsWith("tsv")) {
-						tsvParseRows(value);
+						const small_df = v
+							.split("\n")
+							.slice(0, 4)
+							.map((v) => v.split("\t").slice(0, 4).join("\t"))
+							.join("\n");
+
+						value = tsvParseRows(small_df);
 					} else {
 						throw new Error(
 							"Incorrect format, only CSV and TSV files are supported"
@@ -40,13 +52,16 @@
 				<tr>
 					{#each row.slice(0, 3) as cell, j}
 						<td
-							class="p-2 {i < 3 ? 'border-b border-b-slate-700' : ''} 
-							{j < 3 ? 'border-r border-r-slate-700 ' : ''}">{cell}</td
+							class="p-2 {i < 3
+								? 'border-b border-b-slate-300 dark:border-b-slate-700'
+								: ''} 
+							{j < 3 ? 'border-r border-r-slate-300 dark:border-r-slate-700 ' : ''}"
+							>{cell}</td
 						>
 					{/each}
 					{#if row.length > 3}
 						<td
-							class="p-2  border-r border-b border-r-slate-700 border-b-slate-700"
+							class="p-2  border-r border-b  border-r-slate-300 dark:border-r-slate-700 border-b-slate-300 dark:border-b-slate-700"
 							>…</td
 						>
 					{/if}
@@ -54,16 +69,11 @@
 			{/each}
 			{#if value.length > 3}
 				<div
-					class="absolute w-full h-[50%] bottom-0 bg-gradient-to-b from-transparent to-slate-900"
-					class:to-slate-800={hovered}
+					class="absolute w-full h-[50%] bottom-0 bg-gradient-to-b from-transparent to-white dark:to-slate-900"
+					class:dark:to-slate-800={hovered}
+					class:to-gray-50={hovered}
 				/>
 			{/if}
-			<!--	{#if value[0].length > 3}
-			<div
-				class="absolute h-full w-[50%] right-0 top-0 bg-gradient-to-r from-transparent to-slate-900"
-				class:to-slate-800={hovered}
-			/>
-		{/if} -->
 		</table>
 	</div>
 {/if}

--- a/ui/packages/app/src/components/Dataset/ExampleComponents/Dataframe.svelte
+++ b/ui/packages/app/src/components/Dataset/ExampleComponents/Dataframe.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	//@ts-ignore
-	import { csvParseRows } from "d3-dsv";
+	import { csvParseRows, tsvParseRows } from "d3-dsv";
 	export let value: Array<Array<string | number>> | string;
 	export let samples_dir: string;
 	let hovered = false;
@@ -11,7 +11,16 @@
 			.then((v) => v.text())
 			.then((v) => {
 				try {
-					value = csvParseRows(v);
+					if ((value as string).endsWith("csv")) {
+						value = csvParseRows(v);
+					} else if ((value as string).endsWith("tsv")) {
+						tsvParseRows(value);
+					} else {
+						throw new Error(
+							"Incorrect format, only CSV and TSV files are supported"
+						);
+					}
+
 					loaded = true;
 				} catch (e) {
 					console.error(e);

--- a/ui/packages/app/src/components/Dataset/ExampleComponents/Dataframe.svelte
+++ b/ui/packages/app/src/components/Dataset/ExampleComponents/Dataframe.svelte
@@ -69,8 +69,9 @@
 			{/each}
 			{#if value.length > 3}
 				<div
-					class="absolute w-full h-[50%] bottom-0 bg-gradient-to-b from-transparent to-white dark:to-slate-900"
-					class:dark:to-slate-800={hovered}
+					class="absolute w-full h-[50%] bottom-0 bg-gradient-to-b from-transparent to-white"
+					class:dark:to-gray-950={!hovered}
+					class:dark:to-gray-800={hovered}
 					class:to-gray-50={hovered}
 				/>
 			{/if}

--- a/ui/packages/theme/src/tokens.css
+++ b/ui/packages/theme/src/tokens.css
@@ -109,10 +109,13 @@
 	.gr-sample-checkboxgroup,
 	.gr-sample-file,
 	.gr-sample-number,
-	.gr-sample-dataframe,
 	.gr-sample-audio,
 	.gr-sample-3d {
 		@apply flex items-center border cursor-pointer px-2 py-1.5 rounded-lg bg-white hover:bg-gray-50 text-sm text-left dark:hover:bg-gray-800 dark:bg-transparent;
+	}
+
+	.gr-sample-dataframe {
+		@apply overflow-hidden items-center border border-collapse cursor-pointer px-2 py-1.5 rounded-lg bg-white hover:bg-gray-50 text-sm text-left dark:hover:bg-gray-800 dark:bg-transparent;
 	}
 }
 

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -102,6 +102,7 @@ importers:
       '@gradio/upload': workspace:^0.0.1
       '@gradio/utils': workspace:^0.0.1
       '@gradio/video': workspace:^0.0.1
+      d3-dsv: ^3.0.1
       mime-types: ^2.1.34
       playwright: ^1.22.2
       svelte-i18n: ^3.3.13
@@ -129,9 +130,10 @@ importers:
       '@gradio/upload': link:../upload
       '@gradio/utils': link:../utils
       '@gradio/video': link:../video
+      d3-dsv: 3.0.1
       mime-types: 2.1.34
       playwright: 1.22.2
-      svelte-i18n: 3.3.13_svelte@3.49.0
+      svelte-i18n: 3.3.13
 
   packages/atoms:
     specifiers:
@@ -3066,7 +3068,7 @@ packages:
       queue-microtask: 1.2.3
 
   /rw/1.3.3:
-    resolution: {integrity: sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=}
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
     dev: false
 
   /sade/1.8.1:
@@ -3351,6 +3353,20 @@ packages:
       svelte: '>=3.19.0'
     dependencies:
       svelte: 3.49.0
+
+  /svelte-i18n/3.3.13:
+    resolution: {integrity: sha512-RQM+ys4+Y9ztH//tX22H1UL2cniLNmIR+N4xmYygV6QpQ6EyQvloZiENRew8XrVzfvJ8HaE8NU6/yurLkl7z3g==}
+    engines: {node: '>= 11.15.0'}
+    hasBin: true
+    peerDependencies:
+      svelte: ^3.25.1
+    dependencies:
+      deepmerge: 4.2.2
+      estree-walker: 2.0.2
+      intl-messageformat: 9.11.4
+      sade: 1.8.1
+      tiny-glob: 0.2.9
+    dev: false
 
   /svelte-i18n/3.3.13_svelte@3.49.0:
     resolution: {integrity: sha512-RQM+ys4+Y9ztH//tX22H1UL2cniLNmIR+N4xmYygV6QpQ6EyQvloZiENRew8XrVzfvJ8HaE8NU6/yurLkl7z3g==}


### PR DESCRIPTION
Closes #2092.

(rows x cols )
- 3 x 3, no truncation
- 4+ x 3, rows truncated to 3 and fade on bottom
- 3 x 4+, cols truncated to 3 and ellipsis on right
- 4+ x 4+, both truncated to 3, fade on bottom, ellipsis on right

Looks like this now (one of each variant), the far right preview is a CSV, these are now loaded parsed and displayed with everything else. The file name is not particularly useful information (although I could add the name as well if needed):
<img width="727" alt="Screenshot 2022-08-30 at 18 02 16" src="https://user-images.githubusercontent.com/12937446/187499647-abcc90f3-f35b-4f43-bd0b-f3463eb92760.png">

The final
Can be tested with the following snippet + the `test.csv` in the same folder [here](https://github.com/gradio-app/gradio/files/9434365/test.csv):

```py
import gradio as gr
import pandas as pd

examples = [
    [
        [
            [ 1, 2, 3 ],
            [ 1, 2, 3 ],
            [ 1, 2, 3 ],
        ],
    ],
    [
        [
            [ "a", "b", "c" ],
            [ "a", "b", "c" ],
            [ "a", "b", "c" ],
            [ "a", "b", "c" ],
        ]
    ],
    [
        [
            ["a", "b", "c", "d"],
            ["a", "b", "c", "d"],
            ["a", "b", "c", "d"],
        ]
    ],
    [
        [
            ["hi", "none", "1", "1"],
            ["hello", "nada", "1", "1"],
            ["hey there", "zilch", "1", "1"],
            ["heeeeeeeeey", "nothing", "1", "1"],
        ]
    ],
    ["test.csv"],
]


def get_max(df: pd.DataFrame) -> float:
    return df.max().max()


demo = gr.Interface(
    get_max,
    gr.DataFrame(type="pandas", headers=["a", "b", "c"]),
    gr.Number(),
    examples=examples,
)

if __name__ == "__main__":
    demo.launch()
```

