### PR TITLE
Skops integration: Load tabular classification and regression models from the hub

### DIFF
--- a/gradio/external.py
+++ b/gradio/external.py
@@ -52,7 +52,6 @@ def load_blocks_from_repo(name, src=None, api_key=None, alias=None, **kwargs):
 
 
 def get_tabular_examples(model_name) -> Dict[str, List[float]]:
-    breakpoint()
     readme = requests.get(f"https://huggingface.co/{model_name}/resolve/main/README.md")
     if readme.status_code != 200:
         warnings.warn(f"Cannot load examples from README for {model_name}", UserWarning)
@@ -61,7 +60,6 @@ def get_tabular_examples(model_name) -> Dict[str, List[float]]:
         yaml_regex = re.search(
             "(?:^|[\r\n])---[\n\r]+([\\S\\s]*?)[\n\r]+---([\n\r]|$)", readme.text
         )
-        breakpoint()
         example_yaml = next(yaml.safe_load_all(readme.text[: yaml_regex.span()[-1]]))
         example_data = example_yaml.get("widget", {}).get("structuredData", {})
     if not example_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pillow
 pycryptodome
 python-multipart
 pydub
+pyyaml
 requests
 uvicorn
 Jinja2

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -287,7 +287,7 @@ def test_cols_to_rows():
     )
     assert cols_to_rows({"a": None, "b": [1, "NaN", 3, 5]}) == (
         ["a", "b"],
-        [["Na", 1], ["NaN", "NaN"], ["NaN", 3], ["NaN", 5]],
+        [["NaN", 1], ["NaN", "NaN"], ["NaN", 3], ["NaN", 5]],
     )
     assert cols_to_rows({"a": None, "b": None}) == (["a", "b"], [])
 

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -260,6 +260,7 @@ def test_cols_to_rows():
         ["a", "b"],
         [[None, 1], [None, "NaN"], [None, 3], [None, 5]],
     )
+    assert cols_to_rows({"a": None, "b": None}) == (["a", "b"], [])
 
 
 def check_dataframe(config):
@@ -272,19 +273,24 @@ def check_dataframe(config):
 
 
 def check_dataset(config, readme_examples):
-    dataset = next(c for c in config["components"] if c["type"] == "dataset")
-    assert dataset["props"]["samples"] == [
-        [utils.delete_none(cols_to_rows(readme_examples)[1])]
-    ]
+    # No Examples
+    if not any(readme_examples.values()):
+        assert not any([c for c in config["components"] if c["type"] == "dataset"])
+    else:
+        dataset = next(c for c in config["components"] if c["type"] == "dataset")
+        assert dataset["props"]["samples"] == [
+            [utils.delete_none(cols_to_rows(readme_examples)[1])]
+        ]
 
 
 @pytest.mark.parametrize(
     "hypothetical_readme",
     [
-        {"a": [1, 2, "NaN", 4], "b": [1, "NaN", 3]},
+        {"a": [1, 2, "NaN"], "b": [1, "NaN", 3]},
         {"a": [1, 2, "NaN", 4], "b": [1, "NaN", 3]},
         {"a": [1, 2, "NaN"], "b": [1, "NaN", 3, 5]},
         {"a": None, "b": [1, "NaN", 3, 5]},
+        {"a": None, "b": None},
     ],
 )
 def test_can_load_tabular_model_with_different_widget_data(hypothetical_readme):


### PR DESCRIPTION
# Description

Ability to load tabular classification and regression models from the hub and turn it into a demo.

Closes: #2015

### Tabular Regression
```python
import gradio as gr

gr.Interface.load("models/skops-ci/test-3255bd22-bb75-4641-8655-824cd25d140f").launch()
```
Users can edit the dataframe to get new predictions

![tabular_regression_demo](https://user-images.githubusercontent.com/41651716/187936019-d9edb3e1-3663-47dd-8e6a-78e4f2801387.gif)

### Tabular classification
```python
import gradio as gr

gr.Interface.load("models/scikit-learn/tabular-playground").launch()
```

![image](https://user-images.githubusercontent.com/41651716/187936493-5c90c01d-a6dd-400f-aa42-833a096156a1.png)

### Demo with missing data in the input widget
```python
import gradio as gr

gr.Interface.load("models/demo-org/tabular-playground").launch()
```

![image](https://user-images.githubusercontent.com/41651716/187982914-7b05cf20-bfc0-48f5-95fb-013457c8535b.png)


### What happens when api request fails
![image](https://user-images.githubusercontent.com/41651716/187935807-99a029d6-db87-4f1e-8d23-8136aa4d18a0.png)




# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
