### PR TITLE
Better processing of example data prior to creating dataset component

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -10,6 +10,7 @@ import math
 import numbers
 import operator
 import os
+import pathlib
 import random
 import tempfile
 import uuid
@@ -1538,9 +1539,9 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent, ImgSeriali
         )
 
     def as_example(self, input_data):
-        is_str = isinstance(input_data, str)
-        is_file = Path(input_data).is_file()
-        if not all([is_str, is_file]):
+        is_valid = isinstance(input_data, str) or isinstance(input_data, pathlib.Path)
+        exists = Path(input_data).is_file()
+        if not all([is_valid, exists]):
             raise ValueError(
                 f"Example data for an image component must be a valid file, received {input_data}"
             )

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -1538,6 +1538,12 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent, ImgSeriali
         )
 
     def as_example(self, input_data):
+        is_str = isinstance(input_data, str)
+        is_file = Path(input_data).is_file()
+        if not all([is_str, is_file]):
+            raise ValueError(
+                f"Example data for an image component must be a valid file, received {input_data}"
+            )
         return input_data
 
 

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -10,7 +10,6 @@ import math
 import numbers
 import operator
 import os
-import pathlib
 import random
 import tempfile
 import uuid
@@ -1539,7 +1538,7 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent, ImgSeriali
         )
 
     def as_example(self, input_data):
-        is_valid = isinstance(input_data, str) or isinstance(input_data, pathlib.Path)
+        is_valid = isinstance(input_data, str) or isinstance(input_data, Path)
         exists = Path(input_data).is_file()
         if not all([is_valid, exists]):
             raise ValueError(
@@ -3692,7 +3691,7 @@ class Model3D(Changeable, Editable, Clearable, IOComponent, FileSerializable):
         )
 
     def as_example(self, input_data):
-        return input_data
+        return Path(input_data).name
 
 
 @document("change", "clear")

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -212,9 +212,9 @@ class IOComponent(Component, Serializable):
             load_fn = None
         return load_fn, initial_value
 
-    @abstractmethod
     def as_example(self, input_data):
         """Return the input data in a way that can be displayed by the examples dataset component in the front-end."""
+        return input_data
 
 
 class FormComponent:
@@ -386,9 +386,6 @@ class Textbox(Changeable, Submittable, IOComponent, SimpleSerializable, FormComp
             result.append((self.interpretation_separator, 0))
         return result
 
-    def as_example(self, input_data):
-        return input_data
-
 
 @document("change", "submit", "style")
 class Number(Changeable, Submittable, IOComponent, SimpleSerializable, FormComponent):
@@ -556,9 +553,6 @@ class Number(Changeable, Submittable, IOComponent, SimpleSerializable, FormCompo
     def generate_sample(self) -> float:
         return self._round_to_precision(1, self.precision)
 
-    def as_example(self, input_data):
-        return input_data
-
 
 @document("change", "style")
 class Slider(Changeable, IOComponent, SimpleSerializable, FormComponent):
@@ -717,9 +711,6 @@ class Slider(Changeable, IOComponent, SimpleSerializable, FormComponent):
             container=container,
         )
 
-    def as_example(self, input_data):
-        return input_data
-
 
 @document("change", "style")
 class Checkbox(Changeable, IOComponent, SimpleSerializable, FormComponent):
@@ -810,9 +801,6 @@ class Checkbox(Changeable, IOComponent, SimpleSerializable, FormComponent):
             return scores[0], None
         else:
             return None, scores[0]
-
-    def as_example(self, input_data):
-        return input_data
 
 
 @document("change", "style")
@@ -976,9 +964,6 @@ class CheckboxGroup(Changeable, IOComponent, SimpleSerializable, FormComponent):
             container=container,
         )
 
-    def as_example(self, input_data):
-        return input_data
-
 
 @document("change", "style")
 class Radio(Changeable, IOComponent, SimpleSerializable, FormComponent):
@@ -1119,9 +1104,6 @@ class Radio(Changeable, IOComponent, SimpleSerializable, FormComponent):
             self,
             container=container,
         )
-
-    def as_example(self, input_data):
-        return input_data
 
 
 @document("change", "style")
@@ -1534,9 +1516,6 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent, ImgSeriali
             _postprocess=_postprocess,
         )
 
-    def as_example(self, input_data):
-        return input_data
-
 
 @document("change", "clear", "play", "pause", "stop", "style")
 class Video(Changeable, Clearable, Playable, IOComponent, FileSerializable):
@@ -1718,9 +1697,6 @@ class Video(Changeable, Clearable, Playable, IOComponent, FileSerializable):
             self,
             rounded=rounded,
         )
-
-    def as_example(self, input_data):
-        return input_data
 
 
 @document("change", "clear", "play", "pause", "stop", "stream", "style")
@@ -2011,9 +1987,6 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent, FileSerial
             self,
             rounded=rounded,
         )
-
-    def as_example(self, input_data):
-        return input_data
 
 
 @document("change", "clear", "style")
@@ -2454,6 +2427,8 @@ class Dataframe(Changeable, IOComponent, JSONSerializable):
     def as_example(self, input_data):
         if isinstance(input_data, pd.DataFrame):
             return input_data.head(n=5).to_dict(orient="split")["data"]
+        elif isinstance(input_data, np.ndarray):
+            return input_data.tolist()
         return input_data
 
 
@@ -2589,9 +2564,6 @@ class Timeseries(Changeable, IOComponent, JSONSerializable):
             rounded=rounded,
         )
 
-    def as_example(self, input_data):
-        return input_data
-
 
 @document()
 class State(IOComponent, SimpleSerializable):
@@ -2621,9 +2593,6 @@ class State(IOComponent, SimpleSerializable):
 
     def style(self):
         return self
-
-    def as_example(self, input_data):
-        return input_data
 
 
 class Variable(State):
@@ -2711,9 +2680,6 @@ class Button(Clickable, IOComponent, SimpleSerializable):
             rounded=rounded,
             border=border,
         )
-
-    def as_example(self, input_data):
-        return input_data
 
 
 @document("change", "submit", "style")
@@ -2810,9 +2776,6 @@ class ColorPicker(Changeable, Submittable, IOComponent, SimpleSerializable):
             return None
         else:
             return str(y)
-
-    def as_example(self, input_data):
-        return input_data
 
 
 ############################
@@ -2929,9 +2892,6 @@ class Label(Changeable, IOComponent, JSONSerializable):
             container: If True, will add a container to the label - providing some extra padding around the border.
         """
         return IOComponent.style(self, container=container)
-
-    def as_example(self, input_data):
-        return input_data
 
 
 @document("change", "style")
@@ -3080,9 +3040,6 @@ class HighlightedText(Changeable, IOComponent, JSONSerializable):
 
         return IOComponent.style(self, rounded=rounded, container=container)
 
-    def as_example(self, input_data):
-        return input_data
-
 
 @document("change", "style")
 class JSON(Changeable, IOComponent, JSONSerializable):
@@ -3167,9 +3124,6 @@ class JSON(Changeable, IOComponent, JSONSerializable):
         """
         return IOComponent.style(self, container=container)
 
-    def as_example(self, input_data):
-        return input_data
-
 
 @document("change")
 class HTML(Changeable, IOComponent, SimpleSerializable):
@@ -3234,9 +3188,6 @@ class HTML(Changeable, IOComponent, SimpleSerializable):
 
     def style(self):
         return self
-
-    def as_example(self, input_data):
-        return input_data
 
 
 @document("style")
@@ -3362,9 +3313,6 @@ class Gallery(IOComponent):
             files.append(img)
         return files
 
-    def as_example(self, input_data):
-        return input_data
-
 
 class Carousel(IOComponent, Changeable):
     """
@@ -3450,9 +3398,6 @@ class Carousel(IOComponent, Changeable):
             return output
         else:
             raise ValueError("Unknown type. Please provide a list for the Carousel.")
-
-    def as_example(self, input_data):
-        return input_data
 
 
 @document("change", "style")
@@ -3554,9 +3499,6 @@ class Chatbot(Changeable, IOComponent, JSONSerializable):
             self,
             rounded=rounded,
         )
-
-    def as_example(self, input_data):
-        return input_data
 
 
 @document("change", "edit", "clear", "style")
@@ -3765,9 +3707,6 @@ class Plot(Changeable, Clearable, IOComponent, JSONSerializable):
     def style(self):
         return self
 
-    def as_example(self, input_data):
-        return input_data
-
 
 @document("change")
 class Markdown(IOComponent, Changeable, SimpleSerializable):
@@ -3831,9 +3770,6 @@ class Markdown(IOComponent, Changeable, SimpleSerializable):
 
     def style(self):
         return self
-
-    def as_example(self, input_data):
-        return input_data
 
 
 ############################

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -14,7 +14,6 @@ import random
 import tempfile
 import uuid
 import warnings
-from abc import abstractmethod
 from copy import deepcopy
 from pathlib import Path
 from types import ModuleType

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -1188,9 +1188,6 @@ class Dropdown(Radio):
             self, rounded=rounded, border=border, container=container
         )
 
-    def as_example(self, input_data):
-        return input_data
-
 
 @document("edit", "clear", "change", "stream", "change")
 class Image(Editable, Clearable, Changeable, Streamable, IOComponent, ImgSerializable):
@@ -1538,12 +1535,6 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent, ImgSeriali
         )
 
     def as_example(self, input_data):
-        is_valid = isinstance(input_data, str) or isinstance(input_data, Path)
-        exists = Path(input_data).is_file()
-        if not all([is_valid, exists]):
-            raise ValueError(
-                f"Example data for an image component must be a valid file, received {input_data}"
-            )
         return input_data
 
 

--- a/gradio/examples.py
+++ b/gradio/examples.py
@@ -281,4 +281,5 @@ class Examples:
         output = []
         for component, value in zip(self.outputs, example):
             output.append(component.serialize(value, self.cached_folder))
+        breakpoint()
         return output

--- a/gradio/examples.py
+++ b/gradio/examples.py
@@ -281,5 +281,4 @@ class Examples:
         output = []
         for component, value in zip(self.outputs, example):
             output.append(component.serialize(value, self.cached_folder))
-        breakpoint()
         return output

--- a/gradio/examples.py
+++ b/gradio/examples.py
@@ -6,15 +6,17 @@ from __future__ import annotations
 import csv
 import inspect
 import os
+import pathlib
 import shutil
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
 
 import anyio
+import pandas as pd
 
 from gradio import utils
-from gradio.components import Dataset
+from gradio.components import Dataframe, Dataset, File
 from gradio.context import Context
 from gradio.documentation import document, set_documentation_group
 from gradio.flagging import CSVLogger
@@ -165,6 +167,12 @@ class Examples:
             [ex for (ex, keep) in zip(example, input_has_examples) if keep]
             for example in examples
         ]
+        for example in non_none_examples:
+            for i, (component, ex) in enumerate(zip(inputs, example)):
+                if isinstance(component, Dataframe) and isinstance(ex, pd.DataFrame):
+                    example[i] = ex.to_dict(orient="split")["data"]
+                elif isinstance(component, File):
+                    example[i] = pathlib.Path(ex).name
 
         self.examples = examples
         self.non_none_examples = non_none_examples

--- a/gradio/examples.py
+++ b/gradio/examples.py
@@ -6,17 +6,14 @@ from __future__ import annotations
 import csv
 import inspect
 import os
-import pathlib
-import shutil
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
 
 import anyio
-import pandas as pd
 
 from gradio import utils
-from gradio.components import Dataframe, Dataset, File
+from gradio.components import Dataset
 from gradio.context import Context
 from gradio.documentation import document, set_documentation_group
 from gradio.flagging import CSVLogger

--- a/gradio/examples.py
+++ b/gradio/examples.py
@@ -167,12 +167,6 @@ class Examples:
             [ex for (ex, keep) in zip(example, input_has_examples) if keep]
             for example in examples
         ]
-        for example in non_none_examples:
-            for i, (component, ex) in enumerate(zip(inputs, example)):
-                if isinstance(component, Dataframe) and isinstance(ex, pd.DataFrame):
-                    example[i] = ex.to_dict(orient="split")["data"]
-                elif isinstance(component, File):
-                    example[i] = pathlib.Path(ex).name
 
         self.examples = examples
         self.non_none_examples = non_none_examples

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1780,5 +1780,41 @@ class TestState:
         assert result[0] == 2
 
 
+def test_dataframe_as_example_converts_dataframes():
+    df_comp = gr.Dataframe()
+    assert df_comp.as_example(pd.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})) == [
+        [1, 5],
+        [2, 6],
+        [3, 7],
+        [4, 8],
+    ]
+    assert df_comp.as_example(np.array([[1, 2], [3, 4.0]])) == [[1.0, 2.0], [3.0, 4.0]]
+
+
+@pytest.mark.parametrize("component", [gr.Model3D, gr.File])
+def test_as_example_returns_file_basename(component):
+    component = component()
+    assert component.as_example("/home/freddy/sources/example.ext") == "example.ext"
+
+
+@patch("gradio.components.IOComponent.as_example")
+@patch("gradio.components.File.as_example")
+@patch("gradio.components.Dataframe.as_example")
+@patch("gradio.components.Model3D.as_example")
+def test_dataset_calls_as_example(*mocks):
+    gr.Dataset(
+        components=[gr.Dataframe(), gr.File(), gr.Image(), gr.Model3D()],
+        samples=[
+            [
+                pd.DataFrame({"a": np.array([1, 2, 3])}),
+                "foo.png",
+                "bar.jpeg",
+                "duck.obj",
+            ]
+        ],
+    )
+    assert all([m.called for m in mocks])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Description
The goal of this PR is to add some processing to the example data passed in by users to either:

1. Accept more data formats as valid examples for a given component, e.g. pandas dataframes for dataframes
2. Improve how the data is displayed in the UI, e.g. only display the filename for a file as opposed to the full path
3. Validate the data matches the expected format by the UI, e.g. an image example must be a path to an image file.

Points 1 and 2 follow my discussion with @abidlabs [here](https://huggingface.slack.com/archives/C02SPHC1KD1/p1661808604873899)

Point 3 is **not implemented** since I did not discuss that with anyone prior  but I think will improve the developer experience. Unfortunately, I don't think we'll be able to validate file-path based components due to the ambiguity between absolute paths and relative paths when reading from a csv file: #2129

In terms of design, we opted to add an `as_example` method that will be called by the Dataset component on init. Didn't want to couple the component-specific example logic with the dataset component implementation in case the developer is defining their own component. We might have to re-work how we do examples when we get to community components though.

You can test the original dataframe issue here:

```python
import gradio as gr
import pandas as pd


examples = [[pd.DataFrame([[7, 8, 9], [10, 11, 12]])],
             [pd.DataFrame([[5, 6, 7], [8, 9, 10]])]]


def get_max(df: pd.DataFrame, *args) -> float:
    return df.max().max()


gr.Interface(get_max, [gr.DataFrame(type="pandas"), gr.Number()], gr.Number(),
             examples=examples).launch()
```

Closes: #2089



# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
