### PR TITLE
Some enhancements to `gr.Examples`

### DIFF
--- a/gradio/examples.py
+++ b/gradio/examples.py
@@ -37,6 +37,7 @@ def create_examples(
     examples_per_page: int = 10,
     _api_mode: bool = False,
     label: Optional[str] = None,
+    elem_id: Optional[str] = None,
 ):
     """Top-level synchronous function that creates Examples. Provided for backwards compatibility, i.e. so that gr.Examples(...) can be used to create the Examples component."""
     examples_obj = Examples(
@@ -48,6 +49,7 @@ def create_examples(
         examples_per_page=examples_per_page,
         _api_mode=_api_mode,
         label=label,
+        elem_id=elem_id,
         _initiated_directly=False,
     )
     utils.synchronize_async(examples_obj.create)
@@ -75,8 +77,9 @@ class Examples:
         cache_examples: bool = False,
         examples_per_page: int = 10,
         _api_mode: bool = False,
-        _initiated_directly: bool = True,
         label: str = "Examples",
+        elem_id: Optional[str] = None,
+        _initiated_directly: bool = True,
     ):
         """
         Parameters:
@@ -87,7 +90,7 @@ class Examples:
             cache_examples: if True, caches examples for fast runtime. If True, then `fn` and `outputs` need to be provided
             examples_per_page: how many examples to show per page (this parameter currently has no effect)
             label: the label to use for the examples component (by default, "Examples")
-        """
+            elem_id: an optional string that is assigned as the id of this component in the HTML DOM.        """
         if _initiated_directly:
             warnings.warn(
                 "Please use gr.Examples(...) instead of gr.examples.Examples(...) to create the Examples.",
@@ -186,6 +189,7 @@ class Examples:
             samples=non_none_examples,
             type="index",
             label=label,
+            elem_id=elem_id,
         )
 
         self.cached_folder = os.path.join(CACHED_FOLDER, str(self.dataset._id))

--- a/gradio/examples.py
+++ b/gradio/examples.py
@@ -226,12 +226,12 @@ class Examples:
                 _postprocess=False,
                 queue=False,
             )
-        if self.run_on_click and not (self.cache_examples):
-            self.dataset.click(
-                self.fn,
-                inputs=self.inputs,
-                outputs=self.outputs,
-            )
+            if self.run_on_click and not self.cache_examples:
+                self.dataset.click(
+                    self.fn,
+                    inputs=self.inputs,
+                    outputs=self.outputs,
+                )
 
     async def cache_interface_examples(self) -> None:
         """Caches all of the examples from an interface."""

--- a/gradio/examples.py
+++ b/gradio/examples.py
@@ -38,6 +38,7 @@ def create_examples(
     _api_mode: bool = False,
     label: Optional[str] = None,
     elem_id: Optional[str] = None,
+    run_on_click: bool = False,
 ):
     """Top-level synchronous function that creates Examples. Provided for backwards compatibility, i.e. so that gr.Examples(...) can be used to create the Examples component."""
     examples_obj = Examples(
@@ -50,6 +51,7 @@ def create_examples(
         _api_mode=_api_mode,
         label=label,
         elem_id=elem_id,
+        run_on_click=run_on_click,
         _initiated_directly=False,
     )
     utils.synchronize_async(examples_obj.create)
@@ -79,6 +81,7 @@ class Examples:
         _api_mode: bool = False,
         label: str = "Examples",
         elem_id: Optional[str] = None,
+        run_on_click: bool = False,
         _initiated_directly: bool = True,
     ):
         """
@@ -90,7 +93,9 @@ class Examples:
             cache_examples: if True, caches examples for fast runtime. If True, then `fn` and `outputs` need to be provided
             examples_per_page: how many examples to show per page (this parameter currently has no effect)
             label: the label to use for the examples component (by default, "Examples")
-            elem_id: an optional string that is assigned as the id of this component in the HTML DOM.        """
+            elem_id: an optional string that is assigned as the id of this component in the HTML DOM.
+            run_on_click: if cache_examples is False, clicking on an example does not run the function when an example is clicked. Set this to True to run the function when an example is clicked. Has no effect if cache_examples is True.
+        """
         if _initiated_directly:
             warnings.warn(
                 "Please use gr.Examples(...) instead of gr.examples.Examples(...) to create the Examples.",
@@ -195,6 +200,7 @@ class Examples:
         self.cached_folder = os.path.join(CACHED_FOLDER, str(self.dataset._id))
         self.cached_file = os.path.join(self.cached_folder, "log.csv")
         self.cache_examples = cache_examples
+        self.run_on_click = run_on_click
 
     async def create(self) -> None:
         """Caches the examples if self.cache_examples is True and creates the Dataset
@@ -219,6 +225,12 @@ class Examples:
                 + (self.outputs if self.cache_examples else []),
                 _postprocess=False,
                 queue=False,
+            )
+        if self.run_on_click and not (self.cache_examples):
+            self.dataset.click(
+                self.fn,
+                inputs=self.inputs,
+                outputs=self.outputs,
             )
 
     async def cache_interface_examples(self) -> None:

--- a/guides/3)building_with_blocks/2)controlling_layout.md
+++ b/guides/3)building_with_blocks/2)controlling_layout.md
@@ -56,7 +56,6 @@ The solution to this is to define the `gr.Textbox` outside of the `gr.Blocks()` 
 Here's a full code example:
 
 ```python
-
 input_textbox = gr.Textbox()
 
 with gr.Blocks() as demo:

--- a/guides/3)building_with_blocks/2)controlling_layout.md
+++ b/guides/3)building_with_blocks/2)controlling_layout.md
@@ -46,3 +46,21 @@ Both Components and Layout elements have a `visible` argument that can set initi
 
 $code_blocks_form
 $demo_blocks_form
+
+## Defining and Rendering Components Separately
+
+In some cases, you might want to define components before you actually render them in your UI. For instance, you might want to show an examples section using `gr.Examples` above the corresponding `gr.Textbox` input. Since `gr.Examples` requires as a parameter the input component object, you will need to first define the input component, but then render it later, after you have definted the `gr.Examples` object.
+
+The solution to this is to define the `gr.Textbox` outside of the `gr.Blocks()` scope and use the component's `.render()` method wherever you'd like it placed in the UI.
+
+Here's a full code example:
+
+```python
+
+input_textbox = gr.Textbox()
+
+with gr.Blocks() as demo:
+    gr.Examples(["hello", "bonjour", "merhaba"], input_textbox)
+    input_textbox.render()
+```
+


### PR DESCRIPTION
* Fixes: #2117 so that `gr.Examples` supports an `elem_id` field.

Test by running:

```py
with gr.Blocks(css="#ex{background-color: red}") as demo:
    t = gr.Textbox()
    gr.Examples(["hi", "hello"], t, elem_id="ex")
    
demo.launch()
```

* Fixes: #2101 by adding a `run_on_click` parameter to `gr.Examples`

Test by running:

```py
def test(x):
    time.sleep(2)
    return "xx"

with gr.Blocks() as demo:
    t = gr.Textbox()
    o = gr.Textbox()
    ex = gr.Examples(["hi", "hello"], t, o, test, run_on_click=True)
    
demo.launch()
``` 

* Also adds documentation around rendering `gr.Examples()` using components that are placed later in the UI as we tend to get questions around this frequently (e.g. #2042) 