### PR TITLE
Respect original filename when cached example files are downloaded

### DIFF
--- a/demo/model3D/run.py
+++ b/demo/model3D/run.py
@@ -1,4 +1,3 @@
-import time
 import gradio as gr
 import os
 

--- a/gradio/serializing.py
+++ b/gradio/serializing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Dict
 
 from gradio import processing_utils
@@ -110,6 +111,7 @@ class FileSerializable(Serializable):
             "data": processing_utils.encode_url_or_file_to_base64(
                 filename, encryption_key=encryption_key
             ),
+            "orig_name": Path(filename).name,
             "is_file": False,
         }
 

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -850,10 +850,12 @@ class TestFile(unittest.TestCase):
         file_input = gr.File()
         output = file_input.preprocess(x_file)
         self.assertIsInstance(output, tempfile._TemporaryFileWrapper)
+        serialized = file_input.serialize("test/test_files/sample_file.pdf")
         assert filecmp.cmp(
-            file_input.serialize("test/test_files/sample_file.pdf")["name"],
+            serialized["name"],
             "test/test_files/sample_file.pdf",
         )
+        assert serialized["orig_name"] == "sample_file.pdf"
         assert output.orig_name == "test/test_files/sample_file.pdf"
 
         self.assertIsInstance(file_input.generate_sample(), dict)


### PR DESCRIPTION
# Description

Fixes #2140

The downloaded filename is the same as what is returned from the prediction function now but you'll note that the extension for the file in the Model3D demo is messed up. 

This is because when the output is cached, we return a base64 representation of the file as opposed to serving the file itself. The data streams for Model3D files have `application/x-tgif` and `application/octet-stream` mime types and I think Chrome can't guess the file extension for those mime types. 

To get around this we'd have to serve the file for examples too but decided to hold off and hear other's thoughts on the matter.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
