### PR TITLE
Fixed Named API Requests

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -147,9 +147,12 @@ class Block:
             outputs = [outputs]
         Context.root_block.fns.append(BlockFunction(fn, preprocess, postprocess))
         if api_name is not None:
-            api_name = utils.append_unique_suffix(
+            api_name_ = utils.append_unique_suffix(
                 api_name, [dep["api_name"] for dep in Context.root_block.dependencies]
             )
+            if not(api_name == api_name_):
+                warnings.warn("api_name {} already exists, using {}".format(api_name, api_name_))
+                api_name = api_name_
         dependency = {
             "targets": [self._id] if not no_target else [],
             "trigger": event_name,
@@ -577,11 +580,15 @@ class Blocks(BlockContext):
             Context.root_block.blocks.update(self.blocks)
             Context.root_block.fns.extend(self.fns)
             for dependency in self.dependencies:
-                if dependency["api_name"] is not None:
-                    dependency["api_name"] = utils.append_unique_suffix(
-                        dependency["api_name"],
+                api_name = dependency["api_name"]
+                if api_name is not None:
+                    api_name_ = utils.append_unique_suffix(
+                        api_name,
                         [dep["api_name"] for dep in Context.root_block.dependencies],
                     )
+                    if not(api_name == api_name_):
+                        warnings.warn("api_name {} already exists, using {}".format(api_name, api_name_))
+                        dependency["api_name"] = api_name_
                 Context.root_block.dependencies.append(dependency)
             Context.root_block.temp_dirs = Context.root_block.temp_dirs | self.temp_dirs
         if Context.block is not None:

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -150,8 +150,10 @@ class Block:
             api_name_ = utils.append_unique_suffix(
                 api_name, [dep["api_name"] for dep in Context.root_block.dependencies]
             )
-            if not(api_name == api_name_):
-                warnings.warn("api_name {} already exists, using {}".format(api_name, api_name_))
+            if not (api_name == api_name_):
+                warnings.warn(
+                    "api_name {} already exists, using {}".format(api_name, api_name_)
+                )
                 api_name = api_name_
         dependency = {
             "targets": [self._id] if not no_target else [],
@@ -586,8 +588,12 @@ class Blocks(BlockContext):
                         api_name,
                         [dep["api_name"] for dep in Context.root_block.dependencies],
                     )
-                    if not(api_name == api_name_):
-                        warnings.warn("api_name {} already exists, using {}".format(api_name, api_name_))
+                    if not (api_name == api_name_):
+                        warnings.warn(
+                            "api_name {} already exists, using {}".format(
+                                api_name, api_name_
+                            )
+                        )
                         dependency["api_name"] = api_name_
                 Context.root_block.dependencies.append(dependency)
             Context.root_block.temp_dirs = Context.root_block.temp_dirs | self.temp_dirs

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -146,6 +146,10 @@ class Block:
         if not isinstance(outputs, list):
             outputs = [outputs]
         Context.root_block.fns.append(BlockFunction(fn, preprocess, postprocess))
+        if api_name is not None:
+            api_name = utils.append_unique_suffix(
+                api_name, [dep["api_name"] for dep in Context.root_block.dependencies]
+            )
         dependency = {
             "targets": [self._id] if not no_target else [],
             "trigger": event_name,
@@ -572,7 +576,13 @@ class Blocks(BlockContext):
         if Context.root_block is not None:
             Context.root_block.blocks.update(self.blocks)
             Context.root_block.fns.extend(self.fns)
-            Context.root_block.dependencies.extend(self.dependencies)
+            for dependency in self.dependencies:
+                if dependency["api_name"] is not None:
+                    dependency["api_name"] = utils.append_unique_suffix(
+                        dependency["api_name"],
+                        [dep["api_name"] for dep in Context.root_block.dependencies],
+                    )
+                Context.root_block.dependencies.append(dependency)
             Context.root_block.temp_dirs = Context.root_block.temp_dirs | self.temp_dirs
         if Context.block is not None:
             Context.block.children.extend(self.children)

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -68,7 +68,7 @@ class QueuePushBody(BaseModel):
 class PredictBody(BaseModel):
     session_hash: Optional[str]
     data: Any
-    fn_index: int = 0
+    fn_index: Optional[int]
 
 
 ###########

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -656,3 +656,17 @@ def sanitize_list_for_csv(
             sanitized_value = sanitize_value_for_csv(value)
             sanitized_values.append(sanitized_value)
     return sanitized_values
+
+
+def append_unique_suffix(name: str, list_of_names: List[str]):
+    """Appends a numerical suffix to `name` so that it does not appear in `list_of_names`."""
+    list_of_names = set(list_of_names)  # for O(1) lookup
+    if name not in list_of_names:
+        return name
+    else:
+        suffix_counter = 1
+        new_name = name + f"_{suffix_counter}"
+        while new_name in list_of_names:
+            suffix_counter += 1
+            new_name = name + f"_{suffix_counter}"
+        return new_name

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -82,7 +82,7 @@ class TestRoutes(unittest.TestCase):
         assert response.status_code == 200
         output = dict(response.json())
         assert output["data"] == ["test1"]
-        
+
     def test_multiple_renamed(self):
         with Blocks() as demo:
             i = Textbox()
@@ -101,12 +101,12 @@ class TestRoutes(unittest.TestCase):
         response = client.post("/api/p_1/", json={"data": ["test"]})
         assert response.status_code == 200
         output = dict(response.json())
-        assert output["data"] == ["test1"]        
+        assert output["data"] == ["test1"]
 
         response = client.post("/api/p_1_1/", json={"data": ["test"]})
         assert response.status_code == 200
         output = dict(response.json())
-        assert output["data"] == ["test2"]        
+        assert output["data"] == ["test2"]
 
     def test_predict_route_without_fn_index(self):
         response = self.client.post("/api/predict/", json={"data": ["test"]})

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -54,12 +54,12 @@ class TestRoutes(unittest.TestCase):
 
         app, _, _ = demo.launch(prevent_thread_lock=True)
         client = TestClient(app)
-        response = client.post("/api/p/", json={"data": ["test"], "fn_index": 0})
+        response = client.post("/api/p/", json={"data": ["test"]})
         assert response.status_code == 200
         output = dict(response.json())
         assert output["data"] == ["test1"]
 
-        response = client.post("/api/q/", json={"data": ["test"], "fn_index": 0})
+        response = client.post("/api/q/", json={"data": ["test"]})
         assert response.status_code == 200
         output = dict(response.json())
         assert output["data"] == ["test2"]
@@ -68,20 +68,20 @@ class TestRoutes(unittest.TestCase):
         with Blocks() as demo:
             i = Textbox()
             o = Textbox()
+            i.change(lambda x: x + "0", i, o, api_name="p")
             i.change(lambda x: x + "1", i, o, api_name="p")
-            i.change(lambda x: x + "2", i, o, api_name="p")
 
         app, _, _ = demo.launch(prevent_thread_lock=True)
         client = TestClient(app)
-        response = client.post("/api/p/", json={"data": ["test"], "fn_index": 0})
+        response = client.post("/api/p/", json={"data": ["test"]})
+        assert response.status_code == 200
+        output = dict(response.json())
+        assert output["data"] == ["test0"]
+
+        response = client.post("/api/p_1/", json={"data": ["test"]})
         assert response.status_code == 200
         output = dict(response.json())
         assert output["data"] == ["test1"]
-
-        response = client.post("/api/p_2/", json={"data": ["test"], "fn_index": 0})
-        assert response.status_code == 200
-        output = dict(response.json())
-        assert output["data"] == ["test2"]
 
     def test_predict_route_without_fn_index(self):
         response = self.client.post("/api/predict/", json={"data": ["test"]})

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -7,7 +7,7 @@ import unittest.mock as mock
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from gradio import Interface, close_all, routes
+from gradio import Interface, Blocks, Textbox, close_all, routes
 
 os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
 
@@ -44,6 +44,52 @@ class TestRoutes(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         output = dict(response.json())
         self.assertEqual(output["data"], ["testtest"])
+
+    def test_named_predict_route(self):
+        with Blocks() as demo:
+            i = Textbox()
+            o = Textbox()
+            i.change(lambda x: x + "1", i, o, api_name="p")
+            i.change(lambda x: x + "2", i, o, api_name="q")    
+        
+        app, _, _ = demo.launch(prevent_thread_lock=True)
+        client = TestClient(app)
+        response = client.post(
+            "/api/p/", json={"data": ["test"], "fn_index": 0}
+        )
+        assert response.status_code == 200
+        output = dict(response.json())
+        assert output["data"] == ["test1"]
+
+        response = client.post(
+            "/api/q/", json={"data": ["test"], "fn_index": 0}
+        )
+        assert response.status_code == 200
+        output = dict(response.json())
+        assert output["data"] == ["test2"]
+
+    def test_same_named_predict_route(self):
+        with Blocks() as demo:
+            i = Textbox()
+            o = Textbox()
+            i.change(lambda x: x + "1", i, o, api_name="p")
+            i.change(lambda x: x + "2", i, o, api_name="p")    
+        
+        app, _, _ = demo.launch(prevent_thread_lock=True)
+        client = TestClient(app)
+        response = client.post(
+            "/api/p/", json={"data": ["test"], "fn_index": 0}
+        )
+        assert response.status_code == 200
+        output = dict(response.json())
+        assert output["data"] == ["test1"]
+
+        response = client.post(
+            "/api/p_2/", json={"data": ["test"], "fn_index": 0}
+        )
+        assert response.status_code == 200
+        output = dict(response.json())
+        assert output["data"] == ["test2"]
 
     def test_predict_route_without_fn_index(self):
         response = self.client.post("/api/predict/", json={"data": ["test"]})

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -7,7 +7,7 @@ import unittest.mock as mock
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from gradio import Interface, Blocks, Textbox, close_all, routes
+from gradio import Blocks, Interface, Textbox, close_all, routes
 
 os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
 
@@ -50,20 +50,16 @@ class TestRoutes(unittest.TestCase):
             i = Textbox()
             o = Textbox()
             i.change(lambda x: x + "1", i, o, api_name="p")
-            i.change(lambda x: x + "2", i, o, api_name="q")    
-        
+            i.change(lambda x: x + "2", i, o, api_name="q")
+
         app, _, _ = demo.launch(prevent_thread_lock=True)
         client = TestClient(app)
-        response = client.post(
-            "/api/p/", json={"data": ["test"], "fn_index": 0}
-        )
+        response = client.post("/api/p/", json={"data": ["test"], "fn_index": 0})
         assert response.status_code == 200
         output = dict(response.json())
         assert output["data"] == ["test1"]
 
-        response = client.post(
-            "/api/q/", json={"data": ["test"], "fn_index": 0}
-        )
+        response = client.post("/api/q/", json={"data": ["test"], "fn_index": 0})
         assert response.status_code == 200
         output = dict(response.json())
         assert output["data"] == ["test2"]
@@ -73,20 +69,16 @@ class TestRoutes(unittest.TestCase):
             i = Textbox()
             o = Textbox()
             i.change(lambda x: x + "1", i, o, api_name="p")
-            i.change(lambda x: x + "2", i, o, api_name="p")    
-        
+            i.change(lambda x: x + "2", i, o, api_name="p")
+
         app, _, _ = demo.launch(prevent_thread_lock=True)
         client = TestClient(app)
-        response = client.post(
-            "/api/p/", json={"data": ["test"], "fn_index": 0}
-        )
+        response = client.post("/api/p/", json={"data": ["test"], "fn_index": 0})
         assert response.status_code == 200
         output = dict(response.json())
         assert output["data"] == ["test1"]
 
-        response = client.post(
-            "/api/p_2/", json={"data": ["test"], "fn_index": 0}
-        )
+        response = client.post("/api/p_2/", json={"data": ["test"], "fn_index": 0})
         assert response.status_code == 200
         output = dict(response.json())
         assert output["data"] == ["test2"]

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -82,6 +82,31 @@ class TestRoutes(unittest.TestCase):
         assert response.status_code == 200
         output = dict(response.json())
         assert output["data"] == ["test1"]
+        
+    def test_multiple_renamed(self):
+        with Blocks() as demo:
+            i = Textbox()
+            o = Textbox()
+            i.change(lambda x: x + "0", i, o, api_name="p")
+            i.change(lambda x: x + "1", i, o, api_name="p")
+            i.change(lambda x: x + "2", i, o, api_name="p_1")
+
+        app, _, _ = demo.launch(prevent_thread_lock=True)
+        client = TestClient(app)
+        response = client.post("/api/p/", json={"data": ["test"]})
+        assert response.status_code == 200
+        output = dict(response.json())
+        assert output["data"] == ["test0"]
+
+        response = client.post("/api/p_1/", json={"data": ["test"]})
+        assert response.status_code == 200
+        output = dict(response.json())
+        assert output["data"] == ["test1"]        
+
+        response = client.post("/api/p_1_1/", json={"data": ["test"]})
+        assert response.status_code == 200
+        output = dict(response.json())
+        assert output["data"] == ["test2"]        
 
     def test_predict_route_without_fn_index(self):
         response = self.client.post("/api/predict/", json={"data": ["test"]})

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -20,6 +20,7 @@ from gradio.test_data.blocks_configs import (
 )
 from gradio.utils import (
     Request,
+    append_unique_suffix,
     assert_configs_are_equivalent_besides_ids,
     colab_check,
     delete_none,
@@ -490,6 +491,23 @@ class TestSanitizeForCSV:
             [["=abc", "def", "gh,+ij"], ["abc", "=def", "+ghij"]]
         ) == [["'=abc", "def", "'gh,+ij"], ["abc", "'=def", "'+ghij"]]
         assert sanitize_list_for_csv([1, ["ab", "=de"]]) == [1, ["ab", "'=de"]]
+
+
+class TestAppendUniqueSuffix:
+    def test_no_suffix(self):
+        name = "test"
+        list_of_names = ["test_1", "test_2"]
+        assert append_unique_suffix(name, list_of_names) == name
+
+    def test_first_suffix(self):
+        name = "test"
+        list_of_names = ["test", "test_-1"]
+        assert append_unique_suffix(name, list_of_names) == "test_1"
+
+    def test_later_suffix(self):
+        name = "test"
+        list_of_names = ["test", "test_1", "test_2", "test_3"]
+        assert append_unique_suffix(name, list_of_names) == "test_4"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I realized during some routine testing that our named API endpoints didn't actually work -- no matter what `{name}` we provide when we make a POST request to at `/api/{name}`, it is ignored and the function with `fn_index` equal to 0 would be called.

The reason for that is that our `PredictBody` data class would automatically set `fn_index` to `0` if it was not provided:

```py
class PredictBody(BaseModel):
    session_hash: Optional[str]
    data: Any
    fn_index: 0
``` 

This has been fixed now, additional tests have been added. Along the way, also fixed #2135, which concerned the case when two prediction functions had the same `api_name`.

Fixes: #2135