### PR TITLE
Quick Fix: Cannot upload Model3D image after clearing it

### DIFF
--- a/ui/packages/model3D/src/Model3DUpload.svelte
+++ b/ui/packages/model3D/src/Model3DUpload.svelte
@@ -60,7 +60,7 @@
 	let engine: BABYLON.Engine;
 
 	function addNewModel() {
-		if (scene && engine) {
+		if (scene && !scene.isDisposed && engine) {
 			scene.dispose();
 			engine.dispose();
 		}


### PR DESCRIPTION
# Description
Quick fix for when the "X" button is pressed on the model3D upload interface, another 3d image would not upload.

https://user-images.githubusercontent.com/12725292/188227654-5bbfdaa7-592d-4e59-a6f5-3a32f40afb37.mov


Please include: 
* relevant motivation
* a summary of the change 
* which issue is fixed. 
* any additional dependencies that are required for this change.

Closes: # (issue)
#2148

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
