### PR TITLE
Keep embedded PngInfo metadata

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -1359,8 +1359,9 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent, ImgSeriali
             raise ValueError("Cannot process this value as an Image")
         if dtype in ["numpy", "pil"]:
             if dtype == "pil":
-                y = np.array(y)
-            out_y = processing_utils.encode_array_to_base64(y)
+                out_y = processing_utils.encode_pil_to_base64(y)
+            else:
+                out_y = processing_utils.encode_array_to_base64(y)
         elif dtype == "file":
             out_y = processing_utils.encode_url_or_file_to_base64(y)
         return out_y
@@ -3262,8 +3263,7 @@ class Gallery(IOComponent):
             if isinstance(img, np.ndarray):
                 img = processing_utils.encode_array_to_base64(img)
             elif isinstance(img, PIL.Image.Image):
-                img = np.array(img)
-                img = processing_utils.encode_array_to_base64(img)
+                img = processing_utils.encode_pil_to_base64(img)
             elif isinstance(img, str):
                 img = processing_utils.encode_url_or_file_to_base64(img)
             else:

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -1357,11 +1357,10 @@ class Image(Editable, Clearable, Changeable, Streamable, IOComponent, ImgSeriali
             dtype = "file"
         else:
             raise ValueError("Cannot process this value as an Image")
-        if dtype in ["numpy", "pil"]:
-            if dtype == "pil":
-                out_y = processing_utils.encode_pil_to_base64(y)
-            else:
-                out_y = processing_utils.encode_array_to_base64(y)
+        if dtype == "pil":
+            out_y = processing_utils.encode_pil_to_base64(y)
+        elif dtype == "numpy":
+            out_y = processing_utils.encode_array_to_base64(y)
         elif dtype == "file":
             out_y = processing_utils.encode_url_or_file_to_base64(y)
         return out_y

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -12,7 +12,7 @@ from io import BytesIO
 import numpy as np
 import requests
 from ffmpy import FFmpeg, FFprobe, FFRuntimeError
-from PIL import Image, ImageOps
+from PIL import Image, ImageOps, PngImagePlugin
 
 from gradio import encryptor
 
@@ -101,6 +101,25 @@ def save_pil_to_file(pil_image, dir=None):
     file_obj = tempfile.NamedTemporaryFile(delete=False, suffix=".png", dir=dir)
     pil_image.save(file_obj)
     return file_obj
+
+
+def encode_pil_to_base64(pil_image):
+    with BytesIO() as output_bytes:
+
+        # Copy any text-only metadata
+        use_metadata = False
+        metadata = PngImagePlugin.PngInfo()
+        for key, value in pil_image.info.items():
+            if isinstance(key, str) and isinstance(value, str):
+                metadata.add_text(key, value)
+                use_metadata = True
+
+        pil_image.save(
+            output_bytes, "PNG", pnginfo=(metadata if use_metadata else None)
+        )
+        bytes_data = output_bytes.getvalue()
+    base64_str = str(base64.b64encode(bytes_data), "utf-8")
+    return "data:image/png;base64," + base64_str
 
 
 def encode_array_to_base64(image_array):

--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -10,7 +10,7 @@ import ffmpy
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-from PIL import Image
+from PIL import Image, PngImagePlugin
 
 import gradio as gr
 from gradio import media_data
@@ -56,6 +56,23 @@ class ImagePreprocessing(unittest.TestCase):
         numpy_data = np.asarray(img, dtype=np.uint8)
         output_base64 = gr.processing_utils.encode_array_to_base64(numpy_data)
         self.assertEqual(output_base64, deepcopy(media_data.ARRAY_TO_BASE64_IMAGE))
+
+    def test_encode_pil_to_base64(self):
+        img = Image.open("gradio/test_data/test_image.png")
+        img = img.convert("RGB")
+        img.info = {}  # Strip metadata
+        output_base64 = gr.processing_utils.encode_pil_to_base64(img)
+        self.assertEqual(output_base64, deepcopy(media_data.ARRAY_TO_BASE64_IMAGE))
+
+    def test_encode_pil_to_base64_keeps_pnginfo(self):
+        input_img = Image.open("gradio/test_data/test_image.png")
+        input_img = input_img.convert("RGB")
+        input_img.info = {"key1": "value1", "key2": "value2"}
+
+        encoded_image = gr.processing_utils.encode_pil_to_base64(input_img)
+        decoded_image = gr.processing_utils.decode_base64_to_image(encoded_image)
+
+        self.assertEqual(decoded_image.info, input_img.info)
 
     def test_resize_and_crop(self):
         img = Image.open("gradio/test_data/test_image.png")

--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -10,7 +10,7 @@ import ffmpy
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-from PIL import Image, PngImagePlugin
+from PIL import Image
 
 import gradio as gr
 from gradio import media_data


### PR DESCRIPTION
Maintain any text-only PngInfo metadata on a PIL image when dragging UI images between components.

# Description

Please include: 
* PNG images can have metadata attached to them. This data could, for example, be added during image generation and store the generation parameters. However, if dragging an annotated image between UI elements in Gradio, the conversion to base64 would lose the metadata
* This change maintains the metadata when dragging PNGs between UI elements

Closes: # (issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes  (well, nothing *new* breaks)
