### PR TITLE
Fixed misleading log when server_name is '0.0.0.0'

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1025,7 +1025,11 @@ class Blocks(BlockContext):
                 else:
                     print(strings.en["COLAB_DEBUG_FALSE"])
         else:
-            print(strings.en["RUNNING_LOCALLY_SEPARATED"].format(self.protocol, self.server_name, self.server_port))
+            print(
+                strings.en["RUNNING_LOCALLY_SEPARATED"].format(
+                    self.protocol, self.server_name, self.server_port
+                )
+            )
         if is_colab and self.requires_permissions:
             print(strings.en["MEDIA_PERMISSIONS_IN_COLAB"])
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -983,7 +983,7 @@ class Blocks(BlockContext):
                     "Rerunning server... use `close()` to stop if you need to change `launch()` parameters.\n----"
                 )
         else:
-            server_port, path_to_local_server, app, server = networking.start_server(
+            server_name, server_port, local_url, app, server = networking.start_server(
                 self,
                 server_name,
                 server_port,
@@ -991,11 +991,13 @@ class Blocks(BlockContext):
                 ssl_certfile,
                 ssl_keyfile_password,
             )
-            self.local_url = path_to_local_server
+            self.server_name = server_name
+            self.local_url = local_url
             self.server_port = server_port
             self.server_app = app
             self.server = server
             self.is_running = True
+            self.protocol = "https" if self.local_url.startswith("https") else "http"
 
             event_queue.Queue.set_url(self.local_url)
             # Cannot run async functions in background other than app's scope.
@@ -1023,7 +1025,7 @@ class Blocks(BlockContext):
                 else:
                     print(strings.en["COLAB_DEBUG_FALSE"])
         else:
-            print(strings.en["RUNNING_LOCALLY"].format(self.local_url))
+            print(strings.en["RUNNING_LOCALLY_SEPARATED"].format(self.protocol, self.server_name, self.server_port))
         if is_colab and self.requires_permissions:
             print(strings.en["MEDIA_PERMISSIONS_IN_COLAB"])
 

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -129,7 +129,7 @@ def start_server(
         port = server_port
 
     url_host_name = "localhost" if server_name == "0.0.0.0" else server_name
-    
+
     if ssl_keyfile is not None:
         if ssl_certfile is None:
             raise ValueError(

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -128,16 +128,14 @@ def start_server(
             )
         port = server_port
 
-    url_host_name = "localhost" if server_name == "0.0.0.0" else server_name
-
     if ssl_keyfile is not None:
         if ssl_certfile is None:
             raise ValueError(
                 "ssl_certfile must be provided if ssl_keyfile is provided."
             )
-        path_to_local_server = "https://{}:{}/".format(url_host_name, port)
+        path_to_local_server = "https://{}:{}/".format(server_name, port)
     else:
-        path_to_local_server = "http://{}:{}/".format(url_host_name, port)
+        path_to_local_server = "http://{}:{}/".format(server_name, port)
 
     app = App.create_app(blocks)
 

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -128,14 +128,16 @@ def start_server(
             )
         port = server_port
 
+    url_host_name = "localhost" if server_name == "0.0.0.0" else server_name
+    
     if ssl_keyfile is not None:
         if ssl_certfile is None:
             raise ValueError(
                 "ssl_certfile must be provided if ssl_keyfile is provided."
             )
-        path_to_local_server = "https://{}:{}/".format(server_name, port)
+        path_to_local_server = "https://{}:{}/".format(url_host_name, port)
     else:
-        path_to_local_server = "http://{}:{}/".format(server_name, port)
+        path_to_local_server = "http://{}:{}/".format(url_host_name, port)
 
     app = App.create_app(blocks)
 
@@ -152,7 +154,7 @@ def start_server(
     )
     server = Server(config=config)
     server.run_in_thread()
-    return port, path_to_local_server, app, server
+    return server_name, port, path_to_local_server, app, server
 
 
 def setup_tunnel(local_server_port: int, endpoint: str) -> str:

--- a/gradio/strings.py
+++ b/gradio/strings.py
@@ -6,6 +6,7 @@ MESSAGING_API_ENDPOINT = "https://api.gradio.app/gradio-messaging/en"
 
 en = {
     "RUNNING_LOCALLY": "Running on local URL:  {}",
+    "RUNNING_LOCALLY_SEPARATED": "Running on local URL:  {}://{}:{}",
     "SHARE_LINK_DISPLAY": "Running on public URL: {}",
     "COULD_NOT_GET_SHARE_LINK": "\nCould not create share link, please check your internet connection.",
     "COLAB_NO_LOCAL": "Cannot display local interface on google colab, public link created.",

--- a/test/test_networking.py
+++ b/test/test_networking.py
@@ -68,7 +68,7 @@ class TestStartServer(unittest.TestCase):
             networking.INITIAL_PORT_VALUE + networking.TRY_NUM_PORTS,
         )
         io.enable_queue = False
-        _, local_path, _, server = networking.start_server(io, server_port=port)
+        _, _, local_path, _, server = networking.start_server(io, server_port=port)
         url = urllib.parse.urlparse(local_path)
         self.assertEquals(url.scheme, "http")
         self.assertEquals(url.port, port)


### PR DESCRIPTION
# Description

Assuming I have this script:
```python
import gradio as gr
demo = gr.Blocks(title="Test")
demo.launch(server_name='0.0.0.0', server_port=4567)
```
Currently, running this with gradio 3.2 produce this log:
```console
Running on local URL:  http://localhost:4567/

To create a public link, set `share=True` in `launch()`.
```
But this is misleading to user since `localhost` is often associated  to `127.0.0.1` and the log should say this instead:
```console
Running on local URL:  http://0.0.0.0:4567/
``` 
This small PR basically fixed this misleading log

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
