### PR TITLE
use correct MIME type for js-script file

### DIFF
--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -31,6 +31,9 @@ from gradio import encryptor
 from gradio.event_queue import Estimation, Event, Queue
 from gradio.exceptions import Error
 
+import mimetypes
+mimetypes.init()
+
 STATIC_TEMPLATE_LIB = pkg_resources.resource_filename("gradio", "templates/")
 STATIC_PATH_LIB = pkg_resources.resource_filename("gradio", "templates/frontend/static")
 BUILD_PATH_LIB = pkg_resources.resource_filename("gradio", "templates/frontend/assets")
@@ -165,6 +168,8 @@ class App(FastAPI):
         @app.head("/", response_class=HTMLResponse)
         @app.get("/", response_class=HTMLResponse)
         def main(request: Request, user: str = Depends(get_current_user)):
+            mimetypes.add_type('application/javascript', '.js')
+            
             if app.auth is None or not (user is None):
                 config = app.blocks.config
             else:

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import asyncio
 import inspect
 import io
+import mimetypes
 import os
 import posixpath
 import secrets
 import traceback
-import urllib
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, List, Optional, Type
@@ -31,7 +31,6 @@ from gradio import encryptor
 from gradio.event_queue import Estimation, Event, Queue
 from gradio.exceptions import Error
 
-import mimetypes
 mimetypes.init()
 
 STATIC_TEMPLATE_LIB = pkg_resources.resource_filename("gradio", "templates/")
@@ -168,8 +167,8 @@ class App(FastAPI):
         @app.head("/", response_class=HTMLResponse)
         @app.get("/", response_class=HTMLResponse)
         def main(request: Request, user: str = Depends(get_current_user)):
-            mimetypes.add_type('application/javascript', '.js')
-            
+            mimetypes.add_type("application/javascript", ".js")
+
             if app.auth is None or not (user is None):
                 config = app.blocks.config
             else:


### PR DESCRIPTION
Fixes: #1203 

This makes the server use the proper MIME type for the js-script file.

I made the changes as suggested in the issue. @abidlabs could you please review the changes i made?