### PR TITLE
Add accordion component

### DIFF
--- a/demo/blocks_flipper/run.py
+++ b/demo/blocks_flipper/run.py
@@ -18,7 +18,10 @@ with gr.Blocks() as demo:
             image_input = gr.Image()
             image_output = gr.Image()
         image_button = gr.Button("Flip")
-    
+
+    with gr.Accordion("Open for More!"):
+        gr.Markdown("Look at me...")
+
     text_button.click(flip_text, inputs=text_input, outputs=text_output)
     image_button.click(flip_image, inputs=image_input, outputs=image_output)
     

--- a/demo/rows_and_columns/run.py
+++ b/demo/rows_and_columns/run.py
@@ -15,11 +15,6 @@ with gr.Blocks() as demo:
         with gr.Column(scale=2, min_width=600):
             img1 = gr.Image("images/cheetah.jpg")
             btn = gr.Button("Go").style(full_width=True)
-    with gr.Accordion("Open me!"):
-            text6 = gr.Textbox(label="6")
-            with gr.Row():
-                text7 = gr.Textbox(label="7")
-                text8 = gr.Textbox(label="8")
 
 if __name__ == "__main__":
     demo.launch()

--- a/demo/rows_and_columns/run.py
+++ b/demo/rows_and_columns/run.py
@@ -15,5 +15,11 @@ with gr.Blocks() as demo:
         with gr.Column(scale=2, min_width=600):
             img1 = gr.Image("images/cheetah.jpg")
             btn = gr.Button("Go").style(full_width=True)
+    with gr.Accordion("Open me!"):
+            text6 = gr.Textbox(label="6")
+            with gr.Row():
+                text7 = gr.Textbox(label="7")
+                text8 = gr.Textbox(label="8")
+
 if __name__ == "__main__":
     demo.launch()

--- a/gradio/__init__.py
+++ b/gradio/__init__.py
@@ -55,7 +55,7 @@ from gradio.flagging import (
 )
 from gradio.interface import Interface, TabbedInterface, close_all
 from gradio.ipython_ext import load_ipython_extension
-from gradio.layouts import Box, Column, Group, Row, Tab, TabItem, Tabs
+from gradio.layouts import Accordion, Box, Column, Group, Row, Tab, TabItem, Tabs
 from gradio.mix import Parallel, Series
 from gradio.templates import (
     Files,

--- a/gradio/layouts.py
+++ b/gradio/layouts.py
@@ -296,3 +296,42 @@ class Box(BlockContext):
 class Form(BlockContext):
     def get_config(self):
         return {"type": "form", **super().get_config()}
+
+
+@document()
+class Accordion(BlockContext):
+    """
+    Accordion is a layout element which can be toggled to show/hide the contained content.
+    Example:
+        with gradio.Accordion("See Details"):
+            gr.Markdown("lorem ipsum")
+    """
+
+    def __init__(self, label, *, open: bool = True, **kwargs):
+        """
+        Parameters:
+            label: name of accordion section.
+            open: An optional string that is assigned as the id of this component in the HTML DOM. Can be used for targeting CSS styles.
+        """
+        self.label = label
+        self.open = open
+        super().__init__(**kwargs)
+
+    def get_config(self):
+        return {
+            "type": "accordion",
+            "open": self.open,
+            "label": self.label,
+            **super().get_config(),
+        }
+
+    @staticmethod
+    def update(
+        open: Optional[bool] = None,
+        visible: Optional[bool] = None,
+    ):
+        return {
+            "visible": visible,
+            "open": open,
+            "__type__": "update",
+        }

--- a/gradio/layouts.py
+++ b/gradio/layouts.py
@@ -307,15 +307,18 @@ class Accordion(BlockContext):
             gr.Markdown("lorem ipsum")
     """
 
-    def __init__(self, label, *, open: bool = True, **kwargs):
+    def __init__(
+        self, label, *, open: bool = True, elem_id: Optional[str] = None, **kwargs
+    ):
         """
         Parameters:
             label: name of accordion section.
-            open: An optional string that is assigned as the id of this component in the HTML DOM. Can be used for targeting CSS styles.
+            open: if True, accordion is open by default.
+            elem_id: An optional string that is assigned as the id of this component in the HTML DOM. Can be used for targeting CSS styles.
         """
         self.label = label
         self.open = open
-        super().__init__(**kwargs)
+        super().__init__(elem_id=elem_id, **kwargs)
 
     def get_config(self):
         return {

--- a/guides/3)building_with_blocks/2)controlling_layout.md
+++ b/guides/3)building_with_blocks/2)controlling_layout.md
@@ -31,7 +31,7 @@ $demo_rows_and_columns
 
 See how the first column has two Textboxes arranged vertically. The second column has an Image and Button arranged vertically. Notice how the relative widths of the two columns is set by the `scale` parameter. The column with twice the `scale` value takes up twice the width.
 
-## Tabs
+## Tabs amd Accordions
 
 You can also create Tabs using the `with gradio.Tab('tab_name'):` clause. Any component created inside of a `with gradio.Tab('tab_name'):` context appears in that tab. Consecutive Tab clauses are grouped together so that a single tab can be selected at one time, and only the components within that Tab's context are shown.
 
@@ -39,6 +39,8 @@ For example:
 
 $code_blocks_flipper
 $demo_blocks_flipper
+
+Also note the Accordion that can be opened and closed - another layout element to selectively show content.
 
 ## Visibility
 

--- a/ui/packages/app/src/components/Accordion/Accordion.svelte
+++ b/ui/packages/app/src/components/Accordion/Accordion.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { Component as Column } from "../Column";
+	export let label: string;
+	export let elem_id: string;
+	export let visible: string;
+	export let open: boolean = true;
+
+	const toggle = () => {
+		open = !open;
+	};
+</script>
+
+<div
+	id={elem_id}
+	class="p-3 border border-gray-200 dark:border-gray-700 rounded-lg flex flex-col gap-3 hover:border-gray-300 dark:hover:border-gray-600 transition"
+	class:hidden={!visible}
+>
+	<div
+		on:click={toggle}
+		class="w-full text-lg font-semibold flex justify-between cursor-pointer"
+	>
+		<span>{label}</span>
+		<span class:rotate-90={!open} class="transition">▼</span>
+	</div>
+	<Column visible={open}>
+		<slot />
+	</Column>
+</div>

--- a/ui/packages/app/src/components/Accordion/Accordion.svelte
+++ b/ui/packages/app/src/components/Accordion/Accordion.svelte
@@ -15,10 +15,7 @@
 	class="p-3 border border-gray-200 dark:border-gray-700 rounded-lg flex flex-col gap-3 hover:border-gray-300 dark:hover:border-gray-600 transition"
 	class:hidden={!visible}
 >
-	<div
-		on:click={toggle}
-		class="w-full text-lg font-semibold flex justify-between cursor-pointer"
-	>
+	<div on:click={toggle} class="w-full flex justify-between cursor-pointer">
 		<span>{label}</span>
 		<span class:rotate-90={!open} class="transition">▼</span>
 	</div>

--- a/ui/packages/app/src/components/Accordion/index.ts
+++ b/ui/packages/app/src/components/Accordion/index.ts
@@ -1,0 +1,2 @@
+export { default as Component } from "./Accordion.svelte";
+export const modes = ["static"];

--- a/ui/packages/app/src/components/directory.ts
+++ b/ui/packages/app/src/components/directory.ts
@@ -1,4 +1,5 @@
 export const component_map = {
+	accordion: () => import("./Accordion"),
 	audio: () => import("./Audio"),
 	box: () => import("./Box"),
 	button: () => import("./Button"),


### PR DESCRIPTION
Allows users to wrap elements in an accordion. It's been requested several times and I thought this might be useful for the more complex SD demos being created right now.

Fixes: #938 

Use:
```python
with gr.Accordion("open up"):
   # components here
```

![Recording 2022-09-07 at 17 04 33](https://user-images.githubusercontent.com/7870876/189005690-4fbd8092-aec0-45d4-80a8-38e81b03228a.gif)
