### PR TITLE
Bugfix: null dereference resizing empty textbox

### DIFF
--- a/ui/packages/form/src/Textbox.svelte
+++ b/ui/packages/form/src/Textbox.svelte
@@ -77,7 +77,7 @@
 		el.style.overflowY = "scroll";
 		el.addEventListener("input", resize);
 
-		if (!value.trim()) return;
+		if (!value || !value.trim()) return;
 		resize({ target: el });
 
 		return {


### PR DESCRIPTION
Fixes "TypeError: Cannot read properties of null (reading 'trim')" when resizing an empty textbox. 'value' is an Optional parameter so must be null checked before empty checked.

This causes https://github.com/sd-webui/stable-diffusion-webui/issues/656 . It prevents the UI from appearing at all if the input prompt is defaulted to multiline. The fix is a simple null check.

# Checklist:

- [x ] I have performed a self-review of my own code
- [ x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
