### PR TITLE
Remove creation of test.txt file in test

### DIFF
--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -112,8 +112,8 @@ class OutputPreprocessing(unittest.TestCase):
         self.assertIsInstance(temp_file, tempfile._TemporaryFileWrapper)
 
     def test_create_tmp_copy_of_file(self):
-        os.system("touch test.txt")
-        temp_file = gr.processing_utils.create_tmp_copy_of_file("test.txt")
+        f = tempfile.NamedTemporaryFile(delete=False)
+        temp_file = gr.processing_utils.create_tmp_copy_of_file(f.name)
         self.assertIsInstance(temp_file, tempfile._TemporaryFileWrapper)
 
     float_dtype_list = [


### PR DESCRIPTION
# Description

Closes: #1995 

I don't think we need to modify `TestFile::test_component_as_output` since the File postprocess method will create a temp file internally.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
