### PR TITLE
Fix video controls

### DIFF
--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -236,7 +236,9 @@ class App(FastAPI):
                 Path(temp_dir).resolve() in Path(path).resolve().parents
                 for temp_dir in app.blocks.temp_dirs
             ):
-                return FileResponse(Path(path).resolve())
+                return FileResponse(
+                    Path(path).resolve(), headers={"Accept-Ranges": "bytes"}
+                )
             else:
                 raise ValueError(
                     f"File cannot be fetched: {path}, perhaps because "


### PR DESCRIPTION
Thanks to some nice sleuthing by @dawoodkhan82 and @pngwn, we discovered that the reason the video controls were not working was because Chrome requires very particular headers to be able pause videos. This PR adds those headers.

Tested the kitchen_sink demo and can confirm everything behaves correctly.

Fixes: #2172  