### PR TITLE
Added support for URLs for `Video`, `Audio`, and `Image`

### DIFF
--- a/demo/reverse_audio/run.py
+++ b/demo/reverse_audio/run.py
@@ -14,7 +14,7 @@ demo = gr.Interface(fn=reverse_audio,
                     inputs="microphone", 
                     outputs="audio", 
                     examples=[
-                    os.path.join(os.path.dirname(__file__), "audio/cantina.wav"),
+                    "https://file-examples.com/storage/fe6d784fb46320d949c245e/2017/11/file_example_MP3_700KB.mp3",
                     os.path.join(os.path.dirname(__file__), "audio/recording1.wav")
         ], cache_examples=True)
 

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -1655,13 +1655,13 @@ class Video(Changeable, Clearable, Playable, IOComponent, FileSerializable):
         """
         if y is None:
             return None
-        
+
         is_temp_file = False
 
         if utils.validate_url(y):
             y = processing_utils.download_to_file(y, dir=self.temp_dir).name
             is_temp_file = True
-            
+
         returned_format = y.split(".")[-1].lower()
         if (
             processing_utils.ffmpeg_installed()
@@ -1932,7 +1932,7 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent, FileSerial
         """
         if y is None:
             return None
-        
+
         if utils.validate_url(y):
             y = processing_utils.download_to_file(y, dir=self.temp_dir).name
         elif isinstance(y, tuple):

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -1933,7 +1933,7 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent, FileSerial
         elif isinstance(y, tuple):
             sample_rate, data = y
             file = tempfile.NamedTemporaryFile(
-                prefix="sample", suffix=".wav", delete=False
+                suffix=".wav", dir=self.temp_dir, delete=False
             )
             processing_utils.audio_to_file(sample_rate, data, file.name)
         else:
@@ -1990,7 +1990,7 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent, FileSerial
         )
 
     def as_example(self, input_data: str) -> str:
-        return os.path.basename(input_data)
+        return Path(input_data).name
 
 
 @document("change", "clear", "style")
@@ -2172,7 +2172,7 @@ class File(Changeable, Clearable, IOComponent, FileSerializable):
         )
 
     def as_example(self, input_data: str) -> str:
-        return os.path.basename(input_data)
+        return Path(input_data).name
 
 
 @document("change", "style")
@@ -3635,7 +3635,7 @@ class Model3D(Changeable, Editable, Clearable, IOComponent, FileSerializable):
         )
 
     def as_example(self, input_data: str) -> str:
-        return os.path.basename(input_data)
+        return Path(input_data).name
 
 
 @document("change", "clear")

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -1929,18 +1929,17 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent, FileSerial
             return None
 
         if utils.validate_url(y):
-            y = processing_utils.download_to_file(y, dir=self.temp_dir)
+            file = processing_utils.download_to_file(y, dir=self.temp_dir)
         elif isinstance(y, tuple):
             sample_rate, data = y
             file = tempfile.NamedTemporaryFile(
                 prefix="sample", suffix=".wav", delete=False
             )
             processing_utils.audio_to_file(sample_rate, data, file.name)
-            y = file.name
         else:
-            y = processing_utils.create_tmp_copy_of_file(y, dir=self.temp_dir)
+            file = processing_utils.create_tmp_copy_of_file(y, dir=self.temp_dir)
 
-        return {"name": y.name, "data": None, "is_file": True}
+        return {"name": file.name, "data": None, "is_file": True}
 
     def stream(
         self,
@@ -1989,6 +1988,9 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent, FileSerial
             self,
             rounded=rounded,
         )
+
+    def as_example(self, input_data: str) -> str:
+        return os.path.basename(input_data)
 
 
 @document("change", "clear", "style")
@@ -2169,8 +2171,8 @@ class File(Changeable, Clearable, IOComponent, FileSerializable):
             rounded=rounded,
         )
 
-    def as_example(self, input_data):
-        return Path(input_data).name
+    def as_example(self, input_data: str) -> str:
+        return os.path.basename(input_data)
 
 
 @document("change", "style")
@@ -3632,8 +3634,8 @@ class Model3D(Changeable, Editable, Clearable, IOComponent, FileSerializable):
             rounded=rounded,
         )
 
-    def as_example(self, input_data):
-        return Path(input_data).name
+    def as_example(self, input_data: str) -> str:
+        return os.path.basename(input_data)
 
 
 @document("change", "clear")

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -1656,11 +1656,8 @@ class Video(Changeable, Clearable, Playable, IOComponent, FileSerializable):
         if y is None:
             return None
 
-        is_temp_file = False
-
         if utils.validate_url(y):
             y = processing_utils.download_to_file(y, dir=self.temp_dir).name
-            is_temp_file = True
 
         returned_format = y.split(".")[-1].lower()
         if (
@@ -1677,9 +1674,7 @@ class Video(Changeable, Clearable, Playable, IOComponent, FileSerializable):
             ff.run()
             y = output_file_name
 
-        if not is_temp_file:
-            y = processing_utils.create_tmp_copy_of_file(y, dir=self.temp_dir)
-
+        y = processing_utils.create_tmp_copy_of_file(y, dir=self.temp_dir)
         return {"name": y.name, "data": None, "is_file": True}
 
     def style(
@@ -1934,7 +1929,7 @@ class Audio(Changeable, Clearable, Playable, Streamable, IOComponent, FileSerial
             return None
 
         if utils.validate_url(y):
-            y = processing_utils.download_to_file(y, dir=self.temp_dir).name
+            y = processing_utils.download_to_file(y, dir=self.temp_dir)
         elif isinstance(y, tuple):
             sample_rate, data = y
             file = tempfile.NamedTemporaryFile(

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -14,7 +14,7 @@ import requests
 from ffmpy import FFmpeg, FFprobe, FFRuntimeError
 from PIL import Image, ImageOps, PngImagePlugin
 
-from gradio import encryptor
+from gradio import encryptor, utils
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")  # Ignore pydub warning if ffmpeg is not installed
@@ -31,10 +31,9 @@ def decode_base64_to_image(encoding):
 
 
 def encode_url_or_file_to_base64(path, encryption_key=None):
-    try:
-        requests.get(path)
+    if utils.validate_url(path):
         return encode_url_to_base64(path, encryption_key=encryption_key)
-    except (requests.exceptions.MissingSchema, requests.exceptions.InvalidSchema):
+    else:
         return encode_file_to_base64(path, encryption_key=encryption_key)
 
 
@@ -89,6 +88,13 @@ def encode_plot_to_base64(plt):
     base64_str = str(base64.b64encode(bytes_data), "utf-8")
     return "data:image/png;base64," + base64_str
 
+def download_to_file(url, dir=None):
+    file_suffix = os.path.splitext(url)[1]
+    file_obj = tempfile.NamedTemporaryFile(delete=False, suffix=file_suffix, dir=dir)
+    with requests.get(url, stream=True) as r:
+        with open(file_obj.name, 'wb') as f:
+            shutil.copyfileobj(r.raw, f)
+    return file_obj
 
 def save_array_to_file(image_array, dir=None):
     pil_image = Image.fromarray(_convert(image_array, np.uint8, force_copy=False))

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -88,13 +88,15 @@ def encode_plot_to_base64(plt):
     base64_str = str(base64.b64encode(bytes_data), "utf-8")
     return "data:image/png;base64," + base64_str
 
+
 def download_to_file(url, dir=None):
     file_suffix = os.path.splitext(url)[1]
     file_obj = tempfile.NamedTemporaryFile(delete=False, suffix=file_suffix, dir=dir)
     with requests.get(url, stream=True) as r:
-        with open(file_obj.name, 'wb') as f:
+        with open(file_obj.name, "wb") as f:
             shutil.copyfileobj(r.raw, f)
     return file_obj
+
 
 def save_array_to_file(image_array, dir=None):
     pil_image = Image.fromarray(_convert(image_array, np.uint8, force_copy=False))

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -17,6 +17,7 @@ from typing import Any, List, Optional, Type
 
 import orjson
 import pkg_resources
+import requests
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
@@ -28,9 +29,9 @@ from starlette.responses import RedirectResponse
 from starlette.websockets import WebSocket, WebSocketState
 
 import gradio
-from gradio import encryptor
+from gradio import encryptor, utils
 from gradio.exceptions import Error
-from gradio.queue import Estimation, Event, Queue
+from gradio.queue import Estimation, Event
 
 mimetypes.init()
 
@@ -221,6 +222,8 @@ class App(FastAPI):
 
         @app.get("/file={path:path}", dependencies=[Depends(login_check)])
         def file(path: str):
+            if utils.validate_url(path):
+                return RedirectResponse(url=path, status_code=status.HTTP_302_FOUND)
             if (
                 app.blocks.encrypt
                 and isinstance(app.blocks.examples, str)

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -10,6 +10,7 @@ import json.decoder
 import os
 import pkgutil
 import random
+import urllib
 import warnings
 from contextlib import contextmanager
 from copy import deepcopy
@@ -670,3 +671,12 @@ def append_unique_suffix(name: str, list_of_names: List[str]):
             suffix_counter += 1
             new_name = name + f"_{suffix_counter}"
         return new_name
+
+
+def validate_url(possible_url: str) -> bool:
+    try:
+        if requests.get(possible_url).status_code == 200:
+            return True
+    except Exception:
+        pass
+    return False

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -10,7 +10,6 @@ import json.decoder
 import os
 import pkgutil
 import random
-import urllib
 import warnings
 from contextlib import contextmanager
 from copy import deepcopy


### PR DESCRIPTION
Previously, you could only pass in local filepaths for the `Video` and `Audio` components. This PR adds support for URLs as well. 

Furthermore, while `Image` supported URLs for default values, examples with URLs didn't work. So this PR also fixes that. 

Fixes: #2254