### PR TITLE
Add clarifications about min width vs. scale parameter to docs

### DIFF
--- a/gradio/layouts.py
+++ b/gradio/layouts.py
@@ -66,6 +66,7 @@ class Row(BlockContext):
 class Column(BlockContext):
     """
     Column is a layout element within Blocks that renders all children vertically. The widths of columns can be set through the `scale` and `min_width` parameters.
+    If a certain scale results in a column narrower than min_width, the min_width parameter will win.
     Example:
         with gradio.Blocks() as demo:
             with gradio.Row():
@@ -91,7 +92,7 @@ class Column(BlockContext):
         """
         Parameters:
             scale: relative width compared to adjacent Columns. For example, if Column A has scale=2, and Column B has scale=1, A will be twice as wide as B.
-            min_width: minimum pixel width of Column, will wrap if not sufficient screen space to satisfy this value.
+            min_width: minimum pixel width of Column, will wrap if not sufficient screen space to satisfy this value. min_width takes precedence over the scale parameter if they conflict.
             visible: If False, column will be hidden.
             variant: column type, 'default' (no background) or 'panel' (gray background color and rounded corners)
         """


### PR DESCRIPTION
# Description

This change updates the docstrings to clarify that `min_width` overrides `scale` if they conflict.

Closes: #2223

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
