### PR TITLE
Skip value key in delete_none only during updates

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -707,7 +707,9 @@ class Blocks(BlockContext):
                             == components._Keywords.NO_VALUE
                         ):
                             prediction_value.pop("value")
-                        prediction_value = delete_none(prediction_value)
+                        prediction_value = delete_none(
+                            prediction_value, skip_value=True
+                        )
                         if "value" in prediction_value:
                             prediction_value["value"] = block.postprocess(
                                 prediction_value["value"]

--- a/gradio/test_data/blocks_configs.py
+++ b/gradio/test_data/blocks_configs.py
@@ -51,7 +51,6 @@ XRAY_CONFIG = {
                 "show_label": True,
                 "name": "image",
                 "visible": True,
-                "value": None,
                 "style": {},
             },
         },
@@ -62,7 +61,6 @@ XRAY_CONFIG = {
                 "show_label": True,
                 "name": "json",
                 "visible": True,
-                "value": None,
                 "style": {},
             },
         },
@@ -100,7 +98,6 @@ XRAY_CONFIG = {
                 "name": "image",
                 "visible": True,
                 "style": {},
-                "value": None,
             },
         },
         {
@@ -111,7 +108,6 @@ XRAY_CONFIG = {
                 "name": "json",
                 "visible": True,
                 "style": {},
-                "value": None,
             },
         },
         {
@@ -279,7 +275,6 @@ XRAY_CONFIG_DIFF_IDS = {
             "type": "image",
             "props": {
                 "image_mode": "RGB",
-                "value": None,
                 "source": "upload",
                 "tool": "editor",
                 "streaming": False,
@@ -295,7 +290,6 @@ XRAY_CONFIG_DIFF_IDS = {
             "type": "json",
             "props": {
                 "show_label": True,
-                "value": None,
                 "name": "json",
                 "visible": True,
                 "style": {},
@@ -339,7 +333,6 @@ XRAY_CONFIG_DIFF_IDS = {
                 "name": "image",
                 "visible": True,
                 "style": {},
-                "value": None,
             },
         },
         {
@@ -350,7 +343,6 @@ XRAY_CONFIG_DIFF_IDS = {
                 "name": "json",
                 "visible": True,
                 "style": {},
-                "value": None,
             },
         },
         {

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -281,14 +281,14 @@ def format_ner_list(input_string: str, ner_groups: Dict[str : str | int]):
     return output
 
 
-def delete_none(_dict):
+def delete_none(_dict, skip_value=False):
     """
     Delete None values recursively from all of the dictionaries, tuples, lists, sets.
     Credit: https://stackoverflow.com/a/66127889/5209347
     """
     if isinstance(_dict, dict):
         for key, value in list(_dict.items()):
-            if key == "value":
+            if skip_value and key == "value":
                 continue
             if isinstance(value, (list, dict, tuple, set)):
                 _dict[key] = delete_none(value)


### PR DESCRIPTION
# Description

Fixes issue where None values are not filtered out of the config. Initially we modified `delete_none` in #2157 to not delete the `value` key so that the value of a component could be set to `None` in `gr.update`. However, we should still filter out `None` from the config outside of `gr.update`.

To test, the following demo should work without breaking the `blocks_reset` and `blocks_update` demo on spaces.

```python
import gradio as gr

with gr.Blocks() as demo:
    box = gr.Textbox(value=None)
demo.launch() 
```


Should fix the problem mentioned in #2234



# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
