### PR TITLE
Fix Multiple File Examples

### DIFF
--- a/demo/zip_two_files/run.py
+++ b/demo/zip_two_files/run.py
@@ -4,21 +4,20 @@ from zipfile import ZipFile
 import gradio as gr
 
 
-def zip_two_files(file1, file2):
+def zip_two_files(files):
     with ZipFile("tmp.zip", "w") as zipObj:
-        zipObj.write(file1.name, "file1")
-        zipObj.write(file2.name, "file2")
+        for idx, file in enumerate(files):
+            zipObj.write(file.name, "file" + str(idx))
     return "tmp.zip"
-
 
 demo = gr.Interface(
     zip_two_files,
-    ["file", "file"],
+    gr.File(file_count="multiple"),
     "file",
-    examples=[
-        [os.path.join(os.path.dirname(__file__),"files/titanic.csv"), 
-         os.path.join(os.path.dirname(__file__),"files/titanic.csv")],
-    ],
+    examples=[[[os.path.join(os.path.dirname(__file__),"files/titanic.csv"), 
+    os.path.join(os.path.dirname(__file__),"files/titanic.csv"), 
+    os.path.join(os.path.dirname(__file__),"files/titanic.csv")]]], 
+    cache_examples=True
 )
 
 if __name__ == "__main__":

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2134,7 +2134,7 @@ class File(Changeable, Clearable, IOComponent, FileSerializable):
                     "orig_name": os.path.basename(file),
                     "name": processing_utils.create_tmp_copy_of_file(
                         file, dir=self.temp_dir
-                     ).name,
+                    ).name,
                     "size": os.path.getsize(file),
                     "data": None,
                     "is_file": True,

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2133,8 +2133,8 @@ class File(Changeable, Clearable, IOComponent, FileSerializable):
                 {
                     "orig_name": os.path.basename(file),
                     "name": processing_utils.create_tmp_copy_of_file(
-                        file, self.temp_dir
-                    ).name,
+                        file, dir=self.temp_dir
+                     ).name,
                     "size": os.path.getsize(file),
                     "data": None,
                     "is_file": True,
@@ -2171,8 +2171,11 @@ class File(Changeable, Clearable, IOComponent, FileSerializable):
             rounded=rounded,
         )
 
-    def as_example(self, input_data: str) -> str:
-        return Path(input_data).name
+    def as_example(self, input_data: str | List) -> str:
+        if isinstance(input_data, list):
+            return input_data
+        else:
+            return Path(input_data).name
 
 
 @document("change", "style")

--- a/ui/packages/app/src/components/Dataset/ExampleComponents/File.svelte
+++ b/ui/packages/app/src/components/Dataset/ExampleComponents/File.svelte
@@ -3,4 +3,8 @@
 	export let value: FileData;
 </script>
 
-<div class="truncate">{value}</div>
+{#if Array.isArray(value)}
+	<div class="truncate">{value.join(', ')}</div>
+{:else}
+	<div class="truncate">{value}</div>
+{/if}

--- a/ui/packages/app/src/components/Dataset/ExampleComponents/File.svelte
+++ b/ui/packages/app/src/components/Dataset/ExampleComponents/File.svelte
@@ -4,7 +4,7 @@
 </script>
 
 {#if Array.isArray(value)}
-	<div class="truncate">{value.join(', ')}</div>
+	<div class="truncate">{value.join(", ")}</div>
 {:else}
 	<div class="truncate">{value}</div>
 {/if}


### PR DESCRIPTION
# Description
Fix issue when trying to use examples with multiple file component. Issue was with dataframe examples not having a proper header. Also updated a demo to use a multiple file component.

Please include: 
* relevant motivation
* a summary of the change 
* which issue is fixed. 
* any additional dependencies that are required for this change.

Closes: #2205 

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
