### PR TITLE
Respect Upstream Queue when loading interfaces/blocks from Spaces

### DIFF
--- a/gradio/external.py
+++ b/gradio/external.py
@@ -424,8 +424,8 @@ async def get_pred_from_ws(
 ) -> Dict[str, Any]:
     completed = False
     while not completed:
-        foo = await websocket.recv()
-        resp = json.loads(foo)
+        msg = await websocket.recv()
+        resp = json.loads(msg)
         if resp["msg"] == "queue_full":
             raise exceptions.Error("Queue is full! Please try again.")
         elif resp["msg"] == "send_data":
@@ -436,7 +436,7 @@ async def get_pred_from_ws(
 
 def get_ws_fn(ws_url):
     async def ws_fn(data):
-        async with websockets.connect(ws_url) as websocket:
+        async with websockets.connect(ws_url, open_timeout=10) as websocket:
             return await get_pred_from_ws(websocket, data)
 
     return ws_fn
@@ -445,7 +445,7 @@ def get_ws_fn(ws_url):
 def use_websocket(config):
     return config["enable_queue"] and version.parse(
         config["version"]
-    ) >= version.Version("3.1.5")
+    ) >= version.Version("3.2")
 
 
 def get_spaces_blocks(model_name, config):

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -12,6 +12,7 @@ import re
 import warnings
 from copy import deepcopy
 from typing import TYPE_CHECKING, Callable, Dict, List, Tuple
+import websockets
 
 import requests
 import yaml
@@ -417,6 +418,20 @@ def get_spaces(model_name, api_key, alias, **kwargs):
         return get_spaces_blocks(model_name, config)
 
 
+def get_ws_fn(ws_url):
+    async def get_pred_from_ws(data):
+        async with websockets.connect(ws_url) as websocket:
+            completed = False
+            while not completed:
+                resp = json.loads(await websocket.recv())
+                print(resp)
+                if resp['msg'] == "send_data":
+                    await websocket.send(data)
+                completed = resp['msg'] == 'process_completed'
+            return resp["output"]
+    return get_pred_from_ws
+
+
 def get_spaces_blocks(model_name, config):
     def streamline_config(config: dict) -> dict:
         """Streamlines the blocks config dictionary to fix components that don't render correctly."""
@@ -429,6 +444,7 @@ def get_spaces_blocks(model_name, config):
     config = streamline_config(config)
     api_url = "https://hf.space/embed/{}/api/predict/".format(model_name)
     headers = {"Content-Type": "application/json"}
+    ws_url = "wss://spaces.huggingface.tech/{}/queue/join".format(model_name)
 
     fns = []
     for d, dependency in enumerate(config["dependencies"]):
@@ -437,18 +453,22 @@ def get_spaces_blocks(model_name, config):
             def get_fn(outputs, fn_index):
                 def fn(*data):
                     data = json.dumps({"data": data, "fn_index": fn_index})
-                    response = requests.post(api_url, headers=headers, data=data)
-                    result = json.loads(response.content.decode("utf-8"))
-                    try:
+                    if config['enable_queue']:
+                        result = utils.synchronize_async(get_ws_fn(ws_url), data)
                         output = result["data"]
-                    except KeyError:
-                        if "error" in result and "429" in result["error"]:
-                            raise TooManyRequestsError(
-                                "Too many requests to the Hugging Face API"
+                    else:
+                        response = requests.post(api_url, headers=headers, data=data)
+                        result = json.loads(response.content.decode("utf-8"))
+                        try:
+                            output = result["data"]
+                        except KeyError:
+                            if "error" in result and "429" in result["error"]:
+                                raise TooManyRequestsError(
+                                    "Too many requests to the Hugging Face API"
+                                )
+                            raise KeyError(
+                                f"Could not find 'data' key in response from external Space. Response received: {result}"
                             )
-                        raise KeyError(
-                            f"Could not find 'data' key in response from external Space. Response received: {result}"
-                        )
                     if len(outputs) == 1:
                         output = output[0]
                     return output

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -471,10 +471,10 @@ def get_spaces_blocks(model_name, config):
     for d, dependency in enumerate(config["dependencies"]):
         if dependency["backend_fn"]:
 
-            def get_fn(outputs, fn_index):
+            def get_fn(outputs, fn_index, use_ws):
                 def fn(*data):
                     data = json.dumps({"data": data, "fn_index": fn_index})
-                    if use_websocket(config, dependency):
+                    if use_ws:
                         result = utils.synchronize_async(ws_fn, data)
                         output = result["data"]
                     else:
@@ -496,7 +496,9 @@ def get_spaces_blocks(model_name, config):
 
                 return fn
 
-            fn = get_fn(deepcopy(dependency["outputs"]), d)
+            fn = get_fn(
+                deepcopy(dependency["outputs"]), d, use_websocket(config, dependency)
+            )
             fns.append(fn)
         else:
             fns.append(None)

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -340,18 +340,22 @@ def test_can_load_tabular_model_with_different_widget_data(hypothetical_readme):
 
 
 @pytest.mark.parametrize(
-    "config, answer",
+    "config, dependency, answer",
     [
-        ({"version": "3.3", "enable_queue": True}, True),
-        ({"version": "3.3", "enable_queue": False}, False),
-        ({"version": "3.2", "enable_queue": False}, False),
-        ({"version": "3.2", "enable_queue": True}, True),
-        ({"version": "3.1.3", "enable_queue": True}, False),
-        ({"version": "3.1.3", "enable_queue": False}, False),
+        ({"version": "3.3", "enable_queue": True}, {"queue": True}, True),
+        ({"version": "3.3", "enable_queue": False}, {"queue": None}, False),
+        ({"version": "3.3", "enable_queue": True}, {"queue": None}, True),
+        ({"version": "3.3", "enable_queue": True}, {"queue": False}, False),
+        ({"enable_queue": True}, {"queue": False}, False),
+        ({"version": "3.2", "enable_queue": False}, {"queue": None}, False),
+        ({"version": "3.2", "enable_queue": True}, {"queue": None}, True),
+        ({"version": "3.2", "enable_queue": True}, {"queue": False}, False),
+        ({"version": "3.1.3", "enable_queue": True}, {"queue": None}, False),
+        ({"version": "3.1.3", "enable_queue": False}, {"queue": True}, False),
     ],
 )
-def test_use_websocket_after_315(config, answer):
-    assert use_websocket(config) == answer
+def test_use_websocket_after_315(config, dependency, answer):
+    assert use_websocket(config, dependency) == answer
 
 
 class AsyncMock(MagicMock):
@@ -385,7 +389,10 @@ async def test_get_pred_from_ws_raises_if_queue_full():
         await get_pred_from_ws(mock_ws, data)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="Async mocks don't work for 3.7")
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="Mocks of async context manager don't work for 3.7",
+)
 def test_respect_queue_when_load_from_config():
     with unittest.mock.patch("websockets.connect"):
         with unittest.mock.patch(

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -343,8 +343,8 @@ def test_can_load_tabular_model_with_different_widget_data(hypothetical_readme):
 @pytest.mark.parametrize(
     "config, answer",
     [
-        ({"version": "3.1.5", "enable_queue": True}, True),
-        ({"version": "3.1.5", "enable_queue": False}, False),
+        ({"version": "3.3", "enable_queue": True}, True),
+        ({"version": "3.3", "enable_queue": False}, False),
         ({"version": "3.2", "enable_queue": False}, False),
         ({"version": "3.2", "enable_queue": True}, True),
         ({"version": "3.1.3", "enable_queue": True}, False),

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -1,7 +1,7 @@
-import asyncio
 import json
 import os
 import pathlib
+import sys
 import textwrap
 import unittest
 from unittest.mock import MagicMock, patch
@@ -17,7 +17,6 @@ from gradio.external import (
     cols_to_rows,
     get_pred_from_ws,
     get_tabular_examples,
-    get_ws_fn,
     use_websocket,
 )
 
@@ -386,6 +385,7 @@ async def test_get_pred_from_ws_raises_if_queue_full():
         await get_pred_from_ws(mock_ws, data)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Async mocks don't work for 3.7")
 def test_respect_queue_when_load_from_config():
     with unittest.mock.patch("websockets.connect"):
         with unittest.mock.patch(

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -398,7 +398,7 @@ def test_respect_queue_when_load_from_config():
         with unittest.mock.patch(
             "gradio.external.get_pred_from_ws", return_value={"data": ["foo"]}
         ):
-            interface = gr.Interface.load("spaces/multimodalart/saymyname")
+            interface = gr.Interface.load("spaces/freddyaboulton/saymyname")
             assert interface("bob") == "foo"
 
 


### PR DESCRIPTION
# Description

Closes: #1316

The approach taken is to open up a websocket connection to the space for each prediction request sent to the loaded space. The main limitation of this approach is that the loaded app doesn't display information about the request's position in the original app's queue. However, there are a couple of reasons why I went with this approach:

1. We can't send updates to the front-end if the front-end isn't running, e.g. when using the interface or app as a function.
2. The app that's loading the interface may have its own queue, and if so, it doesn't make sense to display another app's queue. Imagine you're a user of an app with a queue that's loading another app with a queue. You'd see your position decrease until your request is being processed, but then you'd see your queue position jump back up again when the upstream queue gets the request sent from the downstream. I think that will be confusing to users who have no idea about how the downstream app they are using is implemented. In short, passing updates from the upstream queue to the downstream app would only make sense for `gr.Interface.load().launch` workflows but not more complex uses of `gr.Interface.load`. 

How to test,

Launch the following app:

```python
import gradio as gr

io = gr.Interface.load("spaces/freddyaboulton/saymyname")
print(io("foo"))
io.launch(enable_queue=True)
```

Then go to this space: https://huggingface.co/spaces/freddyaboulton/saymyname

Launch three simultaneous requests but make sure the first two are on the HF space. On the app running locally, it should take around ~15 seconds to complete the request.


![respect_upstream_spaces](https://user-images.githubusercontent.com/41651716/191133292-c0072733-05df-41e0-9acf-af5862cbd35e.gif)




# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
