### PR TITLE
Supports `gr.update()` in example caching

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -182,13 +182,11 @@ class Block:
             "elem_id": self.elem_id,
             "style": self._style,
         }
-        
+
     @classmethod
     def get_specific_update(cls, generic_update):
         del generic_update["__type__"]
-        generic_update = cls.update(
-            **generic_update
-        )
+        generic_update = cls.update(**generic_update)
         return generic_update
 
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -40,6 +40,8 @@ set_documentation_group("blocks")
 
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
     import comet_ml
+    import mlflow
+    import wandb
     from fastapi.applications import FastAPI
 
     from gradio.components import Component, IOComponent

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -205,7 +205,7 @@ class IOComponent(Component, Serializable):
         if interactive is not None:
             config["mode"] = "dynamic" if interactive else "static"
         return config
-    
+
     @staticmethod
     def get_load_fn_and_initial_value(value):
         if callable(value):

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -59,7 +59,7 @@ from gradio.serializing import (
 set_documentation_group("component")
 
 
-class _Keywords(Enum):
+class _Keywords(str, Enum):
     NO_VALUE = "NO_VALUE"  # Used as a sentinel to determine if nothing is provided as a argument for `value` in `Component.update()`
     FINISHED_ITERATING = "FINISHED_ITERATING"  # Used to skip processing of a component's value (needed for generators + state)
 
@@ -205,7 +205,7 @@ class IOComponent(Component, Serializable):
         if interactive is not None:
             config["mode"] = "dynamic" if interactive else "static"
         return config
-
+    
     @staticmethod
     def get_load_fn_and_initial_value(value):
         if callable(value):

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -59,7 +59,7 @@ from gradio.serializing import (
 set_documentation_group("component")
 
 
-class _Keywords(str, Enum):
+class _Keywords(Enum):
     NO_VALUE = "NO_VALUE"  # Used as a sentinel to determine if nothing is provided as a argument for `value` in `Component.update()`
     FINISHED_ITERATING = "FINISHED_ITERATING"  # Used to skip processing of a component's value (needed for generators + state)
 

--- a/gradio/examples.py
+++ b/gradio/examples.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional
 import anyio
 
 from gradio import utils
-from gradio.blocks import postprocess_update_dict
+from gradio.blocks import convert_update_dict_to_list, postprocess_update_dict
 from gradio.components import Dataset
 from gradio.context import Context
 from gradio.documentation import document, set_documentation_group
@@ -274,6 +274,11 @@ class Examples:
             predictions = await self.fn(*processed_input)
         else:
             predictions = await anyio.to_thread.run_sync(self.fn, *processed_input)
+
+        output_ids = [output._id for output in self.outputs]
+        if type(predictions) is dict and len(predictions) > 0:
+            predictions = convert_update_dict_to_list(output_ids, predictions)
+
         if len(self.outputs) == 1:
             predictions = [predictions]
         if not self._api_mode:

--- a/gradio/examples.py
+++ b/gradio/examples.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import csv
 import inspect
+import json
 import os
 import warnings
 from pathlib import Path
@@ -294,5 +295,10 @@ class Examples:
         example = examples[example_id + 1]  # +1 to adjust for header
         output = []
         for component, value in zip(self.outputs, example):
-            output.append(component.serialize(value, self.cached_folder))
+            try:
+                value_as_dict = json.loads(value)
+                assert utils.is_update(value_as_dict)
+                output.append(component.get_specific_update(value_as_dict))
+            except (json.decoder.JSONDecodeError, ValueError, AssertionError):
+                output.append(component.serialize(value, self.cached_folder))
         return output

--- a/gradio/examples.py
+++ b/gradio/examples.py
@@ -190,10 +190,8 @@ class Examples:
             for example in self.processed_examples
         ]
         if cache_examples:
-            for ex in non_none_examples:
-                if len([sample for sample in ex if sample is not None]) != len(
-                    self.inputs_with_examples
-                ):
+            for example in self.examples:
+                if len([ex for ex in example if ex is not None]) != len(self.inputs):
                     warnings.warn(
                         "Examples are being cached but not all input components have "
                         "example values. This may result in an exception being thrown by "

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -206,15 +206,18 @@ class CSVLogger(FlaggingCallback):
                         component.label or f"component {idx}"
                     ),
                 )
-                csv_data.append(
-                    component.deserialize(
-                        sample,
-                        save_dir=save_dir,
-                        encryption_key=self.encryption_key,
+                if utils.is_update(sample):
+                    csv_data.append(json.dumps(sample))
+                else:
+                    csv_data.append(
+                        component.deserialize(
+                            sample,
+                            save_dir=save_dir,
+                            encryption_key=self.encryption_key,
+                        )
+                        if sample is not None
+                        else ""
                     )
-                    if sample is not None
-                    else ""
-                )
             csv_data.append(flag_option if flag_option is not None else "")
             csv_data.append(username if username is not None else "")
             csv_data.append(str(datetime.datetime.now()))

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -207,7 +207,7 @@ class CSVLogger(FlaggingCallback):
                     ),
                 )
                 if utils.is_update(sample):
-                    csv_data.append(json.dumps(sample))
+                    csv_data.append(str(sample))
                 else:
                     csv_data.append(
                         component.deserialize(

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -675,3 +675,8 @@ def validate_url(possible_url: str) -> bool:
     except Exception:
         pass
     return False
+
+
+def is_update(val):
+    return type(val) is dict and "update" in val.get("__type__", "")
+

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import copy
 import inspect

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -679,4 +679,3 @@ def validate_url(possible_url: str) -> bool:
 
 def is_update(val):
     return type(val) is dict and "update" in val.get("__type__", "")
-

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -16,7 +16,6 @@ import pytest
 import wandb
 
 import gradio as gr
-from gradio.components import component
 from gradio.routes import PredictBody
 from gradio.test_data.blocks_configs import XRAY_CONFIG
 from gradio.utils import assert_configs_are_equivalent_besides_ids

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -413,33 +413,35 @@ class TestSpecificUpdate:
     def test_without_update(self):
         with pytest.raises(KeyError):
             gr.Textbox.get_specific_update({"lines": 4})
-        
+
     def test_with_update(self):
-        specific_update = gr.Textbox.get_specific_update({"lines": 4, "__type__": "update"})        
+        specific_update = gr.Textbox.get_specific_update(
+            {"lines": 4, "__type__": "update"}
+        )
         assert specific_update == {
-            'lines': 4,
-            'max_lines': None,
-            'placeholder': None,
-            'label': None,
-            'show_label': None,
-            'visible': None,
-            'value': gr.components._Keywords.NO_VALUE,
-            '__type__': 'update'}         
-    
+            "lines": 4,
+            "max_lines": None,
+            "placeholder": None,
+            "label": None,
+            "show_label": None,
+            "visible": None,
+            "value": gr.components._Keywords.NO_VALUE,
+            "__type__": "update",
+        }
+
     def test_with_generic_update(self):
         specific_update = gr.Video.get_specific_update(
-            {"visible": True, 
-             "value": "test.mp4", 
-             "__type__": "generic_update"
-        })
+            {"visible": True, "value": "test.mp4", "__type__": "generic_update"}
+        )
         assert specific_update == {
-            'source': None,
-            'label': None,
-            'show_label': None,
-            'interactive': None,
-            'visible': True,
-            'value': 'test.mp4',
-            '__type__': 'update'}
+            "source": None,
+            "label": None,
+            "show_label": None,
+            "interactive": None,
+            "visible": True,
+            "value": "test.mp4",
+            "__type__": "update",
+        }
 
 
 if __name__ == "__main__":

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -16,6 +16,7 @@ import pytest
 import wandb
 
 import gradio as gr
+from gradio.components import component
 from gradio.routes import PredictBody
 from gradio.test_data.blocks_configs import XRAY_CONFIG
 from gradio.utils import assert_configs_are_equivalent_besides_ids
@@ -406,6 +407,39 @@ class TestCallFunction:
         assert output["iterator"] is None
         output = await demo.call_function(1, [3], iterator=output["iterator"])
         assert output["prediction"] == (0, 3)
+
+
+class TestSpecificUpdate:
+    def test_without_update(self):
+        with pytest.raises(KeyError):
+            gr.Textbox.get_specific_update({"lines": 4})
+        
+    def test_with_update(self):
+        specific_update = gr.Textbox.get_specific_update({"lines": 4, "__type__": "update"})        
+        assert specific_update == {
+            'lines': 4,
+            'max_lines': None,
+            'placeholder': None,
+            'label': None,
+            'show_label': None,
+            'visible': None,
+            'value': gr.components._Keywords.NO_VALUE,
+            '__type__': 'update'}         
+    
+    def test_with_generic_update(self):
+        specific_update = gr.Video.get_specific_update(
+            {"visible": True, 
+             "value": "test.mp4", 
+             "__type__": "generic_update"
+        })
+        assert specific_update == {
+            'source': None,
+            'label': None,
+            'show_label': None,
+            'interactive': None,
+            'visible': True,
+            'value': 'test.mp4',
+            '__type__': 'update'}
 
 
 if __name__ == "__main__":

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -85,11 +85,33 @@ class TestProcessExamples:
             "text",
             examples=[["World"], ["Dunya"], ["Monde"]],
         )
-        io.launch(prevent_thread_lock=True)
         await io.examples_handler.cache_interface_examples()
         prediction = await io.examples_handler.load_from_cache(1)
-        io.close()
         assert prediction[0] == "Hello Dunya"
+
+    @pytest.mark.asyncio
+    async def test_caching_with_update(self):
+        io = gr.Interface(
+            lambda x: gr.update(visible=False),
+            "text",
+            "image",
+            examples=[["World"], ["Dunya"], ["Monde"]],
+        )
+        await io.examples_handler.cache_interface_examples()
+        prediction = await io.examples_handler.load_from_cache(1)
+        assert prediction[0] == {"visible": False, "__type__": "update"}
+
+    @pytest.mark.asyncio
+    async def test_caching_with_mix_update(self):
+        io = gr.Interface(
+            lambda x: [gr.update(lines=4, value="hello"), "test/test_files/bus.png"],
+            "text",
+            ["text", "image"],
+            examples=[["World"], ["Dunya"], ["Monde"]],
+        )
+        await io.examples_handler.cache_interface_examples()
+        prediction = await io.examples_handler.load_from_cache(1)
+        assert prediction[0] == {"lines": 4, "value": "hello", "__type__": "update"}
 
 
 def test_raise_helpful_error_message_if_providing_partial_examples(tmp_path):


### PR DESCRIPTION
Previously, we couldn't handle `gr.update()` in flagging or example caching, as described in #2305. This PR fixes that.

Fixes: #2305

I'm still writing some tests but ready to be reviewed