### PR TITLE
Make buttons respect full_width = False [hotfix]

### DIFF
--- a/ui/packages/button/src/Button.svelte
+++ b/ui/packages/button/src/Button.svelte
@@ -19,6 +19,7 @@
 <button
 	on:click
 	class:!hidden={!visible}
+	class:!grow-0={style.full_width === false}
 	class="gr-button gr-button-{size} gr-button-{variant} self-start
 		{classes}"
 	id={elem_id}


### PR DESCRIPTION
Fixes `Button.style(full_width=False)`