### PR TITLE
Gallery events WIP

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3205,8 +3205,8 @@ class HTML(Changeable, IOComponent, SimpleSerializable):
         return self
 
 
-@document("style")
-class Gallery(IOComponent):
+@document("style", "change", "click")
+class Gallery(IOComponent, Changeable, Clickable):
     """
     Used to display a list of images as a gallery that can be scrolled through.
     Preprocessing: this component does *not* accept input.


### PR DESCRIPTION
Colab with @pngwn to add `click()` and `change()` events to `Gallery`.

* The `click()` event should fire when an image is clicked, so that it can be used for some downstream function
* The `change()` event should fire when the Gallery loads images, allowing it to trigger downstream actions

Fixes: #1976, fixes: #1379 which should be marked as duplicates 