### PR TITLE
Start queue when gradio is a sub application

### DIFF
--- a/demo/custom_path/run.py
+++ b/demo/custom_path/run.py
@@ -5,13 +5,17 @@ CUSTOM_PATH = "/gradio"
 
 app = FastAPI()
 
+
 @app.get("/")
 def read_main():
     return {"message": "This is your main app"}
 
+
 io = gr.Interface(lambda x: "Hello, " + x + "!", "textbox", "textbox")
 gradio_app = gr.routes.App.create_app(io)
+app = gr.mount_gradio_app(app, gradio_app, server_name="localhost", port="8000", path="/gradio")
 
-app.mount(CUSTOM_PATH, gradio_app)
 
 # Run this from the terminal as you would normally start a FastAPI app: `uvicorn run:app` and navigate to http://localhost:8000/gradio in your browser.
+# Note that if you run uvicorn by setting the --host and --port flags, the values you set must match the values passed to
+# mount_gradio_app

--- a/demo/custom_path/run.py
+++ b/demo/custom_path/run.py
@@ -12,7 +12,7 @@ def read_main():
 
 
 io = gr.Interface(lambda x: "Hello, " + x + "!", "textbox", "textbox")
-app = gr.mount_gradio_app(app, io, path="/gradio")
+app = gr.mount_gradio_app(app, io, path=CUSTOM_PATH)
 
 
 # Run this from the terminal as you would normally start a FastAPI app: `uvicorn run:app`

--- a/demo/custom_path/run.py
+++ b/demo/custom_path/run.py
@@ -16,6 +16,7 @@ gradio_app = gr.routes.App.create_app(io)
 app = gr.mount_gradio_app(app, gradio_app, server_name="localhost", port="8000", path="/gradio")
 
 
-# Run this from the terminal as you would normally start a FastAPI app: `uvicorn run:app` and navigate to http://localhost:8000/gradio in your browser.
-# Note that if you run uvicorn by setting the --host and --port flags, the values you set must match the values passed to
-# mount_gradio_app
+# Run this from the terminal as you would normally start a FastAPI app: `uvicorn run:app`
+# and navigate to http://localhost:8000/gradio in your browser.
+# Note that if you run uvicorn by setting the --host and --port flags, the values you set
+# must match the values passed to mount_gradio_app

--- a/demo/custom_path/run.py
+++ b/demo/custom_path/run.py
@@ -12,11 +12,8 @@ def read_main():
 
 
 io = gr.Interface(lambda x: "Hello, " + x + "!", "textbox", "textbox")
-gradio_app = gr.routes.App.create_app(io)
-app = gr.mount_gradio_app(app, gradio_app, server_name="localhost", port="8000", path="/gradio")
+app = gr.mount_gradio_app(app, io, path="/gradio")
 
 
 # Run this from the terminal as you would normally start a FastAPI app: `uvicorn run:app`
 # and navigate to http://localhost:8000/gradio in your browser.
-# Note that if you run uvicorn by setting the --host and --port flags, the values you set
-# must match the values passed to mount_gradio_app

--- a/gradio/__init__.py
+++ b/gradio/__init__.py
@@ -57,6 +57,7 @@ from gradio.interface import Interface, TabbedInterface, close_all
 from gradio.ipython_ext import load_ipython_extension
 from gradio.layouts import Accordion, Box, Column, Group, Row, Tab, TabItem, Tabs
 from gradio.mix import Parallel, Series
+from gradio.routes import mount_gradio_app
 from gradio.templates import (
     Files,
     Highlight,
@@ -75,7 +76,6 @@ from gradio.templates import (
     TextArea,
     Webcam,
 )
-from gradio.routes import mount_gradio_app
 
 current_pkg_version = pkgutil.get_data(__name__, "version.txt").decode("ascii").strip()
 __version__ = current_pkg_version

--- a/gradio/__init__.py
+++ b/gradio/__init__.py
@@ -75,7 +75,7 @@ from gradio.templates import (
     TextArea,
     Webcam,
 )
-from gradio.utils import mount_gradio_app
+from gradio.routes import mount_gradio_app
 
 current_pkg_version = pkgutil.get_data(__name__, "version.txt").decode("ascii").strip()
 __version__ = current_pkg_version

--- a/gradio/__init__.py
+++ b/gradio/__init__.py
@@ -75,6 +75,7 @@ from gradio.templates import (
     TextArea,
     Webcam,
 )
+from gradio.utils import mount_gradio_app
 
 current_pkg_version = pkgutil.get_data(__name__, "version.txt").decode("ascii").strip()
 __version__ = current_pkg_version

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -912,6 +912,7 @@ class Blocks(BlockContext):
             update_intervals=status_update_rate if status_update_rate != "auto" else 1,
             max_size=max_size,
         )
+        self.config = self.get_config_file()
         return self
 
     def launch(
@@ -1257,3 +1258,8 @@ class Blocks(BlockContext):
                     no_target=True,
                     queue=False,
                 )
+
+    def startup_events(self):
+        if self.enable_queue:
+            utils.run_coro_in_background(self._queue.start)
+        utils.run_coro_in_background(self.create_limiter)

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1260,6 +1260,7 @@ class Blocks(BlockContext):
                 )
 
     def startup_events(self):
+        """Events that should be run when the app containing this block starts up."""
         if self.enable_queue:
             utils.run_coro_in_background(self._queue.start)
         utils.run_coro_in_background(self.create_limiter)

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -314,7 +314,7 @@ class App(FastAPI):
                 ws_url = urlparse(str(websocket.url))
                 scheme = "http" if ws_url.scheme == "ws" else "https"
                 port = f":{ws_url.port}" if ws_url.port else ""
-                predict_endpoint = f"{scheme}://{ws_url.hostname}:{port}{ws_url.path.replace('queue/join', '')}"
+                predict_endpoint = f"{scheme}://{ws_url.hostname}{port}{ws_url.path.replace('queue/join', '')}"
                 print(f"New endpoint: {predict_endpoint}")
                 app.blocks._queue.set_url(predict_endpoint)
 

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -336,12 +336,12 @@ class App(FastAPI):
         )
         async def startup_events():
             from gradio.utils import run_coro_in_background
+            app.blocks._queue.set_url(app.blocks.local_url)
 
             if app.blocks.enable_queue:
-                gradio.utils.run_coro_in_background(app.blocks._queue.start)
+               gradio.utils.run_coro_in_background(app.blocks._queue.start)
             gradio.utils.run_coro_in_background(app.blocks.create_limiter)
 
-            return True
 
         return app
 

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -402,7 +402,7 @@ def mount_gradio_app(
     app: fastapi.FastAPI,
     blocks: gradio.Blocks,
     path: str,
-    gradio_api_url: Optional[str],
+    gradio_api_url: Optional[str] = None,
 ) -> fastapi.FastAPI:
     """Mount a gradio.Blocks to an existing FastAPI application.
 
@@ -411,6 +411,16 @@ def mount_gradio_app(
         blocks: The blocks object we want to mount to the parent app.
         path: The path at which the gradio application will be mounted.
         gradio_api_url: The full url at which the gradio app will run. This is only needed if deploying to Huggingface spaces of if the websocket endpoints of your deployed app are on a different network location than the gradio app. If deploying to spaces, set gradio_api_url to 'http://localhost:7860/'
+    Example:
+        from fastapi import FastAPI
+        import gradio as gr
+        app = FastAPI()
+        @app.get("/")
+        def read_main():
+            return {"message": "This is your main app"}
+        io = gr.Interface(lambda x: "Hello, " + x + "!", "textbox", "textbox")
+        app = gr.mount_gradio_app(app, io, path="/gradio")
+        # Then run `uvicorn run:app` from the terminal and navigate to http://localhost:8000/gradio.
     """
 
     gradio_app = App.create_app(blocks)

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -314,7 +314,7 @@ class App(FastAPI):
                 ws_url = urlparse(str(websocket.url))
                 scheme = "http" if ws_url.scheme == "ws" else "https"
                 port = f":{ws_url.port}" if ws_url.port else ""
-                predict_endpoint = f"{scheme}://{ws_url.hostname}:{ws_url.port}{ws_url.path.replace('queue/join', '')}"
+                predict_endpoint = f"{scheme}://{ws_url.hostname}:{port}{ws_url.path.replace('queue/join', '')}"
                 print(f"New endpoint: {predict_endpoint}")
                 app.blocks._queue.set_url(predict_endpoint)
 
@@ -405,9 +405,6 @@ def mount_gradio_app(
     @app.on_event("startup")
     async def start_queue():
         if gradio_app.blocks.enable_queue:
-            #gradio_app.blocks._queue.set_url(
-            #    urljoin(f"http://{server_name}:{port}", f"{path}" + "/")
-            #)
             gradio_app.blocks.startup_events()
 
     app.mount(path, gradio_app)

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -17,7 +17,6 @@ from typing import Any, List, Optional, Type
 
 import orjson
 import pkg_resources
-import requests
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
@@ -335,13 +334,8 @@ class App(FastAPI):
             dependencies=[Depends(login_check)],
         )
         async def startup_events():
-            from gradio.utils import run_coro_in_background
-            app.blocks._queue.set_url(app.blocks.local_url)
-
-            if app.blocks.enable_queue:
-               gradio.utils.run_coro_in_background(app.blocks._queue.start)
-            gradio.utils.run_coro_in_background(app.blocks.create_limiter)
-
+            app.blocks.startup_events()
+            return True
 
         return app
 

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -15,7 +15,6 @@ from contextlib import contextmanager
 from distutils.version import StrictVersion
 from enum import Enum
 from numbers import Number
-from urllib.parse import urljoin
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -28,6 +27,7 @@ from typing import (
     Tuple,
     Type,
 )
+from urllib.parse import urljoin
 
 import aiohttp
 import analytics
@@ -682,12 +682,15 @@ def is_update(val):
     return type(val) is dict and "update" in val.get("__type__", "")
 
 
-def mount_gradio_app(app: fastapi.FastAPI, gradio_app: App, server_name: str, port: str, path: str) -> fastapi.FastAPI:
-
+def mount_gradio_app(
+    app: fastapi.FastAPI, gradio_app: App, server_name: str, port: str, path: str
+) -> fastapi.FastAPI:
     @app.on_event("startup")
     async def start_queue():
         if gradio_app.blocks.enable_queue:
-            gradio_app.blocks._queue.set_url(urljoin(f'http://{server_name}:{port}', f'{path}' + "/"))
+            gradio_app.blocks._queue.set_url(
+                urljoin(f"http://{server_name}:{port}", f"{path}" + "/")
+            )
             gradio_app.blocks.startup_events()
 
     app.mount(path, gradio_app)

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -685,6 +685,16 @@ def is_update(val):
 def mount_gradio_app(
     app: fastapi.FastAPI, gradio_app: App, server_name: str, port: str, path: str
 ) -> fastapi.FastAPI:
+    """Mount a gradio application (created with gr.routes.App.create_app(block)) to an existing FastAPI application.
+
+    Parameters:
+        app: The parent FastAPI application.
+        gradio_app: The gradio application we are mounting on `app`.
+        server_name: The host where the FastAPI application will run. Must match the value of uvicorn --host (or whatever) server you use to run the app.
+        port: The port where the application will run.
+        path: The path at which the gradio application will be mounted.
+    """
+
     @app.on_event("startup")
     async def start_queue():
         if gradio_app.blocks.enable_queue:

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -675,5 +675,3 @@ def validate_url(possible_url: str) -> bool:
 
 def is_update(val):
     return type(val) is dict and "update" in val.get("__type__", "")
-
-

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -312,6 +312,8 @@ def component_or_layout_class(cls_name: str) -> Component | BlockContext:
     Returns:
     cls: the component class
     """
+    import gradio.components
+    import gradio.layouts
     import gradio.templates
 
     components = [

--- a/guides/1)getting_started/3)sharing_your_app.md
+++ b/guides/1)getting_started/3)sharing_your_app.md
@@ -108,7 +108,7 @@ demo.launch(auth=same_auth)
 
 ## Mounting Within Another FastAPI App
 
-In some cases, you might have an existing FastAPI app, and you'd like to add a path for a Gradio demo. You can do this by easily using the `gradio.routes.App.create_app()` function, which creates a FastAPI app (but does not launch it), and then adding it to your existing FastAPI app with `FastAPI.mount()`.
+In some cases, you might have an existing FastAPI app, and you'd like to add a path for a Gradio demo. You can do this by easily using the `gradio.routes.App.create_app()` function, which creates a FastAPI app (but does not launch it), and then adding it to your existing FastAPI app with `gradio.mount_gradio_app()`.
 
 Here's a complete example:
 

--- a/guides/1)getting_started/3)sharing_your_app.md
+++ b/guides/1)getting_started/3)sharing_your_app.md
@@ -108,7 +108,8 @@ demo.launch(auth=same_auth)
 
 ## Mounting Within Another FastAPI App
 
-In some cases, you might have an existing FastAPI app, and you'd like to add a path for a Gradio demo. You can do this by easily using the `gradio.routes.App.create_app()` function, which creates a FastAPI app (but does not launch it), and then adding it to your existing FastAPI app with `gradio.mount_gradio_app()`.
+In some cases, you might have an existing FastAPI app, and you'd like to add a path for a Gradio demo.
+You can easily do this with `gradio.mount_gradio_app()`.
 
 Here's a complete example:
 

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -357,6 +357,7 @@ class TestCallFunction:
             )
 
         demo.queue()
+        assert demo.config["enable_queue"]
 
         output = await demo.call_function(0, [3])
         assert output["prediction"] == 0

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1,6 +1,7 @@
 """Contains tests for networking.py and app.py"""
 import json
 import os
+import sys
 import unittest
 from unittest.mock import patch
 
@@ -218,6 +219,10 @@ class TestAuthenticatedRoutes(unittest.TestCase):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="Mocks don't work with async context managers in 3.7",
+)
 @patch("gradio.routes.get_server_url_from_ws_url", return_value="foo_url")
 async def test_queue_join_routes_sets_url_if_none_set(mock_get_url):
     io = Interface(lambda x: x, "text", "text").queue()

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1,8 +1,11 @@
 """Contains tests for networking.py and app.py"""
-
+import json
 import os
 import unittest
+from unittest.mock import patch
 
+import pytest
+import websockets
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -212,6 +215,42 @@ class TestAuthenticatedRoutes(unittest.TestCase):
     def tearDown(self) -> None:
         self.io.close()
         close_all()
+
+
+@pytest.mark.asyncio
+@patch("gradio.routes.get_server_url_from_ws_url", return_value="foo_url")
+async def test_queue_join_routes_sets_url_if_none_set(mock_get_url):
+    io = Interface(lambda x: x, "text", "text").queue()
+    app, _, _ = io.launch(prevent_thread_lock=True)
+    io._queue.server_path = None
+    async with websockets.connect(
+        f"{io.local_url.replace('http', 'ws')}queue/join"
+    ) as ws:
+        completed = False
+        while not completed:
+            msg = json.loads(await ws.recv())
+            if msg["msg"] == "send_data":
+                await ws.send(json.dumps({"data": ["foo"], "fn_index": 0}))
+            completed = msg["msg"] == "process_completed"
+    assert io._queue.server_path == "foo_url"
+
+
+@pytest.mark.parametrize(
+    "ws_url,answer",
+    [
+        ("ws://127.0.0.1:7861/queue/join", "http://127.0.0.1:7861/"),
+        (
+            "ws://127.0.0.1:7861/gradio/gradio/gradio/queue/join",
+            "http://127.0.0.1:7861/gradio/gradio/gradio/",
+        ),
+        (
+            "wss://huggingface.co.tech/path/queue/join",
+            "https://huggingface.co.tech/path/",
+        ),
+    ],
+)
+def test_get_server_url_from_ws_url(ws_url, answer):
+    assert routes.get_server_url_from_ws_url(ws_url) == answer
 
 
 if __name__ == "__main__":

--- a/ui/packages/app/src/api.ts
+++ b/ui/packages/app/src/api.ts
@@ -115,17 +115,17 @@ export const fn =
 			var ws_endpoint = api_endpoint === "api/" ? location.href : api_endpoint;
 			var ws_protocol = ws_endpoint.startsWith("https") ? "wss:" : "ws:";
 			if (is_space) {
-				const SPACE_REGEX = /embed\/(.*)\/\+/g;
+				const SPACE_REGEX = /embed\/(.*)\/\+\//g;
 				var ws_path = Array.from(ws_endpoint.matchAll(SPACE_REGEX))[0][1];
 				var ws_host = "spaces.huggingface.tech/";
 			} else {
-				var ws_path = location.pathname === "/" ? "" : location.pathname;
+				var ws_path = location.pathname === "/" ? "/" : location.pathname;
 				var ws_host =
 					BUILD_MODE === "dev" || location.origin === "http://localhost:3000"
 						? BACKEND_URL.replace("http://", "").slice(0, -1)
 						: location.host;
 			}
-			const WS_ENDPOINT = `${ws_protocol}//${ws_host}${ws_path}/queue/join`;
+			const WS_ENDPOINT = `${ws_protocol}//${ws_host}${ws_path}queue/join`;
 
 			var websocket = new WebSocket(WS_ENDPOINT);
 			ws_map.set(fn_index, websocket);
@@ -146,6 +146,7 @@ export const fn =
 
 			websocket.onmessage = async function (event) {
 				const data = JSON.parse(event.data);
+				console.log(data);
 
 				switch (data.msg) {
 					case "send_data":

--- a/ui/packages/app/src/api.ts
+++ b/ui/packages/app/src/api.ts
@@ -115,8 +115,10 @@ export const fn =
 			var ws_endpoint = api_endpoint === "api/" ? location.href : api_endpoint;
 			var ws_protocol = ws_endpoint.startsWith("https") ? "wss:" : "ws:";
 			if (is_space) {
-				const SPACE_REGEX = /embed\/(.*)\/\+\//g;
-				var ws_path = Array.from(ws_endpoint.matchAll(SPACE_REGEX))[0][1];
+				const SPACE_REGEX = /embed\/(.*)\/\+/g;
+				var ws_path = Array.from(
+					ws_endpoint.matchAll(SPACE_REGEX)
+				)[0][1].concat("/");
 				var ws_host = "spaces.huggingface.tech/";
 			} else {
 				var ws_path = location.pathname === "/" ? "/" : location.pathname;
@@ -146,7 +148,6 @@ export const fn =
 
 			websocket.onmessage = async function (event) {
 				const data = JSON.parse(event.data);
-				console.log(data);
 
 				switch (data.msg) {
 					case "send_data":

--- a/website/homepage/src/docs/template.html
+++ b/website/homepage/src/docs/template.html
@@ -73,6 +73,10 @@
           <a class="px-4 block thin-link" href="#{{ component['name'].lower() }}">{{ component['name'] }}</a>
         {% endfor %}
         <a class="thin-link px-4 block" href="#update">Update</a>
+        <a class="link px-4 my-2 block" href="#routes">Routes
+          {% for component in docs["routes"] %}
+            <a class="px-4 block thin-link" href="#{{ component['name'].lower() }}">{{ component['name'] }}</a>
+          {% endfor %}
       </div>
       <div class="flex flex-col">
         <p class="bg-gradient-to-r from-orange-100 to-orange-50 border border-orange-200 px-4 py-1 rounded-full text-orange-800 mb-1">
@@ -201,6 +205,21 @@
                 {% include "docs/obj_doc_template.html" %}
               {% endwith %}
             </div>
+          </section>
+          <section id="routes" class="pt-2 flex flex-col gap-10">
+            <div>
+              <h2 id="routes-header"
+                  class="text-4xl font-light mb-2 pt-2 text-orange-500">Routes</h2>
+              <p class="mt-8 text-lg">
+                Gradio includes some helper functions for exposing and interacting with the FastAPI app
+                used to run your demo.
+              </p>
+            </div>
+            {% for component in docs["routes"] %}
+            {% with obj=component, parent="gradio" %}
+              {% include "docs/obj_doc_template.html" %}
+            {% endwith %}
+          {% endfor %}
           </section>
       </div>
     </main>


### PR DESCRIPTION
# Description

Closes: #2292

There were two problems as noted on the original issue:

1. The ws socket path was incorrect when running as a sub application
2. The thread to run the queue was not started because that's started by the `startup-events` route that's called during `Blocks.launch`.

I think I figured out the ws path issue although I'd like some feedback from @aliabid94 .

The queue thread not starting automatically is an interesting problem. I think the cleanest thing would be to use fastapi startup events to start the queue however there are two issues with that:

- Startup events are not started for sub applications ([docs](https://fastapi.tiangolo.com/advanced/events/)) so it wouldn't solve the problem of the queue not starting when gradio is mounted
- The queue needs to know about the URL where the gradio app is running in order to get the predictions. Since startup events happen before the app is running, the URL is not defined when the event runs.

I opted for adding a helper method called `mount_gradio_app` that will add a startup event to the parent application that runs the queue. This is not as nice as using the built-in FastAPI `app.mount(gradio_app, ...)` syntax but it's the best solution I see now. 

### Changes to the guide

![image](https://user-images.githubusercontent.com/41651716/191610492-e7855cc7-c3d4-4335-a5dc-2d740ba441ff.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
