### PR TITLE
Clipboard fix for iframes

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1120,13 +1120,13 @@ class Blocks(BlockContext):
                         time.sleep(1)
                     display(
                         HTML(
-                            f'<div><iframe src="{self.share_url}" width="{self.width}" height="{self.height}" allow="autoplay; camera; microphone;" frameborder="0" allowfullscreen></iframe></div>'
+                            f'<div><iframe src="{self.share_url}" width="{self.width}" height="{self.height}" allow="autoplay; camera; microphone; clipboard-read; clipboard-write;" frameborder="0" allowfullscreen></iframe></div>'
                         )
                     )
                 else:
                     display(
                         HTML(
-                            f'<div><iframe src="{self.local_url}" width="{self.width}" height="{self.height}" allow="autoplay; camera; microphone;" frameborder="0" allowfullscreen></iframe></div>'
+                            f'<div><iframe src="{self.local_url}" width="{self.width}" height="{self.height}" allow="autoplay; camera; microphone; clipboard-read; clipboard-write;" frameborder="0" allowfullscreen></iframe></div>'
                         )
                     )
             except ImportError:


### PR DESCRIPTION
Previously, the copy button in the JSON output would not work when the Gradio demo was embedded in a jupyter/colab notebook. 

This grants the <iframe> permission to copy. 

Fixes: #2311 (well not the original issue, since that's beyond our control, but the version of it for iframes)

