### PR TITLE
Adds the option to run gradio from the remote Jupyter notebook accessible at the non-localhost IP address.

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1067,7 +1067,7 @@ class Blocks(BlockContext):
         # If running in a colab or not able to access localhost,
         # a shareable link must be created.
         is_colab = utils.colab_check()
-        if is_colab or (_frontend and not networking.url_ok(self.local_url)):
+        if is_colab or (_frontend and network_interface_address == "127.0.0.1" and not networking.url_ok(self.local_url)):
             if not self.share:
                 raise ValueError(
                     "When running in Google Colab or when localhost is not accessible, a shareable link must be created. Please set share=True."

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1034,8 +1034,8 @@ class Blocks(BlockContext):
         else:
             server_name, network_interface_address, server_port, local_url, app, server = networking.start_server(
                 self,
-                server_name,
                 network_interface_address,
+                server_name,
                 server_port,
                 ssl_keyfile,
                 ssl_certfile,

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -930,6 +930,7 @@ class Blocks(BlockContext):
         prevent_thread_lock: bool = False,
         show_error: bool = False,
         server_name: Optional[str] = None,
+        network_interface_address: Optional[str] = None,
         server_port: Optional[int] = None,
         show_tips: bool = False,
         height: int = 500,
@@ -957,6 +958,8 @@ class Blocks(BlockContext):
             prevent_thread_lock: If True, the interface will block the main thread while the server is running.
             show_error: If True, any errors in the interface will be displayed in an alert modal and printed in the browser console log
             server_port: will start gradio app on this port (if available). Can be set by environment variable GRADIO_SERVER_PORT. If None, will search for an available port starting at 7860.
+            network_interface_address: The address to use for the server network interface. Defaults to the local interface 127.0.0.1. Change it to 0.0.0.0 or an ip address 
+            of a specific network interface if you want the gradio server be available over the network. 
             server_name: to make app accessible on local network, set this to "0.0.0.0". Can be set by environment variable GRADIO_SERVER_NAME. If None, will use "127.0.0.1".
             show_tips: if True, will occasionally show tips about new Gradio features
             enable_queue: DEPRECATED (use .queue() method instead.) if True, inference requests will be served through a queue instead of with parallel threads. Required for longer inference times (> 1min) to prevent timeout. The default option in HuggingFace Spaces is True. The default option elsewhere is False.
@@ -1029,9 +1032,10 @@ class Blocks(BlockContext):
                     "Rerunning server... use `close()` to stop if you need to change `launch()` parameters.\n----"
                 )
         else:
-            server_name, server_port, local_url, app, server = networking.start_server(
+            server_name, network_interface_address, server_port, local_url, app, server = networking.start_server(
                 self,
                 server_name,
+                network_interface_address,
                 server_port,
                 ssl_keyfile,
                 ssl_certfile,
@@ -1040,6 +1044,7 @@ class Blocks(BlockContext):
             self.server_name = server_name
             self.local_url = local_url
             self.server_port = server_port
+            self.network_interface_address = network_interface_address
             self.server_app = app
             self.server = server
             self.is_running = True
@@ -1144,6 +1149,7 @@ class Blocks(BlockContext):
             "enable_queue": self.enable_queue,
             "show_tips": self.show_tips,
             "server_name": server_name,
+            "network_interface_address": network_interface_address,
             "server_port": server_port,
             "is_spaces": self.is_space,
             "mode": self.mode,

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -955,8 +955,7 @@ class Blocks(BlockContext):
             prevent_thread_lock: If True, the interface will block the main thread while the server is running.
             show_error: If True, any errors in the interface will be displayed in an alert modal and printed in the browser console log
             server_port: will start gradio app on this port (if available). Can be set by environment variable GRADIO_SERVER_PORT. If None, will search for an available port starting at 7860.
-            network_interface_address: The address to use for the server network interface. Defaults to the local interface 127.0.0.1. Change it to 0.0.0.0 or an ip address 
-            of a specific network interface if you want the gradio server be available over the network. 
+            network_interface_address: The address to use for the server network interface. Defaults to the local interface 127.0.0.1. Change it to 0.0.0.0 or an ip address of a specific network interface if you want the gradio server be available over the network. 
             server_name: to make app accessible on local network, set this to "0.0.0.0". Can be set by environment variable GRADIO_SERVER_NAME. If None, will use "127.0.0.1".
             show_tips: if True, will occasionally show tips about new Gradio features
             enable_queue: DEPRECATED (use .queue() method instead.) if True, inference requests will be served through a queue instead of with parallel threads. Required for longer inference times (> 1min) to prevent timeout. The default option in HuggingFace Spaces is True. The default option elsewhere is False.

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -99,14 +99,15 @@ def start_server(
     Parameters:
     blocks: The Blocks object to run on the server
     server_name: to make app accessible on local network, set this to "0.0.0.0". Can be set by environment variable GRADIO_SERVER_NAME.
-    network_interface_address: The address to use for the server network interface. Defaults to the local interface 127.0.0.1. Change it to 0.0.0.0 or an ip address 
-    of a specific network interface if you want the gradio server be available over the network. 
+    network_interface_address: The address to use for the server network interface. Defaults to the local interface 127.0.0.1. Change it to 0.0.0.0 or an ip address of a specific network interface if you want the gradio server be available over the network. 
     server_port: will start gradio app on this port (if available). Can be set by environment variable GRADIO_SERVER_PORT.
     auth: If provided, username and password (or list of username-password tuples) required to access the Blocks. Can also provide function that takes username and password and returns True if valid login.
     ssl_keyfile: If a path to a file is provided, will use this as the private key file to create a local server running on https.
     ssl_certfile: If a path to a file is provided, will use this as the signed certificate for https. Needs to be provided if ssl_keyfile is provided.
     ssl_keyfile_password: If a password is provided, will use this with the ssl certificate for https.
     Returns:
+    url_host_name: actual hostname as used for in the user-facing URL
+    network_interface_address: ip address of the internal interface to use to serve the gradio content
     port: the port number the server is running on
     path_to_local_server: the complete address that the local server can be accessed at
     app: the FastAPI app object

--- a/test/test_networking.py
+++ b/test/test_networking.py
@@ -68,7 +68,7 @@ class TestStartServer(unittest.TestCase):
             networking.INITIAL_PORT_VALUE + networking.TRY_NUM_PORTS,
         )
         io.enable_queue = False
-        _, _, local_path, _, server = networking.start_server(io, server_port=port)
+        _, _, _, local_path, _, server = networking.start_server(io, server_port=port)
         url = urllib.parse.urlparse(local_path)
         self.assertEquals(url.scheme, "http")
         self.assertEquals(url.port, port)


### PR DESCRIPTION
# Description

## Motivation

I want to run gradio on the Jupyter notebook on the server accessible via the LAN/VPN

## Summary of the change 

Adds a new launch parameter, `network_interface_address`, that denotes the IP address of the network interface to be used to serve the gradio content. Defaults to the local interface (127.0.0.1) if `server_name` is None, or all local interfaces (0.0.0.0) if `server_name` is specified. 

Changes the meaning of the `server_name` parameter. Now it is used to specify the address of the gradio server as seen from the browser perspective. Defaults to the server's fully qualified domain name if `network_interface_address` is provided, otherwise `localhost`. 

My change modifies the number of the elements returned by the `networking.py:start_server` function. 

I did not write unit tests for this change.

- [X] I have performed a self-review of my own code
- [X] My code follows the style guidelines of this project
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
