### PR TITLE
Fix typo in iterator variable name in run_predict function

### DIFF
--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -268,7 +268,7 @@ class App(FastAPI):
                 iterators = app.iterators[body.session_hash]
             else:
                 session_state = {}
-                iterator = {}
+                iterators = {}
             raw_input = body.data
             fn_index = body.fn_index
             try:


### PR DESCRIPTION
# Description
Noticed a small typo in the `run_predict` method. In the case where there are no pre-existing generators in the app, the iterators are stored in a variable called `iterator` as opposed to `iterators`. This was causing a `local variable iterators referenced before assignment` warning to pop up:

![image](https://user-images.githubusercontent.com/41651716/192360628-e4886212-2c94-4e07-8536-f329553b3b92.png)


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
