### PR TITLE
Removes `analytics` dependency

### DIFF
--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -29,7 +29,6 @@ from typing import (
 )
 
 import aiohttp
-import analytics
 import fsspec.asyn
 import httpx
 import requests
@@ -43,7 +42,6 @@ if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
 
 analytics_url = "https://api.gradio.app/"
 PKG_VERSION_URL = "https://api.gradio.app/pkg-version"
-analytics.write_key = "uxIFddIEuuUcFLf9VgH2teTEtPlWdkNy"
 JSON_PATH = os.path.join(os.path.dirname(gradio.__file__), "launches.json")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-analytics-python
 aiohttp
 h11<0.13,>=0.11
 fastapi


### PR DESCRIPTION
It turns out we never needed `analytics` given that our analytics are processed through our own backend server hehe

Closes: #2337 