### PR TITLE
Small fixes to docs for `Image` component

### DIFF
--- a/gradio/inputs.py
+++ b/gradio/inputs.py
@@ -245,7 +245,7 @@ class Image(components.Image):
         """
         Parameters:
         shape (Tuple[int, int]): (width, height) shape to crop and resize image to; if None, matches input image size.
-        image_mode (str): "RGB" if color, or "L" if black and white.
+        image_mode (str): How to process the uploaded image. Accepts any of the PIL image modes, e.g. "RGB" for color images, "RGBA" to include the transparency mask, "L" for black-and-white images.
         invert_colors (bool): whether to invert the image as a preprocessing step.
         source (str): Source of image. "upload" creates a box where user can drop an image file, "webcam" allows user to take snapshot from their webcam, "canvas" defaults to a white image that can be edited and drawn upon with tools.
         tool (str): Tools used for editing. "editor" allows a full screen editor, "select" provides a cropping and zoom tool.

--- a/gradio/templates.py
+++ b/gradio/templates.py
@@ -54,7 +54,7 @@ class Sketchpad(components.Image):
 
 class Paint(components.Image):
     """
-    Sets source="canvas", tool="color-sketch"
+    Sets: source="canvas", tool="color-sketch"
     """
 
     is_template = True
@@ -67,7 +67,7 @@ class Paint(components.Image):
 
 class ImageMask(components.Image):
     """
-    Sets source="canvas", tool="sketch"
+    Sets: source="canvas", tool="sketch"
     """
 
     is_template = True
@@ -78,7 +78,7 @@ class ImageMask(components.Image):
 
 class ImagePaint(components.Image):
     """
-    Sets source="upload", tool="color-sketch"
+    Sets: source="upload", tool="color-sketch"
     """
 
     is_template = True

--- a/website/homepage/src/docs/__init__.py
+++ b/website/homepage/src/docs/__init__.py
@@ -15,14 +15,14 @@ def add_component_shortcuts():
         if not getattr(component["class"], "allow_string_shortcut", True):
             continue
         component["string_shortcuts"] = [
-            (component["name"].lower(), "Uses default values")
+            (component["class"].__name__, component["name"].lower(), "Uses default values")
         ]
         for subcls in component["class"].__subclasses__():
             if getattr(subcls, "is_template", False):
                 _, tags, _ = document_cls(subcls)
                 component["string_shortcuts"].append(
-                    (subcls.__name__.lower(), "Uses " + tags.get("sets", "default values"))
-                )
+                    (subcls.__name__, subcls.__name__.lower(), "Uses " + tags.get("sets", "default values"))
+                )                
 add_component_shortcuts()
 def add_demos():
     for mode in docs:

--- a/website/homepage/src/docs/obj_doc_template.html
+++ b/website/homepage/src/docs/obj_doc_template.html
@@ -106,13 +106,17 @@
   <table class="mb-4 table-fixed w-full mt-6">
     <thead class="text-left">
       <tr>
-        <th class="p-3 font-semibold w-2/5">Interface String Shortcut</th>
+        <th class="p-3 font-semibold w-2/5">Class</th>
+        <th class="p-3 font-semibold">Interface String Shortcut</th>
         <th class="p-3 font-semibold">Initialization</th>
       </tr>
     </thead>
     <tbody class="text-left divide-y rounded-lg bg-gray-50 border border-gray-100 overflow-hidden">
-    {% for shortcut, settings in obj["string_shortcuts"] %}
+    {% for name, shortcut, settings in obj["string_shortcuts"] %}
         <tr class="group hover:bg-gray-200/60 odd:bg-gray-100/80">
+          <td class="p-3 w-2/5">
+            <p><code class="lang-python">gradio.{{ name }}</code></p>
+          </td>
           <td class="p-3 w-2/5">
             <p>"{{ shortcut }}"</p>
           </td>


### PR DESCRIPTION
I noticed that the string shortcuts for some of the new variants of `gr.Image` like `gr.Paint()` were not showing up correctly because of a missing colon:

<img width="753" alt="image" src="https://user-images.githubusercontent.com/1778297/193139041-83823281-423e-4754-bf2b-3568cae84d91.png">

This PR fixes that and also fixes two other outstanding issues with the docs, fixes: #2040, fixes: #134. Now:

<img width="747" alt="image" src="https://user-images.githubusercontent.com/1778297/193139267-51e6d477-7dc4-4adc-8eea-6a9f9df7f2e2.png">


