### PR TITLE
Prevent apps from hanging when running in reload mode and error occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ No changes to highlight.
 * Adds ability to disable pre/post-processing for examples [@abidlabs](https://github.com/abidlabs) in [PR 2383](https://github.com/gradio-app/gradio/pull/2383)
 * Copy changelog file in website docker by [@aliabd](https://github.com/aliabd) in [PR 2384](https://github.com/gradio-app/gradio/pull/2384)
 * Lets users provide a `gr.update()` dictionary even if post-processing is diabled [@abidlabs](https://github.com/abidlabs) in [PR 2385](https://github.com/gradio-app/gradio/pull/2385)
+* Fix bug where errors would cause apps run in reload mode to hang forever by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2394](https://github.com/gradio-app/gradio/pull/2394)
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -434,6 +434,7 @@ class Blocks(BlockContext):
         self.share = False
         self.enable_queue = None
         self.max_threads = 40
+        self.show_error = True
         if css is not None and os.path.exists(css):
             with open(css) as css_file:
                 self.css = css_file.read()
@@ -786,7 +787,6 @@ class Blocks(BlockContext):
         block_fn.total_runs += 1
 
         predictions = self.postprocess_data(fn_index, result["prediction"], state)
-
         return {
             "data": predictions,
             "is_generating": result["is_generating"],

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -219,8 +219,8 @@ class TestBlocksMethods(unittest.TestCase):
         demo.close()
 
     @mock.patch("requests.post")
-    def test_initiated_analytics_and_show_error(self, mock_post):
-        with gr.Blocks(analytics_enabled=True) as demo:
+    def test_initiated_analytics(self, mock_post):
+        with gr.Blocks(analytics_enabled=True):
             pass
         mock_post.assert_called_once()
 

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -219,10 +219,22 @@ class TestBlocksMethods(unittest.TestCase):
         demo.close()
 
     @mock.patch("requests.post")
-    def test_initiated_analytics(self, mock_post):
-        with gr.Blocks(analytics_enabled=True):
+    def test_initiated_analytics_and_show_error(self, mock_post):
+        with gr.Blocks(analytics_enabled=True) as demo:
             pass
         mock_post.assert_called_once()
+
+    def test_show_error(self):
+        with gr.Blocks() as demo:
+            pass
+
+        assert demo.show_error
+        demo.launch(prevent_thread_lock=True)
+        assert not demo.show_error
+        demo.close()
+        demo.launch(show_error=True, prevent_thread_lock=True)
+        assert demo.show_error
+        demo.close()
 
 
 class TestComponentsInBlocks:


### PR DESCRIPTION
# Description

Fix is to set `show_error` to True in init. This will be overwritten in `launch` but has the benefit of showing errors in reload mode which I think is good DX since developers are writing/debugging their apps simultaneously. 

Closes: #2106

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.