### PR TITLE
Fix embedded demos in some guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ No changes to highlight.
 
 ## Full Changelog:
 * Speeds up Gallery component by using temporary files instead of base64 representation in the front-end by [@proxyphi](https://github.com/proxyphi), [@pngwn](https://github.com/pngwn), and [@abidlabs](https://github.com/abidlabs) in [PR 2265](https://github.com/gradio-app/gradio/pull/2265)
+* Fixed some embedded demos in the guides by not loading the gradio web component in some guides by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2403](https://github.com/gradio-app/gradio/pull/2403) 
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/guides/5)other_tutorials/connecting_to_a_database.md
+++ b/guides/5)other_tutorials/connecting_to_a_database.md
@@ -1,5 +1,3 @@
-<script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.1.0/gradio.js"></script>
-
 # Connecting to a Database
 
 Related spaces: https://huggingface.co/spaces/freddyaboulton/chicago-bike-share-dashboard

--- a/guides/5)other_tutorials/custom_interpretations_with_blocks.md
+++ b/guides/5)other_tutorials/custom_interpretations_with_blocks.md
@@ -1,5 +1,3 @@
-<script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.1.0/gradio.js"></script>
-
 # Custom Machine Learning Interpretations with Blocks
 Tags: INTERPRETATION, SENTIMENT ANALYSIS
 

--- a/guides/5)other_tutorials/running_background_tasks.md
+++ b/guides/5)other_tutorials/running_background_tasks.md
@@ -1,5 +1,3 @@
-<script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.4.0/gradio.js"></script>
-
 # Running Background Tasks 
 
 Related spaces: https://huggingface.co/spaces/freddyaboulton/gradio-google-forms


### PR DESCRIPTION
# Description
Some of the embedded demos in the guides were not loading because the guide loaded the gradio web component. I think this was causing conflicts because a different version of the web component was loaded elsewhere. 


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.