### PR TITLE
Automatically restart spaces if they're down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ No changes to highlight.
 No changes to highlight.
 
 ## Full Changelog:
-No changes to highlight.
+* Automatically restart spaces if they're down by [@aliabd](https://github.com/aliabd) in [PR 2404](https://github.com/gradio-app/gradio/pull/2404)
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ No changes to highlight.
 No changes to highlight.
 
 ## Full Changelog:
-* Automatically restart spaces if they're down by [@aliabd](https://github.com/aliabd) in [PR 2404](https://github.com/gradio-app/gradio/pull/2404)
+* Automatically restart spaces if they're down by [@aliabd](https://github.com/aliabd) in [PR 2405](https://github.com/gradio-app/gradio/pull/2405)
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/website/homepage/src/demos/restart_demos.py
+++ b/website/homepage/src/demos/restart_demos.py
@@ -1,0 +1,10 @@
+from upload_demos import demos_by_category, upload_demo_to_space, AUTH_TOKEN, gradio_version
+from gradio.networking import url_ok
+
+
+for category in demos_by_category:
+    for demo in category["demos"]:
+        space_id = "gradio/" + demo["dir"]
+        if not url_ok(f"https://hf.space/embed/{space_id}/+"):
+            print(f"{space_id} was down, restarting")
+            upload_demo_to_space(demo_name=demo["dir"], space_id=space_id, hf_token=AUTH_TOKEN, gradio_version=gradio_version)

--- a/website/homepage/src/demos/upload_demos.py
+++ b/website/homepage/src/demos/upload_demos.py
@@ -68,8 +68,9 @@ def upload_demo_to_space(
     return f"https://huggingface.co/spaces/{space_id}"
 
 if __name__ == "__main__":
-    for category in demos_by_category:
-        for demo in category["demos"]:
-            space_id = "gradio/" + demo["dir"]
-            upload_demo_to_space(demo_name=demo["dir"], space_id=space_id, hf_token=AUTH_TOKEN, gradio_version=gradio_version)
+    if AUTH_TOKEN is not None:
+        for category in demos_by_category:
+            for demo in category["demos"]:
+                space_id = "gradio/" + demo["dir"]
+                upload_demo_to_space(demo_name=demo["dir"], space_id=space_id, hf_token=AUTH_TOKEN, gradio_version=gradio_version)
 

--- a/website/homepage/src/demos/upload_demos.py
+++ b/website/homepage/src/demos/upload_demos.py
@@ -67,8 +67,9 @@ def upload_demo_to_space(
         )
     return f"https://huggingface.co/spaces/{space_id}"
 
-for category in demos_by_category:
-    for demo in category["demos"]:
-        space_id = "gradio/" + demo["dir"]
-        upload_demo_to_space(demo_name=demo["dir"], space_id=space_id, hf_token=AUTH_TOKEN, gradio_version=gradio_version)
+if __name__ == "__main__":
+    for category in demos_by_category:
+        for demo in category["demos"]:
+            space_id = "gradio/" + demo["dir"]
+            upload_demo_to_space(demo_name=demo["dir"], space_id=space_id, hf_token=AUTH_TOKEN, gradio_version=gradio_version)
 


### PR DESCRIPTION
This PR adds a script that will check if any of the spaces in the /demos tab are down, and if they are it will restart them. This is important because spaces have gone down recently, especially when we programmatically update many of them at the same time. And often they can be down for a while before we notice. 

Once it's merged I will create a cronjob in the server to run it every 15mins. 

Also, stopped the website build from failing if the AUTH_TOKEN env variable is missing, so that we can build it locally, like @freddy suggested. 

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes