### PR TITLE
Use async iteration for progressive outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,12 @@
 ## Bug Fixes:
 
 * Ensure that Gradio does not take control of the HTML page title when embedding a gradio app as a web component, this behaviour flipped by adding `control_page_title="true"` to the webcomponent. [@pngwn](https://github.com/pngwn) in [PR 2400](https://github.com/gradio-app/gradio/pull/2400)
+* Decreased latency in iterative-output demos by making the iteration asynchronous [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2409](https://github.com/gradio-app/gradio/pull/2409)
 
 ## New Features:
 
 * When an `Image` component is set to `source="upload"`, it is now possible to drag and drop and image to replace a previously uploaded image by [@pngwn](https://github.com/pngwn) in [PR 1711](https://github.com/gradio-app/gradio/issues/1711)
 
-## Bug Fixes:
-No changes to highlight.
 
 ## Documentation Changes:
 No changes to highlight.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ No changes to highlight.
 * Speeds up Gallery component by using temporary files instead of base64 representation in the front-end by [@proxyphi](https://github.com/proxyphi), [@pngwn](https://github.com/pngwn), and [@abidlabs](https://github.com/abidlabs) in [PR 2265](https://github.com/gradio-app/gradio/pull/2265)
 * Fixed some embedded demos in the guides by not loading the gradio web component in some guides by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2403](https://github.com/gradio-app/gradio/pull/2403) 
 * When an `Image` component is set to `source="upload"`, it is now possible to drag and drop and image to replace a previously uploaded image by [@pngwn](https://github.com/pngwn) in [PR 2400](https://github.com/gradio-app/gradio/pull/2410)
+* Decreased latency in iterative-output demos by making the iteration asynchronous [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2409](https://github.com/gradio-app/gradio/pull/2409)
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -17,7 +17,6 @@ import anyio
 import requests
 from anyio import CapacityLimiter
 
-import gradio.exceptions
 from gradio import (
     components,
     encryptor,
@@ -35,7 +34,7 @@ from gradio.documentation import (
     document_component_api,
     set_documentation_group,
 )
-from gradio.exceptions import DuplicateBlockError
+from gradio.exceptions import DuplicateBlockError, GradioStopIteration
 from gradio.utils import component_or_layout_class, delete_none
 
 set_documentation_group("blocks")
@@ -708,7 +707,7 @@ class Blocks(BlockContext):
                     utils.async_iteration, iterator, limiter=self.limiter
                 )
                 is_generating = True
-            except gradio.exceptions.GradioStopIteration:
+            except GradioStopIteration:
                 n_outputs = len(self.dependencies[fn_index].get("outputs"))
                 prediction = (
                     components._Keywords.FINISHED_ITERATING

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -34,7 +34,7 @@ from gradio.documentation import (
     document_component_api,
     set_documentation_group,
 )
-from gradio.exceptions import DuplicateBlockError, GradioStopIteration
+from gradio.exceptions import DuplicateBlockError
 from gradio.utils import component_or_layout_class, delete_none
 
 set_documentation_group("blocks")

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -707,7 +707,7 @@ class Blocks(BlockContext):
                     utils.async_iteration, iterator, limiter=self.limiter
                 )
                 is_generating = True
-            except GradioStopIteration:
+            except StopAsyncIteration:
                 n_outputs = len(self.dependencies[fn_index].get("outputs"))
                 prediction = (
                     components._Keywords.FINISHED_ITERATING

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -9,7 +9,3 @@ class Error(Exception):
 
     def __str__(self):
         return repr(self.message)
-
-
-class GradioStopIteration(ValueError):
-    pass

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -9,3 +9,7 @@ class Error(Exception):
 
     def __str__(self):
         return repr(self.message)
+
+
+class GradioStopIteration(ValueError):
+    pass

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -389,7 +389,7 @@ def async_iteration(iterator):
         return next(iterator)
     except StopIteration:
         # raise a ValueError here because co-routines can't raise StopIteration themselves
-        raise gradio.exceptions.GradioStopIteration()
+        raise StopAsyncIteration()
 
 
 class Request:

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -388,6 +388,7 @@ def async_iteration(iterator):
     try:
         return next(iterator)
     except StopIteration:
+        # raise a ValueError here because co-routines can't raise StopIteration themselves
         raise gradio.exceptions.GradioStopIteration()
 
 

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -384,6 +384,13 @@ def run_coro_in_background(func: Callable, *args, **kwargs):
     return event_loop.create_task(func(*args, **kwargs))
 
 
+def async_iteration(iterator):
+    try:
+        return next(iterator)
+    except StopIteration:
+        raise gradio.exceptions.GradioStopIteration()
+
+
 class Request:
     """
     The Request class is a low-level API that allow you to create asynchronous HTTP requests without a context manager.


### PR DESCRIPTION
# Description
I noticed that if two different users are running an iterative output demo at the same time, the two demos will not iterate asynchronously. When one demo is iterating, the other is not. This increases the latency of serving outputs to users.

You can see this here:

### Main
![iterators_blocking_each_other](https://user-images.githubusercontent.com/41651716/194570993-a2139638-4f3a-4390-b9ef-f1b24d3f913c.gif)

### This branch
![iterators_not_blocking_each_other](https://user-images.githubusercontent.com/41651716/194571030-0bbbead5-57be-4ebc-be45-cfb7153728c4.gif)

The culprit is that `next(iterator)` is not async, so it blocks the event loop for all users. 

This is the demo code to test:
```python
import time
import gradio as gr
import random

def fake_diffusion(steps):
    for i in range(steps):
        time.sleep(1)
        yield random.choice([
            "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80",
            "https://images.unsplash.com/photo-1554151228-14d9def656e4?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=386&q=80",
            "https://images.unsplash.com/photo-1542909168-82c3e7fdca5c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8aHVtYW4lMjBmYWNlfGVufDB8fDB8fA%3D%3D&w=1000&q=80",
            "https://images.unsplash.com/photo-1546456073-92b9f0a8d413?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80",
            "https://images.unsplash.com/photo-1601412436009-d964bd02edbc?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=464&q=80",
            ])

with gr.Blocks() as demo:
    n = gr.Slider(1, 10, value=3, step=1)
    output = gr.Image().style(height=250, width=250)
    run = gr.Button()
    run.click(fake_diffusion, n, output)

demo.queue(concurrency_count=20, max_size=20).launch()
```


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.