### PR TITLE
Port reuse block fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ No changes to highlight.
 * Carousel component is now deprecated by [@abidlabs](https://github.com/abidlabs) in [PR 2434](https://github.com/gradio-app/gradio/pull/2434)
 * Build Gradio from source in ui tests by by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2440](https://github.com/gradio-app/gradio/pull/2440) 
 * Change "return ValueError" to "raise ValueError" by [@vzakharov](https://github.com/vzakharov) in [PR 2445](https://github.com/gradio-app/gradio/pull/2445) 
+* Stops a gradio launch from hogging a port even after it's been killed [@aliabid94](https://github.com/aliabid94) in [PR 2453](https://github.com/gradio-app/gradio/pull/2453) 
 
 
 

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -44,7 +44,7 @@ class Server(uvicorn.Server):
         self.thread.join()
 
 
-def get_first_available_port(initial: int, final: int, reuse_port: bool = False) -> int:
+def get_first_available_port(initial: int, final: int) -> int:
     """
     Gets the first open port in a specified range of port numbers
     Parameters:
@@ -56,8 +56,7 @@ def get_first_available_port(initial: int, final: int, reuse_port: bool = False)
     for port in range(initial, final):
         try:
             s = socket.socket()  # create a socket object
-            if reuse_port:
-                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.bind((LOCALHOST_NAME, port))  # Bind to the port
             s.close()
             return port

--- a/gradio/reload.py
+++ b/gradio/reload.py
@@ -33,7 +33,7 @@ def run_in_reload_mode():
 
     port = networking.get_first_available_port(
         networking.INITIAL_PORT_VALUE,
-        networking.INITIAL_PORT_VALUE + networking.TRY_NUM_PORTS
+        networking.INITIAL_PORT_VALUE + networking.TRY_NUM_PORTS,
     )
     print(
         f"\nLaunching in *reload mode* on: http://{networking.LOCALHOST_NAME}:{port} (Press CTRL+C to quit)\n"

--- a/gradio/reload.py
+++ b/gradio/reload.py
@@ -33,8 +33,7 @@ def run_in_reload_mode():
 
     port = networking.get_first_available_port(
         networking.INITIAL_PORT_VALUE,
-        networking.INITIAL_PORT_VALUE + networking.TRY_NUM_PORTS,
-        True,
+        networking.INITIAL_PORT_VALUE + networking.TRY_NUM_PORTS
     )
     print(
         f"\nLaunching in *reload mode* on: http://{networking.LOCALHOST_NAME}:{port} (Press CTRL+C to quit)\n"


### PR DESCRIPTION
@pngwn fixed ports with the `reuse_ports` argument in `get_first_available_port`, but when it was called from networking.start_server, it was never set to True. I just removed the argument and made the reuse logic always happen. Hopefully will never have to deal with this annoying problem again!

Btw the port would only get clogged if you make an actual request to the server, e.g. open it in a tab. If you just started an app and killed it right after, it wouldn't. FYI in case you're testing this. 