### PR TITLE
Fix embedded interfaces on touch screen devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ No changes to highlight.
 * Carousel component is now deprecated by [@abidlabs](https://github.com/abidlabs) in [PR 2434](https://github.com/gradio-app/gradio/pull/2434)
 * Build Gradio from source in ui tests by by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2440](https://github.com/gradio-app/gradio/pull/2440) 
 * Change "return ValueError" to "raise ValueError" by [@vzakharov](https://github.com/vzakharov) in [PR 2445](https://github.com/gradio-app/gradio/pull/2445) 
+* Fix embedded interfaces on touch screen devices by [@aliabd](https://github.com/aliabd) in [PR 2457](https://github.com/gradio-app/gradio/pull/2457)
 
 
 

--- a/website/homepage/src/templates/add_anchors.js
+++ b/website/homepage/src/templates/add_anchors.js
@@ -27,11 +27,10 @@ function isTouchDevice() {
 
 if (isTouchDevice()) {
       for (let i = 0; i < headers.length; i++) {
-        let link = '#' + headers[i].id;
-        var parent = headers[i].parentNode;
-        var wrapper = createMobileAnchorTag(link);
-        parent.replaceChild(wrapper, headers[i]);
-        wrapper.appendChild(headers[i]);
+            let link = '#' + headers[i].id;
+            var wrapper = createMobileAnchorTag(link);
+            headers[i].replaceWith(wrapper);
+            wrapper.appendChild(headers[i]);
       }
 } else {
       for (let i = 0; i < headers.length; i++) {


### PR DESCRIPTION
Fixes the issue where the mobile anchor link code is causing the embedded gradio interface to think it's inside an iframe.  

Closes: #1792 

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.