### PR TITLE
Small fix for version check before reuploading demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ No changes to highlight.
 
 ## Full Changelog:
 * Enable running events to be cancelled from other events by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2433](https://github.com/gradio-app/gradio/pull/2433)
+* Small fix for version check before reuploading demos by [@aliabd](https://github.com/aliabd) in [PR 2469](https://github.com/gradio-app/gradio/pull/2469)
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/website/homepage/upload_demos.py
+++ b/website/homepage/upload_demos.py
@@ -66,6 +66,6 @@ demos = [demo for demo in demos if demo != "all_demos" and os.path.isdir(os.path
 
 if __name__ == "__main__":
     if AUTH_TOKEN is not None:
-        if huggingface_hub.space_info("gradio/hello_world").cardData["sdk_version"] != gradio_version:
+        if str(huggingface_hub.space_info("gradio/hello_world").cardData["sdk_version"]) != gradio_version:
             for demo in demos:
                 upload_demo_to_space(demo_name=demo, space_id="gradio/" + demo, hf_token=AUTH_TOKEN, gradio_version=gradio_version)


### PR DESCRIPTION
Demos were unnecessarily reuploading even when the version hasn't changed. This fixes that by correcting the comparison.
