### PR TITLE
Fix share error message when files are built locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ No changes to highlight.
 No changes to highlight.
 
 ## Full Changelog:
-No changes to highlight.
+* Fixes the error message if a user builds Gradio locally and tries to use `share=True` by [@abidlabs](https://github.com/abidlabs) in [PR 2502](https://github.com/gradio-app/gradio/pull/2502)
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -196,10 +196,16 @@ class App(FastAPI):
                     template, {"request": request, "config": config}
                 )
             except TemplateNotFound:
-                raise ValueError(
-                    "Did you install Gradio from source files? You need to build "
-                    "the frontend by running /scripts/build_frontend.sh"
-                )
+                if app.blocks.share:
+                    raise ValueError(
+                        "Did you install Gradio from source files? Share mode only "
+                        "works when Gradio is installed through the pip package."
+                    )
+                else:                    
+                    raise ValueError(
+                        "Did you install Gradio from source files? You need to build "
+                        "the frontend by running /scripts/build_frontend.sh"
+                    )
 
         @app.get("/config/", dependencies=[Depends(login_check)])
         @app.get("/config", dependencies=[Depends(login_check)])

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -201,7 +201,7 @@ class App(FastAPI):
                         "Did you install Gradio from source files? Share mode only "
                         "works when Gradio is installed through the pip package."
                     )
-                else:                    
+                else:
                     raise ValueError(
                         "Did you install Gradio from source files? You need to build "
                         "the frontend by running /scripts/build_frontend.sh"


### PR DESCRIPTION
As discussed with @aliabid94, if a user builds `gradio` locally, we do not want them to be using `share=True` because local changes to the frontend will not be used. Instead, the frontend files from AWS S3 will be fetched. This could lead to some confusion, so instead we raise an Exception.