### PR TITLE
client-side hotfix for port issue

### DIFF
--- a/demo/calculator/run.py
+++ b/demo/calculator/run.py
@@ -30,4 +30,4 @@ demo = gr.Interface(
     description="Here's a sample toy calculator. Enjoy!",
 )
 if __name__ == "__main__":
-    demo.launch()
+    demo.launch(share=True)


### PR DESCRIPTION
Basically waits until app is up, then checks if the app config matches the share link config. If not, tries to create another share link.
Possible issues:
- Currently tries 10 times to connect to share link, 1 per second. Some apps may take longer than 10 seconds to come up. (could wait forever also?)
- Checking to see if the config is up every second might add load to the server.