### PR TITLE
Allow render() to return self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ No changes to highlight.
 
 ## Full Changelog:
 * Fixes the error message if a user builds Gradio locally and tries to use `share=True` by [@abidlabs](https://github.com/abidlabs) in [PR 2502](https://github.com/gradio-app/gradio/pull/2502)
+* Allows the render() function to return self by [@Raul9595](https://github.com/Raul9595) in [PR 2484](https://github.com/gradio-app/gradio/issues/2484)
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ No changes to highlight.
 
 ## Full Changelog:
 * Fixes the error message if a user builds Gradio locally and tries to use `share=True` by [@abidlabs](https://github.com/abidlabs) in [PR 2502](https://github.com/gradio-app/gradio/pull/2502)
-* Allows the render() function to return self by [@Raul9595](https://github.com/Raul9595) in [PR 2484](https://github.com/gradio-app/gradio/issues/2484)
+* Allows the render() function to return self by [@Raul9595](https://github.com/Raul9595) in [PR 2514](https://github.com/gradio-app/gradio/pull/2514)
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -73,6 +73,7 @@ class Block:
             Context.root_block.blocks[self._id] = self
             if hasattr(self, "temp_dir"):
                 Context.root_block.temp_dirs.add(self.temp_dir)
+        return self
 
     def unrender(self):
         """

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -669,6 +669,8 @@ class Blocks(BlockContext):
         if Context.block is not None:
             Context.block.children.extend(self.children)
 
+        return self
+
     def preprocess_data(self, fn_index, raw_input, state):
         block_fn = self.fns[fn_index]
         dependency = self.dependencies[fn_index]

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -494,8 +494,8 @@ class TestSpecificUpdate:
         }
 
 
-class TestDuplicateBlockError:
-    def test_error(self):
+class TestRender:
+    def test_duplicate_error(self):
         with pytest.raises(DuplicateBlockError):
             t = gr.Textbox()
             with gr.Blocks():
@@ -526,7 +526,8 @@ class TestDuplicateBlockError:
         t2 = gr.Textbox()
         with gr.Blocks():
             t.render()
-            t2.render()
+            t3 = t2.render()
+        assert t2 == t3
 
         t = gr.Textbox()
         io = gr.Interface(lambda x: x, t, gr.Textbox())
@@ -538,7 +539,8 @@ class TestDuplicateBlockError:
         io2 = gr.Interface(lambda x: x, gr.Textbox(), gr.Textbox())
         with gr.Blocks():
             io.render()
-            io2.render()
+            io3 = io2.render()
+        assert io2 == io3
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
# Description

Updated render() function in Blocks to return self

Please include: 
* relevant motivation
* a summary of the change 
* which issue is fixed. 
* any additional dependencies that are required for this change.

Closes: #2484 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.