### PR TITLE
Remove special ws path for spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ No changes to highlight.
 * Allows the render() function to return self by [@Raul9595](https://github.com/Raul9595) in [PR 2514](https://github.com/gradio-app/gradio/pull/2514)
 * Fixes issue where plotly animations, interactivity, titles, legends, were not working properly. [@dawoodkhan82](https://github.com/dawoodkhan82) in [PR 2486](https://github.com/gradio-app/gradio/pull/2486)
 * Gradio now supports batched functions by [@abidlabs](https://github.com/abidlabs) in [PR 2218](https://github.com/gradio-app/gradio/pull/2218)
+* Changes websocket path for Spaces as it is no longer necessary to have a different URL for websocket connections on Spaces by [@abidlabs](https://github.com/abidlabs) in [PR 2528](https://github.com/gradio-app/gradio/pull/2528)
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/ui/packages/app/src/api.ts
+++ b/ui/packages/app/src/api.ts
@@ -116,19 +116,11 @@ export const fn =
 			}
 			var ws_endpoint = api_endpoint === "api/" ? location.href : api_endpoint;
 			var ws_protocol = ws_endpoint.startsWith("https") ? "wss:" : "ws:";
-			if (is_space) {
-				const SPACE_REGEX = /embed\/(.*)\/\+/g;
-				var ws_path = Array.from(
-					ws_endpoint.matchAll(SPACE_REGEX)
-				)[0][1].concat("/");
-				var ws_host = "spaces.huggingface.tech/";
-			} else {
-				var ws_path = location.pathname === "/" ? "/" : location.pathname;
-				var ws_host =
-					BUILD_MODE === "dev" || location.origin === "http://localhost:3000"
-						? BACKEND_URL.replace("http://", "").slice(0, -1)
-						: location.host;
-			}
+			var ws_path = location.pathname === "/" ? "/" : location.pathname;
+			var ws_host =
+				BUILD_MODE === "dev" || location.origin === "http://localhost:3000"
+					? BACKEND_URL.replace("http://", "").slice(0, -1)
+					: location.host;
 			const WS_ENDPOINT = `${ws_protocol}//${ws_host}${ws_path}queue/join`;
 
 			var websocket = new WebSocket(WS_ENDPOINT);


### PR DESCRIPTION
As [discussed internally](https://huggingface.slack.com/archives/C02Q9UFS8AW/p1666267765528299), it is no longer necessary to have a different URL for websocket connections on Spaces. 

Quick PR to fix that. 