### PR TITLE
Properly dequeue cancelled events when multiple apps are rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ inference time of 80 seconds).
 * Fixes a bug with `cancels` in event triggers so that it works properly if multiple
 Blocks are rendered by [@abidlabs](https://github.com/abidlabs) in [PR 2530](https://github.com/gradio-app/gradio/pull/2530)  
 * Prevent invalid targets of events from crashing the whole application. [@pngwn](https://github.com/pngwn) in [PR 2534](https://github.com/gradio-app/gradio/pull/2534)
+* Properly dequeue cancelled events when multiple apps are rendered by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2540](https://github.com/gradio-app/gradio/pull/2540) 
 
 ## Documentation Changes:
 * Added an example interactive dashboard to the "Tabular & Plots" section of the Demos page by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2508](https://github.com/gradio-app/gradio/pull/2508)

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -639,6 +639,9 @@ class Blocks(BlockContext):
                 dependency["cancels"] = [
                     c + dependency_offset for c in dependency["cancels"]
                 ]
+                # Recreate the cancel function so that it has the latest
+                # dependency fn indices. This is necessary to properly cancel
+                # events in the backend
                 if dependency["cancels"]:
                     updated_cancels = [
                         Context.root_block.dependencies[i]

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -45,7 +45,7 @@ from gradio.documentation import (
     set_documentation_group,
 )
 from gradio.exceptions import DuplicateBlockError
-from gradio.utils import component_or_layout_class, delete_none
+from gradio.utils import component_or_layout_class, delete_none, get_cancel_function
 
 set_documentation_group("blocks")
 
@@ -622,7 +622,7 @@ class Blocks(BlockContext):
             Context.root_block.blocks.update(self.blocks)
             Context.root_block.fns.extend(self.fns)
             dependency_offset = len(Context.root_block.dependencies)
-            for dependency in self.dependencies:
+            for i, dependency in enumerate(self.dependencies):
                 api_name = dependency["api_name"]
                 if api_name is not None:
                     api_name_ = utils.append_unique_suffix(
@@ -639,6 +639,15 @@ class Blocks(BlockContext):
                 dependency["cancels"] = [
                     c + dependency_offset for c in dependency["cancels"]
                 ]
+                if dependency["cancels"]:
+                    updated_cancels = [
+                        Context.root_block.dependencies[i]
+                        for i in dependency["cancels"]
+                    ]
+                    new_fn = BlockFunction(
+                        get_cancel_function(updated_cancels)[0], False, True
+                    )
+                    Context.root_block.fns[dependency_offset + i] = new_fn
                 Context.root_block.dependencies.append(dependency)
             Context.root_block.temp_dirs = Context.root_block.temp_dirs | self.temp_dirs
 
@@ -650,7 +659,6 @@ class Blocks(BlockContext):
         """Checks if a particular Blocks function is callable (i.e. not stateful or a generator)."""
         block_fn = self.fns[fn_index]
         dependency = self.dependencies[fn_index]
-        block_fn = self.fns[fn_index]
 
         if inspect.isasyncgenfunction(block_fn.fn):
             return False

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -1,43 +1,13 @@
 from __future__ import annotations
 
-import asyncio
-import sys
 import warnings
-from typing import TYPE_CHECKING, Any, AnyStr, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, AnyStr, Callable, Dict, List, Optional
 
-from gradio.blocks import Block, Context, update
+from gradio.blocks import Block
+from gradio.utils import get_cancel_function
 
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
     from gradio.components import Component, StatusTracker
-
-
-def get_cancel_function(
-    dependencies: List[Dict[str, Any]]
-) -> Tuple[Callable, List[int]]:
-    fn_to_comp = {}
-    for dep in dependencies:
-        fn_index = next(
-            i for i, d in enumerate(Context.root_block.dependencies) if d == dep
-        )
-        fn_to_comp[fn_index] = [Context.root_block.blocks[o] for o in dep["outputs"]]
-
-    async def cancel(session_hash: str) -> None:
-        if sys.version_info < (3, 8):
-            return None
-
-        task_ids = set([f"{session_hash}_{fn}" for fn in fn_to_comp])
-
-        matching_tasks = [
-            task for task in asyncio.all_tasks() if task.get_name() in task_ids
-        ]
-        for task in matching_tasks:
-            task.cancel()
-        await asyncio.gather(*matching_tasks, return_exceptions=True)
-
-    return (
-        cancel,
-        list(fn_to_comp.keys()),
-    )
 
 
 def set_cancel_events(

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -10,6 +10,7 @@ import json.decoder
 import os
 import pkgutil
 import random
+import sys
 import warnings
 from contextlib import contextmanager
 from distutils.version import StrictVersion
@@ -35,6 +36,7 @@ import requests
 from pydantic import BaseModel, Json, parse_obj_as
 
 import gradio
+from gradio.context import Context
 
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
     from gradio.blocks import BlockContext
@@ -685,3 +687,32 @@ def validate_url(possible_url: str) -> bool:
 
 def is_update(val):
     return type(val) is dict and "update" in val.get("__type__", "")
+
+
+def get_cancel_function(
+    dependencies: List[Dict[str, Any]]
+) -> Tuple[Callable, List[int]]:
+    fn_to_comp = {}
+    for dep in dependencies:
+        fn_index = next(
+            i for i, d in enumerate(Context.root_block.dependencies) if d == dep
+        )
+        fn_to_comp[fn_index] = [Context.root_block.blocks[o] for o in dep["outputs"]]
+
+    async def cancel(session_hash: str) -> None:
+        if sys.version_info < (3, 8):
+            return None
+
+        task_ids = set([f"{session_hash}_{fn}" for fn in fn_to_comp])
+
+        matching_tasks = [
+            task for task in asyncio.all_tasks() if task.get_name() in task_ids
+        ]
+        for task in matching_tasks:
+            task.cancel()
+        await asyncio.gather(*matching_tasks, return_exceptions=True)
+
+    return (
+        cancel,
+        list(fn_to_comp.keys()),
+    )

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -17,6 +17,7 @@ import wandb
 
 import gradio as gr
 import gradio.events
+import gradio.utils
 from gradio.exceptions import DuplicateBlockError
 from gradio.routes import PredictBody
 from gradio.test_data.blocks_configs import XRAY_CONFIG
@@ -745,13 +746,13 @@ class TestCancel:
             await asyncio.sleep(10)
             print("HELLO FROM LONG JOB")
 
-        with gr.Blocks():
+        with gr.Blocks() as demo:
             button = gr.Button(value="Start")
             click = button.click(long_job, None, None)
             cancel = gr.Button(value="Cancel")
             cancel.click(None, None, None, cancels=[click])
-            cancel_fun, _ = gradio.events.get_cancel_function(dependencies=[click])
 
+        cancel_fun = demo.fns[-1].fn
         task = asyncio.create_task(long_job())
         task.set_name("foo_0")
         # If cancel_fun didn't cancel long_job the message would be printed to the console
@@ -789,7 +790,7 @@ class TestCancel:
         cancel_fun = demo.fns[-1].fn
 
         task = asyncio.create_task(long_job())
-        task.set_name("foo_0")
+        task.set_name("foo_1")
         await asyncio.gather(task, cancel_fun("foo"), return_exceptions=True)
         captured = capsys.readouterr()
         assert "HELLO FROM LONG JOB" not in captured.out


### PR DESCRIPTION
# Description
Continuation of #2530 

Cancelled events were not properly dequeued because the background task was not cancelled. You can see that here:

### Not dequeued (main)
![not_dequeued](https://user-images.githubusercontent.com/41651716/198072407-4a8d0505-fb4e-4dc6-8fdc-52d8f0e0285a.gif)

### Dequeued (this pr)
![properly_dequeued](https://user-images.githubusercontent.com/41651716/198072475-840a5a2a-3aa8-430d-b4e9-74eccbd7d270.gif)

The fix is to also update the fn indices in the cancel functions. I thought about giving the dependencies an id that's invariant to the number of dependencies in the demo but that would be a bigger change that doesn't seem worth it when adding an if statement to `render` fixes the issue.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.