### PR TITLE
Show better error message when events are defined outside of a `Blocks` scope

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -8,6 +8,7 @@ import pkgutil
 import random
 import sys
 import time
+from tkinter import N
 import warnings
 import webbrowser
 from types import ModuleType
@@ -162,6 +163,8 @@ class Block:
             inputs = [inputs]
         if not isinstance(outputs, list):
             outputs = [outputs]
+        if Context.root_block is None:
+            raise AttributeError("Events can only be defined within a Blocks context.")
         Context.root_block.fns.append(BlockFunction(fn, preprocess, postprocess))
         if api_name is not None:
             api_name_ = utils.append_unique_suffix(

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -1,0 +1,16 @@
+import pytest
+
+import gradio as gr
+
+
+class TestEventErrors:
+    def test_event_defined_invalid_scope(self):
+        with gr.Blocks() as demo:
+            textbox = gr.Textbox()
+            textbox.blur(lambda x: x+x, textbox, textbox)
+            
+        with pytest.raises(AttributeError):
+            demo.load(lambda :"hello", None, textbox)
+
+        with pytest.raises(AttributeError):
+            textbox.change(lambda x: x+x, textbox, textbox)


### PR DESCRIPTION
Fixes: #2529