### PR TITLE
Update issue template chooser to link to Discord for general questions 

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Community Support
+    url: https://github.com/orgs/community/discussions
+    about: Please ask and answer questions here.
+  - name: GitHub Security Bug Bounty
+    url: https://bounty.github.com/
+    about: Please report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: GitHub Community Support
-    url: https://github.com/orgs/community/discussions
-    about: Please ask and answer questions here.
-  - name: GitHub Security Bug Bounty
-    url: https://bounty.github.com/
-    about: Please report security vulnerabilities here.
+  - name: 💡 General questions
+    url: https://discord.com/invite/feTf9x3ZSB
+    about: Have general questions about how to use Gradio? Please ask in our Discord channel

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: 💡 General questions
     url: https://discord.com/invite/feTf9x3ZSB
-    about: Have general questions about how to use Gradio? Please ask in our Discord channel
+    about: Have general questions about how to use Gradio? Please ask in our community Discord for quicker responses


### PR DESCRIPTION
We've started to see a lot of general questions on GitHub issues. As discussed internally, it would be best to direct such users to Discord, which is what this PR does. 

See preview on my fork: https://github.com/abidlabs/gradio/issues/new/choose