### PR TITLE
Attempt to Fix Markdown/HTML spacing

### DIFF
--- a/ui/packages/html/src/HTML.svelte
+++ b/ui/packages/html/src/HTML.svelte
@@ -10,6 +10,6 @@
 	$: value, dispatch("change");
 </script>
 
-<div class="output-html min-h-[4rem]" id={elem_id} class:!hidden={!visible}>
+<div class="output-html" id={elem_id} class:!hidden={!visible}>
 	{@html value}
 </div>

--- a/ui/packages/markdown/src/Markdown.svelte
+++ b/ui/packages/markdown/src/Markdown.svelte
@@ -13,7 +13,7 @@
 
 <div
 	id={elem_id}
-	class="output-markdown gr-prose min-h-[6rem]"
+	class="output-markdown gr-prose"
 	class:hidden={!visible}
 	style="max-width: 100%"
 >


### PR DESCRIPTION
I'm attempting to fix this issue here: #2598 

The reason we have this is because we introduced a minimum height to the `Markdown` and `HTML` components, which adds too much padding. I've removed it in this PR, but then I realized that the reason that the height was added was to ensure that the status tracker for these elements always showed up correctly. @pngwn do you have any suggestions on how to fix this?

Here's a minimal example showing the problem:

```py
import gradio as gr
import time

def sl(x):
    time.sleep(1)
    return x

with gr.Blocks() as demo:
    t = gr.Textbox("hi")
    h = gr.Markdown("hi")
    gr.Textbox("hi")
    t.change(sl, t, h)

demo.launch()
```