### PR TITLE
Fix bug with gr.update and interactive=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ No changes to highlight.
 ## Bug Fixes:
 * Updated the minimum FastApi used in tests to version 0.87 [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2647](https://github.com/gradio-app/gradio/pull/2647)
 * Fixed bug where interfaces with examples could not be loaded with `gr.Interface.load` by [@freddyaboulton](https://github.com/freddyaboulton) [PR 2640](https://github.com/gradio-app/gradio/pull/2640)
+* Fixed bug where the `interactive` property of a component could not be updated by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2639](https://github.com/gradio-app/gradio/pull/2639)
 
 ## Documentation Changes:
 No changes to highlight.

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -262,7 +262,11 @@ class Block:
     @classmethod
     def get_specific_update(cls, generic_update):
         del generic_update["__type__"]
+        mode = generic_update.get("mode", None)
+        generic_update.pop("mode", None)
         generic_update = cls.update(**generic_update)
+        if mode:
+            generic_update["mode"] = mode
         return generic_update
 
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -262,11 +262,7 @@ class Block:
     @classmethod
     def get_specific_update(cls, generic_update):
         del generic_update["__type__"]
-        mode = generic_update.get("mode", None)
-        generic_update.pop("mode", None)
         generic_update = cls.update(**generic_update)
-        if mode:
-            generic_update["mode"] = mode
         return generic_update
 
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -425,10 +425,11 @@ def postprocess_update_dict(block: Block, update_dict: Dict, postprocess: bool =
         update_dict: The original update dictionary
         postprocess: Whether to postprocess the "value" key of the update dictionary.
     """
-    prediction_value = block.get_specific_update(update_dict)
-    if prediction_value.get("value") is components._Keywords.NO_VALUE:
-        prediction_value.pop("value")
-    prediction_value = delete_none(prediction_value, skip_value=True)
+    if update_dict.get("__type__", "") == "generic_update":
+        update_dict = block.get_specific_update(update_dict)
+    if update_dict.get("value") is components._Keywords.NO_VALUE:
+        update_dict.pop("value")
+    prediction_value = delete_none(update_dict, skip_value=True)
     if "value" in prediction_value and postprocess:
         prediction_value["value"] = block.postprocess(prediction_value["value"])
     return prediction_value

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -330,7 +330,7 @@ class Textbox(
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = True,
+        interactive: Optional[bool] = None,
     ):
         updated_config = {
             "lines": lines,
@@ -507,7 +507,7 @@ class Number(
         value: Optional[float] = _Keywords.NO_VALUE,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = True,
+        interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -806,7 +806,7 @@ class Checkbox(Changeable, IOComponent, SimpleSerializable, FormComponent):
         value: Optional[bool] = _Keywords.NO_VALUE,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = True,
+        interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -910,7 +910,7 @@ class CheckboxGroup(Changeable, IOComponent, SimpleSerializable, FormComponent):
         choices: Optional[List[str]] = None,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = True,
+        interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -1074,7 +1074,7 @@ class Radio(Changeable, IOComponent, SimpleSerializable, FormComponent):
         choices: Optional[List[str]] = None,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = True,
+        interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -1317,7 +1317,7 @@ class Image(
         value: Optional[Any] = _Keywords.NO_VALUE,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = True,
+        interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -1638,7 +1638,7 @@ class Video(Changeable, Clearable, Playable, Uploadable, IOComponent, FileSerial
         source: Optional[str] = None,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = True,
+        interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -1842,7 +1842,7 @@ class Audio(
         source: Optional[str] = None,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = True,
+        interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -2127,7 +2127,7 @@ class File(Changeable, Clearable, Uploadable, IOComponent, FileSerializable):
         value: Optional[Any] = _Keywords.NO_VALUE,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = True,
+        interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -2373,7 +2373,7 @@ class Dataframe(Changeable, IOComponent, JSONSerializable):
         max_cols: Optional[str] = None,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = True,
+        interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -2584,7 +2584,7 @@ class Timeseries(Changeable, IOComponent, JSONSerializable):
         colors: Optional[List[str]] = None,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = True,
+        interactive: Optional[bool] = None,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -2806,7 +2806,7 @@ class ColorPicker(Changeable, Submittable, IOComponent, SimpleSerializable):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = True,
+        interactive: Optional[bool] = None,
     ):
         updated_config = {
             "value": value,

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -330,7 +330,7 @@ class Textbox(
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = None,
+        interactive: Optional[bool] = True,
     ):
         updated_config = {
             "lines": lines,

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -330,7 +330,7 @@ class Textbox(
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = True,
+        interactive: Optional[bool] = None,
     ):
         updated_config = {
             "lines": lines,

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -330,7 +330,7 @@ class Textbox(
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = None,
+        interactive: Optional[bool] = True,
     ):
         updated_config = {
             "lines": lines,
@@ -507,7 +507,7 @@ class Number(
         value: Optional[float] = _Keywords.NO_VALUE,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = None,
+        interactive: Optional[bool] = True,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -806,7 +806,7 @@ class Checkbox(Changeable, IOComponent, SimpleSerializable, FormComponent):
         value: Optional[bool] = _Keywords.NO_VALUE,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = None,
+        interactive: Optional[bool] = True,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -910,7 +910,7 @@ class CheckboxGroup(Changeable, IOComponent, SimpleSerializable, FormComponent):
         choices: Optional[List[str]] = None,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = None,
+        interactive: Optional[bool] = True,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -1074,7 +1074,7 @@ class Radio(Changeable, IOComponent, SimpleSerializable, FormComponent):
         choices: Optional[List[str]] = None,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = None,
+        interactive: Optional[bool] = True,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -1317,7 +1317,7 @@ class Image(
         value: Optional[Any] = _Keywords.NO_VALUE,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = None,
+        interactive: Optional[bool] = True,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -1638,7 +1638,7 @@ class Video(Changeable, Clearable, Playable, Uploadable, IOComponent, FileSerial
         source: Optional[str] = None,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = None,
+        interactive: Optional[bool] = True,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -1842,7 +1842,7 @@ class Audio(
         source: Optional[str] = None,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = None,
+        interactive: Optional[bool] = True,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -2127,7 +2127,7 @@ class File(Changeable, Clearable, Uploadable, IOComponent, FileSerializable):
         value: Optional[Any] = _Keywords.NO_VALUE,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = None,
+        interactive: Optional[bool] = True,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -2373,7 +2373,7 @@ class Dataframe(Changeable, IOComponent, JSONSerializable):
         max_cols: Optional[str] = None,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = None,
+        interactive: Optional[bool] = True,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -2584,7 +2584,7 @@ class Timeseries(Changeable, IOComponent, JSONSerializable):
         colors: Optional[List[str]] = None,
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
-        interactive: Optional[bool] = None,
+        interactive: Optional[bool] = True,
         visible: Optional[bool] = None,
     ):
         updated_config = {
@@ -2806,7 +2806,7 @@ class ColorPicker(Changeable, Submittable, IOComponent, SimpleSerializable):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
-        interactive: Optional[bool] = None,
+        interactive: Optional[bool] = True,
     ):
         updated_config = {
             "value": value,

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -395,22 +395,30 @@ class TestComponentsInBlocks:
     async def test_blocks_update_interactive(
         self,
     ):
-        def infer():
+        def specific_update():
+            return [
+                gr.Image.update(interactive=True),
+                gr.Textbox.update(interactive=True),
+            ]
+
+        def generic_update():
             return [gr.update(interactive=True), gr.update(interactive=True)]
 
         with gr.Blocks() as demo:
             run = gr.Button(value="Make interactive")
             image = gr.Image()
             textbox = gr.Text()
-            run.click(infer, None, [image, textbox])
+            run.click(specific_update, None, [image, textbox])
+            run.click(generic_update, None, [image, textbox])
 
-        output = await demo.process_api(0, [])
-        assert output["data"][0] == {
-            "interactive": True,
-            "__type__": "update",
-            "mode": "dynamic",
-        }
-        assert output["data"][1] == {"__type__": "update", "mode": "dynamic"}
+        for fn_index in range(2):
+            output = await demo.process_api(fn_index, [])
+            assert output["data"][0] == {
+                "interactive": True,
+                "__type__": "update",
+                "mode": "dynamic",
+            }
+            assert output["data"][1] == {"__type__": "update", "mode": "dynamic"}
 
 
 class TestCallFunction:

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -388,6 +388,8 @@ class TestComponentsInBlocks:
         output = await demo.process_api(0, ["test"])
         assert output["data"][0] == {
             "__type__": "update",
+            "interactive": True,
+            "mode": "dynamic",
             "value": gr.media_data.BASE64_IMAGE,
         }
 
@@ -688,6 +690,7 @@ class TestSpecificUpdate:
             "visible": None,
             "value": gr.components._Keywords.NO_VALUE,
             "__type__": "update",
+            "mode": "dynamic",
         }
 
     def test_with_generic_update(self):
@@ -698,10 +701,11 @@ class TestSpecificUpdate:
             "source": None,
             "label": None,
             "show_label": None,
-            "interactive": None,
+            "interactive": True,
             "visible": True,
             "value": "test.mp4",
             "__type__": "update",
+            "mode": "dynamic",
         }
 
 

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -391,6 +391,27 @@ class TestComponentsInBlocks:
             "value": gr.media_data.BASE64_IMAGE,
         }
 
+    @pytest.mark.asyncio
+    async def test_blocks_update_interactive(
+        self,
+    ):
+        def infer():
+            return [gr.update(interactive=True), gr.update(interactive=True)]
+
+        with gr.Blocks() as demo:
+            run = gr.Button(value="Make interactive")
+            image = gr.Image()
+            textbox = gr.Text()
+            run.click(infer, None, [image, textbox])
+
+        output = await demo.process_api(0, [])
+        assert output["data"][0] == {
+            "interactive": True,
+            "__type__": "update",
+            "mode": "dynamic",
+        }
+        assert output["data"][1] == {"__type__": "update", "mode": "dynamic"}
+
 
 class TestCallFunction:
     @pytest.mark.asyncio

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -388,8 +388,6 @@ class TestComponentsInBlocks:
         output = await demo.process_api(0, ["test"])
         assert output["data"][0] == {
             "__type__": "update",
-            "interactive": True,
-            "mode": "dynamic",
             "value": gr.media_data.BASE64_IMAGE,
         }
 
@@ -679,7 +677,7 @@ class TestSpecificUpdate:
 
     def test_with_update(self):
         specific_update = gr.Textbox.get_specific_update(
-            {"lines": 4, "__type__": "update", "interactive": False}
+            {"lines": 4, "__type__": "update", "mode": "static"}
         )
         assert specific_update == {
             "lines": 4,
@@ -693,19 +691,39 @@ class TestSpecificUpdate:
             "mode": "static",
         }
 
+        specific_update = gr.Textbox.get_specific_update(
+            {"lines": 4, "__type__": "update", "mode": "dynamic"}
+        )
+        assert specific_update == {
+            "lines": 4,
+            "max_lines": None,
+            "placeholder": None,
+            "label": None,
+            "show_label": None,
+            "visible": None,
+            "value": gr.components._Keywords.NO_VALUE,
+            "__type__": "update",
+            "mode": "dynamic",
+        }
+
     def test_with_generic_update(self):
         specific_update = gr.Video.get_specific_update(
-            {"visible": True, "value": "test.mp4", "__type__": "generic_update"}
+            {
+                "visible": True,
+                "value": "test.mp4",
+                "__type__": "generic_update",
+                "mode": "static",
+            }
         )
         assert specific_update == {
             "source": None,
             "label": None,
             "show_label": None,
-            "interactive": True,
             "visible": True,
             "value": "test.mp4",
+            "interactive": None,
+            "mode": "static",
             "__type__": "update",
-            "mode": "dynamic",
         }
 
 

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -706,7 +706,7 @@ class TestSpecificUpdate:
 
     def test_with_update(self):
         specific_update = gr.Textbox.get_specific_update(
-            {"lines": 4, "__type__": "update", "mode": "static"}
+            {"lines": 4, "__type__": "update", "interactive": False}
         )
         assert specific_update == {
             "lines": 4,
@@ -721,7 +721,7 @@ class TestSpecificUpdate:
         }
 
         specific_update = gr.Textbox.get_specific_update(
-            {"lines": 4, "__type__": "update", "mode": "dynamic"}
+            {"lines": 4, "__type__": "update", "interactive": True}
         )
         assert specific_update == {
             "lines": 4,
@@ -741,7 +741,7 @@ class TestSpecificUpdate:
                 "visible": True,
                 "value": "test.mp4",
                 "__type__": "generic_update",
-                "mode": "static",
+                "interactive": True,
             }
         )
         assert specific_update == {
@@ -750,8 +750,8 @@ class TestSpecificUpdate:
             "show_label": None,
             "visible": True,
             "value": "test.mp4",
-            "interactive": None,
-            "mode": "static",
+            "mode": "dynamic",
+            "interactive": True,
             "__type__": "update",
         }
 

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -679,7 +679,7 @@ class TestSpecificUpdate:
 
     def test_with_update(self):
         specific_update = gr.Textbox.get_specific_update(
-            {"lines": 4, "__type__": "update"}
+            {"lines": 4, "__type__": "update", "interactive": False}
         )
         assert specific_update == {
             "lines": 4,
@@ -690,7 +690,7 @@ class TestSpecificUpdate:
             "visible": None,
             "value": gr.components._Keywords.NO_VALUE,
             "__type__": "update",
-            "mode": "dynamic",
+            "mode": "static",
         }
 
     def test_with_generic_update(self):

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -191,7 +191,6 @@ class TestProcessExamples:
             {"label": "lion"},
         ]
 
-
     def test_raise_helpful_error_message_if_providing_partial_examples(self, tmp_path):
         def foo(a, b):
             return a + b

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -151,7 +151,12 @@ class TestProcessExamples:
             cache_examples=True,
         )
         prediction = await io.examples_handler.load_from_cache(1)
-        assert prediction[0] == {"visible": False, "__type__": "update"}
+        assert prediction[0] == {
+            "visible": False,
+            "__type__": "update",
+            "mode": "dynamic",
+            "interactive": True,
+        }
 
     @pytest.mark.asyncio
     async def test_caching_with_mix_update(self):
@@ -163,7 +168,12 @@ class TestProcessExamples:
             cache_examples=True,
         )
         prediction = await io.examples_handler.load_from_cache(1)
-        assert prediction[0] == {"lines": 4, "value": "hello", "__type__": "update"}
+        assert prediction[0] == {
+            "lines": 4,
+            "value": "hello",
+            "__type__": "update",
+            "mode": "dynamic",
+        }
 
     @pytest.mark.asyncio
     async def test_caching_with_dict(self):
@@ -178,8 +188,12 @@ class TestProcessExamples:
             cache_examples=True,
         )
         prediction = await io.examples_handler.load_from_cache(0)
-        assert prediction == [{"lines": 4, "__type__": "update"}, {"label": "lion"}]
         assert not any(d["trigger"] == "fake_event" for d in io.config["dependencies"])
+        assert prediction == [
+            {"lines": 4, "__type__": "update", "mode": "dynamic"},
+            {"label": "lion"},
+        ]
+
 
     def test_raise_helpful_error_message_if_providing_partial_examples(self, tmp_path):
         def foo(a, b):

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -154,8 +154,6 @@ class TestProcessExamples:
         assert prediction[0] == {
             "visible": False,
             "__type__": "update",
-            "mode": "dynamic",
-            "interactive": True,
         }
 
     @pytest.mark.asyncio
@@ -172,7 +170,6 @@ class TestProcessExamples:
             "lines": 4,
             "value": "hello",
             "__type__": "update",
-            "mode": "dynamic",
         }
 
     @pytest.mark.asyncio
@@ -181,7 +178,7 @@ class TestProcessExamples:
         out = gr.Label()
 
         io = gr.Interface(
-            lambda _: {text: gr.update(lines=4), out: "lion"},
+            lambda _: {text: gr.update(lines=4, interactive=False), out: "lion"},
             "textbox",
             [text, out],
             examples=["abc"],
@@ -190,7 +187,7 @@ class TestProcessExamples:
         prediction = await io.examples_handler.load_from_cache(0)
         assert not any(d["trigger"] == "fake_event" for d in io.config["dependencies"])
         assert prediction == [
-            {"lines": 4, "__type__": "update", "mode": "dynamic"},
+            {"lines": 4, "__type__": "update", "mode": "static"},
             {"label": "lion"},
         ]
 


### PR DESCRIPTION
# Description

Fixes #2636 

The original bug is fixed by modifying `Block.get_specific_update` to not pass "mode" as a kwarg to `update` as that's not a user facing argument.

In addition, I made it so that the default value of `interactive` in `update` methods is True. This is because if an update method sets `interactive=False` the user has to explicitly set `interactive=True` again in a separate update call if they want to make the component interactive.

For example, in the original repro, if the default value of `interactive` in the textbox update method is None, after clicking on `short` the textbox will never be interactive again. I figured this might be too confusing for users. Wondering what others thoughts are. See the example below:

### Cant type in "long" after clicking on "short" if the default value of interactive is None
![interactivity](https://user-images.githubusercontent.com/41651716/201225611-faddd7bf-d50e-43ba-a89d-c2d5c7b7945b.gif)

### Can type in "long" a
![interactivity_2](https://user-images.githubusercontent.com/41651716/201226535-40cc208a-76f4-497a-84b9-c06c306ae6f9.gif)
fter clicking on "short" if the default value of interactive is None

Repro code:
```python
```python

def change_textbox(choice):
    if choice == "short":
        return gr.Textbox.update(lines=2, visible=True, interactive=False)
    elif choice == "long":
        return gr.Textbox.update(lines=8, visible=True)
    else:
        return gr.Textbox.update(visible=False)


with gr.Blocks() as demo:
    radio = gr.Radio(
        ["short", "long", "none"], label="What kind of essay would you like to write?"
    )
    text = gr.Textbox(lines=2, interactive=True)
    gr.Textbox(value="Foo")

    radio.change(fn=change_textbox, inputs=radio, outputs=text)

demo.launch()
```

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.