### PR TITLE
Fix some website demos that were not building

### DIFF
--- a/demo/Echocardiogram-Segmentation/run.py
+++ b/demo/Echocardiogram-Segmentation/run.py
@@ -80,8 +80,8 @@ def segment(input):
 
 import gradio as gr
 
-i = gr.inputs.Image(shape=(112, 112), label="Echocardiogram")
-o = gr.outputs.Image(label="Segmentation Mask")
+i = gr.Image(shape=(112, 112), label="Echocardiogram")
+o = gr.Image(label="Segmentation Mask")
 
 examples = [["img1.jpg"], ["img2.jpg"]]
 title = None #"Left Ventricle Segmentation"

--- a/demo/generate_english_german/run.py
+++ b/demo/generate_english_german/run.py
@@ -2,7 +2,7 @@ import gradio as gr
 
 from transformers import pipeline
 
-english_translator = gr.Blocks.load(name="spaces/gradio/english-translator")
+english_translator = gr.Blocks.load(name="spaces/gradio/english_translator")
 english_generator = pipeline("text-generation", model="distilgpt2")
 
 

--- a/demo/stable-diffusion/requirements.txt
+++ b/demo/stable-diffusion/requirements.txt
@@ -2,4 +2,4 @@ diffusers
 transformers
 nvidia-ml-py3
 ftfy
---extra-index-url https://download.pytorch.org/whl/cu113 torch
+torch


### PR DESCRIPTION
# Description

The following spaces were not building:

![image](https://user-images.githubusercontent.com/41651716/201764588-4b039fc2-0070-4e41-aea4-1493749329de.png)

For generate_english_german, it was caused by a typo in gr.Blocks.load. Echocardiogram-Segmentation was using deprecated gr.inputs and gr.outputs modules. stable diffusion was not able to successfully install pytorch.

I manually made fixes to those spaces and now they build. By committing these changes to the repo, they should not break again.

![image](https://user-images.githubusercontent.com/41651716/201764819-c14396ba-8326-4b8d-8bd6-cdb73298e0b0.png)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.