### PR TITLE
Quick fix to `gr.utils.validate_url`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Updated the minimum FastApi used in tests to version 0.87 [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2647](https://github.com/gradio-app/gradio/pull/2647)
 * Fixed bug where interfaces with examples could not be loaded with `gr.Interface.load` by [@freddyaboulton](https://github.com/freddyaboulton) [PR 2640](https://github.com/gradio-app/gradio/pull/2640)
 * Fixed bug where the `interactive` property of a component could not be updated by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2639](https://github.com/gradio-app/gradio/pull/2639)
+* Fixed bug where some URLs were not being recognized as valid URLs and thus were not
+loading correctly in various components by [@abidlabs](https://github.com/abidlabs) in [PR 2659](https://github.com/gradio-app/gradio/pull/2659)
+
 
 ## Documentation Changes:
 No changes to highlight.

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -678,12 +678,11 @@ def append_unique_suffix(name: str, list_of_names: List[str]):
 
 
 def validate_url(possible_url: str) -> bool:
+    headers = {'User-Agent': 'gradio (https://gradio.app/; team@gradio.app)'}
     try:
-        if requests.get(possible_url).status_code == 200:
-            return True
+        return requests.get(possible_url, headers=headers).ok
     except Exception:
-        pass
-    return False
+        return False
 
 
 def is_update(val):

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -678,7 +678,7 @@ def append_unique_suffix(name: str, list_of_names: List[str]):
 
 
 def validate_url(possible_url: str) -> bool:
-    headers = {'User-Agent': 'gradio (https://gradio.app/; team@gradio.app)'}
+    headers = {"User-Agent": "gradio (https://gradio.app/; team@gradio.app)"}
     try:
         return requests.get(possible_url, headers=headers).ok
     except Exception:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -488,16 +488,20 @@ class TestSanitizeForCSV:
         ) == [["'=abc", "def", "'gh,+ij"], ["abc", "'=def", "'+ghij"]]
         assert sanitize_list_for_csv([1, ["ab", "=de"]]) == [1, ["ab", "'=de"]]
 
+
 class TestValidateURL:
     def test_valid_urls(self):
         assert validate_url("https://www.gradio.app")
         assert validate_url("www.gradio.dev")
-        assert validate_url("https://upload.wikimedia.org/wikipedia/commons/b/b0/Bengal_tiger_%28Panthera_tigris_tigris%29_female_3_crop.jpg")
+        assert validate_url(
+            "https://upload.wikimedia.org/wikipedia/commons/b/b0/Bengal_tiger_%28Panthera_tigris_tigris%29_female_3_crop.jpg"
+        )
 
     def test_invalid_urls(self):
-        assert not(validate_url("C:/Users/"))
-        assert not(validate_url("C:\\Users\\"))
-        assert not(validate_url("/home/user"))
+        assert not (validate_url("C:/Users/"))
+        assert not (validate_url("C:\\Users\\"))
+        assert not (validate_url("/home/user"))
+
 
 class TestAppendUniqueSuffix:
     def test_no_suffix(self):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -490,6 +490,7 @@ class TestSanitizeForCSV:
 
 
 class TestValidateURL:
+    @pytest.mark.flaky
     def test_valid_urls(self):
         assert validate_url("https://www.gradio.app")
         assert validate_url("http://gradio.dev")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -492,7 +492,7 @@ class TestSanitizeForCSV:
 class TestValidateURL:
     def test_valid_urls(self):
         assert validate_url("https://www.gradio.app")
-        assert validate_url("www.gradio.dev")
+        assert validate_url("http://gradio.dev")
         assert validate_url(
             "https://upload.wikimedia.org/wikipedia/commons/b/b0/Bengal_tiger_%28Panthera_tigris_tigris%29_female_3_crop.jpg"
         )

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -31,6 +31,7 @@ from gradio.utils import (
     readme_to_html,
     sanitize_list_for_csv,
     sanitize_value_for_csv,
+    validate_url,
     version_check,
 )
 
@@ -487,6 +488,16 @@ class TestSanitizeForCSV:
         ) == [["'=abc", "def", "'gh,+ij"], ["abc", "'=def", "'+ghij"]]
         assert sanitize_list_for_csv([1, ["ab", "=de"]]) == [1, ["ab", "'=de"]]
 
+class TestValidateURL:
+    def test_valid_urls(self):
+        assert validate_url("https://www.gradio.app")
+        assert validate_url("www.gradio.dev")
+        assert validate_url("https://upload.wikimedia.org/wikipedia/commons/b/b0/Bengal_tiger_%28Panthera_tigris_tigris%29_female_3_crop.jpg")
+
+    def test_invalid_urls(self):
+        assert not(validate_url("C:/Users/"))
+        assert not(validate_url("C:\\Users\\"))
+        assert not(validate_url("/home/user"))
 
 class TestAppendUniqueSuffix:
     def test_no_suffix(self):


### PR DESCRIPTION
**Context**: we use `gr.utils.validate_url` to determine if a string is a URL or a filepath. The logic is quite simple -- we make a GET request to the URL and see if we get a result. 

However, some common media hosting sites (e.g. WikiCommons) [require a User Agent to be set](https://meta.wikimedia.org/wiki/User-Agent_policy#Python) when making a request -- otherwise, the request is immediately rejected. This fact causes `gr.utils.validate_url` to fail for these URLs. In addition, since we were checking for a strict 200 response, URLs that redirected to other URLs would fail.

This PR fixes those issues and add tests. 

Code to reproduce:

```py
import gradio as gr

with gr.Blocks() as demo:
    gr.Audio("https://upload.wikimedia.org/wikipedia/commons/e/ef/Yellowstone_sound_library_-_Grizzly_Bears_Roar_-_001.mp3")
    
demo.launch()
```