### PR TITLE
pass in kwargs to `Blocks.load()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 No changes to highlight.
 
 ## Bug Fixes:
-No changes to highlight.
+* Passes kwargs into `gr.Interface.load()` by [@abidlabs](https://github.com/abidlabs) in [PR 2669](https://github.com/gradio-app/gradio/pull/2669)
 
 ## Documentation Changes:
 No changes to highlight.

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -105,7 +105,7 @@ class Interface(Blocks):
             demo = gr.Interface.load("models/EleutherAI/gpt-neo-1.3B", description=description, examples=examples)
             demo.launch()
         """
-        return super().load(name=name, src=src, api_key=api_key, alias=alias)
+        return super().load(name=name, src=src, api_key=api_key, alias=alias, **kwargs)
 
     @classmethod
     def from_pipeline(cls, pipeline: transformers.Pipeline, **kwargs) -> Interface:

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -49,7 +49,9 @@ class TestLoadInterface:
     def test_question_answering(self):
         model_type = "image-classification"
         interface = gr.Blocks.load(
-            name="lysandre/tiny-vit-random", src="models", alias=model_type
+            name="lysandre/tiny-vit-random",
+            src="models",
+            alias=model_type,
         )
         assert interface.__name__ == model_type
         assert isinstance(interface.input_components[0], gr.components.Image)
@@ -57,10 +59,16 @@ class TestLoadInterface:
 
     def test_text_generation(self):
         model_type = "text_generation"
-        interface = gr.Interface.load("models/gpt2", alias=model_type)
+        interface = gr.Interface.load(
+            "models/gpt2", alias=model_type, description="This is a test description"
+        )
         assert interface.__name__ == model_type
         assert isinstance(interface.input_components[0], gr.components.Textbox)
         assert isinstance(interface.output_components[0], gr.components.Textbox)
+        assert any(
+            "This is a test description" in d["props"].get("value", "")
+            for d in interface.get_config_file()["components"]
+        )
 
     def test_summarization(self):
         model_type = "summarization"


### PR DESCRIPTION
It seems like we accidentally stopped passing in `**kwarg` arguments from `gr.Interface.load()` to `gr.Blocks.load()`. This brings that back and adds a test to prevent regressions in the future.

Fixes: #2665 