### PR TITLE
Fix website launch script

### DIFF
--- a/scripts/launch_website.sh
+++ b/scripts/launch_website.sh
@@ -8,7 +8,8 @@ npm_required
 echo "Building the website..."
 set -e
 cd website/homepage
+LATEST_COMMIT=$(git log -1 --format="%H")
 npm install
-npm run build
+npm run build --url=https://gradio-main-build.s3.amazonaws.com/$LATEST_COMMIT/
 cd build
 python -m http.server


### PR DESCRIPTION
Adds the url arg to the website launch script. Note that this arg is only needed to display to the wheel url in the instructions on building from main in https://gradio.app/docs/main Because running the script locally won't actually build and upload a gradio wheel to aws, that url won't always work, but the website will otherwise build fine.