### PR TITLE
Fixing h11 error in build version docs gh action

### DIFF
--- a/.github/workflows/build-version-docs.yml
+++ b/.github/workflows/build-version-docs.yml
@@ -31,6 +31,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install requirements
         run: python -m pip install -r website/homepage/requirements.txt 
+      - name: Pin httpx, httpcore, and h11
+        run: pip install h11==0.12.0 httpcore==0.15.0 httpx==0.23.0
       - name: Install gradio
         run: python -m pip install gradio -U
       - name: Build Docs


### PR DESCRIPTION
There's a weird httpx, httpcore and h11 version issue in the build version docs gh action that caused the 3.10.1 action to fail: https://github.com/gradio-app/gradio/actions/runs/3499729237/jobs/5862982854 

It suddenly started installing httpcore==0.16.1 which is conflicting with h11 and httpx. This doesn't seem to be a problem locally or on colab right now, so just going to fix it on the action itself by pinning the versions there. 