### PR TITLE
Fix id clashes in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ No changes to highlight.
 
 ## Full Changelog:
 * Make try examples button more prominent by [@aliabd](https://github.com/aliabd) in [PR 2705](https://github.com/gradio-app/gradio/pull/2705)
+* Fix id clashes in docs by [@aliabd](https://github.com/aliabd) in [PR 2713](https://github.com/gradio-app/gradio/pull/2713)
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/website/homepage/src/docs/obj_doc_template.html
+++ b/website/homepage/src/docs/obj_doc_template.html
@@ -1,4 +1,9 @@
+{% if parent != "gradio" %}
+<div class="obj" id="{{ parent[7:].lower() + '-' + obj['name'].lower() }}">
+{% else %}
 <div class="obj" id="{{ obj['name'].lower() }}">
+{% endif %}
+
   {% if obj['demos'] %}
   <div class="demo-window fixed hidden inset-0 bg-gray-500 bg-opacity-75 overflow-y-auto h-full w-full" style="z-index: 100">
     <div class="relative mx-auto my-auto p-5 border w-11/12 shadow-lg rounded-md bg-white overflow-auto" style="top: 5%; height: 90%">
@@ -31,8 +36,14 @@
   </div>
   {% endif %}
   <div class="flex flex-row items-center justify-between">
-    <h3 id="{{ obj['name'].lower() }}-header"
-        class="text-3xl font-light py-4">{{ obj['name'] }}</h3>
+    {% if parent != "gradio"%}
+      <h3 id="{{ parent[7:].lower() + '-' + obj['name'].lower() }}-header"
+      class="text-3xl font-light py-4">{{ obj['name'] }}</h3>
+    {% else %}
+      <h3 id="{{ obj['name'].lower() }}-header"
+      class="text-3xl font-light py-4">{{ obj['name'] }}</h3>
+    {% endif %}
+
     {% if obj['demos'] %}
     <button 
       class="h-2/4 rounded-full bg-orange-500 hover:bg-orange-400 transition-colors text-white py-1 px-3 my-3 mx-2 ml-auto"

--- a/website/homepage/src/docs/template.html
+++ b/website/homepage/src/docs/template.html
@@ -56,24 +56,6 @@
         </a>
       </nav>
     </div>
-
-    <!-- <script>
-      document.getElementById("toggle").onchange = changeListener;
-      
-      function changeListener(){
-      
-      var value = this.value  
-      console.log(value);      
-      if (value == "main") {
-        
-      } else if (value == "v{{ gradio_version }}" ) {
-        document.querySelector('#main-docs').classList.add('hidden'); 
-        document.querySelector('#pip-docs').classList.remove('hidden');
-      }
-        
-    };
-    
-    </script> -->
   
   <main class="container mx-auto px-4 flex gap-4">
     <div class="navigation pb-4 h-screen leading-relaxed sticky top-0 text-md overflow-y-auto hidden lg:block rounded-t-xl bg-gradient-to-r from-white to-gray-50 overflow-x-clip"
@@ -93,7 +75,7 @@
       {% with obj=find_cls("Interface") %}
         {% if "fns" in obj and obj["fns"]|length %}
           {% for fn in obj["fns"] %}
-            <a class="thinner-link px-4 pl-8 block" href="#{{ fn['name'].lower()}}">{{ fn["name"] }}</a>
+            <a class="thinner-link px-4 pl-8 block" href="#interface-{{ fn['name'].lower()}}">{{ fn["name"] }}</a>
           {% endfor %}
         {% endif %}
       {% endwith %}
@@ -117,7 +99,7 @@
           {% with obj=find_cls("Blocks") %}
             {% if "fns" in obj and obj["fns"]|length %}
               {% for fn in obj["fns"] %}
-                <a class="thinner-link px-4 pl-8 block" href="#{{ fn['name'].lower()}}">{{ fn["name"] }}</a>
+                <a class="thinner-link px-4 pl-8 block" href="#blocks-{{ fn['name'].lower()}}">{{ fn["name"] }}</a>
               {% endfor %}
             {% endif %}
           {% endwith %}


### PR DESCRIPTION
Methods with the same name were clashing in the docs, breaking navigation and anchor links. For example `load` in both `Interface` and `Blocks`, or `change` in every component. 

Closes: #2712 