### PR TITLE
Fixed a type bug where the validation was "binary"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ No changes to highlight.
 
 ## Bug Fixes:
 * Fixed bug where requests timeout is missing from utils.version_check() by [@yujiehecs](https://github.com/yujiehecs) in [PR 2729](https://github.com/gradio-app/gradio/pull/2729)
+* Fixed bug where so that the `File` component can properly preprocess files to "binary" byte-string format by [CoffeeVampir3](https://github.com/CoffeeVampir3) in [PR 2727](https://github.com/gradio-app/gradio/pull/2727)
 
 ## Documentation Changes:
 No changes to highlight.

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2180,7 +2180,7 @@ class File(Changeable, Clearable, Uploadable, IOComponent, FileSerializable):
                     )
                     file.orig_name = file_name
                 return file
-            elif self.type == "bytes":
+            elif self.type == "binary":
                 if is_file:
                     with open(file_name, "rb") as file_data:
                         return file_data.read()

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2110,10 +2110,18 @@ class File(Changeable, Clearable, Uploadable, IOComponent, FileSerializable):
         self.temp_dir = tempfile.mkdtemp()
         self.file_count = file_count
         self.file_types = file_types
-        valid_types = ["file", "binary"]
+        valid_types = [
+            "file",
+            "binary",
+            "bytes",
+        ]  # "bytes" is included for backwards compatibility
         if type not in valid_types:
             raise ValueError(
                 f"Invalid value for parameter `type`: {type}. Please choose from one of: {valid_types}"
+            )
+        if type == "bytes":
+            warnings.warn(
+                "The `bytes` type is deprecated and may not work as expected. Please use `binary` instead."
             )
         self.type = type
         self.test_input = None
@@ -2180,7 +2188,9 @@ class File(Changeable, Clearable, Uploadable, IOComponent, FileSerializable):
                     )
                     file.orig_name = file_name
                 return file
-            elif self.type == "binary":
+            elif (
+                self.type == "binary" or self.type == "bytes"
+            ):  # "bytes" is included for backwards compatibility
                 if is_file:
                     with open(file_name, "rb") as file_data:
                         return file_data.read()

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -842,6 +842,10 @@ class TestFile:
         x_file["is_example"] = True
         assert file_input.preprocess(x_file) is not None
 
+        file_input = gr.File(type="binary")
+        output = file_input.preprocess(x_file)
+        assert type(output) == bytes
+
     def test_in_interface_as_input(self):
         """
         Interface, process
@@ -854,8 +858,7 @@ class TestFile:
         iface = gr.Interface(get_size_of_file, "file", "number")
         assert iface(x_file) == 10558
 
-    @pytest.mark.asyncio
-    async def test_as_component_as_output(self):
+    def test_as_component_as_output(self):
         """
         Interface, process
         """


### PR DESCRIPTION
Bugfix for the type component, without this fix it is impossible to pick "binary" or "bytes" files because one is thrown out by the validator and one is thrown out by the type check in the process single file loop.

In line 2113 the type was validated as either file or binary:
```python
        valid_types = ["file", "binary"]
        if type not in valid_types:
            raise ValueError(
                f"Invalid value for parameter `type`: {type}. Please choose from one of: {valid_types}"
            )
```

However line 2183 preprocess single file wanted either "file" or "bytes"
```python
            elif self.type == "bytes":
```

I have picked binary as the one to match because the documentation currently reflects the choice of "file" or "binary". No changes should be needed to existing docs.

Please see the following errors for reference:

Process single file value error:
```python
  File "x/gradio/components.py", line 2189, in process_single_file
    raise ValueError(
ValueError: Unknown type: binary. Please choose from: 'file', 'bytes'.
```

Initialization error
```python
  File "x/gradio/components.py", line 2115, in __init__
    raise ValueError(
ValueError: Invalid value for parameter `type`: bytes. Please choose from one of: ['file', 'binary']
```


# Description

Please include: 
* relevant motivation
* a summary of the change 
* which issue is fixed. 
* any additional dependencies that are required for this change.

Closes: # (issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.