### PR TITLE
Enable requests timout for version_check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 No changes to highlight.
 
 ## Bug Fixes:
-* Fixed bug where requests timeout is missing for utils.version_check() [@yujiehecs](https://github.com/yujiehecs) in [PR 2729](https://github.com/gradio-app/gradio/pull/2729)
+* Fixed bug where requests timeout is missing from utils.version_check() by [@yujiehecs](https://github.com/yujiehecs) in [PR 2729](https://github.com/gradio-app/gradio/pull/2729)
 
 ## Documentation Changes:
 No changes to highlight.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 No changes to highlight.
 
 ## Bug Fixes:
-No changes to highlight.
+* Fixed bug where requests timeout is missing for utils.version_check() [@yujiehecs](https://github.com/yujiehecs) in [PR 2729](https://github.com/gradio-app/gradio/pull/2729)
 
 ## Documentation Changes:
 No changes to highlight.

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -54,7 +54,7 @@ def version_check():
         current_pkg_version = (
             pkgutil.get_data(__name__, "version.txt").decode("ascii").strip()
         )
-        latest_pkg_version = requests.get(url=PKG_VERSION_URL).json()["version"]
+        latest_pkg_version = requests.get(url=PKG_VERSION_URL, timeout=3).json()["version"]
         if StrictVersion(latest_pkg_version) > StrictVersion(current_pkg_version):
             print(
                 "IMPORTANT: You are using gradio version {}, "

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -54,7 +54,9 @@ def version_check():
         current_pkg_version = (
             pkgutil.get_data(__name__, "version.txt").decode("ascii").strip()
         )
-        latest_pkg_version = requests.get(url=PKG_VERSION_URL, timeout=3).json()["version"]
+        latest_pkg_version = requests.get(url=PKG_VERSION_URL, timeout=3).json()[
+            "version"
+        ]
         if StrictVersion(latest_pkg_version) > StrictVersion(current_pkg_version):
             print(
                 "IMPORTANT: You are using gradio version {}, "


### PR DESCRIPTION
# Description

As described in the issue https://github.com/gradio-app/gradio/issues/2726: No timeout for version_check's requests, there was no timeout config for `utils.version_check()`, which blocks the Interface initiation under certain network environment.

This is a tiny PR that enables timeout for version_check, after which the waiting time would be 3 seconds instead of the default 5 minutes, or even longer.

Closes: #2726

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

