### PR TITLE
Performance improvements to docs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ No changes to highlight.
 * Fixed bug to ensure that filenames are less than 200 characters even for non-English languages by [@SkyTNT](https://github.com/SkyTNT) in [PR 2685](https://github.com/gradio-app/gradio/pull/2685) 
 
 ## Documentation Changes:
-No changes to highlight.
+* Performance improvements to docs on mobile by  [@aliabd](https://github.com/aliabd) in [PR 2730](https://github.com/gradio-app/gradio/pull/2730)
 
 ## Testing and Infrastructure Changes:
 No changes to highlight.

--- a/website/homepage/src/docs/obj_doc_template.html
+++ b/website/homepage/src/docs/obj_doc_template.html
@@ -4,6 +4,13 @@
 <div class="obj" id="{{ obj['name'].lower() }}">
 {% endif %}
 
+{% if version == "main" %}
+{% set gradio_js = '/assets/index.js' %}
+{% else %}
+{% set gradio_js = 'https://gradio.s3-us-west-2.amazonaws.com/' + gradio_version + '/gradio.js' %}
+{% endif %}
+
+
   {% if obj['demos'] %}
   <div class="demo-window fixed hidden inset-0 bg-gray-500 bg-opacity-75 overflow-y-auto h-full w-full" style="z-index: 100">
     <div class="relative mx-auto my-auto p-5 border w-11/12 shadow-lg rounded-md bg-white overflow-auto" style="top: 5%; height: 90%">
@@ -47,7 +54,7 @@
     {% if obj['demos'] %}
     <button 
       class="h-2/4 rounded-full bg-orange-500 hover:bg-orange-400 transition-colors text-white py-1 px-3 my-3 mx-2 ml-auto"
-      onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden')"
+      onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden'); load_gradio('{{ gradio_js }}');"
     >
       Try Examples
     </button>
@@ -94,7 +101,7 @@
     {% if obj["demos"] %}
       <button 
       class="h-2/4 rounded-full bg-orange-500 hover:bg-orange-400 transition-colors text-white py-1 px-3 my-2 mx-2"
-      onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden')"
+      onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden'); load_gradio('{{ gradio_js }}');"
     >
       More Examples →
     </button>
@@ -108,7 +115,7 @@
       <div class="absolute top-16" style="left: 44%;">
           <button 
           class="h-2/4 rounded-full bg-orange-500 hover:bg-orange-400 transition-colors text-white py-1 px-3 my-3 mx-2"
-          onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden')"
+          onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden'); load_gradio('{{ gradio_js }}');"
         >
           Try Examples
         </button>
@@ -205,3 +212,16 @@
       {% endif %}
   {% endif %}
 </div>
+
+<script>
+  function load_gradio(FILE_URL) {
+        console.log(FILE_URL);
+        var len = Array.from(document.querySelectorAll('script')).filter(e => e.getAttribute('src') == FILE_URL).length;
+        if (len === 0) {
+          let scriptEle = document.createElement("script");
+          scriptEle.setAttribute("src", FILE_URL);
+          scriptEle.setAttribute("type", "module");
+          document.body.appendChild(scriptEle);
+        }
+      }
+</script>

--- a/website/homepage/src/docs/obj_doc_template.html
+++ b/website/homepage/src/docs/obj_doc_template.html
@@ -4,13 +4,6 @@
 <div class="obj" id="{{ obj['name'].lower() }}">
 {% endif %}
 
-{% if version == "main" %}
-{% set gradio_js = '/assets/index.js' %}
-{% else %}
-{% set gradio_js = 'https://gradio.s3-us-west-2.amazonaws.com/' + gradio_version + '/gradio.js' %}
-{% endif %}
-
-
   {% if obj['demos'] %}
   <div class="demo-window fixed hidden inset-0 bg-gray-500 bg-opacity-75 overflow-y-auto h-full w-full" style="z-index: 100">
     <div class="relative mx-auto my-auto p-5 border w-11/12 shadow-lg rounded-md bg-white overflow-auto" style="top: 5%; height: 90%">
@@ -54,7 +47,7 @@
     {% if obj['demos'] %}
     <button 
       class="h-2/4 rounded-full bg-orange-500 hover:bg-orange-400 transition-colors text-white py-1 px-3 my-3 mx-2 ml-auto"
-      onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden'); load_gradio('{{ gradio_js }}');"
+      onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden')"
     >
       Try Examples
     </button>
@@ -101,7 +94,7 @@
     {% if obj["demos"] %}
       <button 
       class="h-2/4 rounded-full bg-orange-500 hover:bg-orange-400 transition-colors text-white py-1 px-3 my-2 mx-2"
-      onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden'); load_gradio('{{ gradio_js }}');"
+      onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden')"
     >
       More Examples →
     </button>
@@ -115,7 +108,7 @@
       <div class="absolute top-16" style="left: 44%;">
           <button 
           class="h-2/4 rounded-full bg-orange-500 hover:bg-orange-400 transition-colors text-white py-1 px-3 my-3 mx-2"
-          onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden'), load_gradio('{{ gradio_js }}');"
+          onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden')"
         >
           Try Examples
         </button>
@@ -212,16 +205,3 @@
       {% endif %}
   {% endif %}
 </div>
-
-<script>
-  function load_gradio(FILE_URL) {
-        console.log(FILE_URL);
-        var len = Array.from(document.querySelectorAll('script')).filter(e => e.getAttribute('src') == FILE_URL).length;
-        if (len === 0) {
-          let scriptEle = document.createElement("script");
-          scriptEle.setAttribute("src", FILE_URL);
-          scriptEle.setAttribute("type", "module");
-          document.body.appendChild(scriptEle);
-        }
-      }
-</script>

--- a/website/homepage/src/docs/obj_doc_template.html
+++ b/website/homepage/src/docs/obj_doc_template.html
@@ -137,7 +137,7 @@
       {% for param in obj["parameters"] %}
         {% if param["name"] != "self" %}
           <tr class="group hover:bg-gray-200/60 odd:bg-gray-100/80">
-            <td class="p-3 w-2/5">
+            <td class="p-3 w-2/5 break-words">
               <code class="block">
                 {{ param["name"] }}
               </code>
@@ -148,7 +148,7 @@
               <p class="text-orange-600 font-semibold italic">required</p>
               {% endif %}
             </td>
-            <td class="p-3 text-gray-700">
+            <td class="p-3 text-gray-700 break-words">
               <p>{{ param["doc"] or "" }}</p>
             </td>
           </tr>
@@ -170,13 +170,13 @@
     <tbody class="text-left divide-y rounded-lg bg-gray-50 border border-gray-100 overflow-hidden">
     {% for name, shortcut, settings in obj["string_shortcuts"] %}
         <tr class="group hover:bg-gray-200/60 odd:bg-gray-100/80">
-          <td class="p-3 w-2/5">
+          <td class="p-3 w-2/5 break-words" >
             <p><code class="lang-python">gradio.{{ name }}</code></p>
           </td>
-          <td class="p-3 w-2/5">
+          <td class="p-3 w-2/5 break-words">
             <p>"{{ shortcut }}"</p>
           </td>
-          <td class="p-3 text-gray-700">
+          <td class="p-3 text-gray-700 break-words">
             {{ settings }}
           </td>
         </tr>

--- a/website/homepage/src/docs/obj_doc_template.html
+++ b/website/homepage/src/docs/obj_doc_template.html
@@ -4,6 +4,13 @@
 <div class="obj" id="{{ obj['name'].lower() }}">
 {% endif %}
 
+{% if version == "main" %}
+{% set gradio_js = '/assets/index.js' %}
+{% else %}
+{% set gradio_js = 'https://gradio.s3-us-west-2.amazonaws.com/' + gradio_version + '/gradio.js' %}
+{% endif %}
+
+
   {% if obj['demos'] %}
   <div class="demo-window fixed hidden inset-0 bg-gray-500 bg-opacity-75 overflow-y-auto h-full w-full" style="z-index: 100">
     <div class="relative mx-auto my-auto p-5 border w-11/12 shadow-lg rounded-md bg-white overflow-auto" style="top: 5%; height: 90%">
@@ -47,7 +54,7 @@
     {% if obj['demos'] %}
     <button 
       class="h-2/4 rounded-full bg-orange-500 hover:bg-orange-400 transition-colors text-white py-1 px-3 my-3 mx-2 ml-auto"
-      onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden')"
+      onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden'); load_gradio('{{ gradio_js }}');"
     >
       Try Examples
     </button>
@@ -94,7 +101,7 @@
     {% if obj["demos"] %}
       <button 
       class="h-2/4 rounded-full bg-orange-500 hover:bg-orange-400 transition-colors text-white py-1 px-3 my-2 mx-2"
-      onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden')"
+      onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden'); load_gradio('{{ gradio_js }}');"
     >
       More Examples →
     </button>
@@ -108,7 +115,7 @@
       <div class="absolute top-16" style="left: 44%;">
           <button 
           class="h-2/4 rounded-full bg-orange-500 hover:bg-orange-400 transition-colors text-white py-1 px-3 my-3 mx-2"
-          onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden')"
+          onclick="this.closest('.obj').querySelector('.demo-window').classList.remove('hidden'), load_gradio('{{ gradio_js }}');"
         >
           Try Examples
         </button>
@@ -205,3 +212,16 @@
       {% endif %}
   {% endif %}
 </div>
+
+<script>
+  function load_gradio(FILE_URL) {
+        console.log(FILE_URL);
+        var len = Array.from(document.querySelectorAll('script')).filter(e => e.getAttribute('src') == FILE_URL).length;
+        if (len === 0) {
+          let scriptEle = document.createElement("script");
+          scriptEle.setAttribute("src", FILE_URL);
+          scriptEle.setAttribute("type", "module");
+          document.body.appendChild(scriptEle);
+        }
+      }
+</script>

--- a/website/homepage/src/docs/template.html
+++ b/website/homepage/src/docs/template.html
@@ -59,7 +59,7 @@
   
   <main class="container mx-auto px-4 flex gap-4">
     <div class="navigation pb-4 h-screen leading-relaxed sticky top-0 text-md overflow-y-auto hidden lg:block rounded-t-xl bg-gradient-to-r from-white to-gray-50 overflow-x-clip"
-          style="min-width: 20%">
+          style="width: 20%; min-width: 20%">
       <div class="w-full sticky top-0 bg-gradient-to-r from-white to-gray-50 z-10">
       <input id="search"
              type="search"
@@ -126,7 +126,7 @@
           <a class="px-4 block thin-link" href="#{{ component['name'].lower() }}">{{ component['name'] }}</a>
         {% endfor %}
     </div>
-    <div class="flex flex-col">
+    <div class="flex flex-col" style="width: 80%; min-width: 80%">
       <div>
         <p class="bg-gradient-to-r from-orange-100 to-orange-50 border border-orange-200 px-4 py-1 mr-2 rounded-full text-orange-800 mb-1 w-fit float-left">
                     New to Gradio? Start here: <a class="link" href="/getting_started">Getting Started</a>

--- a/website/homepage/src/docs/template.html
+++ b/website/homepage/src/docs/template.html
@@ -126,7 +126,7 @@
           <a class="px-4 block thin-link" href="#{{ component['name'].lower() }}">{{ component['name'] }}</a>
         {% endfor %}
     </div>
-    <div class="flex flex-col w-full min-w-full	lg:w-10/12 lg:min-w-full">
+    <div class="flex flex-col w-full min-w-full	lg:w-10/12 lg:min-w-0">
       <div>
         <p class="bg-gradient-to-r from-orange-100 to-orange-50 border border-orange-200 px-4 py-1 mr-2 rounded-full text-orange-800 mb-1 w-fit float-left">
                     New to Gradio? Start here: <a class="link" href="/getting_started">Getting Started</a>

--- a/website/homepage/src/docs/template.html
+++ b/website/homepage/src/docs/template.html
@@ -287,11 +287,48 @@
     </div>
   </main>
 
-    {% if version=='main' %}
-    <script type="module" src="/assets/index.js"></script>
-    {% else %}
-    <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/{{ gradio_version }}/gradio.js"></script>
-    {% endif %}
+    <script>
+      let isMobile = window.matchMedia("only screen and (max-width: 480px)").matches;
+
+      function loadJS(FILE_URL) {
+        let scriptEle = document.createElement("script");
+        scriptEle.setAttribute("src", FILE_URL);
+        scriptEle.setAttribute("type", "module");
+        document.body.appendChild(scriptEle);
+      }
+
+      function removeFooters() {
+      window.setTimeout(function() {
+      document.querySelectorAll('.embedded-component gradio-app').forEach(g => {
+          if ( g.shadowRoot ) {
+            let shadowroot = g.shadowRoot;
+            let f = shadowroot.querySelector('footer');
+            if (f != null) {
+              f.classList.add('hidden');
+              let c = shadowroot.querySelector('.gradio-container');
+              c.style.removeProperty('min-height');
+            }
+          };
+        });
+      }, 1000);
+      };
+
+      {% if version=='main' %}
+
+      if (!isMobile) {
+        loadJS('/assets/index.js');
+        window.addEventListener('load', removeFooters());
+      }
+
+      {% else %}
+
+      if (!isMobile) {
+        loadJS('https://gradio.s3-us-west-2.amazonaws.com/{{ gradio_version }}/gradio.js');
+        window.addEventListener('load', removeFooters());
+      }
+
+      {% endif %}
+    </script>
 
     <script src="/assets/prism.js"></script>
     <script>
@@ -401,27 +438,7 @@
         }
       })
 
-   
-
-  </script>
-
-  <script> 
-    function removeFooters() {
-      window.setTimeout(function() {
-      document.querySelectorAll('.embedded-component gradio-app').forEach(g => {
-          if ( g.shadowRoot ) {
-            let shadowroot = g.shadowRoot;
-            let f = shadowroot.querySelector('footer');
-            if (f != null) {
-              f.classList.add('hidden');
-              let c = shadowroot.querySelector('.gradio-container');
-              c.style.removeProperty('min-height');
-            }
-          };
-        });
-      }, 1000);
-      };
-    window.addEventListener('load', removeFooters());
   </script>  
+
   </body>
 </html>

--- a/website/homepage/src/docs/template.html
+++ b/website/homepage/src/docs/template.html
@@ -59,7 +59,7 @@
   
   <main class="container mx-auto px-4 flex gap-4">
     <div class="navigation pb-4 h-screen leading-relaxed sticky top-0 text-md overflow-y-auto hidden lg:block rounded-t-xl bg-gradient-to-r from-white to-gray-50 overflow-x-clip"
-          style="width: 20%; min-width: 20%">
+          style="width: 16.666667%; min-width: 16.666667%;">
       <div class="w-full sticky top-0 bg-gradient-to-r from-white to-gray-50 z-10">
       <input id="search"
              type="search"
@@ -126,7 +126,7 @@
           <a class="px-4 block thin-link" href="#{{ component['name'].lower() }}">{{ component['name'] }}</a>
         {% endfor %}
     </div>
-    <div class="flex flex-col" style="width: 80%; min-width: 80%">
+    <div class="flex flex-col w-full min-w-full	lg:w-10/12 lg:min-w-full">
       <div>
         <p class="bg-gradient-to-r from-orange-100 to-orange-50 border border-orange-200 px-4 py-1 mr-2 rounded-full text-orange-800 mb-1 w-fit float-left">
                     New to Gradio? Start here: <a class="link" href="/getting_started">Getting Started</a>

--- a/website/homepage/src/docs/template.html
+++ b/website/homepage/src/docs/template.html
@@ -230,7 +230,7 @@
             (Number and Gallery), below is a diagram of what our preprocessing will send to the function and what
             our postprocessing will require from it.
           </p>
-          <img src="/assets/img/dataflow.svg" class="mt-4" loading="lazy">
+          <img src="/assets/img/dataflow.svg" class="mt-4">
         </div>
         {% for component in docs["component"] %}
           {% with obj=component, is_class=True, is_component=True, parent="gradio" %}

--- a/website/homepage/src/docs/template.html
+++ b/website/homepage/src/docs/template.html
@@ -287,6 +287,12 @@
     </div>
   </main>
 
+    {% if version=='main' %}
+    <script type="module" src="/assets/index.js"></script>
+    {% else %}
+    <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/{{ gradio_version }}/gradio.js"></script>
+    {% endif %}
+
     <script src="/assets/prism.js"></script>
     <script>
       window.__gradio_mode__ = "website";
@@ -296,6 +302,7 @@
     <script>{% include 'templates/guide-color.js' %}</script>
     <script>{% include 'templates/add_anchors.js' %}</script>
     <script>{% include 'templates/add_copy.js' %}</script>
+    
 
     <script>
     const show_demo = (component, demo) => {

--- a/website/homepage/src/docs/template.html
+++ b/website/homepage/src/docs/template.html
@@ -292,12 +292,6 @@
     <script>
       window.__gradio_mode__ = "website";
     </script>
-    
-    {% if version=='main' %}
-    <script type="module" src="/assets/index.js"></script>
-    {% else %}
-    <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/{{ gradio_version }}/gradio.js"></script>
-    {% endif %}
 
     {% include 'templates/footer.html' %}
     <script>{% include 'templates/guide-color.js' %}</script>

--- a/website/homepage/src/docs/template.html
+++ b/website/homepage/src/docs/template.html
@@ -230,7 +230,7 @@
             (Number and Gallery), below is a diagram of what our preprocessing will send to the function and what
             our postprocessing will require from it.
           </p>
-          <img src="/assets/img/dataflow.svg" class="mt-4">
+          <img src="/assets/img/dataflow.svg" class="mt-4" loading="lazy">
         </div>
         {% for component in docs["component"] %}
           {% with obj=component, is_class=True, is_component=True, parent="gradio" %}

--- a/website/homepage/src/docs/template.html
+++ b/website/homepage/src/docs/template.html
@@ -287,7 +287,6 @@
     </div>
   </main>
 
-
     <script src="/assets/prism.js"></script>
     <script>
       window.__gradio_mode__ = "website";
@@ -395,7 +394,13 @@
         }
       })
 
+   
+
+  </script>
+
+  <script> 
     function removeFooters() {
+      window.setTimeout(function() {
       document.querySelectorAll('.embedded-component gradio-app').forEach(g => {
           if ( g.shadowRoot ) {
             let shadowroot = g.shadowRoot;
@@ -404,18 +409,12 @@
               f.classList.add('hidden');
               let c = shadowroot.querySelector('.gradio-container');
               c.style.removeProperty('min-height');
-            } else {
-              window.setTimeout(removeFooters, 100);
             }
-          } else {
-            window.setTimeout(removeFooters, 100);
-          }
-          
+          };
         });
+      }, 1000);
       };
-   
     window.addEventListener('load', removeFooters());
-
-  </script>
+  </script>  
   </body>
 </html>

--- a/website/homepage/src/templates/meta.html
+++ b/website/homepage/src/templates/meta.html
@@ -19,7 +19,7 @@
 <link rel="stylesheet" href="/assets/prism.css">
 <link
     href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&display=swap"
-    rel="stylesheet" />
+    rel="preload" />
 
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-156449732-1"></script>
 <script>

--- a/website/homepage/src/templates/meta.html
+++ b/website/homepage/src/templates/meta.html
@@ -17,7 +17,9 @@
 <link rel="icon" type="image/png" href="/assets/img/logo.png">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/assets/prism.css">
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&display=swap">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&display=swap" rel="stylesheet">
 
 
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-156449732-1"></script>

--- a/website/homepage/src/templates/meta.html
+++ b/website/homepage/src/templates/meta.html
@@ -17,9 +17,10 @@
 <link rel="icon" type="image/png" href="/assets/img/logo.png">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/assets/prism.css">
-<link
-    href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&display=swap"
-    rel="preload" />
+<link rel="preload" href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&display=swap">
+  </noscript>
 
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-156449732-1"></script>
 <script>

--- a/website/homepage/src/templates/meta.html
+++ b/website/homepage/src/templates/meta.html
@@ -17,10 +17,8 @@
 <link rel="icon" type="image/png" href="/assets/img/logo.png">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/assets/prism.css">
-<link rel="preload" href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&display=swap">
-  </noscript>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&display=swap">
+
 
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-156449732-1"></script>
 <script>


### PR DESCRIPTION
I made some performance improvements to the docs, especially on mobile. I know we've talked about moving the website to a better framework, and we should still do that, but we have to make fixes now as they are currently unusable. 

* Enabled text compression (on nginx) 
* For mobile on load gradio js when example window is clicked. (this means no embedded components on mobile, but much better performance) 
* Figured out a memory leak that was causing the page to climb to insane amounts of memory (>9GB). Was due to some terrible js I wrote for hiding footers from embedded components. Fixed now and page stays at ~350MB.
* Fixed some annoying layout shifts 
* Made the page mobile responsive 

Before changes: 

![Screen Shot 2022-11-25 at 5 10 56 PM](https://user-images.githubusercontent.com/9021060/204204576-af6069d7-2081-43d9-9e79-db1580783779.png)

After: 

![Screen Shot 2022-11-27 at 10 05 09 PM](https://user-images.githubusercontent.com/9021060/204205404-19b4d95f-c108-46b9-8b29-614ff7908bc0.png)



Try comparing between the [website](https://gradio.app/docs/main) and [dev server](https://www.gradio-staging.com/docs/main) on mobile. Note that most of these changes will only apply to /docs/main/ until we release a new pip version and /docs gets updated. 

Closes: #2717 
