### PR TITLE
Fix returning `{}` from a function to update nothing raises an Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ No changes to highlight.
 * Fixed bug where requests timeout is missing from utils.version_check() by [@yujiehecs](https://github.com/yujiehecs) in [PR 2729](https://github.com/gradio-app/gradio/pull/2729)
 * Fixed bug where so that the `File` component can properly preprocess files to "binary" byte-string format by [CoffeeVampir3](https://github.com/CoffeeVampir3) in [PR 2727](https://github.com/gradio-app/gradio/pull/2727)
 * Fixed bug to ensure that filenames are less than 200 characters even for non-English languages by [@SkyTNT](https://github.com/SkyTNT) in [PR 2685](https://github.com/gradio-app/gradio/pull/2685) 
+* Fixed bug where a function returning an empty dictionary `{}` would raise a `KeyError: 0` by [@abidlabs](https://github.com/abidlabs) in []()
 
 ## Documentation Changes:
 * Performance improvements to docs on mobile by  [@aliabd](https://github.com/aliabd) in [PR 2730](https://github.com/gradio-app/gradio/pull/2730)

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -924,7 +924,7 @@ class Blocks(BlockContext):
         dependency = self.dependencies[fn_index]
         batch = dependency["batch"]
 
-        if type(predictions) is dict and len(predictions) > 0:
+        if type(predictions) is dict:
             predictions = convert_component_dict_to_list(
                 dependency["outputs"], predictions
             )


### PR DESCRIPTION
Quickly fixes: #2725.

Context: returning a `{}` from a function would previously raise an Exception. For some reason @aliabid94 you wrote an explicit check in the case that a function returned a dictionary update to check to see if the length of the dictionary was greater than 1 before converting it to a regular list update. I don't see why this check is needed, and removing it solves the bug. 

@aliabid94 can you review this to make sure I'm not missing something?