### PR TITLE
Update Label color from backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,44 @@
 # Upcoming Release
 
 ## New Features:
-No changes to highlight.
+
+### Set the color of a Label component with a function
+
+The `Label` component now accepts a `color` argument by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2736](https://github.com/gradio-app/gradio/pull/2736).
+The `color` argument should either be a valid css color name or hexadecimal string.
+You can update the color with `gr.Label.update`! 
+
+This lets you create Alert and Warning boxes with the `Label` component. See below:
+
+```python
+import gradio as gr
+import random
+
+def update_color(value):
+    if value < 0:
+        # This is bad so use red
+        return "#FF0000"
+    elif 0 <= value <= 20:
+        # Ok but pay attention (use orange)
+        return "#ff9966"
+    else:
+        # Nothing to worry about
+        return None
+
+def update_value():
+    choice = random.choice(['good', 'bad', 'so-so'])
+    color = update_color(choice)
+    return gr.Label.update(value=choice, color=color)
+    
+    
+with gr.Blocks() as demo:
+    label = gr.Label(value=-10)
+    demo.load(lambda: update_value(), inputs=None, outputs=[label], every=1)
+demo.queue().launch()
+```
+
+![label_bg_color_update](https://user-images.githubusercontent.com/41651716/204400372-80e53857-f26f-4a38-a1ae-1acadff75e89.gif)
+
 
 ## Bug Fixes:
 No changes to highlight.
@@ -86,38 +123,6 @@ demo.launch()
 
 ![update_accordion](https://user-images.githubusercontent.com/41651716/203164176-b102eae3-babe-4986-ae30-3ab4f400cedc.gif)
 
-
-### Set the color of a Label component with a function
-
-The `Label` component now accepts a `color` argument by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2736](https://github.com/gradio-app/gradio/pull/2736).
-The `color` argument should be a function that takes a value of the label (either a float or string) and maps it to a color (either a valid css color name or hexadecimal string).
-Whenever the value of the Label is updated, this function will be applied to the value to determine the color.
-This does not apply if the value of the `Label` includes confidences.
-
-This lets you create Alert and Warning boxes with the `Label` component. See below:
-
-```python
-import gradio as gr
-import random
-
-def update_color(value):
-    if value < 0:
-        # This is bad so use red
-        return "#FF0000"
-    elif 0 <= value <= 20:
-        # Ok but pay attention (use orange)
-        return "#ff9966"
-    else:
-        # Nothing to worry about
-        return None
-
-with gr.Blocks() as demo:
-    label = gr.Label(value=-10, color=update_color)
-    demo.load(lambda: random.randrange(-20, 60), inputs=None, outputs=[label], every=1)
-demo.queue().launch()
-```
-
-![label_bg_color_update](https://user-images.githubusercontent.com/41651716/204400372-80e53857-f26f-4a38-a1ae-1acadff75e89.gif)
 
 ## Bug Fixes:
 * Fixed bug where requests timeout is missing from utils.version_check() by [@yujiehecs](https://github.com/yujiehecs) in [PR 2729](https://github.com/gradio-app/gradio/pull/2729)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,35 @@ demo.launch()
 
 ![update_accordion](https://user-images.githubusercontent.com/41651716/203164176-b102eae3-babe-4986-ae30-3ab4f400cedc.gif)
 
+
+### Set the color of a Label component with a function
+
+The `Label` component now accepts a `color` keyword argument by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2736](https://github.com/gradio-app/gradio/pull/2736) 
+The value of this argument should be a function that maps its value to the label's background color.
+
+This lets you create Alert and Warning boxes with the `Label` component. See below:
+
+```python
+import gradio as gr
+import random
+
+def update_color(value):
+    if value < 0:
+        # This is bad so use red
+        return "#FF0000"
+    elif 0 <= value <= 20:
+        # Ok but pay attention (use orange)
+        return "#ff9966"
+    else:
+        # Nothing to worry about
+        return None
+
+with gr.Blocks() as demo:
+    label = gr.Label(value=-10, color=update_color)
+    demo.load(lambda: random.randrange(-20, 60), inputs=None, outputs=[label], every=1)
+demo.queue().launch()
+```
+
 ## Bug Fixes:
 * Fixed bug where requests timeout is missing from utils.version_check() by [@yujiehecs](https://github.com/yujiehecs) in [PR 2729](https://github.com/gradio-app/gradio/pull/2729)
 * Fixed bug where so that the `File` component can properly preprocess files to "binary" byte-string format by [CoffeeVampir3](https://github.com/CoffeeVampir3) in [PR 2727](https://github.com/gradio-app/gradio/pull/2727)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@ with gr.Blocks() as demo:
 demo.queue().launch()
 ```
 
+![label_bg_color_update](https://user-images.githubusercontent.com/41651716/204400372-80e53857-f26f-4a38-a1ae-1acadff75e89.gif)
+
 ## Bug Fixes:
 * Fixed bug where requests timeout is missing from utils.version_check() by [@yujiehecs](https://github.com/yujiehecs) in [PR 2729](https://github.com/gradio-app/gradio/pull/2729)
 * Fixed bug where so that the `File` component can properly preprocess files to "binary" byte-string format by [CoffeeVampir3](https://github.com/CoffeeVampir3) in [PR 2727](https://github.com/gradio-app/gradio/pull/2727)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,6 @@ demo.launch()
 
 ![update_accordion](https://user-images.githubusercontent.com/41651716/203164176-b102eae3-babe-4986-ae30-3ab4f400cedc.gif)
 
-
 ## Bug Fixes:
 * Fixed bug where requests timeout is missing from utils.version_check() by [@yujiehecs](https://github.com/yujiehecs) in [PR 2729](https://github.com/gradio-app/gradio/pull/2729)
 * Fixed bug where so that the `File` component can properly preprocess files to "binary" byte-string format by [CoffeeVampir3](https://github.com/CoffeeVampir3) in [PR 2727](https://github.com/gradio-app/gradio/pull/2727)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,8 +89,10 @@ demo.launch()
 
 ### Set the color of a Label component with a function
 
-The `Label` component now accepts a `color` keyword argument by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2736](https://github.com/gradio-app/gradio/pull/2736) 
-The value of this argument should be a function that maps its value to the label's background color.
+The `Label` component now accepts a `color` argument by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2736](https://github.com/gradio-app/gradio/pull/2736).
+The `color` argument should be a function that takes a value of the label (either a float or string) and maps it to a color (either a valid css color name or hexadecimal string).
+Whenever the value of the Label is updated, this function will be applied to the value to determine the color.
+This does not apply if the value of the `Label` includes confidences.
 
 This lets you create Alert and Warning boxes with the `Label` component. See below:
 

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3111,9 +3111,14 @@ class Label(Changeable, IOComponent, JSONSerializable):
         visible: Optional[bool] = None,
         color: Optional[str] = _Keywords.NO_VALUE,
     ):
-        # If color is None
+        # If color is not specified (NO_VALUE) map it to None so that
+        # it gets filtered out in postprocess. This will mean the color
+        # will not be updated in the front-end
         if color is _Keywords.NO_VALUE:
             color = None
+        # If the color was specified by the developer as None
+        # Map is so that the color is updated to be transparent,
+        # e.g. no background default state.
         elif color is None:
             color = "transparent"
         updated_config = {

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3038,7 +3038,7 @@ class Label(Changeable, IOComponent, JSONSerializable):
         show_label: bool = True,
         visible: bool = True,
         elem_id: Optional[str] = None,
-        color: Optional[Callable[[Any], str]] = None,
+        color: Optional[Callable[[float | str], str]] = None,
         **kwargs,
     ):
         """
@@ -3049,6 +3049,7 @@ class Label(Changeable, IOComponent, JSONSerializable):
             show_label: if True, will display label.
             visible: If False, component will be hidden.
             elem_id: An optional string that is assigned as the id of this component in the HTML DOM. Can be used for targeting CSS styles.
+            color: A function that takes a value of the label (either a float or string) and maps it to a color (either a valid css color name or hexadecimal string). Whenever the value of the Label is updated, this function will be applied to the value to determine the color. This does not apply if the value of the `Label` includes confidences.
         """
         self.num_top_classes = num_top_classes
         self.color_fn = color
@@ -3092,12 +3093,15 @@ class Label(Changeable, IOComponent, JSONSerializable):
             sorted_pred = sorted(y.items(), key=operator.itemgetter(1), reverse=True)
             if self.num_top_classes is not None:
                 sorted_pred = sorted_pred[: self.num_top_classes]
-            return {
+            value = {
                 "label": sorted_pred[0][0],
                 "confidences": [
                     {"label": pred[0], "confidence": pred[1]} for pred in sorted_pred
                 ],
             }
+            if self.color_fn is not None:
+                value["color"] = self.color_fn(value)
+            return value
         raise ValueError(
             "The `Label` output interface expects one of: a string label, or an int label, a "
             "float label, or a dictionary whose keys are labels and values are confidences. "

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3081,7 +3081,10 @@ class Label(Changeable, IOComponent, JSONSerializable):
         if isinstance(y, str) and y.endswith(".json") and os.path.exists(y):
             return self.serialize(y)
         if isinstance(y, (str, numbers.Number)):
-            return {"label": str(y), "color": self.color_fn(y)}
+            value = {"label": str(y)}
+            if self.color_fn is not None:
+                value["color"] = self.color_fn(y)
+            return value
         if isinstance(y, dict):
             if "confidences" in y and isinstance(y["confidences"], dict):
                 y = y["confidences"]

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3038,6 +3038,7 @@ class Label(Changeable, IOComponent, JSONSerializable):
         show_label: bool = True,
         visible: bool = True,
         elem_id: Optional[str] = None,
+        color: Optional[Callable[[Any], str]] = None,
         **kwargs,
     ):
         """
@@ -3050,6 +3051,7 @@ class Label(Changeable, IOComponent, JSONSerializable):
             elem_id: An optional string that is assigned as the id of this component in the HTML DOM. Can be used for targeting CSS styles.
         """
         self.num_top_classes = num_top_classes
+        self.color_fn = color
         IOComponent.__init__(
             self,
             label=label,
@@ -3079,7 +3081,7 @@ class Label(Changeable, IOComponent, JSONSerializable):
         if isinstance(y, str) and y.endswith(".json") and os.path.exists(y):
             return self.serialize(y)
         if isinstance(y, (str, numbers.Number)):
-            return {"label": str(y)}
+            return {"label": str(y), "color": self.color_fn(y)}
         if isinstance(y, dict):
             if "confidences" in y and isinstance(y["confidences"], dict):
                 y = y["confidences"]
@@ -3105,12 +3107,14 @@ class Label(Changeable, IOComponent, JSONSerializable):
         label: Optional[str] = None,
         show_label: Optional[bool] = None,
         visible: Optional[bool] = None,
+        color: Optional[str] = None,
     ):
         updated_config = {
             "label": label,
             "show_label": show_label,
             "visible": visible,
             "value": value,
+            "color": color,
             "__type__": "update",
         }
         return updated_config

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1354,6 +1354,39 @@ class TestLabel:
             "root_url": None,
         }
 
+    def test_color_argument(self):
+        def update_color(value):
+            if value == "bad":
+                # This is bad so use red
+                return "brown"
+            elif value == "so-so":
+                # Ok but pay attention (use orange)
+                return "#ff9966"
+            else:
+                # Nothing to worry about
+                return None
+
+        label = gr.Label(value=-10, color=update_color)
+        assert label.postprocess("bad") == {"color": "brown", "label": "bad"}
+        assert label.postprocess("so-so") == {"color": "#ff9966", "label": "so-so"}
+
+        def update_color_dict(value):
+            if value["label"] == "bad":
+                return "red"
+            return None
+
+        label_dict = gr.Label(color=update_color_dict)
+
+        assert label_dict.postprocess({"bad": 0.9, "good": 0.09, "so-so": 0.01}) == {
+            "confidences": [
+                {"confidence": 0.9, "label": "bad"},
+                {"confidence": 0.09, "label": "good"},
+                {"confidence": 0.01, "label": "so-so"},
+            ],
+            "label": "bad",
+            "color": "red",
+        }
+
     @pytest.mark.asyncio
     async def test_in_interface(self):
         """

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1352,40 +1352,30 @@ class TestLabel:
             "visible": True,
             "interactive": None,
             "root_url": None,
+            "color": None,
         }
 
     def test_color_argument(self):
-        def update_color(value):
-            if value == "bad":
-                # This is bad so use red
-                return "brown"
-            elif value == "so-so":
-                # Ok but pay attention (use orange)
-                return "#ff9966"
-            else:
-                # Nothing to worry about
-                return None
 
-        label = gr.Label(value=-10, color=update_color)
-        assert label.postprocess("bad") == {"color": "brown", "label": "bad"}
-        assert label.postprocess("so-so") == {"color": "#ff9966", "label": "so-so"}
+        label = gr.Label(value=-10, color="red")
+        assert label.get_config()["color"] == "red"
+        update_1 = gr.Label.update(value="bad", color="brown")
+        assert update_1["color"] == "brown"
+        update_2 = gr.Label.update(value="bad", color="#ff9966")
+        assert update_2["color"] == "#ff9966"
 
-        def update_color_dict(value):
-            if value["label"] == "bad":
-                return "red"
-            return None
+        update_3 = gr.Label.update(
+            value={"bad": 0.9, "good": 0.09, "so-so": 0.01}, color="green"
+        )
+        assert update_3["color"] == "green"
 
-        label_dict = gr.Label(color=update_color_dict)
+        update_4 = gr.Label.update(value={"bad": 0.8, "good": 0.18, "so-so": 0.02})
+        assert update_4["color"] is None
 
-        assert label_dict.postprocess({"bad": 0.9, "good": 0.09, "so-so": 0.01}) == {
-            "confidences": [
-                {"confidence": 0.9, "label": "bad"},
-                {"confidence": 0.09, "label": "good"},
-                {"confidence": 0.01, "label": "so-so"},
-            ],
-            "label": "bad",
-            "color": "red",
-        }
+        update_5 = gr.Label.update(
+            value={"bad": 0.8, "good": 0.18, "so-so": 0.02}, color=None
+        )
+        assert update_5["color"] == "transparent"
 
     @pytest.mark.asyncio
     async def test_in_interface(self):
@@ -1623,7 +1613,9 @@ class TestHTML:
 class TestMarkdown:
     def test_component_functions(self):
         markdown_component = gr.Markdown("# Let's learn about $x$", label="Markdown")
-        assert markdown_component.get_config()["value"].startswith("""<h1>Let\'s learn about <span class="math inline"><span style=\'font-size: 0px\'>x</span><svg xmlns:xlink="http://www.w3.org/1999/xlink" width="11.6pt" height="19.35625pt" viewBox="0 0 11.6 19.35625" xmlns="http://www.w3.org/2000/svg" version="1.1">\n \n <defs>\n  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>\n </defs>\n <g id="figure_1">\n  <g id="patch_1">\n   <path d="M 0 19.35625""")
+        assert markdown_component.get_config()["value"].startswith(
+            """<h1>Let\'s learn about <span class="math inline"><span style=\'font-size: 0px\'>x</span><svg xmlns:xlink="http://www.w3.org/1999/xlink" width="11.6pt" height="19.35625pt" viewBox="0 0 11.6 19.35625" xmlns="http://www.w3.org/2000/svg" version="1.1">\n \n <defs>\n  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>\n </defs>\n <g id="figure_1">\n  <g id="patch_1">\n   <path d="M 0 19.35625"""
+        )
 
     @pytest.mark.asyncio
     async def test_in_interface(self):

--- a/ui/packages/app/src/components/Label/Label.svelte
+++ b/ui/packages/app/src/components/Label/Label.svelte
@@ -19,7 +19,6 @@
 
 	export let loading_status: LoadingStatus;
 	export let show_label: boolean;
-	//$: color = value !== undefined ? value.color : undefined;
 
 	const dispatch = createEventDispatcher<{ change: undefined }>();
 

--- a/ui/packages/app/src/components/Label/Label.svelte
+++ b/ui/packages/app/src/components/Label/Label.svelte
@@ -12,14 +12,14 @@
 	export let value: {
 		label: string;
 		confidences?: Array<{ label: string; confidence: number }>;
-		color: string;
+		color?: string;
 	};
 	export let label: string = "Label";
 	export let style: Styles = {};
 
 	export let loading_status: LoadingStatus;
 	export let show_label: boolean;
-	$: color = value.color;
+	$: color = value !== undefined ? value.color : undefined;
 
 	const dispatch = createEventDispatcher<{ change: undefined }>();
 

--- a/ui/packages/app/src/components/Label/Label.svelte
+++ b/ui/packages/app/src/components/Label/Label.svelte
@@ -12,12 +12,14 @@
 	export let value: {
 		label: string;
 		confidences?: Array<{ label: string; confidence: number }>;
+		color: string;
 	};
 	export let label: string = "Label";
 	export let style: Styles = {};
 
 	export let loading_status: LoadingStatus;
 	export let show_label: boolean;
+	$: color = value.color;
 
 	const dispatch = createEventDispatcher<{ change: undefined }>();
 
@@ -39,7 +41,7 @@
 		/>
 	{/if}
 	{#if typeof value === "object" && value !== undefined && value !== null}
-		<Label {value} {show_label} />
+		<Label {value} {show_label} {color} />
 	{:else}
 		<div class="h-full min-h-[6rem] flex justify-center items-center">
 			<div class="h-5 dark:text-white opacity-50"><LabelIcon /></div>

--- a/ui/packages/app/src/components/Label/Label.svelte
+++ b/ui/packages/app/src/components/Label/Label.svelte
@@ -9,17 +9,17 @@
 
 	export let elem_id: string = "";
 	export let visible: boolean = true;
+	export let color: undefined | string = undefined;
 	export let value: {
 		label: string;
 		confidences?: Array<{ label: string; confidence: number }>;
-		color?: string;
 	};
 	export let label: string = "Label";
 	export let style: Styles = {};
 
 	export let loading_status: LoadingStatus;
 	export let show_label: boolean;
-	$: color = value !== undefined ? value.color : undefined;
+	//$: color = value !== undefined ? value.color : undefined;
 
 	const dispatch = createEventDispatcher<{ change: undefined }>();
 

--- a/ui/packages/label/src/Label.svelte
+++ b/ui/packages/label/src/Label.svelte
@@ -5,16 +5,28 @@
 	};
 
 	export let show_label: boolean;
+	export let color: string;
 </script>
 
 <div class="output-label">
-	<div
-		class:sr-only={!show_label}
-		class="output-class font-bold text-2xl py-6 px-4 flex-grow flex items-center justify-center dark:text-slate-200"
-		class:no-confidence={!("confidences" in value)}
-	>
-		{value.label}
-	</div>
+	{#if color !== null}
+		<div
+			class:sr-only={!show_label}
+			class="output-class font-bold text-2xl py-6 px-4 flex-grow flex items-center justify-center dark:text-slate-200"
+			class:no-confidence={!("confidences" in value)}
+			style:background-color={color}
+		>
+			{value.label}
+		</div>
+	{:else}
+		<div
+			class:sr-only={!show_label}
+			class="output-class font-bold text-2xl py-6 px-4 flex-grow flex items-center justify-center dark:text-slate-200"
+			class:no-confidence={!("confidences" in value)}
+		>
+			{value.label}
+		</div>
+	{/if}
 	{#if typeof value === "object" && value.confidences}
 		{#each value.confidences as confidence_set}
 			<div

--- a/ui/packages/label/src/Label.svelte
+++ b/ui/packages/label/src/Label.svelte
@@ -5,7 +5,7 @@
 	};
 
 	export let show_label: boolean;
-	export let color: string;
+	export let color: string | undefined;
 </script>
 
 <div class="output-label">

--- a/ui/packages/label/src/Label.svelte
+++ b/ui/packages/label/src/Label.svelte
@@ -9,24 +9,14 @@
 </script>
 
 <div class="output-label">
-	{#if color !== null}
-		<div
-			class:sr-only={!show_label}
-			class="output-class font-bold text-2xl py-6 px-4 flex-grow flex items-center justify-center dark:text-slate-200"
-			class:no-confidence={!("confidences" in value)}
-			style:background-color={color}
-		>
-			{value.label}
-		</div>
-	{:else}
-		<div
-			class:sr-only={!show_label}
-			class="output-class font-bold text-2xl py-6 px-4 flex-grow flex items-center justify-center dark:text-slate-200"
-			class:no-confidence={!("confidences" in value)}
-		>
-			{value.label}
-		</div>
-	{/if}
+	<div
+		class:sr-only={!show_label}
+		class="output-class font-bold text-2xl py-6 px-4 flex-grow flex items-center justify-center dark:text-slate-200"
+		class:no-confidence={!("confidences" in value)}
+		style:background-color={color || "transparent"}
+	>
+		{value.label}
+	</div>
 	{#if typeof value === "object" && value.confidences}
 		{#each value.confidences as confidence_set}
 			<div


### PR DESCRIPTION
# Description

Demo usecase

```python
import gradio as gr
import random

def update_color(value):
    if value == "bad":
        # This is bad so use red
        return "brown"
    elif value == "so-so":
        # Ok but pay attention (use orange)
        return "#ff9966"
    else:
        # Nothing to worry about
        return None


def update_value():
    choice = random.choice(['good', 'bad', 'so-so'])
    color = update_color(choice)
    return gr.Label.update(value=choice, color=color)

with gr.Blocks() as demo:
    label = gr.Label(value=-10)
    demo.load(lambda: update_value(), inputs=None, outputs=[label], every=1)
demo.queue().launch()
```

![label_bg_color_update](https://user-images.githubusercontent.com/41651716/204543277-cf632f7b-d4d6-45a1-96e2-c180b38e794d.gif)


Question about the api: Went with the suggestion to use a function to determine the label color. The one thing I don't like about it is that it couples the styling of the component with its value. We keep those separate for the other components. Curious what others think before going further. @abidlabs @pngwn @aliabid94 @aliabd 


Fixes #2629

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.