### PR TITLE
Resize images for chatbot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ No changes to highlight.
 No changes to highlight.
 
 ## Full Changelog:
-No changes to highlight.
+* Resized 
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ No changes to highlight.
 No changes to highlight.
 
 ## Full Changelog:
-* Resized 
+* Images in the chatbot component are now resized if they exceed a max width by [@abidlabs](https://github.com/abidlabs) in [PR 2748](https://github.com/gradio-app/gradio/pull/2748) 
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/ui/packages/chatbot/src/ChatBot.svelte
+++ b/ui/packages/chatbot/src/ChatBot.svelte
@@ -65,5 +65,6 @@
 <style>
 	.chat-message :global(img) {
 		border-radius: 13px;
+		max-width: 30vw;
 	}
 </style>


### PR DESCRIPTION
@dawoodkhan82 noticed that images are not resized in the chatbot, which can lead to a degraded experience for very large images. A quick css fix for that.

Before:

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/1778297/204838815-09fa7fce-e14c-4d6d-a4c9-53b65f30bfab.png">


After:

<img width="1057" alt="image" src="https://user-images.githubusercontent.com/1778297/204838690-1b02e1f6-5702-4480-9544-1f66cf905592.png">

Thanks for testing @dawoodkhan82!