### PR TITLE
Deindex share URLs from search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ No changes to highlight.
 ## Full Changelog:
 * Images in the chatbot component are now resized if they exceed a max width by [@abidlabs](https://github.com/abidlabs) in [PR 2748](https://github.com/gradio-app/gradio/pull/2748) 
 * Missing parameters have been added to `gr.Blocks().load()` by [@abidlabs](https://github.com/abidlabs) in [PR 2755](https://github.com/gradio-app/gradio/pull/2755) 
+* Deindex share URLs from search by [@aliabd](https://github.com/aliabd) in [PR 2772](https://github.com/gradio-app/gradio/pull/2772)
 
 
 ## Contributors Shoutout:

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -22,7 +22,7 @@ import orjson
 import pkg_resources
 from fastapi import Depends, FastAPI, HTTPException, WebSocket, status
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, PlainTextResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi.templating import Jinja2Templates
 from jinja2.exceptions import TemplateNotFound
@@ -426,6 +426,10 @@ class App(FastAPI):
                 app.startup_events_triggered = True
                 return True
             return False
+
+        @app.get("/robots.txt", response_class=PlainTextResponse)
+        def robots_txt():
+            return "User-agent: *\nDisallow: /"
 
         return app
 


### PR DESCRIPTION
Adds `/robots.txt` to every gradio app (that disallows all) so that it doesn't get indexed by google and show up in searches. [Example of indexed links](https://www.google.com/search?q=site:gradio.app&sxsrf=ALiCzsYLU0TuFIIwuxxbrPfOPqR6bjApKQ:1670479584635&ei=4H6RY8CxJqeawbkP4ru6sA4&start=40&sa=N&ved=2ahUKEwjAofyxren7AhUnTTABHeKdDuY4HhDy0wN6BAggEAs&biw=1973&bih=1084&dpr=0.9).

