### PR TITLE
Patch ip test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ No changes to highlight.
 No changes to highlight.
 
 ## Testing and Infrastructure Changes:
-No changes to highlight.
+* Fixed test for IP address by [@abidlabs](https://github.com/abidlabs) in [PR 2808](https://github.com/gradio-app/gradio/pull/2808) 
 
 ## Breaking Changes:
 No changes to highlight.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -107,10 +107,7 @@ class TestIPAddress:
         ip = get_local_ip_address()
         if ip == "No internet connection":
             return
-        try:  # check whether ip is valid
-            ipaddress.ip_address(ip)
-        except ValueError:
-            self.fail("Invalid IP address")
+        ipaddress.ip_address(ip)
 
     @mock.patch("requests.get")
     def test_get_ip_without_internet(self, mock_get):


### PR DESCRIPTION
`test/test_utils.py::TestIPAddress::test_get_ip` was failing: https://app.circleci.com/pipelines/github/gradio-app/gradio/7552/workflows/f81e5b0e-a644-4680-ab8c-8c49c1457089/jobs/16668

This patches the test