### PR TITLE
Patching `test_get_ip` attempt 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ No changes to highlight.
 
 ## Full Changelog:
 * Fixed typo in parameter `visible` in classes in `templates.py` by [@abidlabs](https://github.com/abidlabs) in [PR 2805](https://github.com/gradio-app/gradio/pull/2805) 
+* Switched external service for getting IP address from `https://api.ipify.org` to `https://checkip.amazonaws.com/` by [@abidlabs](https://github.com/abidlabs) in [PR 2810](https://github.com/gradio-app/gradio/pull/2810) 
+
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -80,7 +80,9 @@ def version_check():
 def get_local_ip_address() -> str:
     """Gets the public IP address or returns the string "No internet connection" if unable to obtain it."""
     try:
-        ip_address = requests.get("https://checkip.amazonaws.com/", timeout=3).text
+        ip_address = requests.get(
+            "https://checkip.amazonaws.com/", timeout=3
+        ).text.strip()
     except (requests.ConnectionError, requests.exceptions.ReadTimeout):
         ip_address = "No internet connection"
     return ip_address

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -78,8 +78,9 @@ def version_check():
 
 
 def get_local_ip_address() -> str:
+    """Gets the public IP address or returns the string "No internet connection" if unable to obtain it."""
     try:
-        ip_address = requests.get("https://api.ipify.org", timeout=3).text
+        ip_address = requests.get("https://checkip.amazonaws.com/", timeout=3).text
     except (requests.ConnectionError, requests.exceptions.ReadTimeout):
         ip_address = "No internet connection"
     return ip_address

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -103,6 +103,7 @@ class TestUtils:
 
 
 class TestIPAddress:
+    @pytest.mark.flaky
     def test_get_ip(self):
         ip = get_local_ip_address()
         if ip == "No internet connection":


### PR DESCRIPTION
Previously, we were using `https://api.ipify.org` to get the IP address. But this website has started to occasionally return a "Bad Gateway" response. So I switched to `https://checkip.amazonaws.com/`, which should be more reliable and also marked the test as flaky as it still relies on an external service