### PR TITLE
Add workaround to prevent importing gradio breaking PIL.Image.registered_extensions()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ No changes to highlight.
 No changes to highlight.
 
 ## Full Changelog:
-No changes to highlight.
+* Fixed importing gradio can cause PIL.Image.registered_extensions() to break by `[@aliencaocao](https://github.com/aliencaocao)` in `[PR 2846](https://github.com/gradio-app/gradio/pull/2846)`
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -21,13 +21,12 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 import altair as alt
-from PIL import Image as _Image  # using _ to minimize namespace pollution
-_Image.init()  # this have to be ran before importing matplotlib.figure to prevent https://github.com/gradio-app/gradio/issues/2843
 import matplotlib.figure
 import numpy as np
 import pandas as pd
 import PIL
 import PIL.ImageOps
+from PIL import Image as _Image  # using _ to minimize namespace pollution
 from ffmpy import FFmpeg
 from markdown_it import MarkdownIt
 from mdit_py_plugins.dollarmath import dollarmath_plugin
@@ -67,6 +66,7 @@ if TYPE_CHECKING:
 
 
 set_documentation_group("component")
+_Image.init()  # fixes https://github.com/gradio-app/gradio/issues/2843
 
 
 class _Keywords(Enum):

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -21,6 +21,8 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 import altair as alt
+from PIL import Image as _Image  # using _ to minimize namespace pollution
+_Image.init()  # this have to be ran before importing matplotlib.figure to prevent https://github.com/gradio-app/gradio/issues/2843
 import matplotlib.figure
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
# Description
This is a Pillow issue but the folks at Pillow suggested a workaround in https://github.com/python-pillow/Pillow/issues/6809#issuecomment-1356864228
Until Pillow merges https://github.com/python-pillow/Pillow/pull/6811 and publishes a new release (in Jan 2023 according to https://github.com/python-pillow/Pillow/issues/6750), this would be the only way to fix it.

The issue is importing matplotlib.figure will in turn import PIL.PngInfoPlugin, which causes existing extensions to not be initialized fully but only initialized with PNG formats. Thus, Image.init() have to be called before this import.

Closes: #2843 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes