### PR TITLE
Make it so that default_enabled has no impact on queue behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 No changes to highlight.
 
 ## Bug Fixes:
-No changes to highlight.
+* Fixed bug where setting `default_enabled=False` made it so that the entire queue did not start by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2876](https://github.com/gradio-app/gradio/pull/2876)  
 
 ## Documentation Changes:
 No changes to highlight.
@@ -16,7 +16,7 @@ No changes to highlight.
 No changes to highlight.
 
 ## Full Changelog:
-No changes to highlight.
+* The `default_enabled` parameter of the `Blocks.queue` method has no effect by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2876](https://github.com/gradio-app/gradio/pull/2876) 
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1204,7 +1204,7 @@ class Blocks(BlockContext):
             concurrency_count: Number of worker threads that will be processing requests from the queue concurrently. Increasing this number will increase the rate at which requests are processed, but will also increase the memory usage of the queue.
             status_update_rate: If "auto", Queue will send status estimations to all clients whenever a job is finished. Otherwise Queue will send status at regular intervals set by this parameter as the number of seconds.
             client_position_to_load_data: DEPRECATED. This parameter is deprecated and has no effect.
-            default_enabled: Deprecated and has no effect. If True, all event listeners will use queueing by default.
+            default_enabled: Deprecated and has no effect.
             api_open: If True, the REST routes of the backend will be open, allowing requests made directly to those endpoints to skip the queue.
             max_size: The maximum number of events the queue will store at any given moment. If the queue is full, new events will not be added and a user will receive a message saying that the queue is full. If None, the queue size will be unlimited.
         Example:

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1194,7 +1194,7 @@ class Blocks(BlockContext):
         concurrency_count: int = 1,
         status_update_rate: float | str = "auto",
         client_position_to_load_data: int | None = None,
-        default_enabled: bool = True,
+        default_enabled: bool | None = None,
         api_open: bool = True,
         max_size: int | None = None,
     ):
@@ -1204,7 +1204,7 @@ class Blocks(BlockContext):
             concurrency_count: Number of worker threads that will be processing requests from the queue concurrently. Increasing this number will increase the rate at which requests are processed, but will also increase the memory usage of the queue.
             status_update_rate: If "auto", Queue will send status estimations to all clients whenever a job is finished. Otherwise Queue will send status at regular intervals set by this parameter as the number of seconds.
             client_position_to_load_data: DEPRECATED. This parameter is deprecated and has no effect.
-            default_enabled: If True, all event listeners will use queueing by default.
+            default_enabled: Deprecated and has no effect. If True, all event listeners will use queueing by default.
             api_open: If True, the REST routes of the backend will be open, allowing requests made directly to those endpoints to skip the queue.
             max_size: The maximum number of events the queue will store at any given moment. If the queue is full, new events will not be added and a user will receive a message saying that the queue is full. If None, the queue size will be unlimited.
         Example:
@@ -1212,7 +1212,12 @@ class Blocks(BlockContext):
             demo.queue(concurrency_count=3)
             demo.launch()
         """
-        self.enable_queue = default_enabled
+        if default_enabled is not None:
+            warnings.warn(
+                "The default_enabled parameter of queue has no effect and will be removed "
+                "in a future version of gradio."
+            )
+        self.enable_queue = True
         self.api_open = api_open
         if client_position_to_load_data is not None:
             warnings.warn("The client_position_to_load_data parameter is deprecated.")

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -8,6 +8,7 @@ import random
 import sys
 import time
 import unittest.mock as mock
+import warnings
 from contextlib import contextmanager
 from functools import partial
 from string import capwords
@@ -71,6 +72,20 @@ class TestBlocksMethods:
             demo.launch(prevent_thread_lock=True)
             assert demo.share
             demo.close()
+
+    def test_default_enabled_deprecated(self):
+        io = gr.Interface(lambda s: s, gr.Textbox(), gr.Textbox())
+        with pytest.warns(
+            UserWarning, match="The default_enabled parameter of queue has no effect"
+        ):
+            io.queue(default_enabled=True)
+
+        io = gr.Interface(lambda s: s, gr.Textbox(), gr.Textbox())
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            io.queue()
+        for warning in record:
+            assert "default_enabled" not in str(warning.message)
 
     def test_xray(self):
         def fake_func():


### PR DESCRIPTION
# Description

Makes it so that `default_enabled` has no impact on queue behavior as discussed in #2863

Closes: #2863


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.