### PR TITLE
Fix bug displaying dataframe examples in csv/tsv files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ No changes to highlight.
 
 ## Bug Fixes:
 * Fixed bug where setting `default_enabled=False` made it so that the entire queue did not start by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2876](https://github.com/gradio-app/gradio/pull/2876)  
-* Fixed bug where csv preview for DataFrame examples would show filename instead of file contents by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2876](https://github.com/gradio-app/gradio/pull/2876)
+* Fixed bug where csv preview for DataFrame examples would show filename instead of file contents by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2877](https://github.com/gradio-app/gradio/pull/2877)
 
 ## Documentation Changes:
 No changes to highlight.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ No changes to highlight.
 
 ## Bug Fixes:
 * Fixed bug where setting `default_enabled=False` made it so that the entire queue did not start by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2876](https://github.com/gradio-app/gradio/pull/2876)  
+* Fixed bug where csv preview for DataFrame examples would show filename instead of file contents by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2876](https://github.com/gradio-app/gradio/pull/2876)
 
 ## Documentation Changes:
 No changes to highlight.

--- a/ui/packages/app/src/components/Dataset/ExampleComponents/Dataframe.svelte
+++ b/ui/packages/app/src/components/Dataset/ExampleComponents/Dataframe.svelte
@@ -4,7 +4,8 @@
 	export let value: Array<Array<string | number>> | string;
 	export let samples_dir: string;
 	let hovered = false;
-	let loaded = Array.isArray(value);
+	let loaded_value: Array<Array<string | number>> | string = value;
+	let loaded = Array.isArray(loaded_value);
 
 	$: if (!loaded && typeof value === "string" && /\.[a-zA-Z]+$/.test(value)) {
 		fetch(samples_dir + value)
@@ -18,7 +19,7 @@
 							.map((v) => v.split(",").slice(0, 4).join(","))
 							.join("\n");
 
-						value = csvParseRows(small_df);
+						loaded_value = csvParseRows(small_df);
 					} else if ((value as string).endsWith("tsv")) {
 						const small_df = v
 							.split("\n")
@@ -26,7 +27,7 @@
 							.map((v) => v.split("\t").slice(0, 4).join("\t"))
 							.join("\n");
 
-						value = tsvParseRows(small_df);
+						loaded_value = tsvParseRows(small_df);
 					} else {
 						throw new Error(
 							"Incorrect format, only CSV and TSV files are supported"
@@ -48,7 +49,7 @@
 		on:mouseleave={() => (hovered = false)}
 	>
 		<table class="gr-sample-dataframe relative">
-			{#each value.slice(0, 3) as row, i}
+			{#each loaded_value.slice(0, 3) as row, i}
 				<tr>
 					{#each row.slice(0, 3) as cell, j}
 						<td


### PR DESCRIPTION
# Description

Closes: #2602

To test,

1. Clone this space: gradio/test-loading-examples
2. Build this branch and run that space
3. Verify that the dataframe example does not change after click

![df_example_click](https://user-images.githubusercontent.com/41651716/209006117-3aa3595b-8f02-46eb-980e-f88ecde83090.gif)





# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.