### PR TITLE
Fixes error message display when raising errors from a generator function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## Bug Fixes:
 * Fixed bug where setting `default_enabled=False` made it so that the entire queue did not start by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2876](https://github.com/gradio-app/gradio/pull/2876)  
+* Fixed bug where an error raised after yielding iterative output would not be displayed in the browser by 
+[@JaySmithWpg](https://github.com/JaySmithWpg) in [PR 2889](https://github.com/gradio-app/gradio/pull/2889)  
 
 ## Documentation Changes:
 * Added a Guide on using Google Sheets to create a real-time dashboard with Gradio's `DataFrame` and `LinePlot` component, by [@abidlabs](https://github.com/abidlabs) in [PR 2816](https://github.com/gradio-app/gradio/pull/2816) 

--- a/gradio/queue.py
+++ b/gradio/queue.py
@@ -330,12 +330,17 @@ class Queue:
                         return
                     response = await self.call_prediction(awake_events, batch)
                 for event in awake_events:
+                    if response.status != 200:
+                        relevant_response = response
+                    else:
+                        relevant_response = old_response
+
                     await self.send_message(
                         event,
                         {
                             "msg": "process_completed",
-                            "output": old_response.json,
-                            "success": old_response.status == 200,
+                            "output": relevant_response.json,
+                            "success": relevant_response.status == 200,
                         },
                     )
             else:


### PR DESCRIPTION
# Description

When an error is raised in a function that returns iterative output to Gradio, the error is not correctly displayed in the user interface. The message is never delivered to the browser.

This function correctly displays the modal error message in the browser:
```python
def foo():
    raise gr.Error("Bar") # This will appear in the browser
```
But if the function is a generator that yields any results before the error is raised, the error message never appears in the browser:
```python
def foo():
    yield {status_text: "It's about to fail"}
    raise gr.Error("Bar") # This will not appear in the browser
```

Console output, thankfully, is not impacted by this bug.

This happens because Queue.process_events does not check the status of the last message received. It gets the status of the second last message received.

This PR changes Queue's behaviour to check the final message status and use that status to determine which message should be used to communicate the end of the generator to the browser.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


