### PR TITLE
Add reference to Gradio Discord bot to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,4 +275,4 @@ Also check out the paper *[Gradio: Hassle-Free Sharing and Testing of ML Models 
 
 ## See Also
 
-* The [Gradio Discord Bot](https://github.com/gradio-app/gradio-discord-bot), a Discord bot that allows you to try any [Hugging Face Space](https://huggingface.co/spaces) that is running a Gradio demo as a Discord bot
+* The [Gradio Discord Bot](https://github.com/gradio-app/gradio-discord-bot), a Discord bot that allows you to try any [Hugging Face Space](https://huggingface.co/spaces) that is running a Gradio demo as a Discord bot.

--- a/README.md
+++ b/README.md
@@ -272,3 +272,7 @@ Also check out the paper *[Gradio: Hassle-Free Sharing and Testing of ML Models 
   year = {2019},
 }
 ```
+
+## See Also
+
+* The [Gradio Discord Bot](https://github.com/gradio-app/gradio-discord-bot), a Discord bot that allows you to try any [Hugging Face Space](https://huggingface.co/spaces) that is running a Gradio demo as a Discord bot


### PR DESCRIPTION
# Description

Small addition to the readme in case someone comes to the repo looking for information about the Discord bot