### PR TITLE
Fix "audio used before assigned" bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added `title` argument to `TabbedInterface` by @MohamedAliRashad in [#2888](https://github.com/gradio-app/gradio/pull/2888)
 
 ## Bug Fixes:
+* Fixed bug where an error opening an audio file led to a crash by [@FelixDombek](https://github.com/FelixDombek) in [PR 2898](https://github.com/gradio-app/gradio/pull/2898)
 * Fixed bug where setting `default_enabled=False` made it so that the entire queue did not start by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2876](https://github.com/gradio-app/gradio/pull/2876)  
 * Fixed bug where csv preview for DataFrame examples would show filename instead of file contents by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2877](https://github.com/gradio-app/gradio/pull/2877)
 * Fixed bug where an error raised after yielding iterative output would not be displayed in the browser by 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import abstractmethod
 import copy
 import getpass
 import inspect
@@ -13,6 +12,7 @@ import time
 import typing
 import warnings
 import webbrowser
+from abc import abstractmethod
 from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Set, Tuple, Type

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -189,8 +189,8 @@ def audio_from_file(filename, crop_min=0, crop_max=100):
     except FileNotFoundError as e:
         isfile = os.path.isfile(filename)
         msg = (f"Cannot load audio from file: `{'ffprobe' if isfile else filename}` not found."
-               + "Please install `ffmpeg` in your system to use non-WAV audio file formats "
-                 "and make sure `ffprobe` is in your PATH." if isfile else "")
+               + " Please install `ffmpeg` in your system to use non-WAV audio file formats"
+                 " and make sure `ffprobe` is in your PATH." if isfile else "")
         raise RuntimeError(msg) from e
     if crop_min != 0 or crop_max != 100:
         audio_start = len(audio) * crop_min / 100

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -187,12 +187,14 @@ def audio_from_file(filename, crop_min=0, crop_max=100):
     try:
         audio = AudioSegment.from_file(filename)
     except FileNotFoundError as e:
-        error_message = str(e)
-        if "ffprobe" in error_message:
+        isfile = os.path.isfile(filename)
+        print(f"Cannot load audio from file: `{'ffprobe' if isfile else filename}` not found.")
+        if isfile:
             print(
-                "Please install `ffmpeg` in your system to use non-WAV audio file formats."
+                "Please install `ffmpeg` in your system to use non-WAV audio file formats "
+                "and make sure `ffprobe` is in your PATH."
             )
-        return 0, np.empty(0)
+        raise
     if crop_min != 0 or crop_max != 100:
         audio_start = len(audio) * crop_min / 100
         audio_end = len(audio) * crop_max / 100

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -188,9 +188,9 @@ def audio_from_file(filename, crop_min=0, crop_max=100):
         audio = AudioSegment.from_file(filename)
     except FileNotFoundError as e:
         isfile = os.path.isfile(filename)
-        msg = (f"Cannot load audio from file: `{'ffprobe' if isfile else filename}` not found." +
-                "Please install `ffmpeg` in your system to use non-WAV audio file formats "
-                "and make sure `ffprobe` is in your PATH." if isfile else "")
+        msg = (f"Cannot load audio from file: `{'ffprobe' if isfile else filename}` not found."
+               + "Please install `ffmpeg` in your system to use non-WAV audio file formats "
+                 "and make sure `ffprobe` is in your PATH." if isfile else "")
         raise RuntimeError(msg) from e
     if crop_min != 0 or crop_max != 100:
         audio_start = len(audio) * crop_min / 100

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -188,13 +188,10 @@ def audio_from_file(filename, crop_min=0, crop_max=100):
         audio = AudioSegment.from_file(filename)
     except FileNotFoundError as e:
         isfile = os.path.isfile(filename)
-        print(f"Cannot load audio from file: `{'ffprobe' if isfile else filename}` not found, {e}.")
-        if isfile:
-            print(
+        msg = (f"Cannot load audio from file: `{'ffprobe' if isfile else filename}` not found." +
                 "Please install `ffmpeg` in your system to use non-WAV audio file formats "
-                "and make sure `ffprobe` is in your PATH."
-            )
-        raise
+                "and make sure `ffprobe` is in your PATH." if isfile else "")
+        raise RuntimeError(msg) from e
     if crop_min != 0 or crop_max != 100:
         audio_start = len(audio) * crop_min / 100
         audio_end = len(audio) * crop_max / 100

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -192,6 +192,7 @@ def audio_from_file(filename, crop_min=0, crop_max=100):
             print(
                 "Please install `ffmpeg` in your system to use non-WAV audio file formats."
             )
+        return 0, np.empty(0)
     if crop_min != 0 or crop_max != 100:
         audio_start = len(audio) * crop_min / 100
         audio_end = len(audio) * crop_max / 100

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -188,7 +188,7 @@ def audio_from_file(filename, crop_min=0, crop_max=100):
         audio = AudioSegment.from_file(filename)
     except FileNotFoundError as e:
         isfile = os.path.isfile(filename)
-        print(f"Cannot load audio from file: `{'ffprobe' if isfile else filename}` not found.")
+        print(f"Cannot load audio from file: `{'ffprobe' if isfile else filename}` not found, {e}.")
         if isfile:
             print(
                 "Please install `ffmpeg` in your system to use non-WAV audio file formats "


### PR DESCRIPTION
`audio_from_file` did not correctly handle the case where the file cannot be opened. This PR fixes e.g. the crash mentioned in [TheAlly's Riffusion tutorial](https://theally.notion.site/theally/Quick-n-Dirty-Riffusion-txt2audio-Tutorial-18e57df9ef214c3280efc5998bbf774d).

# Description

Please include: 
* relevant motivation
* a summary of the change 
* which issue is fixed. 
* any additional dependencies that are required for this change.

Closes: # (issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.