### PR TITLE
Timeseries hotfix

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2666,7 +2666,7 @@ class Timeseries(Changeable, IOComponent, JSONSerializable):
         value: str | Callable | None = None,
         *,
         x: str | None = None,
-        y: str | List[str | None] | None = None,
+        y: str | List[str] | None = None,
         colors: List[str] | None = None,
         label: str | None = None,
         every: float | None = None,
@@ -2690,7 +2690,7 @@ class Timeseries(Changeable, IOComponent, JSONSerializable):
             elem_id: An optional string that is assigned as the id of this component in the HTML DOM. Can be used for targeting CSS styles.
         """
         self.x = x
-        if isinstance(y, str) or y is None:
+        if isinstance(y, str):
             y = [y]
         self.y = y
         self.colors = colors
@@ -2754,7 +2754,7 @@ class Timeseries(Changeable, IOComponent, JSONSerializable):
         return dataframe
 
     def generate_sample(self):
-        return {"data": [[1] + [2] * len(self.y)] * 4, "headers": [self.x] + self.y}
+        return {"data": [[1] + [2] * len(self.y or [])] * 4, "headers": [self.x] + (self.y or [])}
 
     def postprocess(self, y: str | pd.DataFrame | None) -> Dict | None:
         """

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2754,7 +2754,10 @@ class Timeseries(Changeable, IOComponent, JSONSerializable):
         return dataframe
 
     def generate_sample(self):
-        return {"data": [[1] + [2] * len(self.y or [])] * 4, "headers": [self.x] + (self.y or [])}
+        return {
+            "data": [[1] + [2] * len(self.y or [])] * 4,
+            "headers": [self.x] + (self.y or []),
+        }
 
     def postprocess(self, y: str | pd.DataFrame | None) -> Dict | None:
         """

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -188,9 +188,13 @@ def audio_from_file(filename, crop_min=0, crop_max=100):
         audio = AudioSegment.from_file(filename)
     except FileNotFoundError as e:
         isfile = os.path.isfile(filename)
-        msg = (f"Cannot load audio from file: `{'ffprobe' if isfile else filename}` not found."
-               + " Please install `ffmpeg` in your system to use non-WAV audio file formats"
-                 " and make sure `ffprobe` is in your PATH." if isfile else "")
+        msg = (
+            f"Cannot load audio from file: `{'ffprobe' if isfile else filename}` not found."
+            + " Please install `ffmpeg` in your system to use non-WAV audio file formats"
+            " and make sure `ffprobe` is in your PATH."
+            if isfile
+            else ""
+        )
         raise RuntimeError(msg) from e
     if crop_min != 0 or crop_max != 100:
         audio_start = len(audio) * crop_min / 100

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1331,7 +1331,7 @@ class TestTimeseries:
 
         assert timeseries_output.get_config() == {
             "x": None,
-            "y": [None],
+            "y": None,
             "name": "timeseries",
             "show_label": True,
             "label": "Disease",


### PR DESCRIPTION
As part of #2896, I accidentally made a change which broke `TimeSeries` if the `y` columns were not specified. This undos that change. Can be tested by running ` python demo/kitchen_sink_random/run.py` on this branch vs. `main`. 