### PR TITLE
Use gradio-pr-bot to make notebook check comments on PRs

### DIFF
--- a/.github/workflows/check-demo-notebooks.yml
+++ b/.github/workflows/check-demo-notebooks.yml
@@ -23,18 +23,21 @@ jobs:
           pip install nbformat && cd demo && python generate_notebooks.py
       - name: Print Git Status
         run: echo $(git status) && echo $(git diff)
+      - name: Assert Notebooks Match 
+        id: assertNotebooksMatch
+        run: git status | grep "nothing to commit, working tree clean"
       - name: Get PR Number
+        if: always()
         run: |
           python -c "import os;print(os.environ['GITHUB_REF'].split('/')[2])" > pr_number.txt
           echo "PR_NUMBER=$(cat pr_number.txt)" >> $GITHUB_ENV
       - name: Upload PR Number
+        if: always()
         run: |
           python -c "import json; json.dump({'pr_number': ${{ env.PR_NUMBER }}},  open('metadata.json', 'w'))"
       - name: Upload metadata
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: metadata.json
           path: metadata.json
-      - name: Assert Notebooks Match 
-        id: assertNotebooksMatch
-        run: git status | grep "nothing to commit, working tree clean"

--- a/.github/workflows/check-demo-notebooks.yml
+++ b/.github/workflows/check-demo-notebooks.yml
@@ -3,7 +3,7 @@
 name: Check Demos Match Notebooks
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     paths:
         - 'demo/**'
@@ -23,16 +23,18 @@ jobs:
           pip install nbformat && cd demo && python generate_notebooks.py
       - name: Print Git Status
         run: echo $(git status) && echo $(git diff)
+      - name: Get PR Number
+        run: |
+        python -c "import os;print(os.environ['GITHUB_REF'].split('/')[2])" > pr_number.txt
+        echo "PR_NUMBER=$(cat pr_number.txt)" >> $GITHUB_ENV
+      - name: Upload PR Number
+        run: |
+        python -c "import json; json.dump({'pr_number': ${{ env.PR_NUMBER }}},  open('metadata.json', 'w'))"
+    - name: Upload metadata
+      uses: actions/upload-artifact@v3
+      with:
+        name: metadata.json
+        path: metadata.json
       - name: Assert Notebooks Match 
         id: assertNotebooksMatch
         run: git status | grep "nothing to commit, working tree clean"
-      - name: Comment On PR
-        uses: thollander/actions-comment-pull-request@v1
-        if: always() && (steps.assertNotebooksMatch.outcome == 'failure')
-        with:
-          message: |
-            The demo notebooks don't match the run.py files. Please run this command from the root of the repo and then commit the changes:
-            ```bash
-            pip install nbformat && cd demo && python generate_notebooks.py
-            ```
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-demo-notebooks.yml
+++ b/.github/workflows/check-demo-notebooks.yml
@@ -25,11 +25,11 @@ jobs:
         run: echo $(git status) && echo $(git diff)
       - name: Get PR Number
         run: |
-        python -c "import os;print(os.environ['GITHUB_REF'].split('/')[2])" > pr_number.txt
-        echo "PR_NUMBER=$(cat pr_number.txt)" >> $GITHUB_ENV
+          python -c "import os;print(os.environ['GITHUB_REF'].split('/')[2])" > pr_number.txt
+          echo "PR_NUMBER=$(cat pr_number.txt)" >> $GITHUB_ENV
       - name: Upload PR Number
         run: |
-        python -c "import json; json.dump({'pr_number': ${{ env.PR_NUMBER }}},  open('metadata.json', 'w'))"
+          python -c "import json; json.dump({'pr_number': ${{ env.PR_NUMBER }}},  open('metadata.json', 'w'))"
       - name: Upload metadata
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/check-demo-notebooks.yml
+++ b/.github/workflows/check-demo-notebooks.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Upload PR Number
         run: |
         python -c "import json; json.dump({'pr_number': ${{ env.PR_NUMBER }}},  open('metadata.json', 'w'))"
-    - name: Upload metadata
-      uses: actions/upload-artifact@v3
-      with:
-        name: metadata.json
-        path: metadata.json
+      - name: Upload metadata
+        uses: actions/upload-artifact@v3
+        with:
+          name: metadata.json
+          path: metadata.json
       - name: Assert Notebooks Match 
         id: assertNotebooksMatch
         run: git status | grep "nothing to commit, working tree clean"

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -4,9 +4,8 @@ on:
     types: [completed]
 
 jobs:
-  on-nb-failure:
+  comment-on-failure:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.name == 'Check Demos Match Notebooks'}}
     steps:
       - uses: actions/checkout@v3
       - name: Install Python
@@ -20,7 +19,8 @@ jobs:
       - run: unzip metadata.json.zip
       - name: Pipe metadata to env
         run: echo "pr_number=$(python -c 'import json; print(json.load(open("metadata.json"))["pr_number"])')" >> $GITHUB_ENV
-      - name: Comment On PR
+      - name: Comment On Notebook check fail
+        if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.name == 'Check Demos Match Notebooks'}}
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -31,3 +31,14 @@ jobs:
           comment_includes: The demo notebooks don't match the run.py files
           GITHUB_TOKEN: ${{ secrets.COMMENT_TOKEN }}
           pr_number: ${{ env.pr_number }}
+          comment_tag: notebook-check
+      - name: Comment On Notebook check fail
+        if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.name == 'Check Demos Match Notebooks'}}
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: |
+              🎉 The demo notebooks match the run.py files! 🎉
+          comment_includes: The demo notebooks match the run.py files!
+          GITHUB_TOKEN: ${{ secrets.COMMENT_TOKEN }}
+          pr_number: ${{ env.pr_number }}
+          comment_tag: notebook-check

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   on-nb-failure:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.name == "Check Demos Match Notebooks"}}
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.name == 'Check Demos Match Notebooks'}}
     steps:
       - uses: actions/checkout@v3
       - name: Install Python

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   on-nb-failure:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.name == 'Check Demos Match Notebooks'}}
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.name == "Check Demos Match Notebooks"}}
     steps:
       - uses: actions/checkout@v3
       - name: Install Python
@@ -23,10 +23,10 @@ jobs:
       - name: Comment On PR
         uses: thollander/actions-comment-pull-request@v1
         with:
-        message: |
-            The demo notebooks don't match the run.py files. Please run this command from the root of the repo and then commit the changes:
-            ```bash
-            pip install nbformat && cd demo && python generate_notebooks.py
-            ```
-        GITHUB_TOKEN: ${{ secrets.COMMENT_TOKEN }}
-        pr_number: ${{ env.pr_number }}
+          message: |
+              The demo notebooks don't match the run.py files. Please run this command from the root of the repo and then commit the changes:
+              ```bash
+              pip install nbformat && cd demo && python generate_notebooks.py
+              ```
+          GITHUB_TOKEN: ${{ secrets.COMMENT_TOKEN }}
+          pr_number: ${{ env.pr_number }}

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "pr_number=$(python -c 'import json; print(json.load(open("metadata.json"))["pr_number"])')" >> $GITHUB_ENV
       - name: Comment On Notebook check fail
         if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.name == 'Check Demos Match Notebooks'}}
-        uses: thollander/actions-comment-pull-request@v1
+        uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
               The demo notebooks don't match the run.py files. Please run this command from the root of the repo and then commit the changes:
@@ -34,7 +34,7 @@ jobs:
           comment_tag: notebook-check
       - name: Comment On Notebook check fail
         if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.name == 'Check Demos Match Notebooks'}}
-        uses: thollander/actions-comment-pull-request@v1
+        uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
               🎉 The demo notebooks match the run.py files! 🎉

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -28,5 +28,6 @@ jobs:
               ```bash
               pip install nbformat && cd demo && python generate_notebooks.py
               ```
+          comment_includes: The demo notebooks don't match the run.py files
           GITHUB_TOKEN: ${{ secrets.COMMENT_TOKEN }}
           pr_number: ${{ env.pr_number }}

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -1,0 +1,32 @@
+on:
+  workflow_run:
+    workflows: [Check Demos Match Notebooks]
+    types: [completed]
+
+jobs:
+  on-nb-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.name == "Check Demos Match Notebooks"}}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - name: Install pip
+        run: python -m pip install requests
+      - name: Download metadata
+        run: python scripts/download_artifacts.py ${{github.event.workflow_run.id }} metadata.json ${{ secrets.COMMENT_TOKEN }} --owner ${{ github.repository_owner }}
+      - run: unzip metadata.json.zip
+      - name: Pipe metadata to env
+        run: echo "pr_number=$(python -c 'import json; print(json.load(open("metadata.json"))["pr_number"])')" >> $GITHUB_ENV
+      - name: Comment On PR
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+        message: |
+            The demo notebooks don't match the run.py files. Please run this command from the root of the repo and then commit the changes:
+            ```bash
+            pip install nbformat && cd demo && python generate_notebooks.py
+            ```
+        GITHUB_TOKEN: ${{ secrets.COMMENT_TOKEN }}
+        pr_number: ${{ env.pr_number }}


### PR DESCRIPTION
# Description

Based on #2895 . From now on:

1. The notebook check will run on `pull_request` as opposed to `pull_request_target` to prevent secrets from being leaked to forks
2. The comments will come from @gradio-pr-bot

You can see this running on this PR from my fork: https://github.com/freddyaboulton/gradio/pull/24
# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.