### PR TITLE
Fix the path check for long CSS strings in Blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ No changes to highlight.
 
 ## Bug Fixes:
 - Fix audio file output by [@aliabid94](https://github.com/aliabid94) in [PR 2950](https://github.com/gradio-app/gradio/pull/2950).
+- Fix custom long CSS handling in Blocks by [@anton-l](https://github.com/anton-l) in [PR 2953](https://github.com/gradio-app/gradio/pull/2953)
 
 ## Documentation Changes:
 No changes to highlight.

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -470,7 +470,7 @@ class Blocks(BlockContext):
         self.enable_queue = None
         self.max_threads = 40
         self.show_error = True
-        if css is not None and Path(css).exists():
+        if css is not None and os.path.exists(css):
             with open(css) as css_file:
                 self.css = css_file.read()
         else:

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -12,7 +12,6 @@ import time
 import warnings
 import webbrowser
 from abc import abstractmethod
-from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Set, Tuple, Type
 

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -274,6 +274,19 @@ class TestBlocksMethods:
         assert demo.show_error
         demo.close()
 
+    def test_custom_css(self):
+        css = """
+            .gr-button {
+                color: white;
+                border-color: black;
+                background: black;
+            }
+        """
+        css = css * 5  # simulate a long css string
+        block = gr.Blocks(css=css)
+
+        assert block.css == css
+
 
 class TestComponentsInBlocks:
     def test_slider_random_value_config(self):


### PR DESCRIPTION
# Description

This fixes a bug that prevents passing a long CSS string to `Blocks`
```python
css = """
        .gr-button {
            color: white;
            border-color: black;
            background: black;
        }
"""
css = css * 5  # simulate a long css string

block = gr.Blocks(css=css)
```

The recent switch from `os.path.exists(css)` to `Path(css).exists()` makes it fail with
```
[/usr/local/lib/python3.8/dist-packages/gradio/blocks.py](https://localhost:8080/#) in __init__(self, theme, analytics_enabled, mode, title, css, **kwargs)
    471         self.max_threads = 40
    472         self.show_error = True
--> 473         if css is not None and Path(css).exists():
    474             with open(css) as css_file:
    475                 self.css = css_file.read()

OSError: [Errno 36] File name too long: '\n            .gr-button {\n....
```

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.