### PR TITLE
Fix reload mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ No changes to highlight.
 * Fixed bug where `mount_gradio_app` would not launch if the queue was enabled in a gradio app by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2939](https://github.com/gradio-app/gradio/pull/2939) 
 * Fix custom long CSS handling in Blocks by [@anton-l](https://github.com/anton-l) in [PR 2953](https://github.com/gradio-app/gradio/pull/2953)
 - Recovers the dropdown change event by [@abidlabs](https://github.com/abidlabs) in [PR 2954](https://github.com/gradio-app/gradio/pull/2954).
+* Fix bug where outputs for examples where not being returned by the backend by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2955](https://github.com/gradio-app/gradio/pull/2955) 
 
 ## Documentation Changes:
 No changes to highlight.

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -250,9 +250,9 @@ class Examples:
 
         if Context.root_block:
             if self.cache_examples and self.outputs:
-                targets = self.inputs_with_examples
+                targets = self.inputs_with_examples + self.outputs
             else:
-                targets = self.inputs
+                targets = self.inputs_with_examples
             self.dataset.click(
                 load_example,
                 inputs=[self.dataset],

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -334,4 +334,4 @@ class TestProcessExamples:
         assert response.json()["data"] == ["Hello,", "World", "Hello, World"]
 
         response = client.post("/api/predict/", json={"fn_index": 3, "data": [1]})
-        assert response.json()["data"] == ["Michael", None, "Michael Jordan"]
+        assert response.json()["data"] == ["Michael", "Jordan", "Michael Jordan"]

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -3,6 +3,7 @@ import tempfile
 from unittest.mock import patch
 
 import pytest
+from starlette.testclient import TestClient
 
 import gradio as gr
 
@@ -293,3 +294,44 @@ class TestProcessExamples:
         )
         prediction = await io.examples_handler.load_from_cache(0)
         assert prediction == ["hel", "3"]
+
+    def test_end_to_end(self):
+        def concatenate(str1, str2):
+            return str1 + str2
+
+        io = gr.Interface(
+            concatenate,
+            inputs=[gr.Textbox(), gr.Textbox()],
+            outputs=gr.Textbox(),
+            examples=[["Hello,", None], ["Michael", None]],
+        )
+
+        app, _, _ = io.launch(prevent_thread_lock=True)
+        client = TestClient(app)
+
+        response = client.post("/api/predict/", json={"fn_index": 3, "data": [0]})
+        assert response.json()["data"] == ["Hello,"]
+
+        response = client.post("/api/predict/", json={"fn_index": 3, "data": [1]})
+        assert response.json()["data"] == ["Michael"]
+
+    def test_end_to_end_cache_examples(self):
+        def concatenate(str1, str2):
+            return str1 + " " + str2
+
+        io = gr.Interface(
+            concatenate,
+            inputs=[gr.Textbox(), gr.Textbox()],
+            outputs=gr.Textbox(),
+            examples=[["Hello,", "World"], ["Michael", "Jordan"]],
+            cache_examples=True,
+        )
+
+        app, _, _ = io.launch(prevent_thread_lock=True)
+        client = TestClient(app)
+
+        response = client.post("/api/predict/", json={"fn_index": 3, "data": [0]})
+        assert response.json()["data"] == ["Hello,", "World", "Hello, World"]
+
+        response = client.post("/api/predict/", json={"fn_index": 3, "data": [1]})
+        assert response.json()["data"] == ["Michael", None, "Michael Jordan"]


### PR DESCRIPTION
# Description

The issue was that were were calling `Path().resolve()`, which returned the entire path "/Users/...", and then we were replacing all "/" with "." so the path was something like ".Users.freddy." which was being treated as a relative imported.

Simply removing the leading "." was not enough to fix as uvicorn expected "Users" to be a python module. I brought back the old logic to be safe.

Also noticed that the "abs_parent" was "." since we were only getting the "name" property from the absolute path, i.e. the filename so "run.py".


Also added a unit test.

Fixes: #2936

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.