### PR TITLE
Fix reload mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 No changes to highlight.
 
 ## Bug Fixes:
-No changes to highlight.
+* Fix relative import bug in reload mode by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2992](https://github.com/gradio-app/gradio/pull/2992) 
 
 ## Documentation Changes:
 No changes to highlight.

--- a/gradio/reload.py
+++ b/gradio/reload.py
@@ -24,7 +24,7 @@ def run_in_reload_mode():
         demo_name = args[1]
 
     original_path = args[0]
-    abs_original_path = Path(original_path).name
+    abs_original_path = Path(original_path).resolve()
     path = os.path.normpath(original_path)
     path = path.replace("/", ".")
     path = path.replace("\\", ".")
@@ -48,7 +48,7 @@ def run_in_reload_mode():
         message += f" '{gradio_folder}'"
         message_change_count += 1
 
-    abs_parent = Path(abs_original_path).parent
+    abs_parent = abs_original_path.parent
     if str(abs_parent).strip():
         command += f'--reload-dir "{abs_parent}"'
         if message_change_count == 1:
@@ -56,5 +56,4 @@ def run_in_reload_mode():
         message += f" '{abs_parent}'"
 
     print(message + "\n")
-    print(command)
     os.system(command)

--- a/gradio/reload.py
+++ b/gradio/reload.py
@@ -25,10 +25,10 @@ def run_in_reload_mode():
 
     original_path = args[0]
     abs_original_path = Path(original_path).name
-    path = str(Path(original_path).resolve())
+    path = os.path.normpath(original_path)
     path = path.replace("/", ".")
     path = path.replace("\\", ".")
-    filename = Path(path).stem
+    filename = os.path.splitext(path)[0]
 
     gradio_folder = Path(inspect.getfile(gradio)).parent
 
@@ -56,4 +56,5 @@ def run_in_reload_mode():
         message += f" '{abs_parent}'"
 
     print(message + "\n")
+    print(command)
     os.system(command)

--- a/test/test_reload.py
+++ b/test/test_reload.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import gradio
+from gradio.reload import run_in_reload_mode
+
+
+@patch("gradio.reload.os.system")
+@patch("gradio.reload.sys")
+def test_run_in_reload_mode(mock_sys, mock_system_call):
+
+    mock_sys.argv = ["gradio", "demo/calculator/run.py"]
+    run_in_reload_mode()
+    reload_command = mock_system_call.call_args[0][0]
+    gradio_dir = Path(gradio.__file__).parent
+    demo_dir = Path("demo/calculator/run.py").resolve().parent
+
+    assert "uvicorn demo.calculator.run:demo.app" in reload_command
+    assert f'--reload-dir "{gradio_dir}"' in reload_command
+    assert f'--reload-dir "{demo_dir}"' in reload_command


### PR DESCRIPTION
# Description

The issue was that were were calling Path().resolve(), which returned the entire path "/Users/...", and then we were replacing all "/" with "." so the path was something like ".Users.freddy." which was being treated as a relative imported.

Simply removing the leading "." was not enough to fix as uvicorn expected "Users" to be a python module. I brought back the old logic to be safe.

Also noticed that the "abs_parent" was "." since we were only getting the "name" property from the absolute path, i.e. the filename so "run.py".

Also added a unit test.

Fixes: #2963

Closes: # (issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.