### PR TITLE
Fix interpretation events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 No changes to highlight.
 
 ## Bug Fixes:
-No changes to highlight.
+* Fixes bug where interpretation event was not configured correctly by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2993](https://github.com/gradio-app/gradio/pull/2993) 
 
 ## Documentation Changes:
 No changes to highlight.

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -706,8 +706,7 @@ class Interface(Blocks):
             interpretation_btn.click(
                 self.interpret_func,
                 inputs=self.input_components + self.output_components,
-                outputs=interpretation_set
-                or [] + [input_component_column, interpret_component_column],  # type: ignore
+                outputs=interpretation_set + [input_component_column, interpret_component_column],  # type: ignore
                 preprocess=False,
             )
 

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -706,7 +706,7 @@ class Interface(Blocks):
             interpretation_btn.click(
                 self.interpret_func,
                 inputs=self.input_components + self.output_components,
-                outputs=interpretation_set + [input_component_column, interpret_component_column],  # type: ignore
+                outputs=(interpretation_set or [])+ [input_component_column, interpret_component_column],  # type: ignore
                 preprocess=False,
             )
 

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -706,7 +706,7 @@ class Interface(Blocks):
             interpretation_btn.click(
                 self.interpret_func,
                 inputs=self.input_components + self.output_components,
-                outputs=(interpretation_set or [])+ [input_component_column, interpret_component_column],  # type: ignore
+                outputs=(interpretation_set or []) + [input_component_column, interpret_component_column],  # type: ignore
                 preprocess=False,
             )
 

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -238,6 +238,20 @@ class TestInterfaceInterpretation:
             interpretation="default",
         )
 
+        interpretation_id = None
+        for c in iface.config["components"]:
+            if c["props"].get("value") == "Interpret" and c.get("type") == "button":
+                interpretation_id = c["id"]
+
+        # Make sure the event is configured correctly.
+        interpretation_dep = next(
+            d
+            for d in iface.config["dependencies"]
+            if d["targets"] == [interpretation_id]
+        )
+        assert sorted(interpretation_dep["outputs"]) == [6, 8, 9, 10]
+        assert sorted(interpretation_dep["inputs"]) == [1, 2, 3]
+
         app, _, _ = iface.launch(prevent_thread_lock=True)
         client = TestClient(app)
 

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -249,8 +249,22 @@ class TestInterfaceInterpretation:
             for d in iface.config["dependencies"]
             if d["targets"] == [interpretation_id]
         )
-        assert sorted(interpretation_dep["outputs"]) == [6, 8, 9, 10]
-        assert sorted(interpretation_dep["inputs"]) == [1, 2, 3]
+        interpretation_comps = [
+            c["id"]
+            for c in iface.config["components"]
+            if c.get("type") == "interpretation"
+        ]
+        interpretation_columns = [
+            c["id"]
+            for c in iface.config["components"]
+            if c.get("type") == "column" and c["props"].get("variant") == "default"
+        ]
+        assert sorted(interpretation_dep["outputs"]) == sorted(
+            interpretation_comps + interpretation_columns
+        )
+        assert sorted(interpretation_dep["inputs"]) == sorted(
+            [c._id for c in iface.input_components + iface.output_components]
+        )
 
         app, _, _ = iface.launch(prevent_thread_lock=True)
         client = TestClient(app)


### PR DESCRIPTION
# Description

In a recent refactor, the interpretation event was changed to not include the interpretation component as output.

This PR fixes that and adds a check to make sure the output components of the interpretation event match what's expected.

Fixes #2960

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.