### PR TITLE
Fix file serialization so that output is json serializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ No changes to highlight.
 ## Bug Fixes:
 * Fixes bug where interpretation event was not configured correctly by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2993](https://github.com/gradio-app/gradio/pull/2993) 
 * Fix relative import bug in reload mode by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2992](https://github.com/gradio-app/gradio/pull/2992) 
+* Fix bug where file serialization output was not JSON serializable by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2999](https://github.com/gradio-app/gradio/pull/2999)  
 
 ## Documentation Changes:
 No changes to highlight.

--- a/gradio/serializing.py
+++ b/gradio/serializing.py
@@ -119,7 +119,7 @@ class FileSerializable(Serializable):
         """
         if x is None or x == "":
             return None
-        filename = Path(load_dir) / x
+        filename = str(Path(load_dir) / x)
         return {
             "name": filename,
             "data": processing_utils.encode_url_or_file_to_base64(

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -796,7 +796,6 @@ class TestAudio:
         assert isinstance(audio_input.preprocess(x_wav), str)
         with pytest.raises(ValueError):
             gr.Audio(type="unknown")
-        audio_input = gr.Audio(type="numpy")
 
         # Output functionalities
         y_audio = gr.processing_utils.decode_base64_to_file(
@@ -828,6 +827,15 @@ class TestAudio:
         output1 = audio_output.postprocess(y_audio.name)
         output2 = audio_output.postprocess(y_audio.name)
         assert output1 == output2
+
+    def test_serialize(self):
+        audio_input = gr.Audio()
+        assert audio_input.serialize("test/test_files/audio_sample.wav") == {
+            "data": media_data.BASE64_AUDIO["data"],
+            "is_file": False,
+            "orig_name": "audio_sample.wav",
+            "name": "test/test_files/audio_sample.wav",
+        }
 
     def test_tokenize(self):
         """


### PR DESCRIPTION
# Description

Fixes #2996 and added a unit test


You can also run this demo and it should work

```python
import gradio as gr

whisper = gr.Blocks.load(name="spaces/sanchit-gandhi/whisper-large-v2")

def transcribe(audio):
    return whisper(audio, None, "transcribe", api_name="predict")

gr.Interface(
    transcribe,
    gr.Audio(type="filepath"),
    gr.Textbox()).launch()
```

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.