### PR TITLE
replace x-png with png

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ No changes to highlight.
 ## Bug Fixes:
 * Fixes bug where interpretation event was not configured correctly by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2993](https://github.com/gradio-app/gradio/pull/2993) 
 * Fix relative import bug in reload mode by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2992](https://github.com/gradio-app/gradio/pull/2992) 
+* Fixes bug where png files were not being recognized when uploadin images by [@abidlabs](https://github.com/abidlabs) in [PR 3002](https://github.com/gradio-app/gradio/pull/3002) 
 
 ## Documentation Changes:
 No changes to highlight.

--- a/ui/packages/image/src/Image.svelte
+++ b/ui/packages/image/src/Image.svelte
@@ -169,7 +169,7 @@
 	{#if source === "upload"}
 		<Upload
 			bind:dragging
-			filetype="image/x-png,image/gif,image/jpeg"
+			filetype="image/png,image/gif,image/jpeg"
 			on:load={handle_upload}
 			include_file_metadata={false}
 			disable_click={!!value}


### PR DESCRIPTION
We got some feedback recently to replace the [outdated](https://stackoverflow.com/questions/2086374/what-is-the-difference-between-image-png-and-image-x-png) x-png MIME type with the now standard png MIME type.

I believe this closes: #2110 but if someone with a Mac/Ubuntu could confirm, that would be great