### PR TITLE
Fixing deserialize when loading external Spaces

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -889,7 +889,7 @@ class Blocks(BlockContext):
             assert isinstance(
                 block, components.IOComponent
             ), f"{block.__class__} Component with id {output_id} not a valid output component."
-            deserialized = block.deserialize(outputs[o])
+            deserialized = block.deserialize(outputs[o], root_url=block.root_url)
             predictions.append(deserialized)
 
         return predictions

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -3775,7 +3775,11 @@ class Gallery(IOComponent, TempFileManager, FileSerializable):
         return Component.style(self, container=container, **kwargs)
 
     def deserialize(
-        self, x: Any, save_dir: str = "", encryption_key: bytes | None = None
+        self,
+        x: Any,
+        save_dir: str = "",
+        encryption_key: bytes | None = None,
+        root_url: str | None = None,
     ) -> None | str:
         if x is None:
             return None
@@ -3787,7 +3791,9 @@ class Gallery(IOComponent, TempFileManager, FileSerializable):
                 img_data, caption = img_data
             else:
                 caption = None
-            name = FileSerializable.deserialize(self, img_data, gallery_path)
+            name = FileSerializable.deserialize(
+                self, img_data, gallery_path, root_url=root_url
+            )
             captions[name] = caption
             captions_file = gallery_path / "captions.json"
             with captions_file.open("w") as captions_json:

--- a/gradio/serializing.py
+++ b/gradio/serializing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import urllib.parse
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict
@@ -23,6 +24,7 @@ class Serializable(ABC):
         x: Any,
         save_dir: str | Path | None = None,
         encryption_key: bytes | None = None,
+        root_url: str | None = None,
     ):
         """
         Convert data from serialized format for a browser to human-readable format.
@@ -48,6 +50,7 @@ class SimpleSerializable(Serializable):
         x: Any,
         save_dir: str | Path | None = None,
         encryption_key: bytes | None = None,
+        root_url: str | None = None,
     ):
         """
         Convert data from serialized format to human-readable format. For SimpleSerializable components, this is a no-op.
@@ -55,6 +58,7 @@ class SimpleSerializable(Serializable):
             x: Input data to deserialize
             save_dir: Ignored
             encryption_key: Ignored
+            root_url: Ignored
         """
         return x
 
@@ -85,6 +89,7 @@ class ImgSerializable(Serializable):
         x: str | None,
         save_dir: str | Path | None = None,
         encryption_key: bytes | None = None,
+        root_url: str | None = None,
     ) -> str | None:
         """
         Convert from serialized representation of a file (base64) to a human-friendly
@@ -93,6 +98,7 @@ class ImgSerializable(Serializable):
             x: Base64 representation of image to deserialize into a string filepath
             save_dir: Path to directory to save the deserialized image to
             encryption_key: Used to decrypt the file
+            root_url: Ignored
         """
         if x is None or x == "":
             return None
@@ -134,6 +140,7 @@ class FileSerializable(Serializable):
         x: str | Dict | None,
         save_dir: Path | str | None = None,
         encryption_key: bytes | None = None,
+        root_url: str | None = None,
     ) -> str | None:
         """
         Convert from serialized representation of a file (base64) to a human-friendly
@@ -142,6 +149,7 @@ class FileSerializable(Serializable):
             x: Base64 representation of file to deserialize into a string filepath
             save_dir: Path to directory to save the deserialized file to
             encryption_key: Used to decrypt the file
+            root_url: If this component is loaded from an external Space, this is the URL of the Space
         """
         if x is None:
             return None
@@ -153,6 +161,8 @@ class FileSerializable(Serializable):
             ).name
         elif isinstance(x, dict):
             if x.get("is_file", False):
+                if root_url is not None:
+                    x["name"] = urllib.parse.urljoin(root_url, "file=" + x["name"])
                 if utils.validate_url(x["name"]):
                     file_name = x["name"]
                 else:
@@ -194,6 +204,7 @@ class JSONSerializable(Serializable):
         x: str | Dict,
         save_dir: str | Path | None = None,
         encryption_key: bytes | None = None,
+        root_url: str | None = None,
     ) -> str | None:
         """
         Convert from serialized representation (json string) to a human-friendly
@@ -202,6 +213,7 @@ class JSONSerializable(Serializable):
             x: Json string
             save_dir: Path to save the deserialized json file to
             encryption_key: Ignored
+            root_url: Ignored
         """
         if x is None:
             return None

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -1,9 +1,9 @@
 import json
 import os
-import pathlib
 import sys
 import textwrap
 import warnings
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -279,20 +279,20 @@ class TestLoadInterface:
 
 class TestLoadInterfaceWithExamples:
     def test_interface_load_examples(self, tmp_path):
-        test_file_dir = pathlib.Path(pathlib.Path(__file__).parent, "test_files")
+        test_file_dir = Path(Path(__file__).parent, "test_files")
         with patch("gradio.helpers.CACHED_FOLDER", tmp_path):
             gr.Interface.load(
                 name="models/google/vit-base-patch16-224",
-                examples=[pathlib.Path(test_file_dir, "cheetah1.jpg")],
+                examples=[Path(test_file_dir, "cheetah1.jpg")],
                 cache_examples=False,
             )
 
     def test_interface_load_cache_examples(self, tmp_path):
-        test_file_dir = pathlib.Path(pathlib.Path(__file__).parent, "test_files")
+        test_file_dir = Path(Path(__file__).parent, "test_files")
         with patch("gradio.helpers.CACHED_FOLDER", tmp_path):
             gr.Interface.load(
                 name="models/google/vit-base-patch16-224",
-                examples=[pathlib.Path(test_file_dir, "cheetah1.jpg")],
+                examples=[Path(test_file_dir, "cheetah1.jpg")],
                 cache_examples=True,
             )
 
@@ -305,6 +305,11 @@ class TestLoadInterfaceWithExamples:
                 for c in demo.get_config_file()["components"]
             ]
         )
+
+    def test_root_url_deserialization(self):
+        demo = gr.Interface.load("spaces/gradio/simple_gallery")
+        path_to_files = demo("test")
+        assert (Path(path_to_files) / "captions.json").exists()
 
     def test_interface_with_examples(self):
         # This demo has the "fake_event" correctly removed


### PR DESCRIPTION
There was a bug (reported in #2920) where users would not be able to use external Spaces as functions if the Spaces returned any sort of file. This fixes that and adds a unit test. You can test by running: 

```py
from pathlib import Path
import gradio as gr

demo = gr.Interface.load("spaces/gradio/simple_gallery")
```

Closes: #2920 