### PR TITLE
Adds a GitHub action to detect if any files > 5 MB are present in the PR

### DIFF
--- a/.github/workflows/large-files.yml
+++ b/.github/workflows/large-files.yml
@@ -11,14 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+    - name: Check for large files
+      uses: actionsdesk/lfs-warning@v3.2
+      with:
+        filesizelimit: 5MB
 
-    - name: Find large files
-      run: |
-        for file in $(git diff-tree -r --no-commit-id --name-only HEAD); do
-          if [ $(du -k "$file" | cut -f1) -gt 5120 ]; then
-            echo "File $file is larger than 5 MB"
-            exit 1
-          fi
-        done

--- a/.github/workflows/large-files.yml
+++ b/.github/workflows/large-files.yml
@@ -1,0 +1,24 @@
+name: Check for large files
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+
+jobs:
+  check-files:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Find large files
+      run: |
+        for file in $(git diff-tree -r --no-commit-id --name-only HEAD); do
+          if [ $(du -k "$file" | cut -f1) -gt 5120 ]; then
+            echo "File $file is larger than 5 MB"
+            exit 1
+          fi
+        done

--- a/.github/workflows/large-files.yml
+++ b/.github/workflows/large-files.yml
@@ -1,9 +1,6 @@
 name: Check for large files
 
 on:
-  push:
-    branches:
-      - "main"
   pull_request:
 
 jobs:
@@ -11,8 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check for large files
-      uses: actionsdesk/lfs-warning@v3.2
-      with:
-        filesizelimit: 5MB
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}    
+      - name: Check for large files
+        uses: actionsdesk/lfs-warning@v3.2
+        with:
+          filesizelimit: 5MB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ No changes to highlight.
 * Use `gr.LinePlot` for the `blocks_kinematics` demo by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2998](https://github.com/gradio-app/gradio/pull/2998)  
 
 ## Testing and Infrastructure Changes:
-No changes to highlight.
+* Adds a GitHub action to test if any large files (> 5MB) are present by [@abidlabs](https://github.com/abidlabs) in [PR 3013](https://github.com/gradio-app/gradio/pull/3013)  
 
 ## Breaking Changes:
 No changes to highlight.


### PR DESCRIPTION
Moving everything to GitHub actions reminded me of this old issue that we had: https://github.com/gradio-app/gradio/issues/1372

This PR adds the action and causes the check to fail if any file > 5 MB is present. 

You can see it in action here:
* Successful run (no large files): https://github.com/abidlabs/gradio/pull/1
* Unsuccessful run (large file present): https://github.com/abidlabs/gradio/pull/2

Closes: #1372