### PR TITLE
Switch all pages on the website to use latest stable gradio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3011](https://git
 * Fixes issue where markdown support in chatbot breaks older demos [@dawoodkhan82](https://github.com/dawoodkhan82) in [PR 3006](https://github.com/gradio-app/gradio/pull/3006) 
 * Fixes the `/file/` route that was broken in a recent change in [PR 3010](https://github.com/gradio-app/gradio/pull/3010) 
 * Fix bug where the Image component could not serialize image urls by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2957](https://github.com/gradio-app/gradio/pull/2957)  
+* Switch all pages on the website to use latest stable gradio by [@aliabd](https://github.com/aliabd) in [PR 3016](https://github.com/gradio-app/gradio/pull/3016)
 
 ## Documentation Changes:
 * SEO improvements to guides by[@aliabd](https://github.com/aliabd) in [PR 2915](https://github.com/gradio-app/gradio/pull/2915)

--- a/website/homepage/build.py
+++ b/website/homepage/build.py
@@ -32,8 +32,8 @@ version = version.strip()
 
 gradio_wheel_url = args.url + f"gradio-{version}-py3-none-any.whl"
 
-index.build(BUILD_DIR, jinja_env)
-guides.build(BUILD_DIR, jinja_env)
+index.build(BUILD_DIR, jinja_env, latest_gradio_stable)
+guides.build(BUILD_DIR, jinja_env, latest_gradio_stable)
 docs.build(BUILD_DIR, jinja_env, gradio_wheel_url, latest_gradio_stable)
-demos.build(BUILD_DIR, jinja_env)
-changelog.build(BUILD_DIR, jinja_env)
+demos.build(BUILD_DIR, jinja_env, latest_gradio_stable)
+changelog.build(BUILD_DIR, jinja_env, latest_gradio_stable)

--- a/website/homepage/src/changelog/__init__.py
+++ b/website/homepage/src/changelog/__init__.py
@@ -43,11 +43,11 @@ def render_md():
     return versions
 
 
-def build(output_dir, jinja_env):
+def build(output_dir, jinja_env, latest_gradio_stable):
     versions = render_md()
     os.makedirs(output_dir, exist_ok=True)
     template = jinja_env.get_template("changelog/parent_template.html")
-    output = template.render(versions=versions)
+    output = template.render(versions=versions, latest_gradio_stable=latest_gradio_stable)
     output_folder = os.path.join(output_dir, "changelog")
     os.makedirs(output_folder)
     output_file = os.path.join(output_folder, "index.html")

--- a/website/homepage/src/changelog/parent_template.html
+++ b/website/homepage/src/changelog/parent_template.html
@@ -28,10 +28,11 @@
     </div>
     <script src="/assets/prism.js"></script>
     <script>window.__gradio_mode__ = "website";</script>
-    <script type="module" src="/assets/index.js"></script>
     {% include 'templates/footer.html' %}
     <script>{% include 'templates/add_anchors.js' %}</script>
     <script>{% include 'templates/add_copy.js' %}</script>
+    <script>{% include 'templates/load_latest_stable.js' %}</script>
+
     <script>
       let mainNavLinks = document.querySelectorAll(".side-navigation a");
       window.addEventListener("scroll", event => {

--- a/website/homepage/src/demos/__init__.py
+++ b/website/homepage/src/demos/__init__.py
@@ -144,10 +144,10 @@ for category in demos_by_category:
         demo["code"] = code
         demo["text"] = description
 
-def build(output_dir, jinja_env):
+def build(output_dir, jinja_env, latest_gradio_stable):
     os.makedirs(output_dir, exist_ok=True)
     template = jinja_env.get_template("demos/template.html")
-    output = template.render(demos_by_category=demos_by_category)
+    output = template.render(demos_by_category=demos_by_category, latest_gradio_stable=latest_gradio_stable)
     output_folder = os.path.join(output_dir, "demos")
     os.makedirs(output_folder)
     output_file = os.path.join(output_folder, "index.html")

--- a/website/homepage/src/demos/template.html
+++ b/website/homepage/src/demos/template.html
@@ -53,13 +53,12 @@
     <script>
       window.__gradio_mode__ = "website";
     </script>
-    <script type="module" src="/assets/index.js"></script>
-
-    <script>{% include 'templates/add_copy.js' %}</script>
 
     {% include 'templates/footer.html' %}
-    
+    <script>{% include 'templates/load_latest_stable.js' %}</script>
+
     <script>
+
     const show_demo = (demo) => {
       document.querySelectorAll(`.demo-btn.selected-demo-tab`).forEach(n => n.classList.remove('selected-demo-tab'));
       document.querySelector(`.demo-btn[name=${demo}]`).classList.add('selected-demo-tab');

--- a/website/homepage/src/guides/__init__.py
+++ b/website/homepage/src/guides/__init__.py
@@ -113,7 +113,7 @@ for guide_folder in guide_folders:
         absolute_index += 1
 
 
-def build_guides(output_dir, jinja_env):
+def build_guides(output_dir, jinja_env, latest_gradio_stable):
     shutil.copytree(GUIDE_ASSETS_DIR, os.path.join(output_dir, "assets", "guides"))
     for guide in guides:
         with open(TEMP_TEMPLATE, "w") as temp_html:
@@ -144,6 +144,7 @@ def build_guides(output_dir, jinja_env):
             guides_by_category=guides_by_category,
             prev_guide=prev_guide[0] if len(prev_guide) else None,
             next_guide=next_guide[0] if len(next_guide) else None,
+            latest_gradio_stable=latest_gradio_stable
         )
         with open(output_file, "w") as index_html:
             index_html.write(output)
@@ -163,6 +164,6 @@ def build_gallery(output_dir, jinja_env):
     with open(output_file, "w") as index_html:
         index_html.write(output)
 
-def build(output_dir, jinja_env):
-    build_guides(output_dir, jinja_env)
+def build(output_dir, jinja_env, latest_gradio_stable):
+    build_guides(output_dir, jinja_env, latest_gradio_stable)
     build_gallery(output_dir, jinja_env)

--- a/website/homepage/src/guides/template.html
+++ b/website/homepage/src/guides/template.html
@@ -72,7 +72,6 @@
     </div>
     <script src="/assets/prism.js"></script>
     <script>window.__gradio_mode__ = "website";</script>
-    <script type="module" src="/assets/index.js"></script>
     {% include 'templates/footer.html' %}
     <script>
       let sidebar = document.querySelector(".side-navigation")
@@ -101,5 +100,6 @@
     <script>{% include 'templates/links-nav.js' %}</script>
     <script>{% include 'templates/add_anchors.js' %}</script>
     <script>{% include 'templates/add_copy.js' %}</script>
+    <script>{% include 'templates/load_latest_stable.js' %}</script>
   </body>
 </html>

--- a/website/homepage/src/index/__init__.py
+++ b/website/homepage/src/index/__init__.py
@@ -9,7 +9,7 @@ with open(TWEETS_FILE) as tweets_json:
     tweets = json.load(tweets_json)
 
 
-def build(output_dir, jinja_env):
+def build(output_dir, jinja_env, latest_gradio_stable):
     OUTPUT_FILE = os.path.join(output_dir, "index.html")
     os.makedirs(output_dir, exist_ok=True)
     template = jinja_env.get_template("index/template.html")
@@ -19,6 +19,6 @@ def build(output_dir, jinja_env):
         if "stargazers_count" in star_request
         else ""
     )
-    output = template.render(tweets=tweets, star_count=star_count)
+    output = template.render(tweets=tweets, star_count=star_count, latest_gradio_stable=latest_gradio_stable)
     with open(OUTPUT_FILE, "w") as index_html:
         index_html.write(output)

--- a/website/homepage/src/index/demos_template.html
+++ b/website/homepage/src/index/demos_template.html
@@ -79,8 +79,8 @@ gr<span class="token punctuation">.</span>Interface<span class="token punctuatio
     </div>
 </div>
 
-<script type="module" src="/assets/index.js"></script>
 <script>{% include 'templates/add_copy.js' %}</script>
+<script>{% include 'templates/load_latest_stable.js' %}</script>
 <script>
     let load_demo = demo_id => {
         document.querySelectorAll(".demo-tab").forEach(e => {

--- a/website/homepage/src/templates/load_latest_stable.js
+++ b/website/homepage/src/templates/load_latest_stable.js
@@ -1,0 +1,14 @@
+function load_gradio(FILE_URL) {
+    console.log(FILE_URL);
+    var len = Array.from(document.querySelectorAll('script')).filter(e => e.getAttribute('src') == FILE_URL).length;
+    if (len === 0) {
+      let scriptEle = document.createElement("script");
+      scriptEle.setAttribute("src", FILE_URL);
+      scriptEle.setAttribute("type", "module");
+      document.body.appendChild(scriptEle);
+    }
+  }
+
+  {% set gradio_js = 'https://gradio.s3-us-west-2.amazonaws.com/' + latest_gradio_stable + '/gradio.js' %}
+
+  load_gradio("{{ gradio_js }}");


### PR DESCRIPTION
Switches all the pages on the website except for `/docs/main` to use the latest gradio version instead of building from main. Stops embedding from breaking when there's an unintentional change to main. 

Will fix current embedded interfaces in `index`, `demos`, and `guides`. This will always use latest gradio (version isn't hardcoded) the same way it does for `/docs`. This has the caveat that if we publish a guide on something new we'd need a version bump to show the embedded interfaces in it the correct way, but we can move guides to be from main as well if we choose later. 