### PR TITLE
Fix forwarding for guides after SEO renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3011](https://git
 * Fixes issue where markdown support in chatbot breaks older demos [@dawoodkhan82](https://github.com/dawoodkhan82) in [PR 3006](https://github.com/gradio-app/gradio/pull/3006) 
 * Fixes the `/file/` route that was broken in a recent change in [PR 3010](https://github.com/gradio-app/gradio/pull/3010) 
 * Fix bug where the Image component could not serialize image urls by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 2957](https://github.com/gradio-app/gradio/pull/2957)  
+* Fix forwarding for guides after SEO renaming by [@aliabd](https://github.com/aliabd) in [PR 3017](https://github.com/gradio-app/gradio/pull/3017)
 
 ## Documentation Changes:
 * SEO improvements to guides by[@aliabd](https://github.com/aliabd) in [PR 2915](https://github.com/gradio-app/gradio/pull/2915)

--- a/website/homepage/nginx.conf
+++ b/website/homepage/nginx.conf
@@ -46,144 +46,144 @@ server {
         return 301 /integrating-other-frameworks;
     }
 
-    location /controlling_layout.md {
-	    return 301 /controlling-layout.md;
+    location /controlling_layout {
+	    return 301 /controlling-layout;
     }
 
-    location /state_in_blocks.md {
-        return 301 /state-in-blocks.md;
+    location /state_in_blocks {
+        return 301 /state-in-blocks;
     }
 
-    location /custom_CSS_and_JS.md {
-        return 301 /custom-CSS-and-JS.md;
+    location /custom_CSS_and_JS {
+        return 301 /custom-CSS-and-JS;
     }
 
-    location /blocks_and_event_listeners.md {
-        return 301 /blocks-and-event-listeners.md;
+    location /blocks_and_event_listeners {
+        return 301 /blocks-and-event-listeners;
     }
 
-    location /using_blocks_like_functions.md {
-        return 301 /using-blocks-like-functions.md;
+    location /using_blocks_like_functions {
+        return 301 /using-blocks-like-functions;
     }
 
-    location /using_flagging.md {
-        return 301 /using-flagging.md;
+    location /using_flagging {
+        return 301 /using-flagging;
     }
 
-    location /named_entity_recognition.md {
-        return 301 /named-entity-recognition.md;
+    location /named_entity_recognition {
+        return 301 /named-entity-recognition;
     }
 
-    location /real_time_speech_recognition.md {
-        return 301 /real-time-speech-recognition.md;
+    location /real_time_speech_recognition {
+        return 301 /real-time-speech-recognition;
     }
 
-    location /developing_faster_with_reload_mode.md {
-        return 301 /developing-faster-with-reload-mode.md;
+    location /developing_faster_with_reload_mode {
+        return 301 /developing-faster-with-reload-mode;
     }
 
-    location /create_your_own_friends_with_a_gan.md {
-        return 301 /create-your-own-friends-with-a-gan.md;
+    location /create_your_own_friends_with_a_gan {
+        return 301 /create-your-own-friends-with-a-gan;
     }
 
-    location /setting_up_a_demo_for_maximum_performance.md {
-        return 301 /setting-up-a-demo-for-maximum-performance.md;
+    location /setting_up_a_demo_for_maximum_performance {
+        return 301 /setting-up-a-demo-for-maximum-performance;
     }
 
-    location /building_a_pictionary_app.md {
-        return 301 /building-a-pictionary-app.md;
+    location /building_a_pictionary_app {
+        return 301 /building-a-pictionary-app;
     }
 
-    location /creating_a_chatbot.md {
-        return 301 /creating-a-chatbot.md;
+    location /creating_a_chatbot {
+        return 301 /creating-a-chatbot;
     }
 
-    location /how_to_use_3D_model_component.md {
-        return 301 /how-to-use-3D-model-component.md;
+    location /how_to_use_3D_model_component {
+        return 301 /how-to-use-3D-model-component;
     }
 
-    location /creating_a_new_component.md {
-        return 301 /creating-a-new-component.md;
+    location /creating_a_new_component {
+        return 301 /creating-a-new-component;
     }
 
-    location /running_background_tasks.md {
-        return 301 /running-background-tasks.md;
+    location /running_background_tasks {
+        return 301 /running-background-tasks;
     }
 
-    location /custom_interpretations_with_blocks.md {
-        return 301 /custom-interpretations-with-blocks.md;
+    location /custom_interpretations_with_blocks {
+        return 301 /custom-interpretations-with-blocks;
     }
 
-    location /reactive_interfaces.md {
-        return 301 /reactive-interfaces.md;
+    location /reactive_interfaces {
+        return 301 /reactive-interfaces;
     }
 
-    location /more_on_examples_and_flagging.md {
-        return 301 /more-on-examples.md;
+    location /more_on_examples_and_flagging {
+        return 301 /more-on-examples;
     }
 
-    location /interface_state.md {
-        return 301 /interface-state.md;
+    location /interface_state {
+        return 301 /interface-state;
     }
 
-    location /advanced_interface_features.md {
-        return 301 /advanced-interface-features.md;
+    location /advanced_interface_features {
+        return 301 /advanced-interface-features;
     }
 
-    location /key_features.md {
-        return 301 /key-features.md;
+    location /key_features {
+        return 301 /key-features;
     }
 
-    location /quickstart.md {
-        return 301 /quickstart.md;
+    location /quickstart {
+        return 301 /quickstart;
     }
 
-    location /sharing_your_app.md {
-        return 301 /sharing-your-app.md;
+    location /sharing_your_app {
+        return 301 /sharing-your-app;
     }
 
-    location /connecting_to_a_database.md {
-        return 301 /connecting-to-a-database.md;
+    location /connecting_to_a_database {
+        return 301 /connecting-to-a-database;
     }
 
-    location /creating_a_realtime_dashboard_from_google_sheets.md {
-        return 301 /creating-a-realtime-dashboard-from-google-sheets.md;
+    location /creating_a_realtime_dashboard_from_google_sheets {
+        return 301 /creating-a-realtime-dashboard-from-google-sheets;
     }
 
-    location /plot_component_for_maps.md {
-        return 301 /plot-component-for-maps.md;
+    location /plot_component_for_maps {
+        return 301 /plot-component-for-maps;
     }
 
-    location /creating_a_dashboard_from_bigquery_data.md {
-        return 301 /creating-a-dashboard-from-bigquery-data.md;
+    location /creating_a_dashboard_from_bigquery_data {
+        return 301 /creating-a-dashboard-from-bigquery-data;
     }
 
-    location /using_gradio_for_tabular_workflows.md {
-        return 301 /using-gradio-for-tabular-workflows.md;
+    location /using_gradio_for_tabular_workflows {
+        return 301 /using-gradio-for-tabular-workflows;
     }
 
-    location /image_classification_in_pytorch.md {
-        return 301 /image-classification-in-pytorch.md;
+    location /image_classification_in_pytorch {
+        return 301 /image-classification-in-pytorch;
     }
 
-    location /using_hugging_face_integrations.md {
-        return 301 /using-hugging-face-integrations.md;
+    location /using_hugging_face_integrations {
+        return 301 /using-hugging-face-integrations;
     }
 
-    location /Gradio_and_ONNX_on_Hugging_Face.md {
-        return 301 /Gradio-and-ONNX-on-Hugging-Face.md;
+    location /Gradio_and_ONNX_on_Hugging_Face {
+        return 301 /Gradio-and-ONNX-on-Hugging-Face;
     }
 
-    location /image_classification_with_vision_transformers.md {
-        return 301 /image-classification-with-vision-transformers.md;
+    location /image_classification_with_vision_transformers {
+        return 301 /image-classification-with-vision-transformers;
     }
 
-    location /Gradio_and_Wandb_Integration.md {
-        return 301 /Gradio-and-Wandb-Integration.md;
+    location /Gradio_and_Wandb_Integration {
+        return 301 /Gradio-and-Wandb-Integration;
     }
 
-    location /image_classification_in_tensorflow.md {
-        return 301 /image-classification-in-tensorflow.md;
+    location /image_classification_in_tensorflow {
+        return 301 /image-classification-in-tensorflow;
     }
     
     error_page  404              /404.html;


### PR DESCRIPTION
Fixes a mistake in the nginx where `.md` was kept in the rules