### PR TITLE
Hide upload component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ By [@dawoodkhan82](https://github.com/dawoodkhan82) in [PR 3014](https://github.
 * Fix bug where the queue was not properly restarted after launching a `closed` app by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3022](https://github.com/gradio-app/gradio/pull/3022)
 * Adding missing embedded components on docs by [@aliabd](https://github.com/aliabd) in [PR 3027](https://github.com/gradio-app/gradio/pull/3027)
 * Fixes bug where app would crash if the `file_types` parameter of `gr.File` or `gr.UploadButton` was not a list by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3048](https://github.com/gradio-app/gradio/pull/3048)    
+* Fix bug where input component was not hidden in the frontend for `UploadButton` by  [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3053](https://github.com/gradio-app/gradio/pull/3053)
 
 ## Documentation Changes:
 * SEO improvements to guides by[@aliabd](https://github.com/aliabd) in [PR 2915](https://github.com/gradio-app/gradio/pull/2915)

--- a/ui/packages/upload-button/src/UploadButton.svelte
+++ b/ui/packages/upload-button/src/UploadButton.svelte
@@ -74,7 +74,7 @@
 </script>
 
 <input
-	class="hidden-upload"
+	class="hide"
 	accept={accept_file_types}
 	type="file"
 	bind:this={hidden_upload}
@@ -96,7 +96,7 @@
 </Button>
 
 <style>
-	.hidden-upload {
+	.hide {
 		display: none;
 	}
 </style>

--- a/ui/packages/upload-button/src/UploadButton.svelte
+++ b/ui/packages/upload-button/src/UploadButton.svelte
@@ -74,7 +74,7 @@
 </script>
 
 <input
-	class="hidden-upload hidden"
+	class="hidden-upload"
 	accept={accept_file_types}
 	type="file"
 	bind:this={hidden_upload}
@@ -94,3 +94,9 @@
 >
 	<slot />
 </Button>
+
+<style>
+	.hidden-upload {
+		display: none;
+	}
+</style>


### PR DESCRIPTION
# Description

In the move away from tailwind, we forgot to keep the file upload `input` component hidden for `FileUpload`

### Main

https://huggingface.co/spaces/gradio/upload_button_main

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/41651716/214534261-c968b406-b72d-49c5-87ad-29d316035549.png">


### This branch
<img width="1463" alt="image" src="https://user-images.githubusercontent.com/41651716/214534178-426045e8-f95c-470f-99b8-943a177bbc7e.png">


Closes: # (issue)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.