### PR TITLE
Preserve Gallery selected image through updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ By [@dawoodkhan82](https://github.com/dawoodkhan82) in [PR 3014](https://github.
 * Adding missing embedded components on docs by [@aliabd](https://github.com/aliabd) in [PR 3027](https://github.com/gradio-app/gradio/pull/3027)
 * Fixes bug where app would crash if the `file_types` parameter of `gr.File` or `gr.UploadButton` was not a list by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3048](https://github.com/gradio-app/gradio/pull/3048)    
 * Fix bug where input component was not hidden in the frontend for `UploadButton` by  [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3053](https://github.com/gradio-app/gradio/pull/3053)
+* Preserve selected image of Gallery through updated by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3061](https://github.com/gradio-app/gradio/pull/3061) 
 
 ## Documentation Changes:
 * SEO improvements to guides by[@aliabd](https://github.com/aliabd) in [PR 2915](https://github.com/gradio-app/gradio/pull/2915)

--- a/ui/packages/gallery/src/Gallery.svelte
+++ b/ui/packages/gallery/src/Gallery.svelte
@@ -28,7 +28,11 @@
 	let prevValue: string[] | FileData[] | null = null;
 	let selected_image: number | null = null;
 	$: if (prevValue !== value) {
-		selected_image = null;
+		// so that gallery preserves selected image after update
+		selected_image =
+			selected_image !== null && value !== null && selected_image < value.length
+				? selected_image
+				: null;
 		prevValue = value;
 	}
 


### PR DESCRIPTION
# Description

Fixes #2984 

If the gallery is updated, we'll preserve the selected index if it corresponds to an image in the new gallery. If not, we'll revert to no image being defined.

To test,

```python
import random
import time

import gradio as gr
from PIL import Image

with gr.Blocks(analytics_enabled=False) as demo:
    go = gr.Button('Go', variant="primary")
    gallery = gr.Gallery().style(grid=12)

    def create_images(n_images):
        a = Image.new("RGB", (512, 512), "red")
        b = Image.new("RGB", (512, 512), "green")
        c = Image.new("RGB", (512, 512), "blue")

        res = [a, b, c][:n_images]
        random.shuffle(res)
        return res
    
    n_images = gr.Slider(value=3, minimum=1, maximum=3, step=1)

    go.click(
        fn=create_images,
        inputs=[n_images],
        outputs=[gallery],
    )

demo.launch(share=False)
```


![gallery_selection_fix](https://user-images.githubusercontent.com/41651716/214697853-ffd5dc85-81d1-4151-ada9-ebc67baa4978.gif)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.