### PR TITLE
add argument to allow serving files from additional directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ properly!
 
 By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3089](https://github.com/gradio-app/gradio/pull/3089) 
 
+
+### Allow serving files from additional directories
+
+```python
+demo = gr.Interface(...)
+demo.launch(
+  file_directories=["/var/lib/demo/path/to/resources"]
+)
+```
+
+By [@maxaudron](https://github.com/maxaudron) in [PR 3075](https://github.com/gradio-app/gradio/pull/3075) 
+
 ## Bug Fixes:
 - Fixes URL resolution on Windows by [@abidlabs](https://github.com/abidlabs) in [PR 3108](https://github.com/gradio-app/gradio/pull/3108) 
 - Ensure the Video component correctly resets the UI state whe a new video source is loaded and reduce choppiness of UI by [@pngwn](https://github.com/abidlabs) in [PR 3117](https://github.com/gradio-app/gradio/pull/3117)

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -513,6 +513,8 @@ class Blocks(BlockContext):
         self.api_mode = None
         self.progress_tracking = None
 
+        self.file_directories = []
+
         if self.analytics_enabled:
             data = {
                 "mode": self.mode,
@@ -1259,6 +1261,7 @@ class Blocks(BlockContext):
         ssl_keyfile_password: str | None = None,
         quiet: bool = False,
         show_api: bool = True,
+        file_directories: List[str] | None = None,
         _frontend: bool = True,
     ) -> Tuple[FastAPI, str, str]:
         """
@@ -1288,6 +1291,7 @@ class Blocks(BlockContext):
             ssl_keyfile_password: If a password is provided, will use this with the ssl certificate for https.
             quiet: If True, suppresses most print statements.
             show_api: If True, shows the api docs in the footer of the app. Default True. If the queue is enabled, then api_open parameter of .queue() will determine if the api docs are shown, independent of the value of show_api.
+            file_directories: List of directories that gradio is allowed to serve files from (in addition to the directory containing the gradio script). Must be absolute paths. Warning: these files are exposed to all users of your app.
         Returns:
             app: FastAPI app object that is running the demo
             local_url: Locally accessible link to the demo
@@ -1330,6 +1334,8 @@ class Blocks(BlockContext):
         if self.enable_queue and not hasattr(self, "_queue"):
             self.queue()
         self.show_api = self.api_open if self.enable_queue else show_api
+
+        self.file_directories = file_directories if file_directories is not None else []
 
         if not self.enable_queue and self.progress_tracking:
             raise ValueError("Progress tracking requires queuing to be enabled.")

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1291,7 +1291,7 @@ class Blocks(BlockContext):
             ssl_keyfile_password: If a password is provided, will use this with the ssl certificate for https.
             quiet: If True, suppresses most print statements.
             show_api: If True, shows the api docs in the footer of the app. Default True. If the queue is enabled, then api_open parameter of .queue() will determine if the api docs are shown, independent of the value of show_api.
-            file_directories: List of directories that gradio is allowed to serve files from (in addition to the directory containing the gradio script). Must be absolute paths. Warning: these files are exposed to all users of your app.
+            file_directories: List of directories that gradio is allowed to serve files from (in addition to the directory containing the gradio python file). Must be absolute paths. Warning: any files in these directories or its children are potentially accessible to all users of your app.
         Returns:
             app: FastAPI app object that is running the demo
             local_url: Locally accessible link to the demo

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -274,7 +274,14 @@ class App(FastAPI):
             created_by_app = str(utils.abspath(path_or_url)) in set().union(
                 *blocks.temp_file_sets
             )
-            if in_app_dir or created_by_app:
+            in_file_dir = any(
+                (
+                    utils.abspath(dir) in utils.abspath(path_or_url).parents
+                    for dir in blocks.file_directories
+                )
+            )
+
+            if in_app_dir or created_by_app or in_file_dir:
                 range_val = request.headers.get("Range", "").strip()
                 if range_val.startswith("bytes=") and "-" in range_val:
                     range_val = range_val[6:]

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -2,6 +2,7 @@
 import json
 import os
 import sys
+import tempfile
 from unittest.mock import patch
 
 import numpy as np
@@ -179,6 +180,21 @@ class TestRoutes:
         )
         output = dict(response.json())
         assert output["data"] == ["testtest", None]
+
+    def test_get_file_allowed_by_file_directories(self):
+        allowed_file = tempfile.NamedTemporaryFile(mode="w")
+        allowed_file.write(media_data.BASE64_IMAGE)
+        allowed_file.flush()
+
+        app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
+            prevent_thread_lock=True,
+            file_directories=[os.path.dirname(allowed_file.name)],
+        )
+        client = TestClient(app)
+
+        file_response = client.get(f"/file={allowed_file.name}")
+        assert file_response.status_code == 200
+        assert len(file_response.text) == len(media_data.BASE64_IMAGE)
 
     def test_get_file_created_by_app(self):
         app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -182,9 +182,17 @@ class TestRoutes:
         assert output["data"] == ["testtest", None]
 
     def test_get_file_allowed_by_file_directories(self):
-        allowed_file = tempfile.NamedTemporaryFile(mode="w")
+        allowed_file = tempfile.NamedTemporaryFile(mode="w", delete=False)
         allowed_file.write(media_data.BASE64_IMAGE)
         allowed_file.flush()
+
+        app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
+            prevent_thread_lock=True,
+        )
+        client = TestClient(app)
+
+        with pytest.raises(ValueError):
+            file_response = client.get(f"/file={allowed_file.name}")
 
         app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
             prevent_thread_lock=True,


### PR DESCRIPTION
# Description

Add the `file_directories` argument to allow serving files from additional directories.
I was working on separating user data from source code for AUTOMATIC1111/stable-diffusion-webui to a directory external to the source and ran into trouble with various files the webui tries to serve from these locations.

# Checklist:

- [X] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes