### PR TITLE
Update docs to explain how reload mode can be used with queue/auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -930,7 +930,7 @@ demo.queue().launch()
 No changes to highlight.
 
 ## Documentation Changes:
-No changes to highlight.
+* Explained how to set up `queue` and `auth` when working with reload mode by by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3089](https://github.com/gradio-app/gradio/pull/3089) 
 
 ## Testing and Infrastructure Changes:
 No changes to highlight.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,24 @@
 # Upcoming Release
 
 ## New Features:
-No changes to highlight.
+
+### Queue now works with reload mode!
+
+You can now call `queue` on your `demo` outside of the `if __name__ == "__main__"` block and
+run the script in reload mode with the `gradio` command. 
+
+Any changes to the `app.py` file will be reflected in the webpage automatically and the queue will work
+properly!
+
+
+By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3089](https://github.com/gradio-app/gradio/pull/3089) 
 
 ## Bug Fixes:
 No changes to highlight.
 
 ## Documentation Changes:
 - Added a guide on the 4 kinds of Gradio Interfaces by [@yvrjsharma](https://github.com/yvrjsharma) and [@abidlabs](https://github.com/abidlabs) in [PR 3003](https://github.com/gradio-app/gradio/pull/3003) 
+* Explained that the parameters in `launch` will not be respected when using reload mode, e.g. `gradio` command  by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3089](https://github.com/gradio-app/gradio/pull/3089) 
 
 ## Testing and Infrastructure Changes:
 No changes to highlight.

--- a/demo/calculator_blocks/run.py
+++ b/demo/calculator_blocks/run.py
@@ -15,7 +15,7 @@ def calculator(num1, operation, num2):
 with gr.Blocks() as demo:
     with gr.Row():
         with gr.Column():
-            num_1 = gr.Number(value=6)
+            num_1 = gr.Number(value=4)
             operation = gr.Radio(["add", "subtract", "multiply", "divide"])
             num_2 = gr.Number(value=0)
             submit_btn = gr.Button(value="Calculate")
@@ -29,7 +29,5 @@ with gr.Blocks() as demo:
                                      [0, "subtract", 1.2]],
                            inputs=[num_1, operation, num_2])
 
-demo.queue().launch(auth=("foo", "foo"), auth_message="Please log in.")
-
-# if __name__ == "__main__":
-#     demo.launch()
+if __name__ == "__main__":
+    demo.launch()

--- a/demo/calculator_blocks/run.py
+++ b/demo/calculator_blocks/run.py
@@ -15,7 +15,7 @@ def calculator(num1, operation, num2):
 with gr.Blocks() as demo:
     with gr.Row():
         with gr.Column():
-            num_1 = gr.Number(value=4)
+            num_1 = gr.Number(value=6)
             operation = gr.Radio(["add", "subtract", "multiply", "divide"])
             num_2 = gr.Number(value=0)
             submit_btn = gr.Button(value="Calculate")
@@ -29,5 +29,7 @@ with gr.Blocks() as demo:
                                      [0, "subtract", 1.2]],
                            inputs=[num_1, operation, num_2])
 
-if __name__ == "__main__":
-    demo.launch()
+demo.queue().launch(auth=("foo", "foo"), auth_message="Please log in.")
+
+# if __name__ == "__main__":
+#     demo.launch()

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1232,6 +1232,7 @@ class Blocks(BlockContext):
             blocks_dependencies=self.dependencies,
         )
         self.config = self.get_config_file()
+        self.app = routes.App.create_app(self)
         return self
 
     def launch(

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -479,6 +479,7 @@ class App(FastAPI):
         async def get_queue_status():
             return app.get_blocks()._queue.get_estimation()
 
+        @app.on_event("startup")
         @app.get("/startup-events")
         async def startup_events():
             if not app.startup_events_triggered:

--- a/guides/06_other-tutorials/developing-faster-with-reload-mode.md
+++ b/guides/06_other-tutorials/developing-faster-with-reload-mode.md
@@ -54,10 +54,7 @@ The important part here is the line that says `Watching...` What's happening her
 
 As a small aside, this auto-reloading happens if you change your `app.py` source code or the Gradio source code. Meaning that this can be useful if you decide to [contribute to Gradio itself](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) ✅
 
-⚠️ It is customary to configure the behavior of your gradio app via the `launch()` or `queue()` methods. For example, setting `auth`, or `show_error` in `launch()`. If this is the case, make sure that these methods are
-called **outside** of the `if __name__ == "__main__":` block, otherwise the `gradio` command will not know the 
-value of these parameters. You may have to manually reload the web browser page yourself, but it will reflect
-the latest changes of your `app.py` file!
+⚠️ The `gradio` command will not detect the parameters passed to the `launch()` methods. For example, setting `auth`, or `show_error` in `launch()` will not be reflected in the app.
 
 ## Jupyter Notebook Magic 🔮
 

--- a/guides/06_other-tutorials/developing-faster-with-reload-mode.md
+++ b/guides/06_other-tutorials/developing-faster-with-reload-mode.md
@@ -54,6 +54,10 @@ The important part here is the line that says `Watching...` What's happening her
 
 As a small aside, this auto-reloading happens if you change your `app.py` source code or the Gradio source code. Meaning that this can be useful if you decide to [contribute to Gradio itself](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) ✅
 
+⚠️ It is customary to configure the behavior of your gradio app via the `launch()` or `queue()` methods. For example, setting `auth`, or `show_error` in `launch()`. If this is the case, make sure that these methods are
+called **outside** of the `if __name__ == "__main__":` block, otherwise the `gradio` command will not know the 
+value of these parameters.
+
 ## Jupyter Notebook Magic 🔮
 
 What about if you use Jupyter Notebooks (or Colab Notebooks, etc.) to develop code? We got something for you too!

--- a/guides/06_other-tutorials/developing-faster-with-reload-mode.md
+++ b/guides/06_other-tutorials/developing-faster-with-reload-mode.md
@@ -56,7 +56,8 @@ As a small aside, this auto-reloading happens if you change your `app.py` source
 
 ⚠️ It is customary to configure the behavior of your gradio app via the `launch()` or `queue()` methods. For example, setting `auth`, or `show_error` in `launch()`. If this is the case, make sure that these methods are
 called **outside** of the `if __name__ == "__main__":` block, otherwise the `gradio` command will not know the 
-value of these parameters.
+value of these parameters. You may have to manually reload the web browser page yourself, but it will reflect
+the latest changes of your `app.py` file!
 
 ## Jupyter Notebook Magic 🔮
 


### PR DESCRIPTION
# Description

Fixes #2158
Fixes #1883

I noticed that if you call  `launch(....)` outside of the `if __name__ == "__main__"` block, then the `gradio` reload command will properly pick up whether or not the queue should be enabled as well as `auth` and the other `launch`-related parameters.

The downside is that the page will not reload automatically, but if you reload it yourself, it will reflect the latest state of `app.py`.

I don't think this is too annoying and it beats having to refactor the `launch` method to properly work with reload mode so I'm proposing we just update the docs to explain this behavior and call it a day.

Let me know if you agree!


The script I used to test

```python
import gradio as gr


def calculator(num1, operation, num2):
    if operation == "add":
        return num1 + num2
    elif operation == "subtract":
        return num1 - num2
    elif operation == "multiply":
        return num1 * num2
    elif operation == "divide":
        return num1 / num2


with gr.Blocks() as demo:
    with gr.Row():
        with gr.Column():
            num_1 = gr.Number(value=6)
            operation = gr.Radio(["add", "subtract", "multiply", "divide"])
            num_2 = gr.Number(value=0)
            submit_btn = gr.Button(value="Calculate")
        with gr.Column():
            result = gr.Number()

    submit_btn.click(calculator, inputs=[num_1, operation, num_2], outputs=[result])
    examples = gr.Examples(examples=[[5, "add", 3],
                                     [4, "divide", 2],
                                     [-4, "multiply", 2.5],
                                     [0, "subtract", 1.2]],
                           inputs=[num_1, operation, num_2])

demo.queue().launch(auth=("foo", "foo"), auth_message="Please log in.")
```

### Working with auth
![reload_with_auth_and_queue](https://user-images.githubusercontent.com/41651716/215601074-6c364a9a-b119-4b3d-9975-ce20dcd0465e.gif)

### Reflect latest app.py after manual refresh

![reload_working_queue](https://user-images.githubusercontent.com/41651716/215601164-5012920d-6361-4604-a6ae-fd0e8b529f06.gif)

### Docs changes
![image](https://user-images.githubusercontent.com/41651716/215602026-77f6e34b-fca0-4cb8-bee8-f86d180e002c.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.