### PR TITLE
Fix example gallery mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Previously photos uploaded via iOS would be rotated after processing. This has b
 
 
 ## Bug Fixes:
-No changes to highlight.
+* Fix bug where examples were not rendered correctly for demos created with Blocks api that had multiple input compinents by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3090](https://github.com/gradio-app/gradio/pull/3090)  
 
 ## Documentation Changes:
 No changes to highlight.

--- a/ui/packages/app/src/components/Dataset/Dataset.svelte
+++ b/ui/packages/app/src/components/Dataset/Dataset.svelte
@@ -18,7 +18,7 @@
 
 	let samples_dir: string = (root_url ?? root) + "file=";
 	let page = 0;
-	$: gallery = headers.length < 2;
+	$: gallery = components.length < 2;
 	let paginate = samples.length > samples_per_page;
 
 	let selected_samples: Array<Array<any>>;


### PR DESCRIPTION
# Description

If you run `calculator_blocks` demo, you'll notice that the examples are rendered in "gallery" mode, e.g. a single clickable button, as opposed to a table, which is the right behavior as we have examples for more than one component.

This is because the `Dataset` class is determining whether to use "gallery" mode based on the value of the "headers" array, but that array can be empty if none of the components have labels. Which can be common since the default is for the label to be None.

This PR proposes that we determine whether to use "gallery" mode depending on the length of the `components` array.

### main branch
![image](https://user-images.githubusercontent.com/41651716/215606378-387127b9-f6ba-4bdf-87c1-852166d74957.png)


### this pr
![image](https://user-images.githubusercontent.com/41651716/215606315-75754eef-e57c-4440-a613-08944b4bd880.png)


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.