### PR TITLE
Fix change event listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 No changes to highlight.
 
 ## Bug Fixes:
-No changes to highlight.
+- Fix change event listener for JSON, HighlightedText, Chatbot by [@aliabid94](https://github.com/aliabid94) in [PR 3095](https://github.com/gradio-app/gradio/pull/3095)
 
 ## Documentation Changes:
 No changes to highlight.

--- a/ui/packages/app/src/components/HighlightedText/HighlightedText.svelte
+++ b/ui/packages/app/src/components/HighlightedText/HighlightedText.svelte
@@ -10,6 +10,7 @@
 	export let elem_id: string = "";
 	export let visible: boolean = true;
 	export let value: Array<[string, string | number]>;
+	let old_value: Array<[string, string | number]>;
 	export let show_legend: boolean;
 	export let color_map: Record<string, string> = {};
 	export let label: string;
@@ -23,7 +24,12 @@
 
 	const dispatch = createEventDispatcher<{ change: undefined }>();
 
-	$: value, dispatch("change");
+	$: {
+		if (value !== old_value) {
+			old_value = value;
+			dispatch("change");
+		}
+	}
 </script>
 
 <Block

--- a/ui/packages/app/src/components/Json/Json.svelte
+++ b/ui/packages/app/src/components/Json/Json.svelte
@@ -12,13 +12,19 @@
 	export let elem_id: string = "";
 	export let visible: boolean = true;
 	export let value: any;
+	let old_value: any;
 	export let loading_status: LoadingStatus;
 	export let label: string;
 	export let style: Styles = {};
 
 	const dispatch = createEventDispatcher<{ change: undefined }>();
 
-	$: value, dispatch("change");
+	$: {
+		if (value !== old_value) {
+			old_value = value;
+			dispatch("change");
+		}
+	}
 </script>
 
 <Block

--- a/ui/packages/chatbot/src/ChatBot.svelte
+++ b/ui/packages/chatbot/src/ChatBot.svelte
@@ -4,6 +4,7 @@
 	import type { Styles } from "@gradio/utils";
 
 	export let value: Array<[string, string]> | null;
+	let old_value: Array<[string, string]> | null;
 	export let style: Styles = {};
 	export let pending_message: boolean = false;
 
@@ -29,7 +30,12 @@
 		}
 	});
 
-	$: value && dispatch("change");
+	$: {
+		if (value !== old_value) {
+			old_value = value;
+			dispatch("change");
+		}
+	}
 
 	$: _colors = get_colors();
 


### PR DESCRIPTION
Change event listener was broken on a couple components that simply check for a change in value if the value type is an object. Basically this line:
```javascript
$: value: dispatch("change")
```
will lead to an infinite loop if the value type is an object. See #3056 for example code that causes this bug. 

The reason for this infinite loop is because in a change event listener loop:
1. the value changes, which 
2. fires the event listener, which 
3. triggers a re-render of the whole tree, which 
4. will create a new value object for all components. Values for primitives are still === to their previous values, but objects will not be considered equivalent to their previous values (they have the same internal values to their previous values, but not are not ===). 
5. This causes another dispatch("change"), which repeats the cycle.

Fixes: #3056
