### PR TITLE
Enable gradio to work on kaggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Previously photos uploaded via iOS would be rotated after processing. This has b
 #### After
 ![image](https://user-images.githubusercontent.com/41651716/215846554-e41773ed-70f0-491a-9952-6a18babf91ef.png)
 
+### Run on Kaggle kernels 🧪
+
+A share link will automatically be created when running on Kaggle kernels (notebooks) so that
+the front-end is properly displayed. 
+
+
+By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3101](https://github.com/gradio-app/gradio/pull/3101)
 
 ## Bug Fixes:
 - Fix change event listener for JSON, HighlightedText, Chatbot by [@aliabid94](https://github.com/aliabid94) in [PR 3095](https://github.com/gradio-app/gradio/pull/3095)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Previously photos uploaded via iOS would be rotated after processing. This has b
 A share link will automatically be created when running on Kaggle kernels (notebooks) so that
 the front-end is properly displayed. 
 
+![image](https://user-images.githubusercontent.com/41651716/216104254-2cf55599-449c-436c-b57e-40f6a83f9eee.png)
 
 By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3101](https://github.com/gradio-app/gradio/pull/3101)
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1383,6 +1383,7 @@ class Blocks(BlockContext):
             self.server = server
             self.is_running = True
             self.is_colab = utils.colab_check()
+            self.is_kaggle = utils.kaggle_check()
             self.protocol = (
                 "https"
                 if self.local_url.startswith("https") or self.is_colab
@@ -1405,7 +1406,7 @@ class Blocks(BlockContext):
             share
             if share is not None
             else True
-            if self.is_colab and self.enable_queue
+            if (self.is_colab and self.enable_queue) or self.is_kaggle
             else False
         )
 

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -190,7 +190,9 @@ def colab_check() -> bool:
 
 
 def kaggle_check() -> bool:
-    return bool(os.environ.get('KAGGLE_KERNEL_RUN_TYPE') or os.environ.get('GFOOTBALL_DATA_DIR'))
+    return bool(
+        os.environ.get("KAGGLE_KERNEL_RUN_TYPE") or os.environ.get("GFOOTBALL_DATA_DIR")
+    )
 
 
 def ipython_check() -> bool:

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -189,6 +189,10 @@ def colab_check() -> bool:
     return is_colab
 
 
+def kaggle_check() -> bool:
+    return bool(os.environ.get('KAGGLE_KERNEL_RUN_TYPE') or os.environ.get('GFOOTBALL_DATA_DIR'))
+
+
 def ipython_check() -> bool:
     """
     Check if interface is launching from iPython (not colab)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -29,6 +29,7 @@ from gradio.utils import (
     format_ner_list,
     get_local_ip_address,
     ipython_check,
+    kaggle_check,
     launch_analytics,
     readme_to_html,
     sanitize_list_for_csv,
@@ -102,6 +103,31 @@ class TestUtils:
 
     def test_readme_to_html_correct_parse(self):
         readme_to_html("https://github.com/gradio-app/gradio/blob/master/README.md")
+
+    def test_kaggle_check_false(self):
+        assert not kaggle_check()
+
+    def test_kaggle_check_true_when_run_type_set(self):
+        with mock.patch.dict(
+            os.environ, {"KAGGLE_KERNEL_RUN_TYPE": "Interactive"}, clear=True
+        ):
+            assert kaggle_check()
+
+    def test_kaggle_check_true_when_both_set(self):
+        with mock.patch.dict(
+            os.environ,
+            {"KAGGLE_KERNEL_RUN_TYPE": "Interactive", "GFOOTBALL_DATA_DIR": "./"},
+            clear=True,
+        ):
+            assert kaggle_check()
+
+    def test_kaggle_check_false_when_neither_set(self):
+        with mock.patch.dict(
+            os.environ,
+            {"KAGGLE_KERNEL_RUN_TYPE": "", "GFOOTBALL_DATA_DIR": ""},
+            clear=True,
+        ):
+            assert not kaggle_check()
 
 
 class TestIPAddress:


### PR DESCRIPTION
# Description

Enable gradio to run on kaggle notebooks via share link


Test with this notebook: https://www.kaggle.com/code/freddyboultonhf/kaggle-gradio-share

Basically install this gradio build: https://gradio-builds.s3.amazonaws.com/kaggle-launch/attempt-1/gradio-3.17.0-py3-none-any.whl

![image](https://user-images.githubusercontent.com/41651716/215827002-580005f2-1805-4543-8da1-7a55ba97499c.png)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.