### PR TITLE
Emit warning when using an interface in reload mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3089](https://git
 ## Bug Fixes:
 - Fixes URL resolution on Windows by [@abidlabs](https://github.com/abidlabs) in [PR 3108](https://github.com/gradio-app/gradio/pull/3108) 
 - Ensure the Video component correctly resets the UI state whe a new video source is loaded and reduce choppiness of UI by [@pngwn](https://github.com/abidlabs) in [PR 3117](https://github.com/gradio-app/gradio/pull/3117)
+- Added a warning when attempting to launch an `Interface` via the `%%blocks` jupyter notebook magic command by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3126](https://github.com/gradio-app/gradio/pull/3126)
 
 ## Documentation Changes:
 - Added a guide on the 4 kinds of Gradio Interfaces by [@yvrjsharma](https://github.com/yvrjsharma) and [@abidlabs](https://github.com/abidlabs) in [PR 3003](https://github.com/gradio-app/gradio/pull/3003) 
-* Explained that the parameters in `launch` will not be respected when using reload mode, e.g. `gradio` command  by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3089](https://github.com/gradio-app/gradio/pull/3089) 
+* Explained that the parameters in `launch` will not be respected when using reload mode, e.g. `gradio` command by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3089](https://github.com/gradio-app/gradio/pull/3089) 
 
 ## Testing and Infrastructure Changes:
 No changes to highlight.

--- a/gradio/ipython_ext.py
+++ b/gradio/ipython_ext.py
@@ -3,6 +3,8 @@ try:
 except ImportError:
     pass
 
+import warnings
+
 import gradio
 
 
@@ -12,6 +14,8 @@ def load_ipython_extension(ipython):
     @register_cell_magic
     @needs_local_scope
     def blocks(line, cell, local_ns=None):
+        if "gr.Interface" in cell:
+            warnings.warn("Usage of gr.Interface with %%blocks may result in errors.")
         with __demo.clear():
             exec(cell, None, local_ns)
             __demo.launch(quiet=True)


### PR DESCRIPTION
# Description

Fixes #3035 by emitting a warning when a cell run with `%%blocks` has an Interface. 

Can't think of a way to fix the issue in a backwards compatible way. 

I tried skipping the duplicate id check for the magic command but then the demo rendering is messed up (as expected). See below with the code from the reproducer in the original issue:

![image](https://user-images.githubusercontent.com/41651716/216719071-01673134-22f7-469b-8a7f-ed4421fc60d0.png)

If you already have a full Interface or blocks app defined, the benefit of the %%blocks magic as opposed to re-running the cell is marginal in my opinion. 

What the warning looks like from jupyter

![image](https://user-images.githubusercontent.com/41651716/216719687-9e2792fe-63e0-4ca3-911d-cde666353caa.png)



# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.