### PR TITLE
Sagemaker check

### DIFF
--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -195,6 +195,16 @@ def kaggle_check() -> bool:
     )
 
 
+def sagemaker_check() -> bool:
+    try:
+        import boto3
+        client = boto3.client("sts")
+        response = client.get_caller_identity()        
+        return "sagemaker" in response["Arn"].lower()
+    except:
+        return False
+
+
 def ipython_check() -> bool:
     """
     Check if interface is launching from iPython (not colab)


### PR DESCRIPTION
Similar to the Kaggle check, this PR adds a check to determine if the script is running on a Sagemaker instance and if so, creates a share link automatically. Closes: #399 