### PR TITLE
Fix examples pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ By [@maxaudron](https://github.com/maxaudron) in [PR 3075](https://github.com/gr
 - Fixes loading private Spaces by [@abidlabs](https://github.com/abidlabs) in [PR 3068](https://github.com/gradio-app/gradio/pull/3068) 
 - Added a warning when attempting to launch an `Interface` via the `%%blocks` jupyter notebook magic command by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3126](https://github.com/gradio-app/gradio/pull/3126)
 - A share link will automatically be created when running on Sagemaker notebooks so that the front-end is properly displayed by [@abidlabs](https://github.com/abidlabs) in [PR 3137](https://github.com/gradio-app/gradio/pull/3137) 
+- Fixed bug where example pagination buttons were not visible in dark mode or displayed under the examples table. By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3144](https://github.com/gradio-app/gradio/pull/3144) 
 
 ## Documentation Changes:
 - Added a guide on the 4 kinds of Gradio Interfaces by [@yvrjsharma](https://github.com/yvrjsharma) and [@abidlabs](https://github.com/abidlabs) in [PR 3003](https://github.com/gradio-app/gradio/pull/3003) 

--- a/ui/packages/app/src/components/Dataset/Dataset.svelte
+++ b/ui/packages/app/src/components/Dataset/Dataset.svelte
@@ -159,24 +159,24 @@
 			</table>
 		</div>
 	{/if}
+	{#if paginate}
+		<div class="paginate">
+			Pages:
+			{#each visible_pages as visible_page}
+				{#if visible_page === -1}
+					<div>...</div>
+				{:else}
+					<button
+						class:current-page={page === visible_page}
+						on:click={() => (page = visible_page)}
+					>
+						{visible_page + 1}
+					</button>
+				{/if}
+			{/each}
+		</div>
+	{/if}
 </div>
-{#if paginate}
-	<div class="paginate">
-		Pages:
-		{#each visible_pages as visible_page}
-			{#if visible_page === -1}
-				<div>...</div>
-			{:else}
-				<button
-					class:current-page={page === visible_page}
-					on:click={() => (page = visible_page)}
-				>
-					{visible_page + 1}
-				</button>
-			{/if}
-		{/each}
-	</div>
-{/if}
 
 <style>
 	.wrap {
@@ -288,6 +288,8 @@
 		justify-content: center;
 		align-items: center;
 		gap: var(--size-2);
+		margin-top: var(--size-2);
+		color: var(--color-text-label);
 		font-size: var(--scale-000);
 	}
 


### PR DESCRIPTION
# Description

Fixes #3136 

There were two problems:
* Font for the pagination buttons in dark mode was black so you could not see them
* If the the examples table was not wide enough, the pagination buttons would be displayed in the same row as opposed to in a new row

Added some padding to the top of the pagination buttons so that they would not be too close to the table.

### Reproducer from issue
![image](https://user-images.githubusercontent.com/41651716/217316088-b8484dbc-34af-4a1f-8c5f-f9d77112d78d.png)


### Example with gallery view + pagination
![image](https://user-images.githubusercontent.com/41651716/217316300-2fe65b90-3047-4cf5-9b37-9359fd6e30d3.png)
```python
import gradio as gr

with gr.Blocks() as demo:
    input_ = gr.Number(label="Input")
    output = gr.Number(label="Input * 2")
    calc = gr.Button(value="Calculate")
    examples = gr.Examples(examples=[[i] for i in range(20)],
                           inputs=[input_],
                           examples_per_page=10)
    calc.click(lambda s: s * 2, input_, output)

demo.launch()
```

### Interface example
![image](https://user-images.githubusercontent.com/41651716/217315905-3c509bed-f1ff-44b8-81bb-8547c07c453c.png)
```python
import gradio as gr

def calculator(num1, operation, num2):
    if operation == "add":
        return num1 + num2
    elif operation == "subtract":
        return num1 - num2
    elif operation == "multiply":
        return num1 * num2
    elif operation == "divide":
        if num2 == 0:
            raise gr.Error("Cannot divide by zero!")
        return num1 / num2

demo = gr.Interface(
    calculator,
    [
        "number", 
        gr.Radio(["add", "subtract", "multiply", "divide"]),
        "number"
    ],
    "number",
    examples=[
        [5, "add", 3],
        [4, "divide", 2],
        [-4, "multiply", 2.5],
        [0, "subtract", 1.2],
    ],
    title="Toy Calculator",
    description="Here's a sample toy calculator. Enjoy!",
    examples_per_page=2
)

if __name__ == "__main__":
    demo.launch()
```

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.