### PR TITLE
Fix darkmode toggle on native plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ By [@maxaudron](https://github.com/maxaudron) in [PR 3075](https://github.com/gr
 - Fixes bug where interactive output image cannot be set when in edit mode by [@dawoodkhan82](https://github.com/freddyaboulton) in [PR 3135](https://github.com/gradio-app/gradio/pull/3135)
 - A share link will automatically be created when running on Sagemaker notebooks so that the front-end is properly displayed by [@abidlabs](https://github.com/abidlabs) in [PR 3137](https://github.com/gradio-app/gradio/pull/3137) 
 - Fixed bug where example pagination buttons were not visible in dark mode or displayed under the examples table. By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3144](https://github.com/gradio-app/gradio/pull/3144) 
+- Fixed bug where the font color of axis labels and titles for native plots did not respond to dark mode preferences. By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3146](https://github.com/gradio-app/gradio/pull/3146) 
 
 ## Documentation Changes:
 - Added a guide on the 4 kinds of Gradio Interfaces by [@yvrjsharma](https://github.com/yvrjsharma) and [@abidlabs](https://github.com/abidlabs) in [PR 3003](https://github.com/gradio-app/gradio/pull/3003) 

--- a/ui/packages/plot/src/utils.ts
+++ b/ui/packages/plot/src/utils.ts
@@ -1,30 +1,30 @@
 import type { Config as VegaConfig } from "vega";
 
-const light = "#e2e8f0";
-const dark = "#111827";
+const dark = "#e2e8f0";
+const light = "#111827";
 
 export function create_config(darkmode: boolean): VegaConfig {
 	return {
 		axis: {
 			labelFont: "sans-serif",
-			labelColor: dark,
+			labelColor: darkmode ? dark : light,
 			titleFont: "sans-serif",
-			titleColor: dark,
+			titleColor: darkmode ? dark : light,
 			tickColor: "#aaa",
 			gridColor: "#aaa",
 			titleFontWeight: "normal",
 			labelFontWeight: "normal"
 		},
 		legend: {
-			labelColor: dark,
+			labelColor: darkmode ? dark : light,
 			labelFont: "sans-serif",
-			titleColor: dark,
+			titleColor: darkmode ? dark : light,
 			titleFont: "sans-serif",
 			titleFontWeight: "normal",
 			labelFontWeight: "normal"
 		},
 		title: {
-			color: dark,
+			color: darkmode ? dark : light,
 			font: "sans-serif",
 			fontWeight: "normal"
 		}


### PR DESCRIPTION
# Description

Toggling between dark and light mode would not switch the font colors used for the native plots. This made it so that you could not read the axis labels and title in dark mode.

This PR fixes that.

Will work with pngwn/ali to get the plots working with the new themes better.

### Before
![native_plot_switch_main](https://user-images.githubusercontent.com/41651716/217357312-ed399ebf-6078-475c-8def-48560d69cd48.gif)

### After
![native_plot_switch](https://user-images.githubusercontent.com/41651716/217357323-5735d385-9531-4b48-b224-1522369bdeab.gif)

You can test with `native_plots` demo.


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.