### PR TITLE
Fix loading files from embedded spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3157](https://git
 
 ## Bug Fixes:
 * Fixes `gr.utils.delete_none` to only remove props whose values are `None` from the config by [@abidlabs](https://github.com/abidlabs) in [PR 3188](https://github.com/gradio-app/gradio/pull/3188) 
+* Fix bug where embedded demos were not loading files properly by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3177](https://github.com/gradio-app/gradio/pull/3177)
 
 ## Documentation Changes:
 * Sort components in docs by alphabetic order by [@aliabd](https://github.com/aliabd) in [PR 3152](https://github.com/gradio-app/gradio/pull/3152)

--- a/ui/packages/upload/src/utils.ts
+++ b/ui/packages/upload/src/utils.ts
@@ -28,7 +28,7 @@ export function normalise_file(
 		}
 	} else if (file.is_file) {
 		if (root_url == null) {
-			file.data = "file=" + file.name;
+			file.data = root + "file=" + file.name;
 		} else {
 			file.data = "proxy=" + root_url + "file=" + file.name;
 		}


### PR DESCRIPTION
# Description

Partial fix to #3176. The issue is that we're not using the upstream root to fetch files.

You can test with the following document

```html
<script type="module"
src="https://gradio-dev-cdn.s3.amazonaws.com/3.18.0b1/gradio.js">
</script>

<div>
    <gradio-app space="gradio/gallery_component"></gradio-app>
</div>

<div>
    <gradio-app space="gradio/video_component"></gradio-app>
</div>

<div>
    <gradio-app space="gradio/main_note"></gradio-app>
</div>

<div>
    <gradio-app space="gradio/model3D"></gradio-app>
</div>
```

![embedding_fix](https://user-images.githubusercontent.com/41651716/218167860-05bc35b6-3edb-4fbe-9287-a7265fd7e24e.gif)



# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.