### PR TITLE
Automatically cache Examples in Spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ No changes to highlight.
 No changes to highlight.
 
 ## Breaking Changes:
+No changes to highlight.
 
 ## Full Changelog:
 * Fix demos page css and add close demos button by [@aliabd](https://github.com/aliabd) in [PR 3151](https://github.com/gradio-app/gradio/pull/3151)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,10 +48,10 @@ No changes to highlight.
 No changes to highlight.
 
 ## Breaking Changes:
-No changes to highlight.
 
 ## Full Changelog:
 * Fix demos page css and add close demos button by [@aliabd](https://github.com/aliabd) in [PR 3151](https://github.com/gradio-app/gradio/pull/3151)
+* Automatically cache `gr.Examples` in Spaces by [@osanseviero](https://github.com/osanseviero) in [PR 3186](https://github.com/gradio-app/gradio/pull/3186)
 
 ## Contributors Shoutout:
 No changes to highlight.

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -39,7 +39,7 @@ def create_examples(
     inputs: IOComponent | List[IOComponent],
     outputs: IOComponent | List[IOComponent] | None = None,
     fn: Callable | None = None,
-    cache_examples: bool = False,
+    cache_examples: bool | None = None,
     examples_per_page: int = 10,
     _api_mode: bool = False,
     label: str | None = None,
@@ -88,7 +88,7 @@ class Examples:
         inputs: IOComponent | List[IOComponent],
         outputs: IOComponent | List[IOComponent] | None = None,
         fn: Callable | None = None,
-        cache_examples: bool = False,
+        cache_examples: bool | None = None,
         examples_per_page: int = 10,
         _api_mode: bool = False,
         label: str | None = "Examples",
@@ -105,7 +105,7 @@ class Examples:
             inputs: the component or list of components corresponding to the examples
             outputs: optionally, provide the component or list of components corresponding to the output of the examples. Required if `cache` is True.
             fn: optionally, provide the function to run to generate the outputs corresponding to the examples. Required if `cache` is True.
-            cache_examples: if True, caches examples for fast runtime. If True, then `fn` and `outputs` need to be provided
+            cache_examples: if True, caches examples for fast runtime. If True, then `fn` and `outputs` need to be provided. The default option in HuggingFace Spaces is True. The default option elsewhere is False.
             examples_per_page: how many examples to show per page.
             label: the label to use for the examples component (by default, "Examples")
             elem_id: an optional string that is assigned as the id of this component in the HTML DOM.
@@ -118,6 +118,11 @@ class Examples:
             warnings.warn(
                 "Please use gr.Examples(...) instead of gr.examples.Examples(...) to create the Examples.",
             )
+
+        if os.getenv("SYSTEM") == "spaces" and cache_examples is None:
+            cache_examples = True
+        else:
+            cache_examples = cache_examples or False
 
         if cache_examples and (fn is None or outputs is None):
             raise ValueError("If caching examples, `fn` and `outputs` must be provided")


### PR DESCRIPTION
# Description

To be consistent with `gr.Interface`, this PR will automatically cache the examples also with `gr.Examples` when working in Spaces. This could potentially break some Spaces if upgrading to newer versions as the current requirement for caching is that `gr.Examples` provides a `fn` and `outputs`, so not sure if we want this

Please include: 
* relevant motivation
* a summary of the change 
* which issue is fixed. 
* any additional dependencies that are required for this change.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

