### PR TITLE
Fix Table entry for Pinyin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3157](https://git
 * Fixes `gr.utils.delete_none` to only remove props whose values are `None` from the config by [@abidlabs](https://github.com/abidlabs) in [PR 3188](https://github.com/gradio-app/gradio/pull/3188) 
 * Fix bug where embedded demos were not loading files properly by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3177](https://github.com/gradio-app/gradio/pull/3177)
 * The `change` event is now triggered when users click the 'Clear All' button of the multiselect DropDown component by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3195](https://github.com/gradio-app/gradio/pull/3195)
+* Support Chinese pinyin in Dataframe by [@aliabid94](https://github.com/aliabid94) in [PR 3206](https://github.com/gradio-app/gradio/pull/3206)
 
 ## Documentation Changes:
 * Sort components in docs by alphabetic order by [@aliabd](https://github.com/aliabd) in [PR 3152](https://github.com/gradio-app/gradio/pull/3152)

--- a/ui/packages/table/src/EditableCell.svelte
+++ b/ui/packages/table/src/EditableCell.svelte
@@ -16,11 +16,13 @@
 	<input
 		class:header
 		tabindex="-1"
-		bind:value
+		{value}
 		bind:this={el}
 		on:keydown
-		on:blur={({ currentTarget }) =>
-			currentTarget.setAttribute("tabindex", "-1")}
+		on:blur={({ currentTarget }) => {
+			value = currentTarget.value;
+			currentTarget.setAttribute("tabindex", "-1");
+		}}
 	/>
 {/if}
 <span on:dblclick tabindex="-1" role="button" class:edit>


### PR DESCRIPTION
Right now, entering Pinyin in a Dataframe is not possible - see #3083. The issue is because when a cell is being edited in EditableCell.svelte, its value is bound to the array from the parent Table.svelte. So every edit causes the table to rerender, resetting the value of the input field with pinyin. This treats the next letter as a completely new entry, breaking the pinyin chain of letters. Now, the value is only updated when the input blurs, meaning when a user has completed input.

To test, install the Chinese pinyin keyboard, and enter the keys in order: `"w", "o", "1"`. Originally, this would not get converted into 我, but it should now.

I also believe this should improve performance as the table does not rerender on every edit, only when the cell finishes editing.

Fixes: #3083 