### PR TITLE
Fix matplotlib image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Ensure `mirror_webcam` is always respected by [@pngwn](https://github.com/pngwn) in [PR 3245](https://github.com/gradio-app/gradio/pull/3245)
 - Fix issue where updated markdown links were not being opened in a new tab by [@gante](https://github.com/gante) in [PR 3236](https://github.com/gradio-app/gradio/pull/3236)
 - Fixes the height of rendered LaTeX images so that they match the height of surrounding text by [@abidlabs](https://github.com/abidlabs) in [PR 3258](https://github.com/gradio-app/gradio/pull/3258)
+- Fix bug where matplotlib images where always too small on the front end by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3274](https://github.com/gradio-app/gradio/pull/3274) 
 
 
 ## Documentation Changes:

--- a/ui/packages/plot/src/Plot.svelte
+++ b/ui/packages/plot/src/Plot.svelte
@@ -239,8 +239,6 @@
 	}
 
 	.matplotlib img {
-		width: var(--size-full);
-		max-height: var(--size-32);
 		object-fit: contain;
 	}
 </style>

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -48,7 +48,7 @@ importers:
       '@tailwindcss/forms': 0.5.0_tailwindcss@3.1.6
       '@testing-library/dom': 8.11.3
       '@testing-library/svelte': 3.1.0_svelte@3.49.0
-      '@testing-library/user-event': 13.5.0_@testing-library+dom@8.11.3
+      '@testing-library/user-event': 13.5.0_gzufz4q333be4gqfrvipwvqt6a
       autoprefixer: 10.4.4_postcss@8.4.6
       babylonjs: 5.18.0
       babylonjs-loaders: 5.18.0
@@ -65,14 +65,14 @@ importers:
       postcss-nested: 5.0.6_postcss@8.4.6
       postcss-prefix-selector: 1.16.0_postcss@8.4.6
       prettier: 2.6.2
-      prettier-plugin-css-order: 1.3.0_postcss@8.4.6+prettier@2.6.2
-      prettier-plugin-svelte: 2.7.0_prettier@2.6.2+svelte@3.49.0
+      prettier-plugin-css-order: 1.3.0_ob5okuz2s5mlecytbeo2erc43a
+      prettier-plugin-svelte: 2.7.0_3cyj5wbackxvw67rnaarcmbw7y
       sirv: 2.0.2
       sirv-cli: 2.0.2
       svelte: 3.49.0
-      svelte-check: 2.8.0_postcss@8.4.6+svelte@3.49.0
+      svelte-check: 2.8.0_mgmdnb6x5rpawk37gozc2sbtta
       svelte-i18n: 3.3.13_svelte@3.49.0
-      svelte-preprocess: 4.10.6_62d50a01257de5eec5be08cad9d3ed66
+      svelte-preprocess: 4.10.6_mlkquajfpxs65rn6bdfntu7nmy
       tailwindcss: 3.1.6
       tinyspy: 0.3.0
       typescript: 4.7.4
@@ -330,7 +330,7 @@ importers:
       '@gradio/utils': link:../utils
       '@rollup/plugin-json': 5.0.2
       plotly.js-dist-min: 2.11.1
-      svelte-vega: 1.2.0_vega-lite@5.6.0+vega@5.22.1
+      svelte-vega: 1.2.0_36sthfwhgi34qytpvkzggbhnle
       vega: 5.22.1
       vega-lite: 5.6.0_vega@5.22.1
 
@@ -462,13 +462,13 @@ importers:
       '@gradio/video': link:../video
       svelte: 3.49.0
     devDependencies:
-      '@sveltejs/adapter-auto': 1.0.0-next.91_@sveltejs+kit@1.0.0-next.318
+      '@sveltejs/adapter-auto': 1.0.0-next.91_b2bjiolq6much32vueqoio7eoy
       '@sveltejs/kit': 1.0.0-next.318_svelte@3.49.0
       autoprefixer: 10.4.2_postcss@8.4.6
       postcss: 8.4.6
       postcss-load-config: 3.1.1
-      svelte-check: 2.4.1_736abba5ed1eb6f8ecf70b1d49ead14b
-      svelte-preprocess: 4.10.2_d50790bb30dd88cc44babe7efa52bace
+      svelte-check: 2.4.1_onvlxjpnd23pr3hxbmout2wrjm
+      svelte-preprocess: 4.10.2_2udzbozq3wemyrf2xz7puuv2zy
       tailwindcss: 3.1.6
       tslib: 2.3.1
       typescript: 4.5.5
@@ -671,7 +671,7 @@ packages:
       picomatch: 2.3.1
     dev: false
 
-  /@sveltejs/adapter-auto/1.0.0-next.91_@sveltejs+kit@1.0.0-next.318:
+  /@sveltejs/adapter-auto/1.0.0-next.91_b2bjiolq6much32vueqoio7eoy:
     resolution: {integrity: sha512-U57tQdzTfFINim8tzZSARC9ztWPzwOoHwNOpGdb2o6XrD0mEQwU9DsII7dBblvzg+xCnmd0pw7PDtXz5c5t96w==}
     peerDependencies:
       '@sveltejs/kit': ^1.0.0-next.587
@@ -768,7 +768,7 @@ packages:
       svelte: 3.49.0
     dev: false
 
-  /@testing-library/user-event/13.5.0_@testing-library+dom@8.11.3:
+  /@testing-library/user-event/13.5.0_gzufz4q333be4gqfrvipwvqt6a:
     resolution: {integrity: sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==}
     engines: {node: '>=10', npm: '>=6'}
     peerDependencies:
@@ -3116,7 +3116,7 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  /prettier-plugin-css-order/1.3.0_postcss@8.4.6+prettier@2.6.2:
+  /prettier-plugin-css-order/1.3.0_ob5okuz2s5mlecytbeo2erc43a:
     resolution: {integrity: sha512-wOS4qlbUARCoiiuOG0TiB/j751soC3+gUnMMva5HVWKvHJdLNYqh+jXK3MvvixR6xkJVPxHSF7rIIhkHIuHTFg==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -3131,7 +3131,7 @@ packages:
       - postcss
     dev: false
 
-  /prettier-plugin-svelte/2.7.0_prettier@2.6.2+svelte@3.49.0:
+  /prettier-plugin-svelte/2.7.0_3cyj5wbackxvw67rnaarcmbw7y:
     resolution: {integrity: sha512-fQhhZICprZot2IqEyoiUYLTRdumULGRvw0o4dzl5jt0jfzVWdGqeYW27QTWAeXhoupEZJULmNoH3ueJwUWFLIA==}
     peerDependencies:
       prettier: ^1.16.4 || ^2.0.0
@@ -3589,7 +3589,7 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  /svelte-check/2.4.1_736abba5ed1eb6f8ecf70b1d49ead14b:
+  /svelte-check/2.4.1_onvlxjpnd23pr3hxbmout2wrjm:
     resolution: {integrity: sha512-xhf3ShP5rnRwBokrgTBJ/0cO9QIc1DAVu1NWNRTfCDsDBNjGmkS3HgitgUadRuoMKj1+irZR/yHJ+Uqobnkbrw==}
     hasBin: true
     peerDependencies:
@@ -3603,7 +3603,7 @@ packages:
       sade: 1.8.1
       source-map: 0.7.3
       svelte: 3.49.0
-      svelte-preprocess: 4.10.2_d50790bb30dd88cc44babe7efa52bace
+      svelte-preprocess: 4.10.2_2udzbozq3wemyrf2xz7puuv2zy
       typescript: 4.5.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -3618,7 +3618,7 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-check/2.8.0_postcss@8.4.6+svelte@3.49.0:
+  /svelte-check/2.8.0_mgmdnb6x5rpawk37gozc2sbtta:
     resolution: {integrity: sha512-HRL66BxffMAZusqe5I5k26mRWQ+BobGd9Rxm3onh7ZVu0nTk8YTKJ9vu3LVPjUGLU9IX7zS+jmwPVhJYdXJ8vg==}
     hasBin: true
     peerDependencies:
@@ -3631,7 +3631,7 @@ packages:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 3.49.0
-      svelte-preprocess: 4.10.6_62d50a01257de5eec5be08cad9d3ed66
+      svelte-preprocess: 4.10.6_mlkquajfpxs65rn6bdfntu7nmy
       typescript: 4.7.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -3669,7 +3669,7 @@ packages:
       tiny-glob: 0.2.9
     dev: false
 
-  /svelte-preprocess/4.10.2_d50790bb30dd88cc44babe7efa52bace:
+  /svelte-preprocess/4.10.2_2udzbozq3wemyrf2xz7puuv2zy:
     resolution: {integrity: sha512-aPpkCreSo8EL/y8kJSa1trhiX0oyAtTjlNNM7BNjRAsMJ8Yy2LtqHt0zyd4pQPXt+D4PzbO3qTjjio3kwOxDlA==}
     engines: {node: '>= 9.11.2'}
     requiresBuild: true
@@ -3722,7 +3722,7 @@ packages:
       typescript: 4.5.5
     dev: true
 
-  /svelte-preprocess/4.10.6_62d50a01257de5eec5be08cad9d3ed66:
+  /svelte-preprocess/4.10.6_mlkquajfpxs65rn6bdfntu7nmy:
     resolution: {integrity: sha512-I2SV1w/AveMvgIQlUF/ZOO3PYVnhxfcpNyGt8pxpUVhPfyfL/CZBkkw/KPfuFix5FJ9TnnNYMhACK3DtSaYVVQ==}
     engines: {node: '>= 9.11.2'}
     requiresBuild: true
@@ -3778,7 +3778,7 @@ packages:
     resolution: {integrity: sha512-VTWHOdwDyWbndGZnI0PQJY9DO7hgQlNubtCcCL6Wlypv5dU4vEsc4A1sX9TWMuvebEe4332SgsQQHzOdZ+guhQ==}
     dev: false
 
-  /svelte-vega/1.2.0_vega-lite@5.6.0+vega@5.22.1:
+  /svelte-vega/1.2.0_36sthfwhgi34qytpvkzggbhnle:
     resolution: {integrity: sha512-MsDdO+l7o/d9d4mVkh8MBDhqZvJ45lpuprBaTj0V/ZilIG902QERHFQlam3ZFcR9C9OIKSpmPqINssWNPkDdcA==}
     peerDependencies:
       vega: '*'
@@ -3786,7 +3786,7 @@ packages:
     dependencies:
       fast-deep-equal: 3.1.3
       vega: 5.22.1
-      vega-embed: 6.21.0_vega-lite@5.6.0+vega@5.22.1
+      vega-embed: 6.21.0_36sthfwhgi34qytpvkzggbhnle
       vega-lite: 5.6.0_vega@5.22.1
     dev: false
 
@@ -4018,7 +4018,7 @@ packages:
       - encoding
     dev: false
 
-  /vega-embed/6.21.0_vega-lite@5.6.0+vega@5.22.1:
+  /vega-embed/6.21.0_36sthfwhgi34qytpvkzggbhnle:
     resolution: {integrity: sha512-Tzo9VAfgNRb6XpxSFd7uphSeK2w5OxDY2wDtmpsQ+rQlPSEEI9TE6Jsb2nHRLD5J4FrmXKLrTcORqidsNQSXEg==}
     peerDependencies:
       vega: ^5.21.0
@@ -4032,7 +4032,7 @@ packages:
       vega-interpreter: 1.0.4
       vega-lite: 5.6.0_vega@5.22.1
       vega-schema-url-parser: 2.2.0
-      vega-themes: 2.12.0_vega-lite@5.6.0+vega@5.22.1
+      vega-themes: 2.12.0_36sthfwhgi34qytpvkzggbhnle
       vega-tooltip: 0.28.0
     dev: false
     bundledDependencies:
@@ -4251,7 +4251,7 @@ packages:
       d3-array: 3.1.1
     dev: false
 
-  /vega-themes/2.12.0_vega-lite@5.6.0+vega@5.22.1:
+  /vega-themes/2.12.0_36sthfwhgi34qytpvkzggbhnle:
     resolution: {integrity: sha512-gHNYCzDgexSQDmGzQsxH57OYgFVbAOmvhIYN3MPOvVucyI+zhbUawBVIVNzG9ftucRp0MaaMVXi6ctC5HLnBsg==}
     peerDependencies:
       vega: '*'

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.4
+lockfileVersion: 5.3
 
 importers:
 
@@ -48,7 +48,7 @@ importers:
       '@tailwindcss/forms': 0.5.0_tailwindcss@3.1.6
       '@testing-library/dom': 8.11.3
       '@testing-library/svelte': 3.1.0_svelte@3.49.0
-      '@testing-library/user-event': 13.5.0_gzufz4q333be4gqfrvipwvqt6a
+      '@testing-library/user-event': 13.5.0_@testing-library+dom@8.11.3
       autoprefixer: 10.4.4_postcss@8.4.6
       babylonjs: 5.18.0
       babylonjs-loaders: 5.18.0
@@ -65,14 +65,14 @@ importers:
       postcss-nested: 5.0.6_postcss@8.4.6
       postcss-prefix-selector: 1.16.0_postcss@8.4.6
       prettier: 2.6.2
-      prettier-plugin-css-order: 1.3.0_ob5okuz2s5mlecytbeo2erc43a
-      prettier-plugin-svelte: 2.7.0_3cyj5wbackxvw67rnaarcmbw7y
+      prettier-plugin-css-order: 1.3.0_postcss@8.4.6+prettier@2.6.2
+      prettier-plugin-svelte: 2.7.0_prettier@2.6.2+svelte@3.49.0
       sirv: 2.0.2
       sirv-cli: 2.0.2
       svelte: 3.49.0
-      svelte-check: 2.8.0_mgmdnb6x5rpawk37gozc2sbtta
+      svelte-check: 2.8.0_postcss@8.4.6+svelte@3.49.0
       svelte-i18n: 3.3.13_svelte@3.49.0
-      svelte-preprocess: 4.10.6_mlkquajfpxs65rn6bdfntu7nmy
+      svelte-preprocess: 4.10.6_62d50a01257de5eec5be08cad9d3ed66
       tailwindcss: 3.1.6
       tinyspy: 0.3.0
       typescript: 4.7.4
@@ -330,7 +330,7 @@ importers:
       '@gradio/utils': link:../utils
       '@rollup/plugin-json': 5.0.2
       plotly.js-dist-min: 2.11.1
-      svelte-vega: 1.2.0_36sthfwhgi34qytpvkzggbhnle
+      svelte-vega: 1.2.0_vega-lite@5.6.0+vega@5.22.1
       vega: 5.22.1
       vega-lite: 5.6.0_vega@5.22.1
 
@@ -462,13 +462,13 @@ importers:
       '@gradio/video': link:../video
       svelte: 3.49.0
     devDependencies:
-      '@sveltejs/adapter-auto': 1.0.0-next.91_b2bjiolq6much32vueqoio7eoy
+      '@sveltejs/adapter-auto': 1.0.0-next.91_@sveltejs+kit@1.0.0-next.318
       '@sveltejs/kit': 1.0.0-next.318_svelte@3.49.0
       autoprefixer: 10.4.2_postcss@8.4.6
       postcss: 8.4.6
       postcss-load-config: 3.1.1
-      svelte-check: 2.4.1_onvlxjpnd23pr3hxbmout2wrjm
-      svelte-preprocess: 4.10.2_2udzbozq3wemyrf2xz7puuv2zy
+      svelte-check: 2.4.1_736abba5ed1eb6f8ecf70b1d49ead14b
+      svelte-preprocess: 4.10.2_d50790bb30dd88cc44babe7efa52bace
       tailwindcss: 3.1.6
       tslib: 2.3.1
       typescript: 4.5.5
@@ -671,7 +671,7 @@ packages:
       picomatch: 2.3.1
     dev: false
 
-  /@sveltejs/adapter-auto/1.0.0-next.91_b2bjiolq6much32vueqoio7eoy:
+  /@sveltejs/adapter-auto/1.0.0-next.91_@sveltejs+kit@1.0.0-next.318:
     resolution: {integrity: sha512-U57tQdzTfFINim8tzZSARC9ztWPzwOoHwNOpGdb2o6XrD0mEQwU9DsII7dBblvzg+xCnmd0pw7PDtXz5c5t96w==}
     peerDependencies:
       '@sveltejs/kit': ^1.0.0-next.587
@@ -768,7 +768,7 @@ packages:
       svelte: 3.49.0
     dev: false
 
-  /@testing-library/user-event/13.5.0_gzufz4q333be4gqfrvipwvqt6a:
+  /@testing-library/user-event/13.5.0_@testing-library+dom@8.11.3:
     resolution: {integrity: sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==}
     engines: {node: '>=10', npm: '>=6'}
     peerDependencies:
@@ -3116,7 +3116,7 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  /prettier-plugin-css-order/1.3.0_ob5okuz2s5mlecytbeo2erc43a:
+  /prettier-plugin-css-order/1.3.0_postcss@8.4.6+prettier@2.6.2:
     resolution: {integrity: sha512-wOS4qlbUARCoiiuOG0TiB/j751soC3+gUnMMva5HVWKvHJdLNYqh+jXK3MvvixR6xkJVPxHSF7rIIhkHIuHTFg==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -3131,7 +3131,7 @@ packages:
       - postcss
     dev: false
 
-  /prettier-plugin-svelte/2.7.0_3cyj5wbackxvw67rnaarcmbw7y:
+  /prettier-plugin-svelte/2.7.0_prettier@2.6.2+svelte@3.49.0:
     resolution: {integrity: sha512-fQhhZICprZot2IqEyoiUYLTRdumULGRvw0o4dzl5jt0jfzVWdGqeYW27QTWAeXhoupEZJULmNoH3ueJwUWFLIA==}
     peerDependencies:
       prettier: ^1.16.4 || ^2.0.0
@@ -3589,7 +3589,7 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  /svelte-check/2.4.1_onvlxjpnd23pr3hxbmout2wrjm:
+  /svelte-check/2.4.1_736abba5ed1eb6f8ecf70b1d49ead14b:
     resolution: {integrity: sha512-xhf3ShP5rnRwBokrgTBJ/0cO9QIc1DAVu1NWNRTfCDsDBNjGmkS3HgitgUadRuoMKj1+irZR/yHJ+Uqobnkbrw==}
     hasBin: true
     peerDependencies:
@@ -3603,7 +3603,7 @@ packages:
       sade: 1.8.1
       source-map: 0.7.3
       svelte: 3.49.0
-      svelte-preprocess: 4.10.2_2udzbozq3wemyrf2xz7puuv2zy
+      svelte-preprocess: 4.10.2_d50790bb30dd88cc44babe7efa52bace
       typescript: 4.5.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -3618,7 +3618,7 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-check/2.8.0_mgmdnb6x5rpawk37gozc2sbtta:
+  /svelte-check/2.8.0_postcss@8.4.6+svelte@3.49.0:
     resolution: {integrity: sha512-HRL66BxffMAZusqe5I5k26mRWQ+BobGd9Rxm3onh7ZVu0nTk8YTKJ9vu3LVPjUGLU9IX7zS+jmwPVhJYdXJ8vg==}
     hasBin: true
     peerDependencies:
@@ -3631,7 +3631,7 @@ packages:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 3.49.0
-      svelte-preprocess: 4.10.6_mlkquajfpxs65rn6bdfntu7nmy
+      svelte-preprocess: 4.10.6_62d50a01257de5eec5be08cad9d3ed66
       typescript: 4.7.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -3669,7 +3669,7 @@ packages:
       tiny-glob: 0.2.9
     dev: false
 
-  /svelte-preprocess/4.10.2_2udzbozq3wemyrf2xz7puuv2zy:
+  /svelte-preprocess/4.10.2_d50790bb30dd88cc44babe7efa52bace:
     resolution: {integrity: sha512-aPpkCreSo8EL/y8kJSa1trhiX0oyAtTjlNNM7BNjRAsMJ8Yy2LtqHt0zyd4pQPXt+D4PzbO3qTjjio3kwOxDlA==}
     engines: {node: '>= 9.11.2'}
     requiresBuild: true
@@ -3722,7 +3722,7 @@ packages:
       typescript: 4.5.5
     dev: true
 
-  /svelte-preprocess/4.10.6_mlkquajfpxs65rn6bdfntu7nmy:
+  /svelte-preprocess/4.10.6_62d50a01257de5eec5be08cad9d3ed66:
     resolution: {integrity: sha512-I2SV1w/AveMvgIQlUF/ZOO3PYVnhxfcpNyGt8pxpUVhPfyfL/CZBkkw/KPfuFix5FJ9TnnNYMhACK3DtSaYVVQ==}
     engines: {node: '>= 9.11.2'}
     requiresBuild: true
@@ -3778,7 +3778,7 @@ packages:
     resolution: {integrity: sha512-VTWHOdwDyWbndGZnI0PQJY9DO7hgQlNubtCcCL6Wlypv5dU4vEsc4A1sX9TWMuvebEe4332SgsQQHzOdZ+guhQ==}
     dev: false
 
-  /svelte-vega/1.2.0_36sthfwhgi34qytpvkzggbhnle:
+  /svelte-vega/1.2.0_vega-lite@5.6.0+vega@5.22.1:
     resolution: {integrity: sha512-MsDdO+l7o/d9d4mVkh8MBDhqZvJ45lpuprBaTj0V/ZilIG902QERHFQlam3ZFcR9C9OIKSpmPqINssWNPkDdcA==}
     peerDependencies:
       vega: '*'
@@ -3786,7 +3786,7 @@ packages:
     dependencies:
       fast-deep-equal: 3.1.3
       vega: 5.22.1
-      vega-embed: 6.21.0_36sthfwhgi34qytpvkzggbhnle
+      vega-embed: 6.21.0_vega-lite@5.6.0+vega@5.22.1
       vega-lite: 5.6.0_vega@5.22.1
     dev: false
 
@@ -4018,7 +4018,7 @@ packages:
       - encoding
     dev: false
 
-  /vega-embed/6.21.0_36sthfwhgi34qytpvkzggbhnle:
+  /vega-embed/6.21.0_vega-lite@5.6.0+vega@5.22.1:
     resolution: {integrity: sha512-Tzo9VAfgNRb6XpxSFd7uphSeK2w5OxDY2wDtmpsQ+rQlPSEEI9TE6Jsb2nHRLD5J4FrmXKLrTcORqidsNQSXEg==}
     peerDependencies:
       vega: ^5.21.0
@@ -4032,7 +4032,7 @@ packages:
       vega-interpreter: 1.0.4
       vega-lite: 5.6.0_vega@5.22.1
       vega-schema-url-parser: 2.2.0
-      vega-themes: 2.12.0_36sthfwhgi34qytpvkzggbhnle
+      vega-themes: 2.12.0_vega-lite@5.6.0+vega@5.22.1
       vega-tooltip: 0.28.0
     dev: false
     bundledDependencies:
@@ -4251,7 +4251,7 @@ packages:
       d3-array: 3.1.1
     dev: false
 
-  /vega-themes/2.12.0_36sthfwhgi34qytpvkzggbhnle:
+  /vega-themes/2.12.0_vega-lite@5.6.0+vega@5.22.1:
     resolution: {integrity: sha512-gHNYCzDgexSQDmGzQsxH57OYgFVbAOmvhIYN3MPOvVucyI+zhbUawBVIVNzG9ftucRp0MaaMVXi6ctC5HLnBsg==}
     peerDependencies:
       vega: '*'


### PR DESCRIPTION
# Description

Fixes #3210 . Modifies the matplotlib css so that max_height is not set (this was making all the plots tiny) and removes `width` so that the plot size reflects the python configuration.

You can test with `outbreak_forecast` and this demo:

```python
import matplotlib
import matplotlib.pyplot as plt
import gradio as gr

matplotlib.use("Agg")

def make_plot(width, height):
    fig, ax = plt.subplots(figsize=(width, height))
    fruits = ['apple', 'blueberry', 'cherry', 'orange']
    counts = [40, 100, 30, 55]
    bar_labels = ['red', 'blue', '_red', 'orange']
    bar_colors = ['tab:red', 'tab:blue', 'tab:red', 'tab:orange']

    ax.bar(fruits, counts, label=bar_labels, color=bar_colors)

    ax.set_ylabel('fruit supply')
    ax.set_title('Fruit supply by kind and color')
    ax.legend(title='Fruit color')
    fig.savefig(f"{width}_{height}.png")

    return fig

with gr.Blocks() as demo:
    with gr.Row():
        with gr.Column():
            width = gr.Slider(1, 10, step=1, value=1, label="width")
            height = gr.Slider(1, 10, step=1, value=1, label="height")
        with gr.Column():
            plot = gr.Plot()
    
    width.change(make_plot, [width, height], [plot])
    height.change(make_plot, [width, height], [plot])
    demo.load(make_plot, [width, height], [plot])

demo.launch()
```


### Outbreak forecast before
![image](https://user-images.githubusercontent.com/41651716/220450023-045f4ca0-68bf-4bf2-a44c-7e770dd45a9c.png)


### Outbreak forecast after
![image](https://user-images.githubusercontent.com/41651716/220449476-de9791be-08ef-4423-9d6b-55dbeba69785.png)

### test demo before
![matplotlib_before](https://user-images.githubusercontent.com/41651716/220450165-24e508ef-f8c2-47be-a884-3fb772961420.gif)

###  test demo after
![matplotlib_after](https://user-images.githubusercontent.com/41651716/220449655-67f9f2b0-d0c5-4bb6-8de9-6069b7b95b9b.gif)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.