### PR TITLE
LaTeX fix attempt #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Ensure `mirror_webcam` is always respected by [@pngwn](https://github.com/pngwn) in [PR 3245](https://github.com/gradio-app/gradio/pull/3245)
 - Fix issue where updated markdown links were not being opened in a new tab by [@gante](https://github.com/gante) in [PR 3236](https://github.com/gradio-app/gradio/pull/3236)
 - Added a timeout to queue messages as some demos were experiencing infinitely growing queues from active jobs waiting forever for clients to respond by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3196](https://github.com/gradio-app/gradio/pull/3196)
-- Fixes the height of rendered LaTeX images so that they match the height of surrounding text by [@abidlabs](https://github.com/abidlabs) in [PR 3258](https://github.com/gradio-app/gradio/pull/3258)
+- Fixes the height of rendered LaTeX images so that they match the height of surrounding text by [@abidlabs](https://github.com/abidlabs) in [PR 3258](https://github.com/gradio-app/gradio/pull/3258) and in [PR 3276](https://github.com/gradio-app/gradio/pull/3276)
 - Fix bug where matplotlib images where always too small on the front end by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3274](https://github.com/gradio-app/gradio/pull/3274) 
 
 ## Documentation Changes:

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -887,7 +887,16 @@ def tex2svg(formula, *args):
     svg_code = xml_code[svg_start:]
     svg_code = re.sub(r"<metadata>.*<\/metadata>", "", svg_code, flags=re.DOTALL)
     svg_code = re.sub(r' width="[^"]+"', '', svg_code)
-    svg_code = re.sub(r' height="[^"]+"', '', svg_code)
+    print(svg_code[:100])
+    height_match = re.search(r'height="([\d.]+)pt"', svg_code)
+    print(height_match)
+    if height_match:
+        height = float(height_match.group(1))
+        print("height", height)
+        new_height = height / 20   # rough conversion from pt to em
+        print("new_height", new_height)
+        svg_code = re.sub(r'height="[\d.]+pt"', f'height="{new_height}em"', svg_code)
+    print(svg_code[:100])
     copy_code = f"<span style='font-size: 0px'>{formula}</span>"
     return f"{copy_code}{svg_code}"
 

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -887,16 +887,11 @@ def tex2svg(formula, *args):
     svg_code = xml_code[svg_start:]
     svg_code = re.sub(r"<metadata>.*<\/metadata>", "", svg_code, flags=re.DOTALL)
     svg_code = re.sub(r' width="[^"]+"', '', svg_code)
-    print(svg_code[:100])
     height_match = re.search(r'height="([\d.]+)pt"', svg_code)
-    print(height_match)
     if height_match:
         height = float(height_match.group(1))
-        print("height", height)
         new_height = height / 20   # rough conversion from pt to em
-        print("new_height", new_height)
         svg_code = re.sub(r'height="[\d.]+pt"', f'height="{new_height}em"', svg_code)
-    print(svg_code[:100])
     copy_code = f"<span style='font-size: 0px'>{formula}</span>"
     return f"{copy_code}{svg_code}"
 

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -890,7 +890,7 @@ def tex2svg(formula, *args):
     height_match = re.search(r'height="([\d.]+)pt"', svg_code)
     if height_match:
         height = float(height_match.group(1))
-        new_height = height / 20   # rough conversion from pt to em
+        new_height = height / FONTSIZE   # conversion from pt to em
         svg_code = re.sub(r'height="[\d.]+pt"', f'height="{new_height}em"', svg_code)
     copy_code = f"<span style='font-size: 0px'>{formula}</span>"
     return f"{copy_code}{svg_code}"

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1784,7 +1784,7 @@ class TestMarkdown:
     def test_component_functions(self):
         markdown_component = gr.Markdown("# Let's learn about $x$", label="Markdown")
         assert markdown_component.get_config()["value"].startswith(
-            """<h1>Let’s learn about <span class="math inline"><span style=\'font-size: 0px\'>x</span><svg xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 11.6 19.35625" xmlns="http://www.w3.org/2000/svg" version="1.1">\n \n <defs>\n  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>\n </defs>\n <g id="figure_1">\n  <g id="patch_1">\n   <path d="M 0 19.35625"""
+            """<h1>Let’s learn about <span class="math inline"><span style=\'font-size: 0px\'>x</span><svg xmlns:xlink="http://www.w3.org/1999/xlink" height="0.9678125em" viewBox="0 0 11.6 19.35625" xmlns="http://www.w3.org/2000/svg" version="1.1">\n \n <defs>\n  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>\n </defs>\n <g id="figure_1">\n  <g id="patch_1">"""
         )
 
     def test_in_interface(self):

--- a/ui/packages/markdown/src/Markdown.svelte
+++ b/ui/packages/markdown/src/Markdown.svelte
@@ -35,7 +35,6 @@
 	div :global(.math.inline svg) {
 		display: inline;
 		margin-bottom: 0.22em;
-		height: 1em;
 	}
 
 	div {


### PR DESCRIPTION
Based on perceptive feedback from @aliabid94 and @pngwn, this fixes LaTeX font size rendering so that the height adjusts doesn't just match the surrounding text, but also adjusts based on the contents of the LaTeX formula itself. This allows multiline math (fractions, integrals) to be visible, particularly in regular paragraph tags. 

**Before (at 100% zoom)**

<img width="973" alt="image" src="https://user-images.githubusercontent.com/1778297/220473453-96c335b1-7e9c-4096-a483-1f06cb0a6eb5.png">


**After (at 100% zoom)**

<img width="934" alt="image" src="https://user-images.githubusercontent.com/1778297/220473487-ab680a45-1a39-4430-91d1-0802c994809d.png">
