### PR TITLE
Some fixes to disabled buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## New Features:
 - Updated image upload component to accept all image formats, including lossless formats like .webp by [@fienestar](https://github.com/fienestar) in [PR 3225](https://github.com/gradio-app/gradio/pull/3225)
-- Adds a disabled mode to the `gr.Button` component by setting `interactive=False` by [@abidlabs](https://github.com/abidlabs) in [PR 3266](https://github.com/gradio-app/gradio/pull/3266)
+- Adds a disabled mode to the `gr.Button` component by setting `interactive=False` by [@abidlabs](https://github.com/abidlabs) in [PR 3266](https://github.com/gradio-app/gradio/pull/3266) and [PR 3288](https://github.com/gradio-app/gradio/pull/3288)
 
 
 ## Bug Fixes:

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -2945,13 +2945,13 @@ class Button(Clickable, IOComponent, SimpleSerializable):
         visible: bool | None = None,
         interactive: bool | None = None,
     ):
-        return {
+        updated_config = {
             "variant": variant,
             "visible": visible,
             "value": value,
-            "interactive": interactive,
             "__type__": "update",
         }
+        return IOComponent.add_interactive_to_config(updated_config, interactive)
 
     def style(self, *, full_width: bool | None = None, **kwargs):
         """

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -886,8 +886,8 @@ def tex2svg(formula, *args):
     svg_start = xml_code.index("<svg ")
     svg_code = xml_code[svg_start:]
     svg_code = re.sub(r"<metadata>.*<\/metadata>", "", svg_code, flags=re.DOTALL)
-    svg_code = re.sub(r' width="[^"]+"', '', svg_code)
-    svg_code = re.sub(r' height="[^"]+"', '', svg_code)
+    svg_code = re.sub(r' width="[^"]+"', "", svg_code)
+    svg_code = re.sub(r' height="[^"]+"', "", svg_code)
     copy_code = f"<span style='font-size: 0px'>{formula}</span>"
     return f"{copy_code}{svg_code}"
 

--- a/ui/packages/button/src/Button.svelte
+++ b/ui/packages/button/src/Button.svelte
@@ -39,9 +39,9 @@
 	}
 
 	button[disabled] {
-		cursor: not-allowed;
 		opacity: 0.5;
-  		filter: grayscale(30%);
+		filter: grayscale(30%);
+		cursor: not-allowed;
 	}
 
 	.hide {

--- a/ui/packages/button/src/Button.svelte
+++ b/ui/packages/button/src/Button.svelte
@@ -40,6 +40,8 @@
 
 	button[disabled] {
 		cursor: not-allowed;
+		opacity: 0.5; /* lower the opacity to 50% */
+  		filter: grayscale(30%); /* apply 100% desaturation */	
 	}
 
 	.hide {

--- a/ui/packages/button/src/Button.svelte
+++ b/ui/packages/button/src/Button.svelte
@@ -39,10 +39,9 @@
 	}
 
 	button[disabled] {
-		opacity: 0.5; lowed;
-		opacity: 0.5; /* lowe
-		filter: grayscale(30%); ilter: grayscale(30%); /* app
 		cursor: not-allowed;
+		opacity: 0.5;
+  		filter: grayscale(30%);
 	}
 
 	.hide {

--- a/ui/packages/button/src/Button.svelte
+++ b/ui/packages/button/src/Button.svelte
@@ -39,9 +39,10 @@
 	}
 
 	button[disabled] {
+		opacity: 0.5; lowed;
+		opacity: 0.5; /* lowe
+		filter: grayscale(30%); ilter: grayscale(30%); /* app
 		cursor: not-allowed;
-		opacity: 0.5; /* lower the opacity to 50% */
-  		filter: grayscale(30%); /* apply 100% desaturation */	
 	}
 
 	.hide {


### PR DESCRIPTION
Was testing setting `interactive=False` for `gr.Button()` when I noticed two issues:

1. Setting `interactive=False` via a `gr.update()` wasn't working

2. It wasn't visually clear that a button was disabled unless you actually hovered over the button

This PR fixes both of those issues.

To test, run this script:

```py
import gradio as gr

with gr.Blocks() as demo:
    a = gr.Button()
    b = gr.Button(interactive=True)
    
    a.click(lambda :gr.Button.update("hi", interactive=False), None, b)

    gr.Button(variant="primary")
    gr.Button(variant="primary", interactive=False)
    
    gr.Button(variant="stop")
    gr.Button(variant="stop", interactive=False)

demo.launch()
```

Which looks like this:

<img width="983" alt="image" src="https://user-images.githubusercontent.com/1778297/220685608-225b7f6b-3cfa-4d4b-9152-ccc532e62bab.png">
