### PR TITLE
Fix change event listed twice in image docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3297](https://git
 - Prevent Sketch from crashing when a default image is provided by [@pngwn](https://github.com/pngwn) in [PR 3277](https://github.com/gradio-app/gradio/pull/3277)
 - Respect the `shape` argument on the front end when creating Image Sketches by [@pngwn](https://github.com/pngwn) in [PR 3277](https://github.com/gradio-app/gradio/pull/3277)
 - Fix infinite loop caused by setting `Dropdown's` value to be `[]` and adding a change event on the dropdown by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3295](https://github.com/gradio-app/gradio/pull/3295)  
+- Fix change event listed twice in image docs by [@aliabd](https://github.com/aliabd) in [PR 3318](https://github.com/gradio-app/gradio/pull/3318)
 
 ## Documentation Changes:
 No changes to highlight.

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -1347,7 +1347,7 @@ class Dropdown(Changeable, IOComponent, SimpleSerializable, FormComponent):
         return Component.style(self, container=container, **kwargs)
 
 
-@document("edit", "clear", "change", "stream", "change", "style")
+@document("edit", "clear", "change", "stream", "style")
 class Image(
     Editable,
     Clearable,


### PR DESCRIPTION
Very simple fix to bug in image docs.

Closes: #3309 