### PR TITLE
Gradio Status Page 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3297](https://git
 
 ## Documentation Changes:
 - Added the `types` field to the dependency field in the config by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3315](https://github.com/gradio-app/gradio/pull/3315) 
+- Gradio Status Page by [@aliabd](https://github.com/aliabd) in [PR 3331](https://github.com/gradio-app/gradio/pull/3331)
 
 ## Testing and Infrastructure Changes:
 * Adds a script to benchmark the performance of the queue and adds some instructions on how to use it. By [@freddyaboulton](https://github.com/freddyaboulton) and [@abidlabs](https://github.com/abidlabs) in [PR 3272](https://github.com/gradio-app/gradio/pull/3272)

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1490,7 +1490,7 @@ class Blocks(BlockContext):
                 print(strings.en["SHARE_LINK_DISPLAY"].format(self.share_url))
                 if not (quiet):
                     print(strings.en["SHARE_LINK_MESSAGE"])
-            except RuntimeError:
+            except (RuntimeError, requests.exceptions.ConnectionError):
                 if self.analytics_enabled:
                     utils.error_analytics("Not able to set up tunnel")
                 self.share_url = None

--- a/gradio/strings.py
+++ b/gradio/strings.py
@@ -10,7 +10,7 @@ en = {
     "RUNNING_LOCALLY": "Running on local URL:  {}",
     "RUNNING_LOCALLY_SEPARATED": "Running on local URL:  {}://{}:{}",
     "SHARE_LINK_DISPLAY": "Running on public URL: {}",
-    "COULD_NOT_GET_SHARE_LINK": "\nCould not create share link, please check your internet connection.",
+    "COULD_NOT_GET_SHARE_LINK": "\nCould not create share link. Please check your internet connection or our status page: https://status.gradio.app",
     "COLAB_NO_LOCAL": "Cannot display local interface on google colab, public link created.",
     "PUBLIC_SHARE_TRUE": "\nTo create a public link, set `share=True` in `launch()`.",
     "MODEL_PUBLICLY_AVAILABLE_URL": "Model available publicly at: {} (may take up to a minute for link to be usable)",

--- a/website/homepage/src/templates/footer.html
+++ b/website/homepage/src/templates/footer.html
@@ -1,4 +1,5 @@
 <footer class="container mx-auto flex-row flex items-center px-4 py-6 justify-between">
+  <div class="flex gap-3 items-center">
   <a href="/">
     <svg width="90"
          viewBox="0 0 451 105"
@@ -34,6 +35,10 @@
       fill="#FF7C00" />
     </svg>
   </a>
+  <a href="https://status.gradio.app" target="_blank" class="text-gray-400 hover:text-gray-500">
+    <span>Status</span>
+  </a>
+</div>
   <div class="flex gap-3">
     <a class="hover:opacity-75 transition" href="https://twitter.com/Gradio">
       <img src="/assets/img/twitter.svg" class="w-6">

--- a/website/homepage/src/templates/footer.html
+++ b/website/homepage/src/templates/footer.html
@@ -1,5 +1,4 @@
 <footer class="container mx-auto flex-row flex items-center px-4 py-6 justify-between">
-  <div class="flex gap-3 items-center">
   <a href="/">
     <svg width="90"
          viewBox="0 0 451 105"
@@ -35,11 +34,10 @@
       fill="#FF7C00" />
     </svg>
   </a>
-  <a href="https://status.gradio.app" target="_blank" class="text-gray-400 hover:text-gray-500">
-    <span>Status</span>
-  </a>
-</div>
   <div class="flex gap-3">
+    <a href="https://status.gradio.app" target="_blank" class="text-gray-400 hover:text-gray-500">
+      <span>Status</span>
+    </a>
     <a class="hover:opacity-75 transition" href="https://twitter.com/Gradio">
       <img src="/assets/img/twitter.svg" class="w-6">
     </a>


### PR DESCRIPTION
Created a status page to monitor a few different things: https://status.gradio.app

* Sharing (https://gradio.live) 
* API (https://api.gradio.app/)
* Website (https://gradio.app) 

Will probably change some things around in the page so please give feedback :) 

Also added it to the `COULD_NOT_GET_SHARE_LINK` string message. Which I discovered doesn't actually get printed when there's no internet because we were only catching RuntimeErrors but [this line](https://github.com/gradio-app/gradio/blob/53e4733f2a0cbb9a696a28330dc3927c7997c165/gradio/networking.py#L160) causes a ConnectionError

Closes: #3326 