### PR TITLE
Dont cancel non-flaky tests if flaky tests fail

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.test-type == "flaky" }}
+    continue-on-error: ${{ matrix.test-type == 'flaky' }}
     strategy:
       matrix:
         test-type: ["not flaky", "flaky"]

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.test-type == "flaky" }}
     strategy:
       matrix:
         test-type: ["not flaky", "flaky"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ By [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3297](https://git
 
 ## Testing and Infrastructure Changes:
 * Adds a script to benchmark the performance of the queue and adds some instructions on how to use it. By [@freddyaboulton](https://github.com/freddyaboulton) and [@abidlabs](https://github.com/abidlabs) in [PR 3272](https://github.com/gradio-app/gradio/pull/3272)
-
+* Flaky python tests no longer cancel non-flaky tests by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3344](https://github.com/gradio-app/gradio/pull/3344)  
 
 ## Breaking Changes:
 No changes to highlight.

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -39,6 +39,7 @@ pytestmark = pytest.mark.flaky
 
 class TestLoadInterface:
     def test_audio_to_audio(self):
+        assert False
         model_type = "audio-to-audio"
         interface = gr.Interface.load(
             name="speechbrain/mtl-mimic-voicebank",

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -39,7 +39,6 @@ pytestmark = pytest.mark.flaky
 
 class TestLoadInterface:
     def test_audio_to_audio(self):
-        assert False
         model_type = "audio-to-audio"
         interface = gr.Interface.load(
             name="speechbrain/mtl-mimic-voicebank",


### PR DESCRIPTION
# Description

For the backend tests, if one of the flaky tests fails, the non-flaky tests are immediately cancelled. This is not ideal as the non-flaky tests are the ones that are required for merging.

This PR makes it so that this no longer happens.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.