### PR TITLE
allow set file_directories via environment variable and force GA valu…

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -482,11 +482,10 @@ class Blocks(BlockContext):
 
         # For analytics_enabled and allow_flagging: (1) first check for
         # parameter, (2) check for env variable, (3) default to True/"manual"
-        self.analytics_enabled = (
-            analytics_enabled
-            if analytics_enabled is not None
-            else os.getenv("GRADIO_ANALYTICS_ENABLED", "True") == "True"
-        )
+        if "GRADIO_ANALYTICS_ENABLED" in os.environ:
+            self.analytics_enabled = os.environ.get("GRADIO_ANALYTICS_ENABLED") == "True"
+        else:
+            self.analytics_enabled = analytics_enabled if analytics_enabled is not None else True
 
         super().__init__(render=False, **kwargs)
         self.blocks: Dict[int, Block] = {}
@@ -519,6 +518,9 @@ class Blocks(BlockContext):
         self.progress_tracking = None
 
         self.file_directories = []
+        
+        if "GRADIO_FILE_DIRECTORIES" in os.environ:
+            self.file_directories.append(os.environ.get("GRADIO_FILE_DIRECTORIES"))
 
         if self.analytics_enabled:
             data = {
@@ -1354,7 +1356,8 @@ class Blocks(BlockContext):
             self.queue()
         self.show_api = self.api_open if self.enable_queue else show_api
 
-        self.file_directories = file_directories if file_directories is not None else []
+        if len(self.file_directories) == 0:
+            self.file_directories = file_directories if file_directories is not None else []
 
         if not self.enable_queue and self.progress_tracking:
             raise ValueError("Progress tracking requires queuing to be enabled.")

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -319,11 +319,11 @@ class Interface(Blocks):
 
         # For analytics_enabled and allow_flagging: (1) first check for
         # parameter, (2) check for env variable, (3) default to True/"manual"
-        self.analytics_enabled = (
-            analytics_enabled
-            if analytics_enabled is not None
-            else os.getenv("GRADIO_ANALYTICS_ENABLED", "True") == "True"
-        )
+        if "GRADIO_ANALYTICS_ENABLED" in os.environ:
+            self.analytics_enabled = os.environ.get("GRADIO_ANALYTICS_ENABLED") == "True"
+        else:
+            self.analytics_enabled = analytics_enabled if analytics_enabled is not None else True
+
         if allow_flagging is None:
             allow_flagging = os.getenv("GRADIO_ALLOW_FLAGGING", "manual")
         if allow_flagging is True:


### PR DESCRIPTION
- Allow owner of the environment (where Gradio is deployed) to override and force user to turn of Google Analytics. 
- Allow owner of the environment (where Gradio is deployed) to override and force user to use value of `file_directories`

# Description
I believe that it would be beneficial to have the feature that I'm proposing. This feature would allow users to have greater flexibility when working with the code, as it wouldn't completely restrict their actions. In certain environments, such as within an enterprise, sending user data to Google Analytics may be prohibited due to privacy or security concerns. Additionally, the infrastructure owner may want to specify a directory from which users can freely access files without any security concerns. This is entirely up to the infrastructure team, and in my opinion, it should be implemented as an optional feature to give users more control and flexibility.

Closes: # (https://github.com/gradio-app/gradio/issues/2899)

Please help to review the PR if we agree upon the features above.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
