### PR TITLE
Fix css issue with spaces logo 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ No changes to highlight.
 - Prevent in-place updates of `generic_update` by shallow copying by [@gitgithan](https://github.com/gitgithan) in [PR 3405](https://github.com/gradio-app/gradio/pull/3405) to fix [#3282](https://github.com/gradio-app/gradio/issues/3282)
 - Persist file names of files uploaded through any Gradio component by [@abidlabs](https://github.com/abidlabs) in [PR 3412](https://github.com/gradio-app/gradio/pull/3412)
 - Fix markdown embedded component in docs by [@aliabd](https://github.com/aliabd) in [PR 3410](https://github.com/gradio-app/gradio/pull/3410)
+- Fix css issue with spaces logo by [@aliabd](https://github.com/aliabd) in [PR 3422](https://github.com/gradio-app/gradio/pull/3422)
 
 ## Contributors Shoutout:
 

--- a/website/homepage/src/style.css
+++ b/website/homepage/src/style.css
@@ -92,6 +92,10 @@
 .thinner-link.current-nav-link {
   @apply border-orange-500 text-orange-500;
 }
+.prose :where(img):not(:where([class~=not-prose] *)) {
+  margin-bottom: 0;
+  margin-top: 0;
+}
 
 /* docs */
 .selected-demo {


### PR DESCRIPTION
Fixes the global css that was messing up the embed footer in the guides 

![Screen Shot 2023-03-08 at 3 13 03 PM](https://user-images.githubusercontent.com/9021060/223873796-6c7cffe7-d72d-4448-8ebd-939f2db5e529.png)
