### PR TITLE
Fix BlockContext import bug in utils.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 No changes to highlight.
 
 ## Bug Fixes:
-- Use `huggingface_hub` to send telemetry on `interface` and `blocks`; eventaully to replace segment by [@dawoodkhan82](https://github.com/dawoodkhan82) in [PR 3342](https://github.com/gradio-app/gradio/pull/3342)
+- Use `huggingface_hub` to send telemetry on `interface` and `blocks`; eventually to replace segment by [@dawoodkhan82](https://github.com/dawoodkhan82) in [PR 3342](https://github.com/gradio-app/gradio/pull/3342)
 - Ensure load events created by components (randomize for slider, callable values) are never queued unless every is passed by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3391](https://github.com/gradio-app/gradio/pull/3391) 
 - Prevent in-place updates of `generic_update` by shallow copying by [@gitgithan](https://github.com/gitgithan) in [PR 3405](https://github.com/gradio-app/gradio/pull/3405) to fix [#3282](https://github.com/gradio-app/gradio/issues/3282)
+- Fix bug caused by not importing `BlockContext` in `utils.py` by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3424](https://github.com/gradio-app/gradio/pull/3424)  
 
 ## Documentation Changes:
 - Added a section on security and access when sharing Gradio apps by [@abidlabs](https://github.com/abidlabs) in [PR 3408](https://github.com/gradio-app/gradio/pull/3408) 

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -154,6 +154,8 @@ def launched_telemetry(blocks: gradio.Blocks, data: Dict[str, Any]) -> None:
         [],
     )
 
+    from gradio.blocks import BlockContext
+
     for x in list(blocks.blocks.values()):
         blocks_telemetry.append(x.get_block_name()) if isinstance(
             x, BlockContext


### PR DESCRIPTION
# Description

I can no longer run a demo in the demo folder with a local install because `BlockContext` is not imported when `launched_telemetry` is run. 

Not sure how this made it through unit tests. Can someone recreate this issue on their end?

```bash
❯ python demo/blocks_multiple_event_triggers/run.py
Running on local URL:  http://127.0.0.1:7860

To create a public link, set `share=True` in `launch()`.
Traceback (most recent call last):
  File "demo/blocks_multiple_event_triggers/run.py", line 39, in <module>
    demo.launch()
  File "/Users/freddy/sources/gradio/gradio/blocks.py", line 1581, in launch
    utils.launched_telemetry(self, data)
  File "/Users/freddy/sources/gradio/gradio/utils.py", line 159, in launched_telemetry
    x, BlockContext
NameError: name 'BlockContext' is not defined
```



# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.