### PR TITLE
Site slugs for new website

### DIFF
--- a/ui/packages/_website/package.json
+++ b/ui/packages/_website/package.json
@@ -25,6 +25,7 @@
 	"type": "module",
 	"dependencies": {
 		"@sindresorhus/slugify": "^2.2.0",
+		"hast-util-to-string": "^2.0.0",
 		"mdsvex": "^0.10.6",
 		"postcss": ">=8.3.3 <9.0.0"
 	}

--- a/ui/packages/_website/package.json
+++ b/ui/packages/_website/package.json
@@ -24,6 +24,7 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"@sindresorhus/slugify": "^2.2.0",
 		"mdsvex": "^0.10.6",
 		"postcss": ">=8.3.3 <9.0.0"
 	}

--- a/ui/packages/_website/src/components/FunctionDoc.svelte
+++ b/ui/packages/_website/src/components/FunctionDoc.svelte
@@ -8,7 +8,7 @@
 
 <div class="obj" id={ parent + fn.name.toLowerCase() }>
     <div class="flex flex-row items-center justify-between"> 
-        <h3 id="{ fn.name.toLowerCase }-header" class="text-3xl font-light py-4">{ fn.name }</h3>
+        <h3 id="{ fn.slug }-header" class="text-3xl font-light py-4">{ fn.name }</h3>
     </div>
 
     {#if fn.override_signature }

--- a/ui/packages/_website/src/routes/+layout.svelte
+++ b/ui/packages/_website/src/routes/+layout.svelte
@@ -19,7 +19,6 @@
     if (browser) {
       window.__gradio_mode__ = "website";
     }
-	
 </script>
 
 <svelte:head>

--- a/ui/packages/_website/src/routes/[guide=valid_guide]/+page.server.js
+++ b/ui/packages/_website/src/routes/[guide=valid_guide]/+page.server.js
@@ -24,7 +24,6 @@ export async function load() {
 
 		guide_slugs[guide.name] = guide_slug;
 		const get_slug = make_slug_processor();
-		console.log(to_string);
 		function plugin() {
 			return function transform(tree) {
 				tree.children.forEach((n) => {
@@ -72,8 +71,6 @@ export async function load() {
 		guide.new_html = await compiled.code;
 	}
 
-	// these are the slugs that we can use to build the navigation
-	console.log(guide_slugs);
 	return {
 		guides,
 		guide_slugs

--- a/ui/packages/_website/src/routes/[guide=valid_guide]/+page.server.js
+++ b/ui/packages/_website/src/routes/[guide=valid_guide]/+page.server.js
@@ -1,21 +1,81 @@
 import guides_json from "../guides/guides.json";
-import { compile } from 'mdsvex';
-
-
-
+import { compile } from "mdsvex";
+import anchor from "../../assets/img/anchor.svg";
+import { make_slug_processor } from "../../utils";
+import { toString as to_string } from "hast-util-to-string";
 let guides = guides_json.guides;
 let guides_by_category = guides_json.guides_by_category;
 // let guide;
 
+function plugin() {
+	return function transform(tree) {
+		tree.children.forEach((n) => {
+			if (n.type === "heading") {
+				console.log(n);
+			}
+		});
+	};
+}
 
 export async function load() {
-    for (const guide of guides) {
-        const compiled = await compile(guide.content,
-            {});
-        guide.new_html = await compiled.code;
-    }
+	const guide_slugs = {};
+	for (const guide of guides) {
+		const guide_slug = [];
 
-    return {
-        guides
-    }
+		guide_slugs[guide.name] = guide_slug;
+		const get_slug = make_slug_processor();
+		console.log(to_string);
+		function plugin() {
+			return function transform(tree) {
+				tree.children.forEach((n) => {
+					if (
+						n.type === "element" &&
+						["h2", "h3", "h4", "h5", "h6"].includes(n.tagName)
+					) {
+						const str_of_heading = to_string(n);
+						const slug = get_slug(str_of_heading);
+
+						guide_slug.push({
+							text: str_of_heading,
+							href: `#${slug}`,
+							level: parseInt(n.tagName.replace("h", ""))
+						});
+
+						if (!n.children) n.children = [];
+						n.properties.id = [slug];
+						n.children.push({
+							type: "element",
+							tagName: "a",
+							properties: {
+								href: `#${slug}`
+							},
+							children: [
+								{
+									type: "element",
+									tagName: "img",
+									properties: {
+										src: anchor,
+										className: ["anchor-img"]
+									},
+									children: []
+								}
+							]
+						});
+					}
+				});
+			};
+		}
+
+		const compiled = await compile(guide.content, {
+			rehypePlugins: [plugin]
+		});
+		guide.new_html = await compiled.code;
+	}
+
+	// these are the slugs that we can use to build the navigation
+	console.log(guide_slugs);
+	return {
+		guides,
+		guide_slugs
+	};
 }

--- a/ui/packages/_website/src/routes/[guide=valid_guide]/+page.svelte
+++ b/ui/packages/_website/src/routes/[guide=valid_guide]/+page.svelte
@@ -9,6 +9,8 @@
     let guides = data.guides;
     let guides_by_category = guides_json.guides_by_category;
     let guide;
+    let nav = data.guide_slugs;
+    console.log(nav)
 
     const COLORS = ["bg-green-50", "bg-yellow-50", "bg-red-50", "bg-pink-50", "bg-purple-50"];
 
@@ -71,6 +73,11 @@
                     style="max-width: 12rem"
                     href="{ guide.url }">{guide.pretty_name}</a>
 
+                    <div class="navigation max-w-full bg-gradient-to-r from-orange-50 to-orange-100 p-2 mx-2 border-l-2 border-orange-500 mb-2">
+                        {#each nav[guide_page.name] as heading} 
+                            <a class="subheading block thin-link -indent-2 ml-4 mr-2" href="{heading.href}">{heading.text}</a>
+                        {/each}
+                    </div>
                 {:else}
                 <a
                 class:hidden={!show_all && i === guides_by_category.length - 1 && guides.category !== guide_page.category}
@@ -80,12 +87,12 @@
                     href="{ guide.url }">{guide.pretty_name}</a>
                 {/if}
 
-                {#if guide.name == guide_page.name}
+                <!-- {#if guide.name == guide_page.name}
                     <div 
                     bind:this={navigation}
                     class="navigation max-w-full bg-gradient-to-r from-orange-50 to-orange-100 p-2 mx-2 border-l-2 border-orange-500 mb-2">
                     </div>
-                {/if}
+                {/if} -->
             {/each}
         {/each}
     </div>

--- a/ui/packages/_website/src/routes/docs/+page.server.js
+++ b/ui/packages/_website/src/routes/docs/+page.server.js
@@ -4,6 +4,7 @@ import DocsNav from '../../components/DocsNav.svelte';
 import FunctionDoc from '../../components/FunctionDoc.svelte';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-python';
+import { make_slug_processor } from "../../utils";
 
 let language = 'python';
 
@@ -13,13 +14,25 @@ let helpers = docs_json.docs.helpers;
 let routes = docs_json.docs.routes;
 
 export async function load() {
-    let name = "interface";
-    let obj;
-    let mode;
-    for (const key in docs) {
-        for (const o in docs[key]) {
-            if (o == name) {
-                obj = docs[key][o];
+	let name = "interface";
+	let obj;
+	let mode;
+
+    const get_slug = make_slug_processor();
+
+	for (const key in docs) {
+		for (const o in docs[key]) {
+			if (docs[key][o].name) {
+				docs[key][o].slug = get_slug(docs[key][o].name);
+			}
+
+			if (docs[key][o].fns && docs[key][o].fns.length) {
+				docs[key][o].fns.forEach((fn) => {
+					if (fn.name) fn.slug = get_slug(`${docs[key][o].name} ${fn.name}`);
+				});
+			}
+			if (o == name) {
+				obj = docs[key][o];
                 mode = key;
                 if ("demos" in obj) {
                     obj.demos.forEach(demo => {

--- a/ui/packages/_website/src/routes/docs/+page.svelte
+++ b/ui/packages/_website/src/routes/docs/+page.svelte
@@ -62,7 +62,7 @@
         <div class="obj" id={ obj.name.toLowerCase() }>
             
             <div class="flex flex-row items-center justify-between"> 
-                <h3 id="{ obj.name.toLowerCase }-header" class="text-3xl font-light py-4">{ obj.name }</h3>
+                <h3 id="{ obj.slug }-header" class="text-3xl font-light py-4">{ obj.name }</h3>
             </div>
             
             {#if obj.override_signature }

--- a/ui/packages/_website/src/routes/docs/[doc=valid_doc]/+page.svelte
+++ b/ui/packages/_website/src/routes/docs/[doc=valid_doc]/+page.svelte
@@ -73,7 +73,7 @@
         <div class="obj" id={ obj.name.toLowerCase() }>
             
             <div class="flex flex-row items-center justify-between"> 
-                <h3 id="{ obj.name.toLowerCase }-header" class="text-3xl font-light py-4">{ obj.name }</h3>
+                <h3 id="{ obj.slug }-header" class="text-3xl font-light py-4">{ obj.name }</h3>
             </div>
             
             {#if obj.override_signature }

--- a/ui/packages/_website/src/routes/docs/block-layouts/+page.svelte
+++ b/ui/packages/_website/src/routes/docs/block-layouts/+page.svelte
@@ -64,7 +64,7 @@
             <div class="obj" id={ obj.name.toLowerCase() }>
                 
                 <div class="flex flex-row items-center justify-between"> 
-                    <h3 id="{ obj.name.toLowerCase }-header" class="text-3xl font-light py-4">{ obj.name }</h3>
+                    <h3 id="{ obj.slug }-header" class="text-3xl font-light py-4">{ obj.name }</h3>
                 </div>
                 
                 {#if obj.override_signature }

--- a/ui/packages/_website/src/routes/docs/combining-interfaces/+page.svelte
+++ b/ui/packages/_website/src/routes/docs/combining-interfaces/+page.svelte
@@ -66,7 +66,7 @@
             <div class="obj" id={ obj.name.toLowerCase() }>
                 
                 <div class="flex flex-row items-center justify-between"> 
-                    <h3 id="{ obj.name.toLowerCase }-header" class="text-3xl font-light py-4">{ obj.name }</h3>
+                    <h3 id="{ obj.slug }-header" class="text-3xl font-light py-4">{ obj.name }</h3>
                 </div>
                 
                 {#if obj.override_signature }

--- a/ui/packages/_website/src/routes/docs/flagging/+page.svelte
+++ b/ui/packages/_website/src/routes/docs/flagging/+page.svelte
@@ -65,7 +65,7 @@
             <div class="obj" id={ obj.name.toLowerCase() }>
                 
                 <div class="flex flex-row items-center justify-between"> 
-                    <h3 id="{ obj.name.toLowerCase }-header" class="text-3xl font-light py-4">{ obj.name }</h3>
+                    <h3 id="{ obj.slug }-header" class="text-3xl font-light py-4">{ obj.name }</h3>
                 </div>
                 
                 {#if obj.override_signature }

--- a/ui/packages/_website/src/utils.ts
+++ b/ui/packages/_website/src/utils.ts
@@ -46,3 +46,21 @@ export const media_query = () => {
 
 	return { subscribe };
 };
+
+import slugify from "@sindresorhus/slugify";
+
+export function make_slug_processor() {
+	const seen_slugs = new Map();
+
+	return function (name: string) {
+		const slug = slugify(name, { separator: "-", lowercase: true });
+		let count = seen_slugs.get(slug);
+		if (count) {
+			seen_slugs.set(slug, count + 1);
+			return `${slug}-${count + 1}`;
+		} else {
+			seen_slugs.set(slug, 1);
+			return slug;
+		}
+	};
+}

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -89,10 +89,12 @@ importers:
 
   packages/_website:
     specifiers:
+      '@sindresorhus/slugify': ^2.2.0
       '@sveltejs/adapter-auto': ^2.0.0
       '@sveltejs/kit': ^1.5.0
       '@tailwindcss/forms': ^0.5.0
       '@tailwindcss/typography': ^0.5.4
+      hast-util-to-string: ^2.0.0
       mdsvex: ^0.10.6
       postcss: '>=8.3.3 <9.0.0'
       prismjs: 1.29.0
@@ -103,6 +105,8 @@ importers:
       typescript: ^4.9.3
       vite: ^4.0.0
     dependencies:
+      '@sindresorhus/slugify': 2.2.0
+      hast-util-to-string: 2.0.0
       mdsvex: 0.10.6_svelte@3.55.1
       postcss: 8.4.21
     devDependencies:
@@ -904,6 +908,21 @@ packages:
       picomatch: 2.3.1
     dev: false
 
+  /@sindresorhus/slugify/2.2.0:
+    resolution: {integrity: sha512-9Vybc/qX8Kj6pxJaapjkFbiUJPk7MAkCh/GFCxIBnnsuYCFPIXKvnLidG8xlepht3i24L5XemUmGtrJ3UWrl6w==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@sindresorhus/transliterate': 1.6.0
+      escape-string-regexp: 5.0.0
+    dev: false
+
+  /@sindresorhus/transliterate/1.6.0:
+    resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      escape-string-regexp: 5.0.0
+    dev: false
+
   /@sveltejs/adapter-auto/1.0.0-next.91_b2bjiolq6much32vueqoio7eoy:
     resolution: {integrity: sha512-U57tQdzTfFINim8tzZSARC9ztWPzwOoHwNOpGdb2o6XrD0mEQwU9DsII7dBblvzg+xCnmd0pw7PDtXz5c5t96w==}
     peerDependencies:
@@ -1151,6 +1170,12 @@ packages:
     resolution: {integrity: sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=}
     dependencies:
       '@types/node': 17.0.14
+    dev: false
+
+  /@types/hast/2.3.4:
+    resolution: {integrity: sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==}
+    dependencies:
+      '@types/unist': 2.0.6
     dev: false
 
   /@types/istanbul-lib-coverage/2.0.4:
@@ -2276,6 +2301,11 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: false
 
+  /escape-string-regexp/5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+    dev: false
+
   /esm-env/1.0.0:
     resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
     dev: true
@@ -2548,6 +2578,12 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
+
+  /hast-util-to-string/2.0.0:
+    resolution: {integrity: sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==}
+    dependencies:
+      '@types/hast': 2.3.4
+    dev: false
 
   /he/1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}


### PR DESCRIPTION
@aliabd 

I did this work in a PR to your branch just so you could easily see what I'm doing here. Feel free to adapt the code in here, copy the changes across however you like. You can close this PR whenever you want to.

Don't know if everyone is familiar with the term 'slug' but it just means then end of the url, after the domain. It needs to be a valid url. 

So the first case is that we have some data, rather than markdown. In this case we can simply pass the most appropriate string to the `slugifier`, i grabbed one from npm. For `fn` names i used a combination of the class name + the function name so we get slugs like `#interface-load`. The slugifier also handles collisions, so if we ever have two links with the same name on the same page then it will generate a different url (it just adds a number). I generate these slugs and store them as additional properties on the docs json object. under `.slug`. You can see this better in the code.

For markdown it is moire complicated but the propcess is essentially the same. The only difference is I had to write it as a plugin. We generate the slugs and modify the generated html to add the necessary info + elements. We _also_ store a list of the headings + links for each section so we can build a navigation. The plugin code is what it is, we can't control that plugin API but it is relatively easy to understand and is short at least.


lmk if you have any questions

