### PR TITLE
Fix custom css code block in guide

### DIFF
--- a/guides/03_building-with-blocks/04_custom-CSS-and-JS.md
+++ b/guides/03_building-with-blocks/04_custom-CSS-and-JS.md
@@ -15,7 +15,7 @@ with gr.Blocks(css=".gradio-container {background-color: red}") as demo:
 If you'd like to reference external files in your css, preface the file path (which can be a relative or absolute path) with `"file="`, for example:
 
 ```python
-with gr.Blocks(css=".gradio-container {background-image: url('file=clouds.jpg')}") as demo:
+with gr.Blocks(css=".gradio-container {background: url('file=clouds.jpg')}") as demo:
     ...
 ```
 
@@ -26,9 +26,9 @@ You can also pass the filepath to a CSS file to the `css` argument.
 You can `elem_id` to add an HTML element `id` to any component, and `elem_classes` to add a class or list of classes. This will allow you to select elements more easily with CSS.
 
 ```python
-with gr.Blocks(css="#warning {color: red} .feedback {font-size: 24px}") as demo:
-    box1 = gr.Textbox(value="Good Job", elem_class="feedback")
-    box2 = gr.Textbox(value="Failure", elem_id="warning", elem_class="feedback")
+with gr.Blocks(css="#warning {background-color: red} .feedback {font-size: 24px}") as demo:
+    box1 = gr.Textbox(value="Good Job", elem_classes="feedback")
+    box2 = gr.Textbox(value="Failure", elem_id="warning", elem_classes="feedback")
 ```
 
 The CSS `#warning` ruleset will only target the second Textbox, while the `.feedback` ruleset will target both.


### PR DESCRIPTION
# Description

The code block had a couple of typos, `color` instead of `background-color` and `elem_class` instead of `elem_classes`. 

I still can't get the `elem_class` example to work with font class, however. It doesn't increase the font size, just adds a bunch of weird spacing to the top of the text box. This is with and without `!important` cc @aliabid94 @abidlabs 

![image](https://user-images.githubusercontent.com/41651716/225657133-dbe44896-da5f-4775-8f73-9951bfa4191f.png)


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.