### PR TITLE
Improve error messages for when argument lists mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ No changes to highlight.
 
 ## New Features:
 
-No changes to highlight.
+- Improve error messages when number of inputs/outputs to event handlers mismatch, by [@space-nuko](https://github.com/space-nuko) in [PR 3519](https://github.com/gradio-app/gradio/pull/3519)
 
 ## Bug Fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## New Features:
 
-No changes to highlight.
+- Improve error messages when number of inputs/outputs to event handlers mismatch, by [@space-nuko](https://github.com/space-nuko) in [PR 3519](https://github.com/gradio-app/gradio/pull/3519)
 
 ## Bug Fixes:
 
@@ -38,7 +38,6 @@ No changes to highlight.
 
 ## New Features:
 
-- Improve error messages when number of inputs/outputs to event handlers mismatch, by [@space-nuko](https://github.com/space-nuko) in [PR 3519](https://github.com/gradio-app/gradio/pull/3519)
 
 ## Bug Fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ No changes to highlight.
 
 ## New Features:
 
+- No changes to highlight.
 
 ## Bug Fixes:
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1006,6 +1006,7 @@ class Blocks(BlockContext):
             wanted = ", ".join(wanted_args)
             received = ", ".join(received_args)
 
+            # JS func didn't pass enough arguments
             raise ValueError(f"""An event handler{name} didn't receive enough input values (needed: {len(dep_inputs)}, got: {len(inputs)}).
 Check if the event handler calls a Javascript function, and make sure its return value is correct.
 Wanted inputs:
@@ -1058,7 +1059,6 @@ Received inputs:
             wanted = ", ".join(wanted_args)
             received = ", ".join(received_args)
 
-            # JS func didn't pass enough arguments
             raise ValueError(f"""An event handler{name} didn't receive enough output values (needed: {len(dep_outputs)}, received: {len(predictions)}).
 Wanted outputs:
     [{wanted}]

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -989,7 +989,11 @@ class Blocks(BlockContext):
         # Only check not enough args case, ignore extra arguments (for now)
         # TODO: make this stricter?
         if len(inputs) < len(dep_inputs):
-            name = f" ({block_fn.name})" if block_fn.name and block_fn.name != "<lambda>" else ""
+            name = (
+                f" ({block_fn.name})"
+                if block_fn.name and block_fn.name != "<lambda>"
+                else ""
+            )
 
             wanted_args = []
             received_args = []
@@ -1007,12 +1011,14 @@ class Blocks(BlockContext):
             received = ", ".join(received_args)
 
             # JS func didn't pass enough arguments
-            raise ValueError(f"""An event handler{name} didn't receive enough input values (needed: {len(dep_inputs)}, got: {len(inputs)}).
+            raise ValueError(
+                f"""An event handler{name} didn't receive enough input values (needed: {len(dep_inputs)}, got: {len(inputs)}).
 Check if the event handler calls a Javascript function, and make sure its return value is correct.
 Wanted inputs:
     [{wanted}]
 Received inputs:
-    [{received}]""")
+    [{received}]"""
+            )
 
     def preprocess_data(self, fn_index: int, inputs: List[Any], state: Dict[int, Any]):
         block_fn = self.fns[fn_index]
@@ -1045,7 +1051,11 @@ Received inputs:
             predictions = [predictions]
 
         if len(predictions) < len(dep_outputs):
-            name = f" ({block_fn.name})" if block_fn.name and block_fn.name != "<lambda>" else ""
+            name = (
+                f" ({block_fn.name})"
+                if block_fn.name and block_fn.name != "<lambda>"
+                else ""
+            )
 
             wanted_args = []
             received_args = []
@@ -1062,11 +1072,13 @@ Received inputs:
             wanted = ", ".join(wanted_args)
             received = ", ".join(received_args)
 
-            raise ValueError(f"""An event handler{name} didn't receive enough output values (needed: {len(dep_outputs)}, received: {len(predictions)}).
+            raise ValueError(
+                f"""An event handler{name} didn't receive enough output values (needed: {len(dep_outputs)}, received: {len(predictions)}).
 Wanted outputs:
     [{wanted}]
 Received outputs:
-    [{received}]""")
+    [{received}]"""
+            )
 
     def postprocess_data(
         self, fn_index: int, predictions: List | Dict, state: Dict[int, Any]

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1035,11 +1035,14 @@ Received inputs:
             processed_input = inputs
         return processed_input
 
-    def validate_outputs(self, fn_index: int, predictions: List[Any]):
+    def validate_outputs(self, fn_index: int, predictions: Any | List[Any]):
         block_fn = self.fns[fn_index]
         dependency = self.dependencies[fn_index]
 
         dep_outputs = dependency["outputs"]
+
+        if type(predictions) is not list:
+            predictions = [predictions]
 
         if len(predictions) < len(dep_outputs):
             name = f" ({block_fn.name})" if block_fn.name and block_fn.name != "<lambda>" else ""

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1082,7 +1082,7 @@ Received outputs:
                 predictions,
             ]
 
-        self.validate_outputs(fn_index, predictions)
+        self.validate_outputs(fn_index, predictions)  # type: ignore
 
         output = []
         for i, output_id in enumerate(dependency["outputs"]):

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1041,7 +1041,7 @@ Received inputs:
 
         dep_outputs = dependency["outputs"]
 
-        if type(predictions) is not list:
+        if type(predictions) is not list and type(predictions) is not tuple:
             predictions = [predictions]
 
         if len(predictions) < len(dep_outputs):

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -565,6 +565,47 @@ class TestBlocksPostprocessing:
         ):
             demo.postprocess_data(fn_index=0, predictions=["test"], state={})
 
+    def test_error_raised_if_num_outputs_mismatch_with_function_name(self):
+        def infer(x):
+            return x
+        with gr.Blocks() as demo:
+            textbox1 = gr.Textbox()
+            textbox2 = gr.Textbox()
+            button = gr.Button()
+            button.click(infer, textbox1, [textbox1, textbox2])
+        with pytest.raises(
+            ValueError,
+            match=r'An event handler \(infer\) didn\'t receive enough output values \(needed: 2, received: 1\)\.\nWanted outputs:\n    \[textbox, textbox\]\nReceived outputs:\n    \["test"\]',
+        ):
+            demo.postprocess_data(fn_index=0, predictions=["test"], state={})
+
+    def test_error_raised_if_num_outputs_mismatch_single_output(self):
+        with gr.Blocks() as demo:
+            num1 = gr.Number()
+            num2 = gr.Number()
+            btn = gr.Button(value='1')
+            btn.click(lambda a: a, num1, [num1, num2])
+        with pytest.raises(
+            ValueError,
+            match=r'An event handler didn\'t receive enough output values \(needed: 2, received: 1\)\.\nWanted outputs:\n    \[number, number\]\nReceived outputs:\n    \[1\]',
+        ):
+            demo.postprocess_data(fn_index=0, predictions=1, state={})
+
+    def test_error_raised_if_num_outputs_mismatch_tuple_output(self):
+        def infer(a, b):
+            return a, b
+        with gr.Blocks() as demo:
+            num1 = gr.Number()
+            num2 = gr.Number()
+            num3 = gr.Number()
+            btn = gr.Button(value='1')
+            btn.click(infer, num1, [num1, num2, num3])
+        with pytest.raises(
+            ValueError,
+            match=r'An event handler \(infer\) didn\'t receive enough output values \(needed: 3, received: 2\)\.\nWanted outputs:\n    \[number, number, number\]\nReceived outputs:\n    \[1, 2\]',
+        ):
+            demo.postprocess_data(fn_index=0, predictions=(1, 2), state={})
+
 
 class TestCallFunction:
     @pytest.mark.asyncio

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -561,7 +561,7 @@ class TestBlocksPostprocessing:
             button.click(lambda x: x, textbox1, [textbox1, textbox2])
         with pytest.raises(
             ValueError,
-            match="Number of output components does not match number of values returned from from function <lambda>",
+            match=r'An event handler didn\'t receive enough output values \(needed: 2, received: 1\)\.\nWanted outputs:\n    \[textbox, textbox\]\nReceived outputs:\n    \["test"\]',
         ):
             demo.postprocess_data(fn_index=0, predictions=["test"], state={})
 

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -568,6 +568,7 @@ class TestBlocksPostprocessing:
     def test_error_raised_if_num_outputs_mismatch_with_function_name(self):
         def infer(x):
             return x
+
         with gr.Blocks() as demo:
             textbox1 = gr.Textbox()
             textbox2 = gr.Textbox()
@@ -583,26 +584,27 @@ class TestBlocksPostprocessing:
         with gr.Blocks() as demo:
             num1 = gr.Number()
             num2 = gr.Number()
-            btn = gr.Button(value='1')
+            btn = gr.Button(value="1")
             btn.click(lambda a: a, num1, [num1, num2])
         with pytest.raises(
             ValueError,
-            match=r'An event handler didn\'t receive enough output values \(needed: 2, received: 1\)\.\nWanted outputs:\n    \[number, number\]\nReceived outputs:\n    \[1\]',
+            match=r"An event handler didn\'t receive enough output values \(needed: 2, received: 1\)\.\nWanted outputs:\n    \[number, number\]\nReceived outputs:\n    \[1\]",
         ):
             demo.postprocess_data(fn_index=0, predictions=1, state={})
 
     def test_error_raised_if_num_outputs_mismatch_tuple_output(self):
         def infer(a, b):
             return a, b
+
         with gr.Blocks() as demo:
             num1 = gr.Number()
             num2 = gr.Number()
             num3 = gr.Number()
-            btn = gr.Button(value='1')
+            btn = gr.Button(value="1")
             btn.click(infer, num1, [num1, num2, num3])
         with pytest.raises(
             ValueError,
-            match=r'An event handler \(infer\) didn\'t receive enough output values \(needed: 3, received: 2\)\.\nWanted outputs:\n    \[number, number, number\]\nReceived outputs:\n    \[1, 2\]',
+            match=r"An event handler \(infer\) didn\'t receive enough output values \(needed: 3, received: 2\)\.\nWanted outputs:\n    \[number, number, number\]\nReceived outputs:\n    \[1, 2\]",
         ):
             demo.postprocess_data(fn_index=0, predictions=(1, 2), state={})
 


### PR DESCRIPTION
# Description

When an event handler throws an error, I usually have no idea which event handler it was. This PR attempts to rectify that by introducing the function name and received/required arguments lists in the exception. It also improves the output message for when a JavaScript function modifies the input arguments, but those arguments don't match the list of inputs to the event handler.

Related: #3082