### PR TITLE
Removes leading spaces from all lines of code uniformly in the `gr.Code()` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ No changes to highlight.
 
 ## Bug Fixes:
 
-No changes to highlight.
+* Removes leading spaces from all lines of code uniformly in the `gr.Code()` component. By [@abidlabs](https://github.com/abidlabs) in [PR 3556](https://github.com/gradio-app/gradio/pull/3556) 
+
 
 ## Documentation Changes:
 

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -5593,10 +5593,14 @@ class Code(Changeable, IOComponent, SimpleSerializable):
         }
 
     def postprocess(self, y):
-        if y is not None and isinstance(y, tuple):
+        if y is None:
+            return None
+        elif isinstance(y, tuple):
             with open(y[0]) as file_data:
                 return file_data.read()
-        return y
+        else:
+            unindented_y = inspect.cleandoc(y)
+            return unindented_y
 
     @staticmethod
     def update(

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -2578,7 +2578,11 @@ class TestCode:
         assert code.preprocess("# hello friends") == "# hello friends"
         assert code.preprocess("def fn(a):\n  return a") == "def fn(a):\n  return a"
 
-        assert code.postprocess("def fn(a):\n  return a") == "def fn(a):\n  return a"
+        assert code.postprocess(
+            """
+            def fn(a):
+                return a
+            """) == "def fn(a):\n    return a"
 
         test_file_dir = Path(Path(__file__).parent, "test_files")
         path = str(Path(test_file_dir, "test_label_json.json"))


### PR DESCRIPTION
Fixes: #3552

Test code:

```py
import gradio as gr

with gr.Blocks() as demo:
    gr.Code("""
    def fn(a):
        return a
    """, language="python")
    
demo.launch()
```