### PR TITLE
Remove extra $demo from theme guide

### DIFF
--- a/guides/06_other-tutorials/theming-guide.md
+++ b/guides/06_other-tutorials/theming-guide.md
@@ -145,7 +145,6 @@ with gr.Blocks(theme=gr.themes.Default(font=[gr.themes.GoogleFont("Inconsolata")
     ...
 ```
 
-$demo_theme_extended_step_3
 <div class="wrapper">
 <iframe
 	src="https://gradio-theme-extended-step-3.hf.space?__theme=light"


### PR DESCRIPTION
Missed a $demo from guide that needs to be removed. 