### PR TITLE
Trigger event when Slider number input is released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## New Features:
 
-No changes to highlight.
+- Trigger the release event when Slider number input is released or unfocused  by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3589](https://github.com/gradio-app/gradio/pull/3589)   
 
 ## Bug Fixes:
 

--- a/ui/packages/form/src/Range.svelte
+++ b/ui/packages/form/src/Range.svelte
@@ -24,6 +24,7 @@
 
 	$: dispatch("change", value);
 	const clamp = () => {
+		dispatch("release", value);
 		value = Math.min(Math.max(value, minimum), maximum);
 	};
 </script>
@@ -41,6 +42,7 @@
 			on:blur={clamp}
 			{step}
 			{disabled}
+			on:mouseup={handle_release}
 		/>
 	</div>
 </div>

--- a/ui/packages/form/src/Range.svelte
+++ b/ui/packages/form/src/Range.svelte
@@ -35,6 +35,7 @@
 			<BlockTitle {show_label} {info}>{label}</BlockTitle>
 		</label>
 		<input
+			data-testid="number-input"
 			type="number"
 			bind:value
 			min={minimum}

--- a/ui/packages/form/src/Range.test.ts
+++ b/ui/packages/form/src/Range.test.ts
@@ -1,0 +1,29 @@
+import { test, describe, afterEach, vi, expect } from "vitest";
+import { cleanup, render, fireEvent } from "@gradio/tootils";
+
+import Range from "./Range.svelte";
+
+describe("Range", () => {
+	afterEach(() => cleanup());
+
+	test("Release event called on blur and mouseUp", () => {
+		const results = render(Range, {
+			label: "range",
+			show_label: true,
+			value: 1,
+			minimum: 0,
+			maximum: 10
+		});
+
+		const numberInput = results.getAllByTestId("number-input")[0];
+		const mock = vi.fn();
+		results.component.$on("release", mock);
+
+		fireEvent.mouseUp(numberInput);
+
+		expect(mock).toHaveBeenCalledOnce();
+
+		fireEvent.blur(numberInput);
+		expect(mock).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
# Description

Fixes #3443 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.