### PR TITLE
Set theme name from load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ No changes to highlight.
 
 * Mobile responsive iframes in themes guide by [@aliabd](https://github.com/aliabd) in [PR 3562](https://github.com/gradio-app/gradio/pull/3562) 
 * Remove extra $demo from theme guide by [@aliabd](https://github.com/aliabd) in [PR 3563](https://github.com/gradio-app/gradio/pull/3563)
-
+* Set the theme name to be the upstream repo name when loading from the hub by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3595](https://github.com/gradio-app/gradio/pull/3595)   
 
 ## Contributors Shoutout:
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -505,7 +505,7 @@ class Blocks(BlockContext):
         if not isinstance(theme, Theme):
             warnings.warn("Theme should be a class loaded from gradio.themes")
             theme = DefaultTheme()
-        self.theme = theme
+        self.theme: Theme = theme
         self.theme_css = theme._get_theme_css()
         self.stylesheets = theme._stylesheets
         self.encrypt = False

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -308,7 +308,6 @@ class Interface(Blocks):
         self.article = article
 
         self.thumbnail = thumbnail
-        self.theme = theme
 
         self.examples = examples
         self.num_shap = num_shap

--- a/gradio/themes/base.py
+++ b/gradio/themes/base.py
@@ -28,6 +28,7 @@ set_documentation_group("themes")
 class ThemeClass:
     def __init__(self):
         self._stylesheets = []
+        self.name = None
 
     def _get_theme_css(self):
         css = {}
@@ -101,6 +102,7 @@ class ThemeClass:
                 not prop.startswith("_")
                 or prop.startswith("_font")
                 or prop == "_stylesheets"
+                or prop == "name"
             ) and isinstance(getattr(self, prop), (list, str)):
                 schema["theme"][prop] = getattr(self, prop)
         return schema
@@ -172,7 +174,9 @@ class ThemeClass:
             repo_type="space",
             filename=f"themes/theme_schema@{matching_version.version}.json",
         )
-        return cls.load(theme_file)
+        theme = cls.load(theme_file)
+        theme.name = name
+        return theme
 
     @staticmethod
     def _get_next_version(space_info: huggingface_hub.hf_api.SpaceInfo) -> str:

--- a/gradio/themes/base.py
+++ b/gradio/themes/base.py
@@ -361,6 +361,8 @@ class Base(ThemeClass):
             font_mono: The monospace font to use for the theme, applies to code. Pass a string for a system font, or a gradio.themes.font.GoogleFont object to load a font from Google Fonts. Pass a list of fonts for fallbacks.
         """
 
+        self.name = "base"
+
         def expand_shortcut(shortcut, mode="color", prefix=None):
             if not isinstance(shortcut, str):
                 return shortcut

--- a/gradio/themes/default.py
+++ b/gradio/themes/default.py
@@ -43,6 +43,7 @@ class Default(Base):
             font=font,
             font_mono=font_mono,
         )
+        self.name = "default"
         super().set(
             # Colors
             input_background_fill_dark="*neutral_800",

--- a/gradio/themes/glass.py
+++ b/gradio/themes/glass.py
@@ -44,6 +44,7 @@ class Glass(Base):
             font=font,
             font_mono=font_mono,
         )
+        self.name = "glass"
         super().set(
             body_background_fill_dark="*primary_800",
             background_fill_secondary_dark="*primary_800",

--- a/gradio/themes/monochrome.py
+++ b/gradio/themes/monochrome.py
@@ -43,6 +43,7 @@ class Monochrome(Base):
             font=font,
             font_mono=font_mono,
         )
+        self.name = "monochrome"
         super().set(
             # Colors
             slider_color="*neutral_900",

--- a/gradio/themes/soft.py
+++ b/gradio/themes/soft.py
@@ -43,6 +43,7 @@ class Soft(Base):
             font=font,
             font_mono=font_mono,
         )
+        self.name = "soft"
         super().set(
             # Colors
             background_fill_primary="*neutral_50",

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -2598,11 +2598,15 @@ class TestCode:
         assert code.preprocess("# hello friends") == "# hello friends"
         assert code.preprocess("def fn(a):\n  return a") == "def fn(a):\n  return a"
 
-        assert code.postprocess(
-            """
+        assert (
+            code.postprocess(
+                """
             def fn(a):
                 return a
-            """) == "def fn(a):\n    return a"
+            """
+            )
+            == "def fn(a):\n    return a"
+        )
 
         test_file_dir = Path(Path(__file__).parent, "test_files")
         path = str(Path(test_file_dir, "test_label_json.json"))

--- a/test/test_theme_sharing.py
+++ b/test/test_theme_sharing.py
@@ -169,6 +169,7 @@ dracula = gr.themes.Base(
     panel_background_fill="#31395294",
     block_background_fill_dark="#31395294",
 )
+dracula.name = "gradio/dracula_test"
 
 
 class TestSemverMatch:
@@ -279,6 +280,7 @@ class TestThemeUploadDownload:
             pass
 
         assert demo.theme.to_dict() == dracula.to_dict()
+        assert demo.theme.name == "gradio/dracula_test"
 
     def test_theme_download_raises_error_if_theme_does_not_exist(self):
 

--- a/test/test_theme_sharing.py
+++ b/test/test_theme_sharing.py
@@ -260,6 +260,21 @@ class TestGetThemeAssets:
                 get_theme_assets(space_info)
 
 
+class TestBuiltInThemes:
+    @pytest.mark.parametrize(
+        "theme, name",
+        [
+            (gr.themes.Base(), "base"),
+            (gr.themes.Glass(), "glass"),
+            (gr.themes.Monochrome(), "monochrome"),
+            (gr.themes.Soft(), "soft"),
+            (gr.themes.Default(), "default"),
+        ],
+    )
+    def test_theme_name(self, theme, name):
+        assert theme.name == name
+
+
 class TestThemeUploadDownload:
     @patch("gradio.themes.base.get_theme_assets", return_value=assets)
     def test_get_next_version(self, mock):


### PR DESCRIPTION
# Description

As discussed on slack, let's add the theme name to keep track of which themes are popular.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.