### PR TITLE
Make Vite dev server respect the backend port/address environment variables

### DIFF
--- a/.config/.prettierignore
+++ b/.config/.prettierignore
@@ -11,4 +11,5 @@
 **/.github/**
 **/guides/**
 **/test/**
+**/.mypy_cache/**
 **/*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - Removed heavily-mocked tests related to comet_ml, wandb, and mlflow as they added a significant amount of test dependencies that prevented installation of test dependencies on Windows environemnts. By [@abidlabs](https://github.com/abidlabs) in [PR 3608](https://github.com/gradio-app/gradio/pull/3608)
 - Added Windows continuous integration, by [@space-nuko](https://github.com/space-nuko) in [PR 3628](https://github.com/gradio-app/gradio/pull/3628)
+- Make frontend development server port/address configurable, by [@space-nuko](https://github.com/space-nuko) in [PR 3668](https://github.com/gradio-app/gradio/pull/3668)
 
 ## Breaking Changes:
 

--- a/guides/06_other-tutorials/creating-a-new-component.md
+++ b/guides/06_other-tutorials/creating-a-new-component.md
@@ -383,6 +383,8 @@ To test the application:
 - run on a terminal `python path/demo/run.py` which starts the backend at the address [http://localhost:7860](http://localhost:7860);
 - in another terminal, run `pnpm dev` to start the frontend at [http://localhost:9876](http://localhost:9876) with hot reload functionalities.
 
+**Note**: If you have more than one Gradio backend running and need to configure which backend the dev server will connect to, set the `GRADIO_SERVER_PORT` environment variable when running the frontend and backend. That will configure the backend to listen on the port and the Vite dev server to connect on that port (the default is 7860).
+
 ## Conclusion
 
 In this guide, we have shown how simple it is to add a new component to Gradio, seeing step by step how the ColorPicker component was added. For further details, you can refer to PR: [#1695](https://github.com/gradio-app/gradio/pull/1695).

--- a/js/app/package.json
+++ b/js/app/package.json
@@ -7,6 +7,7 @@
 		"build:cdn": "vite build --mode production:cdn --emptyOutDir",
 		"build:website": "vite build  --mode production:website --emptyOutDir",
 		"build:local": "vite build  --mode production:local --emptyOutDir",
+		"build:dev": "vite build  --mode dev --emptyOutDir",
 		"preview": "vite preview",
 		"test:snapshot": "pnpm exec playwright test snapshots/ --config=../../.config/playwright.config.js",
 		"test:browser": "pnpm exec playwright test test/ --config=../../.config/playwright.config.js",

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -195,8 +195,12 @@
 
 		const api_url =
 			BUILD_MODE === "dev"
-				? "http://localhost:7860"
+				? BACKEND_URL || "http://localhost:7860"
 				: host || space || src || location.origin;
+
+        if (BUILD_MODE === "dev") {
+            console.log(`Backend URL set to ${api_url} for development, configure your demo.launch(...) options to match`);
+        }
 
 		app = await client(api_url, handle_status);
 		config = app.config;

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -198,9 +198,11 @@
 				? BACKEND_URL || "http://localhost:7860"
 				: host || space || src || location.origin;
 
-        if (BUILD_MODE === "dev") {
-            console.log(`Backend URL set to ${api_url} for development, configure your demo.launch(...) options to match`);
-        }
+		if (BUILD_MODE === "dev") {
+			console.log(
+				`Backend URL set to ${api_url} for development, configure your demo.launch(...) options to match`
+			);
+		}
 
 		app = await client(api_url, handle_status);
 		config = app.config;

--- a/js/app/vite.config.js
+++ b/js/app/vite.config.js
@@ -34,9 +34,9 @@ export default defineConfig(({ mode }) => {
 		mode === "production:local" ||
 		mode === "production:website";
 	const is_cdn = mode === "production:cdn" || mode === "production:website";
-    const env = loadEnv(mode, process.cwd(), '');
-    const server_port = env.GRADIO_SERVER_PORT || "7860";
-    const server_name = env.GRADIO_SERVER_NAME || "127.0.0.1";
+	const env = loadEnv(mode, process.cwd(), "");
+	const server_port = env.GRADIO_SERVER_PORT || "7860";
+	const server_name = env.GRADIO_SERVER_NAME || "127.0.0.1";
 
 	return {
 		base: is_cdn ? CDN_URL : "./",

--- a/js/app/vite.config.js
+++ b/js/app/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import sveltePreprocess from "svelte-preprocess";
 // @ts-ignore
@@ -34,6 +34,9 @@ export default defineConfig(({ mode }) => {
 		mode === "production:local" ||
 		mode === "production:website";
 	const is_cdn = mode === "production:cdn" || mode === "production:website";
+    const env = loadEnv(mode, process.cwd(), '');
+    const server_port = env.GRADIO_SERVER_PORT || "7860";
+    const server_name = env.GRADIO_SERVER_NAME || "127.0.0.1";
 
 	return {
 		base: is_cdn ? CDN_URL : "./",
@@ -52,7 +55,7 @@ export default defineConfig(({ mode }) => {
 			BUILD_MODE: production ? JSON.stringify("prod") : JSON.stringify("dev"),
 			BACKEND_URL: production
 				? JSON.stringify("")
-				: JSON.stringify("http://localhost:7860/"),
+				: JSON.stringify(`http://${server_name}:${server_port}`),
 			GRADIO_VERSION: JSON.stringify(version)
 		},
 		css: {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"build:cdn": "pnpm --filter @gradio/app build:cdn --emptyOutDir",
 		"build:website": "pnpm --filter @gradio/app build:website --emptyOutDir",
 		"build:cdn-local": "TEST_CDN=TRUE pnpm build:cdn",
+		"build:dev": "pnpm css && pnpm --filter @gradio/app build:dev --emptyOutDir",
 		"preview:cdn-server": "sirv ../gradio/templates/cdn --single --port=4321 --cors",
 		"preview:cdn-app": "pnpm --filter @gradio/cdn-test dev",
 		"preview:cdn-local": "run-p preview:cdn-server preview:cdn-app",

--- a/scripts/build_frontend.sh
+++ b/scripts/build_frontend.sh
@@ -5,6 +5,13 @@ source scripts/helpers.sh
 
 pnpm_required
 
-echo "Building the frontend..."
+cmd="build"
+if [[ "$1" == "dev" ]]; then
+    echo "Building the frontend (development mode)..."
+    cmd="build:dev"
+else
+    echo "Building the frontend..."
+fi
+
 pnpm i --frozen-lockfile
-pnpm build
+pnpm $cmd


### PR DESCRIPTION
# Description

Now the frontend dev server will respond to the `GRADIO_SERVER_PORT` and `GRADIO_SERVER_NAME` environment variables like the backend does.

Closes: #3656

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes