### PR TITLE
Add root_url to serializers in gradio_client

### DIFF
--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -311,7 +311,7 @@ class Endpoint:
         try:
             assert client.src
             self.serializers, self.deserializers = self._setup_serializers(
-                src=client.src + "/"
+                src=client.src + "/" if not client.src.endswith("/") else client.src
             )
             self.is_valid = self.dependency[
                 "backend_fn"

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -309,7 +309,9 @@ class Endpoint:
         self.input_component_types = []
         self.output_component_types = []
         try:
-            self.serializers, self.deserializers = self._setup_serializers()
+            self.serializers, self.deserializers = self._setup_serializers(
+                src=client.src + "/"
+            )
             self.is_valid = self.dependency[
                 "backend_fn"
             ]  # Only a real API endpoint if backend_fn is True and serializers are valid
@@ -473,7 +475,9 @@ class Endpoint:
             ]
         )
 
-    def _setup_serializers(self) -> Tuple[List[Serializable], List[Serializable]]:
+    def _setup_serializers(
+        self, src: str
+    ) -> Tuple[List[Serializable], List[Serializable]]:
         inputs = self.dependency["inputs"]
         serializers = []
 
@@ -513,7 +517,7 @@ class Endpoint:
                             component_name in serializing.COMPONENT_MAPPING
                         ), f"Unknown component: {component_name}, you may need to update your gradio_client version."
                         deserializer = serializing.COMPONENT_MAPPING[component_name]
-                    deserializers.append(deserializer())  # type: ignore
+                    deserializers.append(deserializer(root_url=src))  # type: ignore
 
         return serializers, deserializers
 

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -309,6 +309,7 @@ class Endpoint:
         self.input_component_types = []
         self.output_component_types = []
         try:
+            assert client.src
             self.serializers, self.deserializers = self._setup_serializers(
                 src=client.src + "/"
             )

--- a/client/python/gradio_client/serializing.py
+++ b/client/python/gradio_client/serializing.py
@@ -11,9 +11,6 @@ from gradio_client import utils
 
 
 class Serializable(ABC):
-    def __init__(self, root_url: str | None = None):
-        self.root_url = root_url
-
     @abstractmethod
     def input_api_info(self) -> Tuple[str, str]:
         """
@@ -191,10 +188,9 @@ class FileSerializable(Serializable):
         Parameters:
             x: Base64 representation of file to deserialize into a string filepath
             save_dir: Path to directory to save the deserialized file to
-            root_url: If this component is loaded from an external Space, this is the URL of the Space. If set during init, this parameter has no effect.
+            root_url: If this component is loaded from an external Space, this is the URL of the Space.
             hf_token: If this component is loaded from an external private Space, this is the access token for the Space
         """
-        _root_url = self.root_url or root_url
         if x is None:
             return None
         if isinstance(save_dir, Path):
@@ -203,9 +199,9 @@ class FileSerializable(Serializable):
             file_name = utils.decode_base64_to_file(x, dir=save_dir).name
         elif isinstance(x, dict):
             if x.get("is_file", False):
-                if _root_url is not None:
+                if root_url is not None:
                     file_name = utils.download_tmp_copy_of_file(
-                        _root_url + "file=" + x["name"],
+                        root_url + "file=" + x["name"],
                         hf_token=hf_token,
                         dir=save_dir,
                     ).name

--- a/client/python/gradio_client/serializing.py
+++ b/client/python/gradio_client/serializing.py
@@ -191,7 +191,7 @@ class FileSerializable(Serializable):
         Parameters:
             x: Base64 representation of file to deserialize into a string filepath
             save_dir: Path to directory to save the deserialized file to
-            root_url: If this component is loaded from an external Space, this is the URL of the Space
+            root_url: If this component is loaded from an external Space, this is the URL of the Space. If set during init, this parameter has no effect.
             hf_token: If this component is loaded from an external private Space, this is the access token for the Space
         """
         _root_url = self.root_url or root_url

--- a/client/python/gradio_client/serializing.py
+++ b/client/python/gradio_client/serializing.py
@@ -194,6 +194,7 @@ class FileSerializable(Serializable):
             root_url: If this component is loaded from an external Space, this is the URL of the Space
             hf_token: If this component is loaded from an external private Space, this is the access token for the Space
         """
+        _root_url = self.root_url or root_url
         if x is None:
             return None
         if isinstance(save_dir, Path):
@@ -202,9 +203,9 @@ class FileSerializable(Serializable):
             file_name = utils.decode_base64_to_file(x, dir=save_dir).name
         elif isinstance(x, dict):
             if x.get("is_file", False):
-                if self.root_url is not None:
+                if _root_url is not None:
                     file_name = utils.download_tmp_copy_of_file(
-                        self.root_url + "file=" + x["name"],
+                        _root_url + "file=" + x["name"],
                         hf_token=hf_token,
                         dir=save_dir,
                     ).name

--- a/client/python/gradio_client/serializing.py
+++ b/client/python/gradio_client/serializing.py
@@ -167,7 +167,10 @@ class FileSerializable(Serializable):
         """
         if x is None or x == "":
             return None
-        filename = str(Path(load_dir) / x)
+        if utils.is_valid_url(x):
+            filename = x
+        else:
+            filename = str(Path(load_dir) / x)
         return {
             "name": filename,
             "data": utils.encode_url_or_file_to_base64(filename),

--- a/client/python/gradio_client/serializing.py
+++ b/client/python/gradio_client/serializing.py
@@ -11,6 +11,9 @@ from gradio_client import utils
 
 
 class Serializable(ABC):
+    def __init__(self, root_url: str | None = None):
+        self.root_url = root_url
+
     @abstractmethod
     def input_api_info(self) -> Tuple[str, str]:
         """
@@ -196,9 +199,9 @@ class FileSerializable(Serializable):
             file_name = utils.decode_base64_to_file(x, dir=save_dir).name
         elif isinstance(x, dict):
             if x.get("is_file", False):
-                if root_url is not None:
+                if self.root_url is not None:
                     file_name = utils.download_tmp_copy_of_file(
-                        root_url + "file=" + x["name"],
+                        self.root_url + "file=" + x["name"],
                         hf_token=hf_token,
                         dir=save_dir,
                     ).name

--- a/client/python/test/test_client.py
+++ b/client/python/test/test_client.py
@@ -258,10 +258,7 @@ class TestAPIInfo:
     def test_test_endpoint_src(self, trailing_char):
         src = "https://gradio-calculator.hf.space" + trailing_char
         client = Client(src=src)
-        assert (
-            client.endpoints[0].deserializers[0].root_url
-            == "https://gradio-calculator.hf.space/"
-        )
+        assert client.endpoints[0].root_url == "https://gradio-calculator.hf.space/"
 
     @pytest.mark.flaky
     def test_numerical_to_label_space(self):

--- a/client/python/test/test_client.py
+++ b/client/python/test/test_client.py
@@ -254,6 +254,15 @@ class TestStatusUpdates:
 
 
 class TestAPIInfo:
+    @pytest.mark.parametrize("trailing_char", ["/", ""])
+    def test_test_endpoint_src(self, trailing_char):
+        src = "https://gradio-calculator.hf.space" + trailing_char
+        client = Client(src=src)
+        assert (
+            client.endpoints[0].deserializers[0].root_url
+            == "https://gradio-calculator.hf.space/"
+        )
+
     @pytest.mark.flaky
     def test_numerical_to_label_space(self):
         client = Client("gradio-tests/titanic-survival")

--- a/client/python/test/test_client.py
+++ b/client/python/test/test_client.py
@@ -1,5 +1,6 @@
 import json
 import os
+import pathlib
 import time
 from datetime import datetime, timedelta
 from unittest.mock import patch
@@ -86,6 +87,15 @@ class TestPredictionsFromSpaces:
             statuses.append(job.status())
         statuses.append(job.status())
         assert all(s.code in [Status.PROCESSING, Status.FINISHED] for s in statuses)
+
+    @pytest.mark.flaky
+    def test_job_output_video(self):
+        client = Client(src="gradio/video_component")
+        job = client.predict(
+            "https://huggingface.co/spaces/gradio/video_component/resolve/main/files/a.mp4",
+            fn_index=0,
+        )
+        assert pathlib.Path(job.result()).exists()
 
 
 class TestStatusUpdates:


### PR DESCRIPTION
# Description

The root_url is not being set for the file-based serializers so the client can't download output files or videos.

Closes: # (issue)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.