### PR TITLE
Hotfix website build

### DIFF
--- a/website/homepage/upload_demos.py
+++ b/website/homepage/upload_demos.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import argparse
 import os
 import pathlib
 import shutil
 import tempfile
 import textwrap
-from typing import Optional
 
 import huggingface_hub
 from utils import get_latest_stable


### PR DESCRIPTION
Website wasn't building because "|" isn't supported in older versions of python. This fixes that