### PR TITLE
CI tweaks for gradio and gradio_client

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: backend-${{ github.ref }}-${{ github.event_name == 'push' || github.event.inputs.fire != null }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   NODE_OPTIONS: "--max-old-space-size=4096"

--- a/client/python/scripts/ci.sh
+++ b/client/python/scripts/ci.sh
@@ -6,6 +6,7 @@ cd "$(dirname ${0})/.."
 echo "Linting..."
 ruff test gradio_client
 black --check test gradio_client
+pyright gradio_client/*.py
 
 echo "Testing..."
 python -m pip install -e ../../.  # Install gradio from local source (as the latest version may not yet be published to PyPI)

--- a/client/python/scripts/format.sh
+++ b/client/python/scripts/format.sh
@@ -5,3 +5,6 @@ cd "$(dirname ${0})/.."
 echo "Formatting the client library.. Our style follows the Black code style."
 ruff --fix test gradio_client
 black test gradio_client
+
+echo "Type checking the client library with pyright"
+pyright gradio_client/*.py

--- a/client/python/test/requirements.txt
+++ b/client/python/test/requirements.txt
@@ -2,3 +2,4 @@ black==22.6.0
 pytest-asyncio
 pytest==7.1.2
 ruff==0.0.260
+pyright==1.1.298

--- a/scripts/type_check_backend.sh
+++ b/scripts/type_check_backend.sh
@@ -3,6 +3,4 @@ source scripts/helpers.sh
 
 pip_required
 
-pip install --upgrade pip
-pip install pyright==1.1.298
-pyright gradio/*.py client/python/gradio_client/*.py
+pyright gradio/*.py

--- a/test/requirements-37.txt
+++ b/test/requirements-37.txt
@@ -163,6 +163,7 @@ pygments==2.12.0
     # via ipython
 pyparsing==3.0.9
     # via packaging
+pyright==1.1.298
 pyrsistent==0.18.1
     # via jsonschema
 pytest==7.1.2

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -168,6 +168,7 @@ python-dateutil==2.8.2
     # via
     #   botocore
     #   pandas
+pyright==1.1.298
 pytz==2022.1
     # via pandas
 pywavelets==1.3.0


### PR DESCRIPTION
# Description

- Move pyright install to test requirements - consistent with how black and ruff are installed
- typecheck_backend.sh only checks gradio lib instead of gradio lib and gradio client - consistent with how linting is done
- ci.sh and format.sh type check the gradio client
- Set `cancel-in-progress` so that subsequent commits cancel running jobs. This frees up the queue a bit - I've seen jobs for my PRs get queued for a while since old commits are running. I think it's an acceptable trade-off, I haven't had to rely on having all the commit CI run to fix errors in my PRs.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.