### PR TITLE
Hot fix token in github action to publish py client to pypi

### DIFF
--- a/.github/workflows/deploy-client-pypi.yml
+++ b/.github/workflows/deploy-client-pypi.yml
@@ -35,6 +35,6 @@ jobs:
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
-        user: aabid93
+        user: __token__
         password: ${{ secrets.PYPI_GRADIO_CLIENT_TOKEN }}
         packages_dir: client/python/dist


### PR DESCRIPTION
The python client didn't successfully push to pypi. But that might be because I forgot to revert something I had changed during testing. Here's a quick reversion