### PR TITLE
Fix for default file name of recorded audio files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ No changes to highlight.
 
 - Increase timeout for sending analytics data by [@dawoodkhan82](https://github.com/dawoodkhan82) in [PR 3647](https://github.com/gradio-app/gradio/pull/3647)
 - Fix bug where http token was not accessed over websocket connections by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3735](https://github.com/gradio-app/gradio/pull/3735)
+- Fix bug where recording an audio file through the microphone resulted in a corrupted file name by [@abidlabs](https://github.com/abidlabs) in [PR 3770](https://github.com/gradio-app/gradio/pull/3770)
 
 ## Documentation Changes:
 

--- a/js/audio/src/Audio.svelte
+++ b/js/audio/src/Audio.svelte
@@ -87,7 +87,7 @@
 		let audio_blob = new Blob(blobs, { type: "audio/wav" });
 		value = {
 			data: await blob_to_data_url(audio_blob),
-			name
+			name: "audio.wav"
 		};
 		dispatch(event, value);
 	};

--- a/test/test_pipelines.py
+++ b/test/test_pipelines.py
@@ -1,8 +1,10 @@
+import pytest
 import transformers
 
 import gradio as gr
 
 
+@pytest.mark.flaky
 class TestLoadFromPipeline:
     def test_text_to_text_model_from_pipeline(self):
         pipe = transformers.pipeline(model="sshleifer/bart-tiny-random")


### PR DESCRIPTION
When audio files were being recorded, the filepath would be "audio" instead of "audio.wav", which would lead to problems like: #3479 and https://github.com/gradio-app/gradio/issues/2768#issuecomment-1497976532

This is a quick fix for this. Thanks @aliabid94 for helping me debug

Test by running:

```py
import gradio as gr

gr.Interface(lambda x:x, gr.Audio(source="microphone", type="filepath"), "textbox").launch()
```

It should now include the `.wav` suffix.

Fixes: #3479