### PR TITLE
Dynamically get the API endpoint's parameter names

### DIFF
--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -97,7 +97,7 @@ class Client:
         Calls the Gradio API and returns the result (this is a blocking call).
         Parameters:
             *args: The arguments to pass to the remote API. The order of the arguments must match the order of the inputs in the Gradio app.
-            api_name: The name of the API endpoint to call starting with a leading slash, e.g. "/predict". Does not need to be provided if the Gradio app has only one named API endpoint.
+            api_name: The name of the API endpoint to call starting with a leading slash, e.g. "/predict". Does not need to be provided if the Gradio app has only one named API endpoint, or if set_endpoint() has been called.
             fn_index: As an alternative to api_name, this parameter takes the index of the API endpoint to call, e.g. 0. Both api_name and fn_index can be provided, but if they conflict, api_name will take precedence.
         Returns:
             The result of the API call. Will be a Tuple if the API has multiple outputs.
@@ -120,7 +120,7 @@ class Client:
         Creates and returns a Job object which calls the Gradio API in a background thread. The job can be used to retrieve the status and result of the remote API call.
         Parameters:
             *args: The arguments to pass to the remote API. The order of the arguments must match the order of the inputs in the Gradio app.
-            api_name: The name of the API endpoint to call starting with a leading slash, e.g. "/predict". Does not need to be provided if the Gradio app has only one named API endpoint.
+            api_name: The name of the API endpoint to call starting with a leading slash, e.g. "/predict". Does not need to be provided if the Gradio app has only one named API endpoint, or if set_endpoint() has been called.
             fn_index: As an alternative to api_name, this parameter takes the index of the API endpoint to call, e.g. 0. Both api_name and fn_index can be provided, but if they conflict, api_name will take precedence.
             result_callbacks: A callback function, or list of callback functions, to be called when the result is ready. If a list of functions is provided, they will be called in order. The return values from the remote API are provided as separate parameters into the callback. If None, no callback will be called.
         Returns:

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -95,7 +95,7 @@ class Client:
         fn_index: int | None = None,
     ) -> None:
         """
-        Sets the API endpoint to call when calling predict() or submit(). Sets the parameter names of the predict() and submit() methods to match the API endpoint for IDE autocomplete. Can be called multiple times to switch between API endpoints.
+        Sets the API endpoint to call when calling predict() or submit(). Sets the parameter names of the predict() and submit() methods to match the API endpoint for IDE autocomplete in interactive environments like jupyter notebooks and allows passing parameters in as keywords. Can be called multiple times to switch between API endpoints.
         Parameters:
             api_name: The name of the API endpoint to call starting with a leading slash, e.g. "/predict".
             fn_index: As an alternative to api_name, this parameter takes the index of the API endpoint to call, e.g. 0. Both api_name and fn_index can be provided, but if they conflict, api_name will take precedence.
@@ -146,6 +146,7 @@ class Client:
         *args,
         api_name: str | None = None,
         fn_index: int | None = None,
+        **kwargs,
     ) -> Any:
         """
         Calls the Gradio API and returns the result (this is a blocking call).
@@ -153,6 +154,7 @@ class Client:
             *args: The arguments to pass to the remote API. The order of the arguments must match the order of the inputs in the Gradio app.
             api_name: The name of the API endpoint to call starting with a leading slash, e.g. "/predict". Does not need to be provided if the Gradio app has only one named API endpoint. Should not be provided (will raise exception) if set_endpoint() has been called.
             fn_index: As an alternative to api_name, this parameter takes the index of the API endpoint to call, e.g. 0. Both api_name and fn_index can be provided, but if they conflict, api_name will take precedence.
+            **kwargs: The keyword arguments to pass to the remote API. Keyword arguments can only be used if .set_endpoint() has been called.
         Returns:
             The result of the API call. Will be a Tuple if the API has multiple outputs.
         Example:
@@ -169,6 +171,7 @@ class Client:
         api_name: str | None = None,
         fn_index: int | None = None,
         result_callbacks: Callable | List[Callable] | None = None,
+        **kwargs,
     ) -> Job:
         """
         Creates and returns a Job object which calls the Gradio API in a background thread. The job can be used to retrieve the status and result of the remote API call.
@@ -177,6 +180,7 @@ class Client:
             api_name: The name of the API endpoint to call starting with a leading slash, e.g. "/predict". Does not need to be provided if the Gradio app has only one named API endpoint. Should not be provided (will raise exception) if set_endpoint() has been called.
             fn_index: As an alternative to api_name, this parameter takes the index of the API endpoint to call, e.g. 0. Both api_name and fn_index can be provided, but if they conflict, api_name will take precedence.
             result_callbacks: A callback function, or list of callback functions, to be called when the result is ready. If a list of functions is provided, they will be called in order. The return values from the remote API are provided as separate parameters into the callback. If None, no callback will be called.
+            **kwargs: The keyword arguments to pass to the remote API. Keyword arguments can only be used if .set_endpoint() has been called.
         Returns:
             A Job object that can be used to retrieve the status and result of the remote API call.
         Example:

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -288,7 +288,9 @@ def decode_base64_to_binary(encoding) -> Tuple[bytes, str | None]:
 
 def santize_parameter_name(original_parameter_name: str) -> str:
     original_parameter_name = original_parameter_name.replace(" ", "_").lower()
-    return "".join([char for char in original_parameter_name if char.isalnum() or char in "_"])
+    return "".join(
+        [char for char in original_parameter_name if char.isalnum() or char in "_"]
+    )
 
 
 def strip_invalid_filename_characters(filename: str, max_bytes: int = 200) -> str:

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -286,6 +286,11 @@ def decode_base64_to_binary(encoding) -> Tuple[bytes, str | None]:
     return base64.b64decode(data), extension
 
 
+def santize_parameter_name(original_parameter_name: str) -> str:
+    original_parameter_name = original_parameter_name.replace(" ", "_").lower()
+    return "".join([char for char in original_parameter_name if char.isalnum() or char in "_"])
+
+
 def strip_invalid_filename_characters(filename: str, max_bytes: int = 200) -> str:
     """Strips invalid characters from a filename and ensures that the file_length is less than `max_bytes` bytes."""
     filename = "".join([char for char in filename if char.isalnum() or char in "._- "])

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -19,6 +19,7 @@ import requests
 from anyio import CapacityLimiter
 from gradio_client import serializing
 from gradio_client import utils as client_utils
+from gradio_client.documentation import document, set_documentation_group
 from typing_extensions import Literal
 
 from gradio import (
@@ -33,7 +34,6 @@ from gradio import (
 )
 from gradio.context import Context
 from gradio.deprecation import check_deprecated_parameters
-from gradio_client.documentation import document, set_documentation_group
 from gradio.exceptions import DuplicateBlockError, InvalidApiName
 from gradio.helpers import EventData, create_tracker, skip, special_args
 from gradio.themes import Default as DefaultTheme

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -32,6 +32,7 @@ import requests
 from fastapi import UploadFile
 from ffmpy import FFmpeg
 from gradio_client import utils as client_utils
+from gradio_client.documentation import document, set_documentation_group
 from gradio_client.serializing import (
     BooleanSerializable,
     FileSerializable,
@@ -50,7 +51,6 @@ from typing_extensions import Literal
 
 from gradio import media_data, processing_utils, utils
 from gradio.blocks import Block, BlockContext
-from gradio_client.documentation import document, set_documentation_group
 from gradio.events import (
     Blurrable,
     Changeable,

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Set, Tuple
 
-from gradio.blocks import Block
 from gradio_client.documentation import document, set_documentation_group
+
+from gradio.blocks import Block
 from gradio.helpers import EventData
 from gradio.utils import get_cancel_function
 


### PR DESCRIPTION
This PR adds and documents a `.set_endpoint()` method to the `Client` class. This class can be used to set the API name once without having to repeatedly pass it into `.predict()`, which should avoid some code duplication.

The additional thing about `.set_endpoint()` is that it's also able get the parameter names corresponding to the API endpoint and make that the function signature of `client.predict()` and `client.submit()`. Which means that you get the ability to pass in keyword arguments like this:

```py
from gradio_client import Client
client = Client("gradio-tests/titanic-survival")
client.set_endpoint('/predict')
client.predict(age=100, sex="male", fare_british_pounds=100)
```

In interactive environments, such as jupyter notebooks, you'll even get IDE parameter name hinting and autocompletion

![image](https://user-images.githubusercontent.com/1778297/230228984-21bd7cec-6033-47c7-8431-2f16ee854d97.png)

However, this last part does come with some limitations, so would appreciate feedback

**Limitations / considerations**
*  You don't get parameter name hinting and autocompletion if you write your entire script at once e.g. in a python file
*  You don't get typing (I looked into this but it's pretty much impossible with complex types such as `List[str]`)
*  You can no longer use `api_name` or `fn_index` in `predict()`/`submit()` after you've called `set_endpoint()`
*  I have to introduce `**kwargs` to `predict()` and `submit()` which are only used if `set_endpoint()`