### PR TITLE
Dicts as inputs with specified keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## New Features:
 
-No changes to highlight.
+* Allow event listeners to accept a single dictionary as its argument, where they keys are user specified, and the values are the component values. This is set by passing passing input components a dictionary with specific key names instead of a list or set. [@jrhe](https://github.com/jrhe) in [PRX](https://github.com/gradio-app/gradio/pull/X)
 
 ## Bug Fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## New Features:
 
-* Allow event listeners to accept a single dictionary as its argument, where they keys are user specified, and the values are the component values. This is set by passing passing input components a dictionary with specific key names instead of a list or set. [@jrhe](https://github.com/jrhe) in [PRX](https://github.com/gradio-app/gradio/pull/X)
+* Allow event listeners to accept a single dictionary as its argument, where they keys are user specified, and the values are the component values. This is set by passing passing input components a dictionary with specific key names instead of a list or set. [@jrhe](https://github.com/jrhe) in [3791](https://github.com/gradio-app/gradio/pull/3791)
 
 ## Bug Fixes:
 

--- a/demo/calculator_list_and_dict/run.ipynb
+++ b/demo/calculator_list_and_dict/run.ipynb
@@ -1,1 +1,150 @@
-{"cells": [{"cell_type": "markdown", "id": 302934307671667531413257853548643485645, "metadata": {}, "source": ["# Gradio Demo: calculator_list_and_dict"]}, {"cell_type": "code", "execution_count": null, "id": 272996653310673477252411125948039410165, "metadata": {}, "outputs": [], "source": ["!pip install -q gradio "]}, {"cell_type": "code", "execution_count": null, "id": 288918539441861185822528903084949547379, "metadata": {}, "outputs": [], "source": ["import gradio as gr\n", "\n", "with gr.Blocks() as demo:\n", "    a = gr.Number(label=\"a\")\n", "    b = gr.Number(label=\"b\")\n", "    with gr.Row():\n", "        add_btn = gr.Button(\"Add\")\n", "        sub_btn = gr.Button(\"Subtract\")\n", "    c = gr.Number(label=\"sum\")\n", "\n", "    def add(num1, num2):\n", "        return num1 + num2\n", "    add_btn.click(add, inputs=[a, b], outputs=c)\n", "\n", "    def sub(data):\n", "        return data[a] - data[b]\n", "    sub_btn.click(sub, inputs={a, b}, outputs=c)\n", "\n", "\n", "if __name__ == \"__main__\":\n", "    demo.launch()"]}], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6ae97474",
+   "metadata": {},
+   "source": [
+    "# Gradio Demo: calculator_list_and_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80ac121d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q gradio "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "8cc054ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running on local URL:  http://127.0.0.1:7862\n",
+      "\n",
+      "To create a public link, set `share=True` in `launch()`.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><iframe src=\"http://127.0.0.1:7862/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "predict session_hash='5ogwosr0e2h' event_id=None data=[12, 3] event_data=None fn_index=2 batched=False request=None\n",
+      "run_predict raw_input [12, 3]\n",
+      "run_predict raw_input [12, 3]\n",
+      "process_api 2 [12, 3] {} <gradio.routes.Request object at 0x13eb7c790> {'should_reset': set()} None <gradio.helpers.EventData object at 0x13eb7cc40>\n",
+      "inputs [12.0, 3.0]\n",
+      "[12.0, 3.0]\n",
+      "{'a': number, 'b': number}\n",
+      "<class 'dict'>\n",
+      "[{'a': 12.0, 'b': 3.0}]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Traceback (most recent call last):\n",
+      "  File \"/Users/jon/repos/github.com/jrhe/gradio/gradio/routes.py\", line 397, in run_predict\n",
+      "    output = await app.get_blocks().process_api(\n",
+      "  File \"/Users/jon/repos/github.com/jrhe/gradio/gradio/blocks.py\", line 1126, in process_api\n",
+      "    result = await self.call_function(\n",
+      "  File \"/Users/jon/repos/github.com/jrhe/gradio/gradio/blocks.py\", line 933, in call_function\n",
+      "    prediction = await anyio.to_thread.run_sync(*call_args, limiter=self.limiter)\n",
+      "  File \"/Users/jon/.pyenv/versions/3.9.16/lib/python3.9/site-packages/anyio/to_thread.py\", line 31, in run_sync\n",
+      "    return await get_asynclib().run_sync_in_worker_thread(\n",
+      "  File \"/Users/jon/.pyenv/versions/3.9.16/lib/python3.9/site-packages/anyio/_backends/_asyncio.py\", line 937, in run_sync_in_worker_thread\n",
+      "    return await future\n",
+      "  File \"/Users/jon/.pyenv/versions/3.9.16/lib/python3.9/site-packages/anyio/_backends/_asyncio.py\", line 867, in run\n",
+      "    result = context.run(func, *args)\n",
+      "  File \"/var/folders/g7/h9hst8551g74rd1jsf7txvj40000gn/T/ipykernel_87785/2341627224.py\", line 18, in sub\n",
+      "    return data[a] - data[b]\n",
+      "KeyError: number\n"
+     ]
+    }
+   ],
+   "source": [
+    "import gradio as gr\n",
+    "\n",
+    "with gr.Blocks() as demo:\n",
+    "    a = gr.Number(label=\"a\")\n",
+    "    b = gr.Number(label=\"b\")\n",
+    "    with gr.Row():\n",
+    "        add_btn = gr.Button(\"Add\")\n",
+    "        sub_btn = gr.Button(\"Subtract\")\n",
+    "        mul_btn = gr.Button(\"Multiply\")\n",
+    "        div_btn = gr.Button(\"Divide\")\n",
+    "    c = gr.Number(label=\"sum\")\n",
+    "\n",
+    "    def add(num1, num2):\n",
+    "        return num1 + num2\n",
+    "    add_btn.click(add, inputs=[a, b], outputs=c)\n",
+    "\n",
+    "    def sub(data):\n",
+    "        return data[a] - data[b]\n",
+    "    sub_btn.click(sub, inputs={a, b}, outputs=c)\n",
+    "\n",
+    "    def mul(*, a, b):\n",
+    "        return a * b\n",
+    "    mul_btn.click(sub, inputs={\"a\": a, \"b\": b}, outputs=c)\n",
+    "\n",
+    "    def div(**data):\n",
+    "        return data['a'] / data['b']\n",
+    "    sub_btn.click(sub, inputs={a, b}, outputs=c)\n",
+    "\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    demo.launch()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb5eaa30",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/demo/calculator_list_and_dict/run.py
+++ b/demo/calculator_list_and_dict/run.py
@@ -6,6 +6,8 @@ with gr.Blocks() as demo:
     with gr.Row():
         add_btn = gr.Button("Add")
         sub_btn = gr.Button("Subtract")
+        mul_btn = gr.Button("Multiply")
+        div_btn = gr.Button("Divide")
     c = gr.Number(label="sum")
 
     def add(num1, num2):
@@ -16,6 +18,13 @@ with gr.Blocks() as demo:
         return data[a] - data[b]
     sub_btn.click(sub, inputs={a, b}, outputs=c)
 
+    def mul(*, a, b):
+        return a * b
+    mul_btn.click(sub, inputs={"a": a, "b": b}, outputs=c)
+
+    def div(**data):
+        return data['a'] / data['b']
+    sub_btn.click(sub, inputs={a, b}, outputs=c)
 
 if __name__ == "__main__":
     demo.launch()

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -837,7 +837,7 @@ def get_cancel_function(
     )
 
 
-def check_function_inputs_match(fn: Callable, inputs: List, inputs_as_dict: bool):
+def check_function_inputs_match(fn: Callable, inputs: List, wrapped_inputs: bool):
     """
     Checks if the input component set matches the function
     Returns: None if valid, a string error message if mismatch
@@ -868,9 +868,8 @@ def check_function_inputs_match(fn: Callable, inputs: List, inputs_as_dict: bool
         elif param.kind == param.VAR_POSITIONAL:
             max_args = infinity
         elif param.kind == param.KEYWORD_ONLY:
-            if not has_default:
-                return f"Keyword-only args must have default values for function {fn}"
-    arg_count = 1 if inputs_as_dict else len(inputs)
+            max_args += 1
+    arg_count = 1 if wrapped_inputs else len(inputs)
     if min_args == max_args and max_args != arg_count:
         warnings.warn(
             f"Expected {max_args} arguments for function {fn}, received {arg_count}."

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -163,7 +163,7 @@ class TestBlocksMethods:
         assert "fn" in str(demo.fns[0])
 
     @pytest.mark.asyncio
-    async def test_dict_inputs_in_config(self):
+    async def test_set_inputs_in_config(self):
         with gr.Blocks() as demo:
             first = gr.Textbox()
             last = gr.Textbox()
@@ -176,6 +176,32 @@ class TestBlocksMethods:
             btn.click(greet, {first, last}, greeting)
 
         result = await demo.process_api(inputs=["huggy", "face"], fn_index=0, state={})
+        assert result["data"] == ["Hello huggy face"]
+
+    @pytest.mark.asyncio
+    async def test_dict_inputs_in_config(self):
+        with gr.Blocks() as demo:
+            first = gr.Textbox()
+            last = gr.Textbox()
+            btn = gr.Button()
+            greeting = gr.Textbox()
+
+            def greet(*, first, last):
+                return f"Hello {first} {last}"
+
+            btn.click(
+                greet,
+                {
+                    "last": last,
+                    "first": first,
+                },
+                greeting,
+                preprocess=True,
+            )
+
+        result = await demo.process_api(
+            inputs={"last": "face", "first": "huggy"}, fn_index=0, state={}
+        )
         assert result["data"] == ["Hello huggy face"]
 
     @pytest.mark.asyncio


### PR DESCRIPTION
# Description

Adds the ability to use dictionary inputs with specified keys. 

Current dict input support sets the keys to be the components of the inputs. This isn't great as it means that event handlers have to bring the input components into their scope to key into the dictionary or iterate over the dictionary to find the component they want, tightly coupling input components and event handlers. With this change event handlers can be independent of Gradio.

*WIP Branch - needs refactoring before merging.*

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Documentation update to follow once the code is in decent shape.

Issues:
- unclear if `input_to_key` should sit on `dependency` or the `BlockFunction`
- Two failing tests due to the extra value `input_to_key` on `dependency`
- General messiness in `Block` `set_event_trigger` and `Blocks` `preprocess_data` which might be improved by substituting `inputs_as_dict` for an input type variable which holds the type of the inputs passed in.

I'm not at all familiar with the codebase so wanted to stop here to get some input.

@abidlabs @aliabid94 @freddyaboulton 


