### PR TITLE
Python Client: Handle invalid space state

### DIFF
--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -83,6 +83,12 @@ class Client:
         self.src = _src
         if self.verbose:
             print(f"Loaded as API: {self.src} ✔")
+        state = self._get_space_state()
+        if state in utils.INVALID_RUNTIME:
+            raise ValueError(
+                f"The current space is in the invalid state: {state}. "
+                "Please contact the owner to fix this."
+            )
 
         self.api_url = urllib.parse.urljoin(self.src, utils.API_URL)
         self.ws_url = urllib.parse.urljoin(
@@ -103,6 +109,12 @@ class Client:
 
         # Disable telemetry by setting the env variable HF_HUB_DISABLE_TELEMETRY=1
         threading.Thread(target=self._telemetry_thread).start()
+
+    def _get_space_state(self):
+        if not self.space_id:
+            return None
+        api = huggingface_hub.HfApi(token=self.hf_token)
+        return api.get_space_runtime(self.space_id).stage
 
     def predict(
         self,

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -34,7 +34,6 @@ INVALID_RUNTIME = [
     "BUILD_ERROR",
     "RUNTIME_ERROR",
     "PAUSED",
-    "SLEEPING",
 ]
 
 __version__ = (pkgutil.get_data(__name__, "version.txt") or b"").decode("ascii").strip()

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -30,6 +30,7 @@ STATE_COMPONENT = "state"
 INVALID_RUNTIME = [
     "NO_APP_FILE",
     "CONFIG_ERROR",
+    "BUILDING",
     "BUILD_ERROR",
     "RUNTIME_ERROR",
     "PAUSED",

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -27,6 +27,14 @@ UPLOAD_URL = "/upload"
 RESET_URL = "/reset"
 DUPLICATE_URL = "https://huggingface.co/spaces/{}?duplicate=true"
 STATE_COMPONENT = "state"
+INVALID_RUNTIME = [
+    "NO_APP_FILE",
+    "CONFIG_ERROR",
+    "BUILD_ERROR",
+    "RUNTIME_ERROR",
+    "PAUSED",
+    "SLEEPING",
+]
 
 __version__ = (pkgutil.get_data(__name__, "version.txt") or b"").decode("ascii").strip()
 

--- a/client/python/test/test_client.py
+++ b/client/python/test/test_client.py
@@ -20,6 +20,11 @@ HF_TOKEN = "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"  # Intentionally reveali
 
 class TestPredictionsFromSpaces:
     @pytest.mark.flaky
+    def test_raise_error_invalid_state(self):
+        with pytest.raises(ValueError, match="invalid state"):
+            Client("gradio-tests/paused-space")
+
+    @pytest.mark.flaky
     def test_numerical_to_label_space(self):
         client = Client("gradio-tests/titanic-survival")
         output = client.predict("male", 77, 10, api_name="/predict")


### PR DESCRIPTION
# Description

Closes: #3803

During init, check if the space is in an invalid state and raise a helpful error if so.

Technically, the space state can switch after init but seems like a corner case for now. 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.