### PR TITLE
Fix video serializing in client

### DIFF
--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -6,7 +6,7 @@ No changes to highlight.
 
 ## Bug Fixes:
 
-No changes to highlight.
+- Fixed bug where `Video` components in latest gradio were not able to be deserialized by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3860](https://github.com/gradio-app/gradio/pull/3860)
 
 ## Documentation Changes:
 

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -574,7 +574,8 @@ class Endpoint:
             self.is_valid = self.dependency[
                 "backend_fn"
             ]  # Only a real API endpoint if backend_fn is True and serializers are valid
-        except AssertionError:
+        except AssertionError as e:
+            print(e)
             self.is_valid = False
 
     def __repr__(self):

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -574,8 +574,7 @@ class Endpoint:
             self.is_valid = self.dependency[
                 "backend_fn"
             ]  # Only a real API endpoint if backend_fn is True and serializers are valid
-        except AssertionError as e:
-            print(e)
+        except AssertionError:
             self.is_valid = False
 
     def __repr__(self):

--- a/client/python/gradio_client/serializing.py
+++ b/client/python/gradio_client/serializing.py
@@ -368,7 +368,7 @@ class VideoSerializable(FileSerializable):
         Convert from serialized representation of a file (base64) to a human-friendly
         version (string filepath). Optionally, save the file to the directory specified by `save_dir`
         """
-        if isinstance(x, tuple):
+        if isinstance(x, (tuple, list)):
             assert len(x) == 2, f"Expected tuple of length 2. Received: {x}"
             x_as_list = [x[0], x[1]]
         else:
@@ -501,7 +501,12 @@ class GallerySerializable(Serializable):
         return os.path.abspath(gallery_path)
 
 
-SERIALIZER_MAPPING = {cls.__name__: cls for cls in Serializable.__subclasses__()}
+SERIALIZER_MAPPING = {}
+for cls in Serializable.__subclasses__():
+    SERIALIZER_MAPPING[cls.__name__] = cls
+    for subcls in cls.__subclasses__():
+        SERIALIZER_MAPPING[subcls.__name__] = subcls
+
 SERIALIZER_MAPPING["Serializable"] = SimpleSerializable
 SERIALIZER_MAPPING["File"] = FileSerializable
 SERIALIZER_MAPPING["UploadButton"] = FileSerializable


### PR DESCRIPTION
# Description

Video components in latest gradio version were not able to be serialized because:
1. VideoSerializer was not included in Serializer map. Solution is to include subclasses as well. 
2. There was an `isinstance(x, tuple)` check in `deserialize` but tuples don't exist in json so when we load the json they get converted to lists.

Should fix the tests on main.


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.