### PR TITLE
theme builder example doesn't work for `3.25.0` or later

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -104,7 +104,7 @@ jobs:
       shell: bash
       run: |
         bash scripts/install_gradio.sh
-        pip install --upgrade pip
+        python -m pip install --upgrade pip
     - name: Install 3.9 Test Dependencies
       shell: bash
       if: ${{ matrix.python-version == '3.9' }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -87,7 +87,7 @@ jobs:
         cache: pnpm
         cache-dependency-path: pnpm-lock.yaml
     - name: Install pip
-      run: python -m pip install build requests virtualenv
+      run: python -m pip install build requests virtualenv wheel
     - name: venv activate Linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install pip
-      run: python -m pip install build requests virtualenv
+      run: python -m pip install build requests virtualenv wheel
     - name: venv activate Linux
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ No changes to highlight.
 ## Full Changelog:
 
 - Add DESCRIPTION.md to image_segmentation demo by [@aliabd](https://github.com/aliabd) in [PR 3866](https://github.com/gradio-app/gradio/pull/3866)
+- Fix error in running `gr.themes.builder()` by [@deepkyu](https://github.com/deepkyu) in [PR 3869](https://github.com/gradio-app/gradio/pull/3869)
 
 ## Contributors Shoutout:
 

--- a/gradio/__init__.py
+++ b/gradio/__init__.py
@@ -10,6 +10,8 @@ from gradio.blocks import Blocks
 from gradio.components import (
     HTML,
     JSON,
+    AnnotatedImage,
+    Annotatedimage,
     Audio,
     BarPlot,
     Button,
@@ -30,8 +32,6 @@ from gradio.components import (
     HighlightedText,
     Highlightedtext,
     Image,
-    AnnotatedImage,
-    Annotatedimage,
     Interpretation,
     Json,
     Label,

--- a/gradio/themes/__init__.py
+++ b/gradio/themes/__init__.py
@@ -13,4 +13,4 @@ from gradio.themes.utils.sizes import Size  # noqa: F401
 def builder(*args, **kwargs):
     from gradio.themes.builder import demo
 
-    demo.launch(*args, **kwargs)
+    return demo.launch(*args, **kwargs)

--- a/gradio/themes/builder.py
+++ b/gradio/themes/builder.py
@@ -3,6 +3,7 @@ import time
 from typing import Iterable
 
 import gradio as gr
+from gradio_client.documentation import document_fn
 
 themes = [
     gr.themes.Base,
@@ -16,10 +17,10 @@ sizes = gr.themes.Size.all
 
 palette_range = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950]
 size_range = ["xxs", "xs", "sm", "md", "lg", "xl", "xxl"]
-docs_theme_core = gr.documentation.document_fn(gr.themes.Base.__init__, gr.themes.Base)[
+docs_theme_core = document_fn(gr.themes.Base.__init__, gr.themes.Base)[
     1
 ]
-docs_theme_vars = gr.documentation.document_fn(gr.themes.Base.set, gr.themes.Base)[1]
+docs_theme_vars = document_fn(gr.themes.Base.set, gr.themes.Base)[1]
 
 
 def get_docstr(var):

--- a/gradio/themes/builder.py
+++ b/gradio/themes/builder.py
@@ -18,9 +18,7 @@ sizes = gr.themes.Size.all
 
 palette_range = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950]
 size_range = ["xxs", "xs", "sm", "md", "lg", "xl", "xxl"]
-docs_theme_core = document_fn(gr.themes.Base.__init__, gr.themes.Base)[
-    1
-]
+docs_theme_core = document_fn(gr.themes.Base.__init__, gr.themes.Base)[1]
 docs_theme_vars = document_fn(gr.themes.Base.set, gr.themes.Base)[1]
 
 

--- a/gradio/themes/builder.py
+++ b/gradio/themes/builder.py
@@ -2,8 +2,9 @@ import inspect
 import time
 from typing import Iterable
 
-import gradio as gr
 from gradio_client.documentation import document_fn
+
+import gradio as gr
 
 themes = [
     gr.themes.Base,

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ semantic_version
 typing_extensions
 uvicorn
 websockets>=10.0
+wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,3 @@ semantic_version
 typing_extensions
 uvicorn
 websockets>=10.0
-wheel

--- a/test/test_theme_sharing.py
+++ b/test/test_theme_sharing.py
@@ -414,3 +414,8 @@ class TestThemeUploadDownload:
             exist_ok=True,
             private=True,
         )
+
+
+def test_theme_builder_launches():
+    gr.themes.builder(prevent_thread_lock=True)
+    gr.close_all()


### PR DESCRIPTION

# Description

The error in running `gr.themes.builder()` should be fixed.

Closes: #3864 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.