### PR TITLE
Fix TypeError when Blocks outputs parameter is set to None

### DIFF
--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -211,7 +211,7 @@
 
 	function handle_update(data: any, fn_index: number) {
 		const outputs = dependencies[fn_index].outputs;
-		data.forEach((value: any, i: number) => {
+		data?.forEach((value: any, i: number) => {
 			if (
 				typeof value === "object" &&
 				value !== null &&


### PR DESCRIPTION
# Description

The changes fix a JavaScript TypeError occurring in the case that `Blocks.load()` is called with `outputs` set to `None` and a script is loaded using `_js`

<br>

For example:
```python
import gradio as gr

with gr.Blocks() as interface:
    image_input = gr.Image(label="Image upload", elem_id="image-container")
    interface.load(fn=None, inputs=image_input, outputs=None, _js='() => document.querySelector("#image-container input").addEventListener("change", () => { alert("File uploaded"); }, false)')
interface.launch()
```
When running the code above and visiting the Gradio web interface, the following error will show in the browser console:

![Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'forEach')](https://user-images.githubusercontent.com/31524206/232366588-9e7ad9a7-6031-4250-9037-ad7d1e980057.png)


This happens because a `forEach()` is called on the empty `data` variable that is passed in the function [`handle_update()`](https://github.com/gradio-app/gradio/blob/d8bfa63a38b2623f79e38d2291c8a6cb33e8e6e5/js/app/src/Blocks.svelte#L212), and can be fixed using optional chaining on the `data` variable

<br>

Closes: N/A

<br>

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have added a short summary of my change to the CHANGELOG.md
- [X] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes