### PR TITLE
Move Google Tag Manager code to analytics_enabled block in Blocks.svelte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ No changes to highlight.
 - Fix bugs with abspath about symlinks, and unresolvable path on Windows by [@micky2be](https://github.com/micky2be) in `[PR 3895](https://github.com/gradio-app/gradio/pull/3895)`.
 - Fixes type in client `Status` enum by [@10zinten](https://github.com/10zinten) in [PR 3931](https://github.com/gradio-app/gradio/pull/3931)
 - Fix `gr.ChatBot` to handle image url [tye-singwa](https://github.com/tye-signwa) in [PR 3953](https://github.com/gradio-app/gradio/pull/3953)
+- Move Google Tag Manager related initialization code to analytics-enabled block by [@akx](https://github.com/akx) in [PR 3956](https://github.com/gradio-app/gradio/pull/3956)
 
 ## Documentation Changes:
 

--- a/js/app/index.html
+++ b/js/app/index.html
@@ -34,15 +34,7 @@
 		/>
 		<meta name="twitter:image" content="{{ config['thumbnail'] or '' }}" />
 
-		<script>
-			window.dataLayer = window.dataLayer || [];
-			function gtag() {
-				dataLayer.push(arguments);
-			}
-			gtag("js", new Date());
-			gtag("config", "UA-156449732-1");
-			window.__gradio_mode__ = "app";
-		</script>
+		<script>window.__gradio_mode__ = "app";</script>
 
 		%gradio_config%
 

--- a/js/app/index.html
+++ b/js/app/index.html
@@ -34,7 +34,9 @@
 		/>
 		<meta name="twitter:image" content="{{ config['thumbnail'] or '' }}" />
 
-		<script>window.__gradio_mode__ = "app";</script>
+		<script>
+			window.__gradio_mode__ = "app";
+		</script>
 
 		%gradio_config%
 

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -386,6 +386,14 @@
 			defer
 			src="https://www.googletagmanager.com/gtag/js?id=UA-156449732-1"
 		></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag() {
+				dataLayer.push(arguments);
+			}
+			gtag("js", new Date());
+			gtag("config", "UA-156449732-1");
+		</script>
 	{/if}
 </svelte:head>
 


### PR DESCRIPTION
It's not really well documented that using Gradio may make your application communicate with Google Tag Manager, which allows whoever owns the property `UA-156449732-1` (hopefully someone benign) to execute basically **any code**; that should probably be made clearer.

# Description

* relevant motivation: I don't think Google Analytics code (even if it does nothing unless GTM is enabled) should exist in the base HTML template when analytics are not enabled.
* a summary of the change: move the initialization code to the Svelte template.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
