### PR TITLE
Allow setting default theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 ## New Features:
 
-No changes to highlight.
+- You can now set the default theme for all `gr.Blocks()` that don't specify a theme with `gradio.context.Context.default_theme`.
+  Implemented by [@akx](https://github.com/akx) in [PR 3957](https://github.com/gradio-app/gradio/pull/3957)
 
 ## Bug Fixes:
 - Fix duplicate play commands in full-screen mode of 'video'. by [@tomchang25](https://github.com/tomchang25) in [PR 3968](https://github.com/gradio-app/gradio/pull/3968).

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -605,7 +605,7 @@ class Blocks(BlockContext):
     ):
         """
         Parameters:
-            theme: a Theme object or a string representing a theme. If a string, will look for a built-in theme with that name (e.g. "soft" or "default"), or will attempt to load a theme from the HF Hub (e.g. "gradio/monochrome"). If None, will use the Default theme.
+            theme: a Theme object or a string representing a theme. If a string, will look for a built-in theme with that name (e.g. "soft" or "default"), or will attempt to load a theme from the HF Hub (e.g. "gradio/monochrome"). If None, will use the default theme class configured with `gradio.themes.set_default_theme_class()` (which defaults to `Default`).
             analytics_enabled: whether to allow basic telemetry. If None, will use GRADIO_ANALYTICS_ENABLED environment variable or default to True.
             mode: a human-friendly name for the kind of Blocks or Interface being created.
             title: The tab title to display when this is opened in a browser window.

--- a/gradio/context.py
+++ b/gradio/context.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
     from gradio.blocks import BlockContext, Blocks
+    from gradio.themes import ThemeClass
 
 
 class Context:
@@ -14,3 +15,6 @@ class Context:
     id: int = 0  # Running id to uniquely refer to any block that gets defined
     ip_address: str | None = None  # The IP address of the user.
     hf_token: str | None = None  # The token provided when loading private HF repos
+
+    # The default theme to use for all blocks.
+    default_theme: ThemeClass | None = None

--- a/gradio/themes/__init__.py
+++ b/gradio/themes/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import warnings
 from typing import Dict
 
+from gradio.context import Context
 from gradio.themes.base import Base, ThemeClass
 from gradio.themes.default import Default
 from gradio.themes.glass import Glass
@@ -54,13 +55,11 @@ def resolve_theme(theme: ThemeClass | str | None) -> ThemeClass:
     Resolve a theme reference to a Theme object.
 
     Args:
-        theme: A theme reference. Can be a theme object, a string referring to a built-in theme or a hub reference, or None. In case of None, the default theme is returned.
+        theme: A theme reference. Can be a theme object, a string referring to a built-in theme or a hub reference, or None. In case of None, the configured default theme is returned.
 
     Returns:
         A theme object.
     """
-    if theme is None:
-        return Default()
     if isinstance(theme, str):
         if theme.lower() in _built_in_themes:
             return _built_in_themes[theme.lower()]
@@ -68,10 +67,11 @@ def resolve_theme(theme: ThemeClass | str | None) -> ThemeClass:
             return ThemeClass.from_hub(theme)
         except Exception as e:
             warnings.warn(f"Cannot load {theme}. Caught Exception: {str(e)}")
-            theme = Default()
+            theme = None
     if not isinstance(theme, ThemeClass):
-        warnings.warn("Theme should be a class loaded from gradio.themes")
-        theme = Default()
+        if theme is not None:
+            warnings.warn("Theme should be a class loaded from gradio.themes")
+        theme = Context.default_theme or Default()
     return theme
 
 

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -22,10 +22,12 @@ from fastapi.testclient import TestClient
 from gradio_client import media_data
 
 import gradio as gr
+from gradio.context import Context
 from gradio.events import SelectData
 from gradio.exceptions import DuplicateBlockError
 from gradio.networking import Server, get_first_available_port
 from gradio.test_data.blocks_configs import XRAY_CONFIG
+from gradio.themes import Soft
 from gradio.utils import assert_configs_are_equivalent_besides_ids
 
 pytest_plugins = ("pytest_asyncio",)
@@ -347,6 +349,15 @@ class TestBlocksMethods:
         ):
             with gr.Blocks(theme="freddyaboulton/this-theme-does-not-exist") as demo:
                 assert demo.theme.to_dict() == gr.themes.Default().to_dict()
+
+    def test_set_default_theme_class(self, monkeypatch):
+        """
+        Test that setting Context.default_theme_class works for Blockses.
+        """
+
+        monkeypatch.setattr(Context, "default_theme_class", Soft)
+        with gr.Blocks() as demo:
+            assert demo.theme.name == "Soft"
 
     def test_exit_called_at_launch(self):
         with gr.Blocks() as demo:


### PR DESCRIPTION
# Description

* relevant motivation: https://github.com/gradio-app/gradio/issues/3544#issuecomment-1520695468
* a summary of the change: instead of referring to `Default`, look at `Context.default_theme_class` (which can be set via envvar too).

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
