### PR TITLE
CI: only run backend lints once, not in all test environments

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   client-test:
+    needs: [client-lint]
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
@@ -79,6 +80,7 @@ jobs:
     - name: Lint
       run: bash scripts/lint.sh
   test:
+    needs: [lint]
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -56,7 +56,28 @@ jobs:
     - name: Tests
       shell: bash
       run: |
-        bash scripts/ci.sh
+        bash scripts/test.sh
+  client-lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client/python
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.9"
+        cache: pip
+        cache-dependency-path: |
+          requirements.txt
+          test/requirements.txt
+    - name: Install Client
+      run: |
+        pip install -e .
+        pip install -r test/requirements.txt
+    - name: Lint
+      run: bash scripts/lint.sh
   test:
     strategy:
       matrix:
@@ -115,14 +136,6 @@ jobs:
       if: ${{ matrix.python-version == '3.7' }}
       run: |
         pip install -r test/requirements-37.txt
-    - name: Lint
-      shell: bash
-      run: |
-        bash scripts/lint_backend.sh
-    - name: Typecheck
-      shell: bash
-      run: |
-        bash scripts/type_check_backend.sh
     - name: Build frontend
       shell: bash
       run: |
@@ -137,4 +150,21 @@ jobs:
       run: |
         coverage run -m pytest -m "${{ matrix.test-type }}" --ignore=client
         coverage xml
-
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            test/requirements.txt
+      - name: Install Test Dependencies
+        run: pip install -e . -r test/requirements.txt
+      - name: Lint
+        run: bash scripts/lint_backend.sh
+      - name: Typecheck
+        run: bash scripts/type_check_backend.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ No changes to highlight.
 
 ## Testing and Infrastructure Changes:
 
-No changes to highlight.
+- CI: Python backend lint is only run once, by [@akx](https://github.com/akx) in [PR 3960](https://github.com/gradio-app/gradio/pull/3960)
 
 ## Breaking Changes:
 

--- a/client/python/scripts/lint.sh
+++ b/client/python/scripts/lint.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
-set -e
 
 cd "$(dirname ${0})/.."
 
 echo "Linting..."
 ruff test gradio_client
 black --check test gradio_client
-pyright gradio_client/*.py
 
-echo "Testing..."
-python -m pytest test
+echo "Type checking the client library with pyright"
+pyright gradio_client/*.py

--- a/client/python/scripts/test.sh
+++ b/client/python/scripts/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname ${0})/.."
+
+echo "Testing..."
+python -m pytest test


### PR DESCRIPTION
# Description

No need to spend cycles running lints multiple times; just run it once in a separate step.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
