### PR TITLE
Fix view_api bug where unnamed rotes where showing api_name instead of fn_index

### DIFF
--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## New Features:
 
-- Progress Updates from `gr.Progress()` can be accessed via `job.status().progress_data` by @freddyaboulton](https://github.com/freddyaboulton) in [PR 3924](https://github.com/gradio-app/gradio/pull/3924)
+- Progress Updates from `gr.Progress()` can be accessed via `job.status().progress_data` by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3924](https://github.com/gradio-app/gradio/pull/3924)
 
 ## Bug Fixes:
 
-No changes to highlight.
+- Fixed bug where unnamed routes where displayed with `api_name` instead of `fn_index` in `view_api` by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3972](https://github.com/gradio-app/gradio/pull/3972)
 
 ## Documentation Changes:
 

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -415,7 +415,6 @@ class Client:
                 info = fetch.json()["api"]
             else:
                 raise ValueError(f"Could not fetch api info for {self.src}")
-
         num_named_endpoints = len(info["named_endpoints"])
         num_unnamed_endpoints = len(info["unnamed_endpoints"])
         if num_named_endpoints == 0 and all_endpoints is None:
@@ -430,7 +429,9 @@ class Client:
         if all_endpoints:
             human_info += f"\nUnnamed API endpoints: {num_unnamed_endpoints}\n"
             for fn_index, endpoint_info in info["unnamed_endpoints"].items():
-                human_info += self._render_endpoints_info(fn_index, endpoint_info)
+                # When loading from json, the fn_indices are read as strings
+                # because json keys can only be strings
+                human_info += self._render_endpoints_info(int(fn_index), endpoint_info)
         else:
             if num_unnamed_endpoints > 0:
                 human_info += f"\nUnnamed API endpoints: {num_unnamed_endpoints}, to view, run Client.view_api(`all_endpoints=True`)\n"

--- a/client/python/test/test_client.py
+++ b/client/python/test/test_client.py
@@ -2,7 +2,6 @@ import json
 import os
 import pathlib
 import tempfile
-import textwrap
 import time
 import uuid
 from concurrent.futures import CancelledError, TimeoutError
@@ -668,38 +667,12 @@ class TestAPIInfo:
             "unnamed_endpoints": {},
         }
 
-    def test_unnamed_endpoints_use_fn_index(self):
-
-        with gr.Blocks() as demo:
-            name = gr.Textbox()
-            greeting = gr.Textbox()
-            greet = gr.Button()
-            greet.click(lambda x: f"Hello {x}", name, greeting)
-
-        _, local_url, _ = demo.launch(prevent_thread_lock=True)
-
-        expected = textwrap.dedent(
-            """Client.predict() Usage Info
----------------------------
-Named API endpoints: 0
-
-Unnamed API endpoints: 1
-
- - predict(parameter1, fn_index=0) -> value2
-    Parameters:
-     - [Textbox] parameter1: str (string value)
-    Returns:
-     - [Textbox] value2: str (string value)
-     """
-        )
-
-        try:
-            client = Client(src=local_url)
+    def test_unnamed_endpoints_use_fn_index(self, count_generator_demo):
+        # This demo has no api_name
+        with connect(count_generator_demo) as client:
             info = client.view_api(return_format="str")
-            assert info == expected
-
-        finally:
-            demo.close()
+            assert "fn_index=0" in info
+            assert "api_name" not in info
 
 
 class TestEndpoints:


### PR DESCRIPTION
# Description

Long-winded title but the issue was that unnamed routes were shown with `api_name='0'` as opposed to `fn_index=0`, which caused user confusion.

```
client = Client("stabilityai/stable-diffusion") 
client.view_api()
Client.predict() Usage Info
---------------------------
Named API endpoints: 0

Unnamed API endpoints: 4

...
- predict(enter_your_prompt, enter_your_negative_prompt, guidance_scale, api_name="1") -> generated_images
    Parameters:
     - [Textbox] enter_your_prompt: str (string value)
     - [Textbox] enter_your_negative_prompt: str (string value)
     - [Slider] guidance_scale: int | float (numeric value)
    Returns:
     - [Gallery] generated_images: str (path to directory with images and a file associating images with captions called captions.json)
...
```


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.