### PR TITLE
code block support in chatbot

### DIFF
--- a/js/chatbot/package.json
+++ b/js/chatbot/package.json
@@ -10,6 +10,7 @@
 	"dependencies": {
 		"@gradio/theme": "workspace:^0.0.1",
 		"@gradio/utils": "workspace:^0.0.1",
-		"@gradio/upload": "workspace:^0.0.1"
+		"@gradio/upload": "workspace:^0.0.1",
+		"@gradio/code": "workspace:^0.0.1"
 	}
 }

--- a/js/chatbot/src/ChatBot.svelte
+++ b/js/chatbot/src/ChatBot.svelte
@@ -74,6 +74,15 @@
 									{/each}
 								</div>
 							{/if}
+						{:else if message !== null && message["code_block"] !== undefined}
+							{#await import("@gradio/code") then Code}
+								<Code.default
+									value={message.code_block}
+									language={message.language}
+									mode={"static"}
+									target={div}
+								/>
+							{/await}
 						{:else if message !== null && message.mime_type?.includes("audio")}
 							<audio
 								controls


### PR DESCRIPTION
# Description
Adds support for code component in the chatbot
![Screenshot 2023-04-26 at 2 55 51 PM](https://user-images.githubusercontent.com/12725292/234678261-35b3ff32-cbca-4097-b8f2-987436adad88.png)


Please include: 
* relevant motivation
* a summary of the change 
* which issue is fixed. 
* any additional dependencies that are required for this change.

Closes: # (issue)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.