### PR TITLE
Deduplicate code in gradio/templates.py by using __init_subclass__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ No changes to highlight.
 ## Testing and Infrastructure Changes:
 
 - CI: Python backend lint is only run once, by [@akx](https://github.com/akx) in [PR 3960](https://github.com/gradio-app/gradio/pull/3960)
+- Deduplicated code in `gradio/templates.py`, by [@akx](https://github.com/akx) in [PR 3983](https://github.com/gradio-app/gradio/pull/3983)
 
 ## Breaking Changes:
 

--- a/gradio/templates.py
+++ b/gradio/templates.py
@@ -1,575 +1,124 @@
 from __future__ import annotations
 
-import typing
-from typing import Any, Callable, Tuple
-
-import numpy as np
-from PIL.Image import Image
+from functools import wraps
 
 from gradio import components
 
 
-class TextArea(components.Textbox):
-    """
-    Sets: lines=7
-    """
+class TemplateMeta:
+    def __init_subclass__(cls):
+        cls.is_template = True  # type: ignore
+        defaults = getattr(cls, "_template_defaults", {})
+        original_init = cls.__init__
 
-    is_template = True
+        # Wrap the original init function, adding the kwargs
+        # from `_template_defaults` the user didn't supply.
+        @wraps(original_init)
+        def template_init(*args, **kwargs):
+            for key, value in defaults.items():
+                if key not in kwargs:
+                    kwargs[key] = value
+            original_init(*args, **kwargs)
 
-    def __init__(
-        self,
-        value: str | Callable | None = "",
-        *,
-        lines: int = 7,
-        max_lines: int = 20,
-        placeholder: str | None = None,
-        label: str | None = None,
-        show_label: bool = True,
-        interactive: bool | None = None,
-        visible: bool = True,
-        elem_id: str | None = None,
-        **kwargs,
-    ):
-        super().__init__(
-            value=value,
-            lines=lines,
-            max_lines=max_lines,
-            placeholder=placeholder,
-            label=label,
-            show_label=show_label,
-            interactive=interactive,
-            visible=visible,
-            elem_id=elem_id,
-            **kwargs,
-        )
+        # Assign qualname and name to make this function
+        # clearly identifiable in the stack trace.
+        template_init.__qualname__ = (
+            template_init.__name__
+        ) = f"{cls.__name__}.__template_init__"
+        cls.__init__ = template_init
 
 
-class Webcam(components.Image):
-    """
-    Sets: source="webcam", interactive=True
-    """
-
-    is_template = True
-
-    def __init__(
-        self,
-        value: str | Image | np.ndarray | None = None,
-        *,
-        shape: Tuple[int, int] | None = None,
-        image_mode: str = "RGB",
-        invert_colors: bool = False,
-        source: str = "webcam",
-        tool: str | None = None,
-        type: str = "numpy",
-        label: str | None = None,
-        show_label: bool = True,
-        interactive: bool | None = True,
-        visible: bool = True,
-        streaming: bool = False,
-        elem_id: str | None = None,
-        mirror_webcam: bool = True,
-        brush_radius: float | None = None,
-        **kwargs,
-    ):
-        super().__init__(
-            value=value,
-            shape=shape,
-            image_mode=image_mode,
-            invert_colors=invert_colors,
-            source=source,
-            tool=tool,
-            type=type,
-            label=label,
-            show_label=show_label,
-            interactive=interactive,
-            visible=visible,
-            streaming=streaming,
-            elem_id=elem_id,
-            mirror_webcam=mirror_webcam,
-            brush_radius=brush_radius,
-            **kwargs,
-        )
+class TextArea(TemplateMeta, components.Textbox):
+    _template_defaults = {
+        "lines": 7,
+    }
 
 
-class Sketchpad(components.Image):
-    """
-    Sets: image_mode="L", source="canvas", shape=(28, 28), invert_colors=True, interactive=True
-    """
-
-    is_template = True
-
-    def __init__(
-        self,
-        value: str | Image | np.ndarray | None = None,
-        *,
-        shape: Tuple[int, int] = (28, 28),
-        image_mode: str = "L",
-        invert_colors: bool = True,
-        source: str = "canvas",
-        tool: str | None = None,
-        type: str = "numpy",
-        label: str | None = None,
-        show_label: bool = True,
-        interactive: bool | None = True,
-        visible: bool = True,
-        streaming: bool = False,
-        elem_id: str | None = None,
-        mirror_webcam: bool = True,
-        brush_radius: float | None = None,
-        **kwargs,
-    ):
-        super().__init__(
-            value=value,
-            shape=shape,
-            image_mode=image_mode,
-            invert_colors=invert_colors,
-            source=source,
-            tool=tool,
-            type=type,
-            label=label,
-            show_label=show_label,
-            interactive=interactive,
-            visible=visible,
-            streaming=streaming,
-            elem_id=elem_id,
-            mirror_webcam=mirror_webcam,
-            brush_radius=brush_radius,
-            **kwargs,
-        )
+class Webcam(TemplateMeta, components.Image):
+    _template_defaults = {
+        "interactive": True,
+        "source": "webcam",
+    }
 
 
-class Paint(components.Image):
-    """
-    Sets: source="canvas", tool="color-sketch", interactive=True
-    """
-
-    is_template = True
-
-    def __init__(
-        self,
-        value: str | Image | np.ndarray | None = None,
-        *,
-        shape: Tuple[int, int] | None = None,
-        image_mode: str = "RGB",
-        invert_colors: bool = False,
-        source: str = "canvas",
-        tool: str = "color-sketch",
-        type: str = "numpy",
-        label: str | None = None,
-        show_label: bool = True,
-        interactive: bool | None = True,
-        visible: bool = True,
-        streaming: bool = False,
-        elem_id: str | None = None,
-        mirror_webcam: bool = True,
-        brush_radius: float | None = None,
-        **kwargs,
-    ):
-        super().__init__(
-            value=value,
-            shape=shape,
-            image_mode=image_mode,
-            invert_colors=invert_colors,
-            source=source,
-            tool=tool,
-            type=type,
-            label=label,
-            show_label=show_label,
-            interactive=interactive,
-            visible=visible,
-            streaming=streaming,
-            elem_id=elem_id,
-            mirror_webcam=mirror_webcam,
-            brush_radius=brush_radius,
-            **kwargs,
-        )
+class Sketchpad(TemplateMeta, components.Image):
+    _template_defaults = {
+        "image_mode": "L",
+        "interactive": True,
+        "invert_colors": True,
+        "shape": (28, 28),
+        "source": "canvas",
+    }
 
 
-class ImageMask(components.Image):
-    """
-    Sets: source="upload", tool="sketch", interactive=True
-    """
-
-    is_template = True
-
-    def __init__(
-        self,
-        value: str | Image | np.ndarray | None = None,
-        *,
-        shape: Tuple[int, int] | None = None,
-        image_mode: str = "RGB",
-        invert_colors: bool = False,
-        source: str = "upload",
-        tool: str = "sketch",
-        type: str = "numpy",
-        label: str | None = None,
-        show_label: bool = True,
-        interactive: bool | None = True,
-        visible: bool = True,
-        streaming: bool = False,
-        elem_id: str | None = None,
-        mirror_webcam: bool = True,
-        brush_radius: float | None = None,
-        **kwargs,
-    ):
-        super().__init__(
-            value=value,
-            shape=shape,
-            image_mode=image_mode,
-            invert_colors=invert_colors,
-            source=source,
-            tool=tool,
-            type=type,
-            label=label,
-            show_label=show_label,
-            interactive=interactive,
-            visible=visible,
-            streaming=streaming,
-            elem_id=elem_id,
-            mirror_webcam=mirror_webcam,
-            brush_radius=brush_radius,
-            **kwargs,
-        )
+class Paint(TemplateMeta, components.Image):
+    _template_defaults = {
+        "interactive": True,
+        "source": "canvas",
+        "tool": "color-sketch",
+    }
 
 
-class ImagePaint(components.Image):
-    """
-    Sets: source="upload", tool="color-sketch", interactive=True
-    """
-
-    is_template = True
-
-    def __init__(
-        self,
-        value: str | Image | np.ndarray | None = None,
-        *,
-        shape: Tuple[int, int] | None = None,
-        image_mode: str = "RGB",
-        invert_colors: bool = False,
-        source: str = "upload",
-        tool: str = "color-sketch",
-        type: str = "numpy",
-        label: str | None = None,
-        show_label: bool = True,
-        interactive: bool | None = True,
-        visible: bool = True,
-        streaming: bool = False,
-        elem_id: str | None = None,
-        mirror_webcam: bool = True,
-        brush_radius: float | None = None,
-        **kwargs,
-    ):
-        super().__init__(
-            value=value,
-            shape=shape,
-            image_mode=image_mode,
-            invert_colors=invert_colors,
-            source=source,
-            tool=tool,
-            type=type,
-            label=label,
-            show_label=show_label,
-            interactive=interactive,
-            visible=visible,
-            streaming=streaming,
-            elem_id=elem_id,
-            mirror_webcam=mirror_webcam,
-            brush_radius=brush_radius,
-            **kwargs,
-        )
+class ImageMask(TemplateMeta, components.Image):
+    _template_defaults = {
+        "interactive": True,
+        "source": "upload",
+        "tool": "sketch",
+    }
 
 
-class Pil(components.Image):
-    """
-    Sets: type="pil"
-    """
-
-    is_template = True
-
-    def __init__(
-        self,
-        value: str | Image | np.ndarray | None = None,
-        *,
-        shape: Tuple[int, int] | None = None,
-        image_mode: str = "RGB",
-        invert_colors: bool = False,
-        source: str = "upload",
-        tool: str | None = None,
-        type: str = "pil",
-        label: str | None = None,
-        show_label: bool = True,
-        interactive: bool | None = None,
-        visible: bool = True,
-        streaming: bool = False,
-        elem_id: str | None = None,
-        mirror_webcam: bool = True,
-        brush_radius: float | None = None,
-        **kwargs,
-    ):
-        super().__init__(
-            value=value,
-            shape=shape,
-            image_mode=image_mode,
-            invert_colors=invert_colors,
-            source=source,
-            tool=tool,
-            type=type,
-            label=label,
-            show_label=show_label,
-            interactive=interactive,
-            visible=visible,
-            streaming=streaming,
-            elem_id=elem_id,
-            mirror_webcam=mirror_webcam,
-            brush_radius=brush_radius,
-            **kwargs,
-        )
+class ImagePaint(TemplateMeta, components.Image):
+    _template_defaults = {
+        "interactive": True,
+        "source": "upload",
+        "tool": "color-sketch",
+    }
 
 
-class PlayableVideo(components.Video):
-    """
-    Sets: format="mp4"
-    """
-
-    is_template = True
-
-    def __init__(
-        self,
-        value: str | Callable | None = None,
-        *,
-        format: str | None = "mp4",
-        source: str = "upload",
-        label: str | None = None,
-        show_label: bool = True,
-        interactive: bool | None = None,
-        visible: bool = True,
-        elem_id: str | None = None,
-        mirror_webcam: bool = True,
-        include_audio: bool | None = None,
-        **kwargs,
-    ):
-        super().__init__(
-            value=value,
-            format=format,
-            source=source,
-            label=label,
-            show_label=show_label,
-            interactive=interactive,
-            visible=visible,
-            elem_id=elem_id,
-            mirror_webcam=mirror_webcam,
-            include_audio=include_audio,
-            **kwargs,
-        )
+class Pil(TemplateMeta, components.Image):
+    _template_defaults = {
+        "source": "upload",
+        "type": "pil",
+    }
 
 
-class Microphone(components.Audio):
-    """
-    Sets: source="microphone"
-    """
-
-    is_template = True
-
-    def __init__(
-        self,
-        value: str | Tuple[int, np.ndarray] | Callable | None = None,
-        *,
-        source: str = "microphone",
-        type: str = "numpy",
-        label: str | None = None,
-        show_label: bool = True,
-        interactive: bool | None = None,
-        visible: bool = True,
-        streaming: bool = False,
-        elem_id: str | None = None,
-        **kwargs,
-    ):
-        super().__init__(
-            value=value,
-            source=source,
-            type=type,
-            label=label,
-            show_label=show_label,
-            interactive=interactive,
-            visible=visible,
-            streaming=streaming,
-            elem_id=elem_id,
-            **kwargs,
-        )
+class PlayableVideo(TemplateMeta, components.Video):
+    _template_defaults = {
+        "format": "mp4",
+        "source": "upload",
+    }
 
 
-class Files(components.File):
-    """
-    Sets: file_count="multiple"
-    """
-
-    is_template = True
-
-    def __init__(
-        self,
-        value: str | typing.List[str] | Callable | None = None,
-        *,
-        file_count: str = "multiple",
-        type: str = "file",
-        label: str | None = None,
-        show_label: bool = True,
-        interactive: bool | None = None,
-        visible: bool = True,
-        elem_id: str | None = None,
-        **kwargs,
-    ):
-        super().__init__(
-            value=value,
-            file_count=file_count,
-            type=type,
-            label=label,
-            show_label=show_label,
-            interactive=interactive,
-            visible=visible,
-            elem_id=elem_id,
-            **kwargs,
-        )
+class Microphone(TemplateMeta, components.Audio):
+    _template_defaults = {
+        "source": "microphone",
+        "type": "numpy",
+    }
 
 
-class Numpy(components.Dataframe):
-    """
-    Sets: type="numpy"
-    """
-
-    is_template = True
-
-    def __init__(
-        self,
-        value: typing.List[typing.List[Any]] | Callable | None = None,
-        *,
-        headers: typing.List[str] | None = None,
-        row_count: int | Tuple[int, str] = (1, "dynamic"),
-        col_count: int | Tuple[int, str] | None = None,
-        datatype: str | typing.List[str] = "str",
-        type: str = "numpy",
-        max_rows: int | None = 20,
-        max_cols: int | None = None,
-        overflow_row_behaviour: str = "paginate",
-        label: str | None = None,
-        show_label: bool = True,
-        interactive: bool | None = None,
-        visible: bool = True,
-        elem_id: str | None = None,
-        wrap: bool = False,
-        **kwargs,
-    ):
-        super().__init__(
-            value=value,
-            headers=headers,
-            row_count=row_count,
-            col_count=col_count,
-            datatype=datatype,
-            type=type,
-            max_rows=max_rows,
-            max_cols=max_cols,
-            overflow_row_behaviour=overflow_row_behaviour,
-            label=label,
-            show_label=show_label,
-            interactive=interactive,
-            visible=visible,
-            elem_id=elem_id,
-            wrap=wrap,
-            **kwargs,
-        )
+class Files(TemplateMeta, components.File):
+    _template_defaults = {
+        "file_count": "multiple",
+    }
 
 
-class Matrix(components.Dataframe):
-    """
-    Sets: type="array"
-    """
-
-    is_template = True
-
-    def __init__(
-        self,
-        value: typing.List[typing.List[Any]] | Callable | None = None,
-        *,
-        headers: typing.List[str] | None = None,
-        row_count: int | Tuple[int, str] = (1, "dynamic"),
-        col_count: int | Tuple[int, str] | None = None,
-        datatype: str | typing.List[str] = "str",
-        type: str = "array",
-        max_rows: int | None = 20,
-        max_cols: int | None = None,
-        overflow_row_behaviour: str = "paginate",
-        label: str | None = None,
-        show_label: bool = True,
-        interactive: bool | None = None,
-        visible: bool = True,
-        elem_id: str | None = None,
-        wrap: bool = False,
-        **kwargs,
-    ):
-        super().__init__(
-            value=value,
-            headers=headers,
-            row_count=row_count,
-            col_count=col_count,
-            datatype=datatype,
-            type=type,
-            max_rows=max_rows,
-            max_cols=max_cols,
-            overflow_row_behaviour=overflow_row_behaviour,
-            label=label,
-            show_label=show_label,
-            interactive=interactive,
-            visible=visible,
-            elem_id=elem_id,
-            wrap=wrap,
-            **kwargs,
-        )
+class Numpy(TemplateMeta, components.Dataframe):
+    _template_defaults = {
+        "type": "numpy",
+    }
 
 
-class List(components.Dataframe):
-    """
-    Sets: type="array", col_count=1
-    """
+class Matrix(TemplateMeta, components.Dataframe):
+    _template_defaults = {
+        "type": "array",
+    }
 
-    is_template = True
 
-    def __init__(
-        self,
-        value: typing.List[typing.List[Any]] | Callable | None = None,
-        *,
-        headers: typing.List[str] | None = None,
-        row_count: int | Tuple[int, str] = (1, "dynamic"),
-        col_count: int | Tuple[int, str] = 1,
-        datatype: str | typing.List[str] = "str",
-        type: str = "array",
-        max_rows: int | None = 20,
-        max_cols: int | None = None,
-        overflow_row_behaviour: str = "paginate",
-        label: str | None = None,
-        show_label: bool = True,
-        interactive: bool | None = None,
-        visible: bool = True,
-        elem_id: str | None = None,
-        wrap: bool = False,
-        **kwargs,
-    ):
-        super().__init__(
-            value=value,
-            headers=headers,
-            row_count=row_count,
-            col_count=col_count,
-            datatype=datatype,
-            type=type,
-            max_rows=max_rows,
-            max_cols=max_cols,
-            overflow_row_behaviour=overflow_row_behaviour,
-            label=label,
-            show_label=show_label,
-            interactive=interactive,
-            visible=visible,
-            elem_id=elem_id,
-            wrap=wrap,
-            **kwargs,
-        )
+class List(TemplateMeta, components.Dataframe):
+    _template_defaults = {
+        "col_count": 1,
+        "type": "array",
+    }
 
 
 Mic = Microphone

--- a/test/test_templates.py
+++ b/test/test_templates.py
@@ -1,0 +1,36 @@
+import pytest
+
+import gradio.templates
+
+
+@pytest.mark.parametrize(
+    "component",
+    [
+        gradio.templates.Files,
+        gradio.templates.ImageMask,
+        gradio.templates.ImagePaint,
+        gradio.templates.List,
+        gradio.templates.Matrix,
+        gradio.templates.Microphone,
+        gradio.templates.Numpy,
+        gradio.templates.Paint,
+        gradio.templates.Pil,
+        gradio.templates.PlayableVideo,
+        gradio.templates.Sketchpad,
+        gradio.templates.TextArea,
+        gradio.templates.Webcam,
+    ],
+)
+def test_template_components(component):
+    """
+    Test that the template components correctly assign
+    the template defaults to the component.
+    """
+    assert component._template_defaults is not None
+    comp = component()
+    for key, value in component._template_defaults.items():
+        if component is gradio.templates.List and key == "col_count":
+            # List is a special case where col_count is internally
+            # mangled in the initializer
+            value = (1, "dynamic")
+        assert getattr(comp, key) == value


### PR DESCRIPTION
# Description

* Relevant motivation: I noticed there was a lot of hard-to-maintain copypaste initialization code in gradio/templates.py.
  * In fact, some of the inits' signatures differed from the superclasses' already.
* Summary: Instead of copy-pasting the `__init__`s of the superclasses, use [`__init_subclass__`](https://docs.python.org/3.11/reference/datamodel.html#object.__init_subclass__) in a small mixin class to override the template classes' ctors to pass those kwargs.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  - Nothing changes for end-users. 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
