### PR TITLE
Fix dropdown default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ No changes to highlight.
 
 ## Bug Fixes:
 
-No changes to highlight.
+- Fix faded coloring of output textboxes in iOS / Safari by [@aliabid94](https://github.com/aliabid94) in [PR ](https://github.com/gradio-app/gradio/pull/)
 
 ## Documentation Changes:
 

--- a/js/form/src/Dropdown.svelte
+++ b/js/form/src/Dropdown.svelte
@@ -25,6 +25,10 @@
 		showOptions = false,
 		filterInput: HTMLElement;
 
+	if (typeof value === "string") {
+		inputValue = value;
+	}
+
 	$: filtered = choices.filter((o) =>
 		inputValue ? o.toLowerCase().includes(inputValue.toLowerCase()) : o
 	);

--- a/js/form/src/Textbox.svelte
+++ b/js/form/src/Textbox.svelte
@@ -207,8 +207,10 @@
 	input[type="password"],
 	input[type="email"],
 	textarea {
+		-webkit-text-fill-color: var(--body-text-color);
 		display: block;
 		position: relative;
+		-webkit-opacity: 1;
 		outline: none !important;
 		box-shadow: var(--input-shadow);
 		border: var(--input-border-width) solid var(--input-border-color);


### PR DESCRIPTION
Fixes: https://github.com/gradio-app/gradio/issues/3994

Try with: 
```python
import gradio as gr

choices = ["World", "Gradio", "World2", "abc "*50, "You"]
with gr.Blocks() as demo:
    drop1 = gr.Dropdown(choices, label="simple", value="World")
    drop2 = gr.Dropdown(choices, label="multi", multiselect=True)
    drop3 = gr.Dropdown(choices, label="custom", allow_custom_value=True)
    drop4 = gr.Dropdown(choices, label="multi-max3", multiselect=True, max_choices=3)
    btn = gr.Button("Click me!")
    with gr.Row():
        with gr.Column():
            gr.Markdown("On Click")
            val1 = gr.Textbox(label="simple")
            val2 = gr.Textbox(label="multi")
            val3 = gr.Textbox(label="custom")
            val4 = gr.Textbox(label="multi-max3")
        with gr.Column():
            gr.Markdown("On Change")
            ins1 = gr.Textbox(label="simple")
            ins2 = gr.Textbox(label="multi")
            ins3 = gr.Textbox(label="custom")
            ins4 = gr.Textbox(label="multi-max3")
    btn.click(lambda *args: args, [drop1, drop2, drop3, drop4], [val1, val2, val3, ins4])
    drop1.change(lambda x:x, drop1, ins1)
    drop2.change(lambda x:x, drop2, ins2)
    drop3.change(lambda x:x, drop3, ins3)
    drop4.change(lambda x:x, drop4, ins4)
        
demo.launch()
```