### PR TITLE
Allow state to be rendered multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ## Bug Fixes:
 
-No changes to highlight.
+- Fixes bug where rendering the same `gr.State` across different Interfaces/Blocks within
+a larger Blocks would not work by [@abidlabs](https://github.com/abidlabs) in [PR 4030](https://github.com/gradio-app/gradio/pull/4030)
 
 ## Documentation Changes:
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -843,10 +843,13 @@ class Blocks(BlockContext):
                 raise DuplicateBlockError(
                     f"A block with id: {self._id} has already been rendered in the current Blocks."
                 )
-            if not set(Context.root_block.blocks).isdisjoint(self.blocks):
-                raise DuplicateBlockError(
-                    "At least one block in this Blocks has already been rendered."
-                )
+            overlapping_ids = set(Context.root_block.blocks).intersection(self.blocks)
+            for id in overlapping_ids:
+                # State componenents are allowed to be reused between Blocks
+                if not isinstance(self.blocks[id], components.State):
+                    raise DuplicateBlockError(
+                        "At least one block in this Blocks has already been rendered."
+                    )
 
             Context.root_block.blocks.update(self.blocks)
             Context.root_block.fns.extend(self.fns)

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1035,17 +1035,25 @@ class TestRender:
             io.render()
             io3 = io2.render()
         assert io2 == io3
-        
+
     def test_no_error_if_state_rendered_multiple_times(self):
         state = gr.State("")
-        gr.TabbedInterface([
-            gr.Interface(lambda _, x: (x, f"I don't know"), 
-                         inputs=[state, gr.Textbox()], 
-                         outputs=[state, gr.Textbox()]),
-            gr.Interface(lambda s: (s, f"User question: {s}"), 
-                         inputs=[state], 
-                         outputs=[state, gr.Textbox(interactive=False)])
-        ], ["Ask question", "Show question"])        
+        gr.TabbedInterface(
+            [
+                gr.Interface(
+                    lambda _, x: (x, "I don't know"),
+                    inputs=[state, gr.Textbox()],
+                    outputs=[state, gr.Textbox()],
+                ),
+                gr.Interface(
+                    lambda s: (s, f"User question: {s}"),
+                    inputs=[state],
+                    outputs=[state, gr.Textbox(interactive=False)],
+                ),
+            ],
+            ["Ask question", "Show question"],
+        )
+
 
 class TestCancel:
     @pytest.mark.skipif(

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1035,7 +1035,17 @@ class TestRender:
             io.render()
             io3 = io2.render()
         assert io2 == io3
-
+        
+    def test_no_error_if_state_rendered_multiple_times(self):
+        state = gr.State("")
+        gr.TabbedInterface([
+            gr.Interface(lambda _, x: (x, f"I don't know"), 
+                         inputs=[state, gr.Textbox()], 
+                         outputs=[state, gr.Textbox()]),
+            gr.Interface(lambda s: (s, f"User question: {s}"), 
+                         inputs=[state], 
+                         outputs=[state, gr.Textbox(interactive=False)])
+        ], ["Ask question", "Show question"])        
 
 class TestCancel:
     @pytest.mark.skipif(


### PR DESCRIPTION
Fixes: #4020 

Generally, we don't allow components to be re-used between Blocks. However, we should make an exception for `gr.State`, which actually can be legitimately reused between different Blocks as the original issue shows. This carves out an exception for `gr.State` and adds a test. See original issue for code to test.