### PR TITLE
Add ability to blocklist filepaths, ability to specify where gradio temp files are created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## New Features:
 
 - Add support for `visual-question-answering`, `document-question-answering`, and `image-to-text` using `gr.Interface.load("models/...")` and `gr.Interface.from_pipeline` by [@osanseviero](https://github.com/osanseviero) in [PR 3887](https://github.com/gradio-app/gradio/pull/3887)
+- Adds the ability to blocklist filepaths (and also improves the allowlist mechanism by [@abidlabs](https://github.com/abidlabs) in [PR 4047](https://github.com/gradio-app/gradio/pull/4047).
 
 ## Bug Fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ## New Features:
 
 - Add support for `visual-question-answering`, `document-question-answering`, and `image-to-text` using `gr.Interface.load("models/...")` and `gr.Interface.from_pipeline` by [@osanseviero](https://github.com/osanseviero) in [PR 3887](https://github.com/gradio-app/gradio/pull/3887)
-- Adds the ability to blocklist filepaths (and also improves the allowlist mechanism by [@abidlabs](https://github.com/abidlabs) in [PR 4047](https://github.com/gradio-app/gradio/pull/4047).
+- Adds the ability to blocklist filepaths (and also improves the allowlist mechanism) by [@abidlabs](https://github.com/abidlabs) in [PR 4047](https://github.com/gradio-app/gradio/pull/4047).
+- Adds the ability to specify the upload directory via an environment variable by [@abidlabs](https://github.com/abidlabs) in [PR 4047](https://github.com/gradio-app/gradio/pull/4047).
 
 ## Bug Fixes:
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -692,8 +692,8 @@ class Blocks(BlockContext):
         self.progress_tracking = None
         self.ssl_verify = True
 
-        self.path_allowlist = []
-        self.path_blocklist = []
+        self.allowed_files = []
+        self.blocked_files = []
 
         if self.analytics_enabled:
             is_custom_theme = not any(
@@ -1589,8 +1589,8 @@ Received outputs:
         quiet: bool = False,
         show_api: bool = True,
         file_directories: List[str] | None = None,
-        path_allowlist: List[str] | None = None,
-        path_blocklist: List[str] | None = None,
+        allowed_files: List[str] | None = None,
+        blocked_files: List[str] | None = None,
         _frontend: bool = True,
     ) -> Tuple[FastAPI, str, str]:
         """
@@ -1621,9 +1621,9 @@ Received outputs:
             ssl_verify: If False, skips certificate validation which allows self-signed certificates to be used.
             quiet: If True, suppresses most print statements.
             show_api: If True, shows the api docs in the footer of the app. Default True. If the queue is enabled, then api_open parameter of .queue() will determine if the api docs are shown, independent of the value of show_api.
-            file_directories: This parameter has been renamed to `path_allowlist`. It will be removed in a future version.
-            path_allowlist: List of filepaths or directories that gradio is allowed to serve files from (in addition to the directory containing the gradio python file). Must be absolute paths. Warning: any files in these directories or its children are potentially accessible to all users of your app.
-            path_blocklist: List of filepaths or directories that gradio is not allowed to serve files from. Must be absolute paths. Warning: takes precedence over `path_allowlist` and all other directories exposed by Gradio by default. 
+            file_directories: This parameter has been renamed to `allowed_files`. It will be removed in a future version.
+            allowed_files: List of complete filepaths or parent directories that gradio is allowed to serve (in addition to the directory containing the gradio python file). Must be absolute paths. Warning: if you provide directories, any files in these directories or their subdirectories are accessible to all users of your app.
+            blocked_files: List of complete filepaths or parent directories that gradio is not allowed to serve (i.e. users of your app are not allowed to access). Must be absolute paths. Warning: takes precedence over `allowed_files` and all other directories exposed by Gradio by default. 
         Returns:
             app: FastAPI app object that is running the demo
             local_url: Locally accessible link to the demo
@@ -1685,16 +1685,16 @@ Received outputs:
         self.show_api = self.api_open if self.enable_queue else show_api
 
         if file_directories is not None:
-            warnings.warn("The `file_directories` parameter has been renamed to `path_allowlist`. Please use that instead.", DeprecationWarning)
-            if path_allowlist is None:
-                path_allowlist = file_directories
-        self.path_allowlist = path_allowlist or []
-        self.path_blocklist = path_blocklist or []
+            warnings.warn("The `file_directories` parameter has been renamed to `allowed_files`. Please use that instead.", DeprecationWarning)
+            if allowed_files is None:
+                allowed_files = file_directories
+        self.allowed_files = allowed_files or []
+        self.blocked_files = blocked_files or []
         
-        if not isinstance(self.path_allowlist, list):
-            raise ValueError("`path_allowlist` must be a list of directories.")
-        if not isinstance(self.path_blocklist, list):
-            raise ValueError("`path_blocklist` must be a list of directories.")
+        if not isinstance(self.allowed_files, list):
+            raise ValueError("`allowed_files` must be a list of directories.")
+        if not isinstance(self.blocked_files, list):
+            raise ValueError("`blocked_files` must be a list of directories.")
 
         self.validate_queue_settings()
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1623,7 +1623,7 @@ Received outputs:
             show_api: If True, shows the api docs in the footer of the app. Default True. If the queue is enabled, then api_open parameter of .queue() will determine if the api docs are shown, independent of the value of show_api.
             file_directories: This parameter has been renamed to `allowed_files`. It will be removed in a future version.
             allowed_files: List of complete filepaths or parent directories that gradio is allowed to serve (in addition to the directory containing the gradio python file). Must be absolute paths. Warning: if you provide directories, any files in these directories or their subdirectories are accessible to all users of your app.
-            blocked_files: List of complete filepaths or parent directories that gradio is not allowed to serve (i.e. users of your app are not allowed to access). Must be absolute paths. Warning: takes precedence over `allowed_files` and all other directories exposed by Gradio by default. 
+            blocked_files: List of complete filepaths or parent directories that gradio is not allowed to serve (i.e. users of your app are not allowed to access). Must be absolute paths. Warning: takes precedence over `allowed_files` and all other directories exposed by Gradio by default.
         Returns:
             app: FastAPI app object that is running the demo
             local_url: Locally accessible link to the demo
@@ -1685,12 +1685,15 @@ Received outputs:
         self.show_api = self.api_open if self.enable_queue else show_api
 
         if file_directories is not None:
-            warnings.warn("The `file_directories` parameter has been renamed to `allowed_files`. Please use that instead.", DeprecationWarning)
+            warnings.warn(
+                "The `file_directories` parameter has been renamed to `allowed_files`. Please use that instead.",
+                DeprecationWarning,
+            )
             if allowed_files is None:
                 allowed_files = file_directories
         self.allowed_files = allowed_files or []
         self.blocked_files = blocked_files or []
-        
+
         if not isinstance(self.allowed_files, list):
             raise ValueError("`allowed_files` must be a list of directories.")
         if not isinstance(self.blocked_files, list):

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -692,8 +692,8 @@ class Blocks(BlockContext):
         self.progress_tracking = None
         self.ssl_verify = True
 
-        self.allowed_files = []
-        self.blocked_files = []
+        self.allowed_paths = []
+        self.blocked_paths = []
 
         if self.analytics_enabled:
             is_custom_theme = not any(
@@ -1589,8 +1589,8 @@ Received outputs:
         quiet: bool = False,
         show_api: bool = True,
         file_directories: List[str] | None = None,
-        allowed_files: List[str] | None = None,
-        blocked_files: List[str] | None = None,
+        allowed_paths: List[str] | None = None,
+        blocked_paths: List[str] | None = None,
         _frontend: bool = True,
     ) -> Tuple[FastAPI, str, str]:
         """
@@ -1621,9 +1621,9 @@ Received outputs:
             ssl_verify: If False, skips certificate validation which allows self-signed certificates to be used.
             quiet: If True, suppresses most print statements.
             show_api: If True, shows the api docs in the footer of the app. Default True. If the queue is enabled, then api_open parameter of .queue() will determine if the api docs are shown, independent of the value of show_api.
-            file_directories: This parameter has been renamed to `allowed_files`. It will be removed in a future version.
-            allowed_files: List of complete filepaths or parent directories that gradio is allowed to serve (in addition to the directory containing the gradio python file). Must be absolute paths. Warning: if you provide directories, any files in these directories or their subdirectories are accessible to all users of your app.
-            blocked_files: List of complete filepaths or parent directories that gradio is not allowed to serve (i.e. users of your app are not allowed to access). Must be absolute paths. Warning: takes precedence over `allowed_files` and all other directories exposed by Gradio by default.
+            file_directories: This parameter has been renamed to `allowed_paths`. It will be removed in a future version.
+            allowed_paths: List of complete filepaths or parent directories that gradio is allowed to serve (in addition to the directory containing the gradio python file). Must be absolute paths. Warning: if you provide directories, any files in these directories or their subdirectories are accessible to all users of your app.
+            blocked_paths: List of complete filepaths or parent directories that gradio is not allowed to serve (i.e. users of your app are not allowed to access). Must be absolute paths. Warning: takes precedence over `allowed_paths` and all other directories exposed by Gradio by default.
         Returns:
             app: FastAPI app object that is running the demo
             local_url: Locally accessible link to the demo
@@ -1686,18 +1686,18 @@ Received outputs:
 
         if file_directories is not None:
             warnings.warn(
-                "The `file_directories` parameter has been renamed to `allowed_files`. Please use that instead.",
+                "The `file_directories` parameter has been renamed to `allowed_paths`. Please use that instead.",
                 DeprecationWarning,
             )
-            if allowed_files is None:
-                allowed_files = file_directories
-        self.allowed_files = allowed_files or []
-        self.blocked_files = blocked_files or []
+            if allowed_paths is None:
+                allowed_paths = file_directories
+        self.allowed_paths = allowed_paths or []
+        self.blocked_paths = blocked_paths or []
 
-        if not isinstance(self.allowed_files, list):
-            raise ValueError("`allowed_files` must be a list of directories.")
-        if not isinstance(self.blocked_files, list):
-            raise ValueError("`blocked_files` must be a list of directories.")
+        if not isinstance(self.allowed_paths, list):
+            raise ValueError("`allowed_paths` must be a list of directories.")
+        if not isinstance(self.blocked_paths, list):
+            raise ValueError("`blocked_paths` must be a list of directories.")
 
         self.validate_queue_settings()
 

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -9,6 +9,7 @@ import inspect
 import json
 import math
 import operator
+import os
 import random
 import secrets
 import shutil
@@ -191,7 +192,9 @@ class IOComponent(Component):
         **kwargs,
     ):
         self.temp_files: Set[str] = set()
-        self.DEFAULT_TEMP_DIR = tempfile.gettempdir()
+        self.DEFAULT_TEMP_DIR = os.environ.get("GRADIO_TEMP_DIR") or str(
+            Path(tempfile.gettempdir()) / "gradio"
+        )
 
         Component.__init__(
             self, elem_id=elem_id, elem_classes=elem_classes, visible=visible, **kwargs

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -309,7 +309,7 @@ class App(FastAPI):
                 (
                     utils.is_in(abs_path, blocked_path)
                     or abs_path == utils.abspath(blocked_path)
-                    for blocked_path in blocks.blocked_files
+                    for blocked_path in blocks.blocked_paths
                 )
             )
             if in_blocklist:
@@ -321,7 +321,7 @@ class App(FastAPI):
                 (
                     utils.is_in(abs_path, allowed_path)
                     or abs_path == utils.abspath(allowed_path)
-                    for allowed_path in blocks.allowed_files
+                    for allowed_path in blocks.allowed_paths
                 )
             )
             was_uploaded = utils.abspath(app.uploaded_file_dir) in abs_path.parents

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -307,18 +307,20 @@ class App(FastAPI):
             abs_path = utils.abspath(path_or_url)
             in_blocklist = any(
                 (
-                    utils.is_in(abs_path, blocked_path) or abs_path == utils.abspath(blocked_path)
+                    utils.is_in(abs_path, blocked_path)
+                    or abs_path == utils.abspath(blocked_path)
                     for blocked_path in blocks.blocked_files
                 )
             )
             if in_blocklist:
                 raise HTTPException(403, f"File not allowed: {path_or_url}.")
-                
+
             in_app_dir = utils.abspath(app.cwd) in abs_path.parents
             created_by_app = str(abs_path) in set().union(*blocks.temp_file_sets)
             in_file_dir = any(
                 (
-                    utils.is_in(abs_path, allowed_path) or abs_path == utils.abspath(allowed_path)
+                    utils.is_in(abs_path, allowed_path)
+                    or abs_path == utils.abspath(allowed_path)
                     for allowed_path in blocks.allowed_files
                 )
             )

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -305,12 +305,21 @@ class App(FastAPI):
                     url=path_or_url, status_code=status.HTTP_302_FOUND
                 )
             abs_path = utils.abspath(path_or_url)
+            in_blocklist = any(
+                (
+                    utils.abspath(path) in abs_path.parents or abs_path == utils.abspath(path)
+                    for path in blocks.path_blocklist
+                )
+            )
+            if in_blocklist:
+                raise HTTPException(403, f"File not allowed: {path_or_url}.")
+                
             in_app_dir = utils.abspath(app.cwd) in abs_path.parents
             created_by_app = str(abs_path) in set().union(*blocks.temp_file_sets)
             in_file_dir = any(
                 (
-                    utils.abspath(dir) in abs_path.parents
-                    for dir in blocks.file_directories
+                    utils.abspath(path) in abs_path.parents or abs_path == utils.abspath(path)
+                    for path in blocks.path_allowlist
                 )
             )
             was_uploaded = utils.abspath(app.uploaded_file_dir) in abs_path.parents

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -307,8 +307,8 @@ class App(FastAPI):
             abs_path = utils.abspath(path_or_url)
             in_blocklist = any(
                 (
-                    utils.abspath(path) in abs_path.parents or abs_path == utils.abspath(path)
-                    for path in blocks.path_blocklist
+                    utils.is_in(abs_path, blocked_path) or abs_path == utils.abspath(blocked_path)
+                    for blocked_path in blocks.blocked_files
                 )
             )
             if in_blocklist:
@@ -318,8 +318,8 @@ class App(FastAPI):
             created_by_app = str(abs_path) in set().union(*blocks.temp_file_sets)
             in_file_dir = any(
                 (
-                    utils.abspath(path) in abs_path.parents or abs_path == utils.abspath(path)
-                    for path in blocks.path_allowlist
+                    utils.is_in(abs_path, allowed_path) or abs_path == utils.abspath(allowed_path)
+                    for allowed_path in blocks.allowed_files
                 )
             )
             was_uploaded = utils.abspath(app.uploaded_file_dir) in abs_path.parents

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -310,8 +310,7 @@ class App(FastAPI):
             abs_path = utils.abspath(path_or_url)
             in_blocklist = any(
                 (
-                    utils.is_in(abs_path, blocked_path)
-                    or abs_path == utils.abspath(blocked_path)
+                    utils.is_in_or_equal(abs_path, blocked_path)
                     for blocked_path in blocks.blocked_paths
                 )
             )
@@ -322,8 +321,7 @@ class App(FastAPI):
             created_by_app = str(abs_path) in set().union(*blocks.temp_file_sets)
             in_file_dir = any(
                 (
-                    utils.is_in(abs_path, allowed_path)
-                    or abs_path == utils.abspath(allowed_path)
+                    utils.is_in_or_equal(abs_path, allowed_path)
                     for allowed_path in blocks.allowed_paths
                 )
             )

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -14,6 +14,7 @@ import traceback
 from asyncio import TimeoutError as AsyncTimeOutError
 from collections import defaultdict
 from copy import deepcopy
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Type
 from urllib.parse import urlparse
 
@@ -111,7 +112,9 @@ class App(FastAPI):
         self.lock = asyncio.Lock()
         self.queue_token = secrets.token_urlsafe(32)
         self.startup_events_triggered = False
-        self.uploaded_file_dir = str(utils.abspath(tempfile.mkdtemp()))
+        self.uploaded_file_dir = os.environ.get("GRADIO_TEMP_DIR") or str(
+            Path(tempfile.gettempdir()) / "gradio"
+        )
         super().__init__(**kwargs, docs_url=None, redoc_url=None)
 
     def configure_app(self, blocks: gradio.Blocks) -> None:

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -962,14 +962,17 @@ def abspath(path: str | Path) -> Path:
         return path.resolve()
 
 
-def is_in(path_1: str | Path, path_2: str | Path):
+def is_in_or_equal(path_1: str | Path, path_2: str | Path):
     """
-    True if path_1 is a descendant (i.e. located within) path_2, False otherwise.
+    True if path_1 is a descendant (i.e. located within) path_2 or if the paths are the
+    same, returns False otherwise.
     Parameters:
         path_1: str or Path (can be a file or directory)
-        path_2: str or Path (should be a directory)
+        path_2: str or Path (can be a file or directory)
     """
-    return abspath(path_2) in abspath(path_1).parents
+    return (abspath(path_2) in abspath(path_1).parents) or abspath(path_1) == abspath(
+        path_2
+    )
 
 
 def get_serializer_name(block: Block) -> str | None:

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -962,6 +962,16 @@ def abspath(path: str | Path) -> Path:
         return path.resolve()
 
 
+def is_in(path_1: str | Path, path_2: str | Path):
+    """
+    True if path_1 is a descendant (i.e. located within) path_2, False otherwise.
+    Parameters:
+        path_1: str or Path (can be a file or directory)
+        path_2: str or Path (should be a directory)
+    """
+    return abspath(path_2) in abspath(path_1).parents    
+
+
 def get_serializer_name(block: Block) -> str | None:
     if not hasattr(block, "serialize"):
         return None

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -969,7 +969,7 @@ def is_in(path_1: str | Path, path_2: str | Path):
         path_1: str or Path (can be a file or directory)
         path_2: str or Path (should be a directory)
     """
-    return abspath(path_2) in abspath(path_1).parents    
+    return abspath(path_2) in abspath(path_1).parents
 
 
 def get_serializer_name(block: Block) -> str | None:

--- a/guides/01_getting-started/03_sharing-your-app.md
+++ b/guides/01_getting-started/03_sharing-your-app.md
@@ -202,4 +202,4 @@ In particular, Gradio apps grant users access to three kinds of files:
 
 * Files that you explicitly allow via the `allowed_paths` parameter in `launch()`. This parameter  allows you to pass in a list of additional directories or exact filepaths you'd like to allow users to have access to. (By default, this parameter is an empty list).
 
-Users should NOT be able to access other arbitrary paths on the host. Furthermore, as a security measure, 
+Users should NOT be able to access other arbitrary paths on the host. Furthermore, as a security measure, you can also **block** specific files or directories from being able to be accessed by users. To do this, pass in a list of additional directories or exact filepaths to the `blocked_paths` parameter in `launch()`. This parameter takes precedence over the files that Gradio exposes by default or by the `allowed_paths`.

--- a/guides/01_getting-started/03_sharing-your-app.md
+++ b/guides/01_getting-started/03_sharing-your-app.md
@@ -198,7 +198,7 @@ In particular, Gradio apps grant users access to three kinds of files:
 
 * Files in the same folder (or a subdirectory) of where the Gradio script is launched from. For example, if the path to your gradio scripts is `/home/usr/scripts/project/app.py` and you launch it from `/home/usr/scripts/project/`, then users of your shared Gradio app will be able to access any files inside `/home/usr/scripts/project/`. This is needed so that you can easily reference these files in your Gradio app.
 
-* Temporary files created by Gradio. These are files that are created by Gradio as part of running your prediction function. For example, if your prediction function returns a video file, then Gradio will save that video to a temporary file and then send the path to the temporary file to the front end. 
+* Temporary files created by Gradio. These are files that are created by Gradio as part of running your prediction function. For example, if your prediction function returns a video file, then Gradio will save that video to a temporary file and then send the path to the temporary file to the front end. You can customize the location of temporary files created by Gradio by setting the environment variable GRADIO_TEMP_DIR to an absolute path, such as `/home/usr/scripts/project/temp/`.
 
 * Files that you explicitly allow via the `allowed_paths` parameter in `launch()`. This parameter  allows you to pass in a list of additional directories or exact filepaths you'd like to allow users to have access to. (By default, this parameter is an empty list).
 

--- a/guides/01_getting-started/03_sharing-your-app.md
+++ b/guides/01_getting-started/03_sharing-your-app.md
@@ -200,6 +200,6 @@ In particular, Gradio apps grant users access to three kinds of files:
 
 * Temporary files created by Gradio. These are files that are created by Gradio as part of running your prediction function. For example, if your prediction function returns a video file, then Gradio will save that video to a temporary file and then send the path to the temporary file to the front end. 
 
-* Files that you explicitly allow via the `file_directories` parameter in `launch()`. In some cases, you may want to reference other files in your file system. The `file_directories` parameter allows you to pass in a list of additional directories you'd like to provide access to. (By default, there are no additional file directories).
+* Files that you explicitly allow via the `allowed_paths` parameter in `launch()`. This parameter  allows you to pass in a list of additional directories or exact filepaths you'd like to allow users to have access to. (By default, this parameter is an empty list).
 
-Users should NOT be able to access other arbitrary paths on the host.  
+Users should NOT be able to access other arbitrary paths on the host. Furthermore, as a security measure, 

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -224,7 +224,7 @@ class TestRoutes:
         file_response = client.get(f"/file={allowed_file.name}")
         assert file_response.status_code == 200
         assert len(file_response.text) == len(media_data.BASE64_IMAGE)
-        
+
         os.remove(allowed_file.name)
 
     def test_get_blocked_paths(self):

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -78,7 +78,6 @@ class TestRoutes:
             assert response.status_code == 200
             file = response.json()[0]
             assert "alphabet" in file
-            print(file)
             assert file.startswith(str(Path(tempfile.gettempdir()) / "gradio-test"))
             assert file.endswith(".txt")
             with open(file) as saved_file:

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -192,7 +192,7 @@ class TestRoutes:
         output = dict(response.json())
         assert output["data"] == ["testtest", None]
 
-    def test_get_allowed_files(self):
+    def test_get_allowed_paths(self):
         allowed_file = tempfile.NamedTemporaryFile(mode="w", delete=False)
         allowed_file.write(media_data.BASE64_IMAGE)
         allowed_file.flush()
@@ -207,7 +207,7 @@ class TestRoutes:
 
         app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
             prevent_thread_lock=True,
-            allowed_files=[os.path.dirname(allowed_file.name)],
+            allowed_paths=[os.path.dirname(allowed_file.name)],
         )
         client = TestClient(app)
 
@@ -215,7 +215,7 @@ class TestRoutes:
         assert file_response.status_code == 200
         assert len(file_response.text) == len(media_data.BASE64_IMAGE)
 
-    def test_get_blocked_files(self):
+    def test_get_blocked_paths(self):
         # Test that blocking a default Gradio file path works
         with tempfile.NamedTemporaryFile(
             dir=".", suffix=".jpg", delete=False
@@ -232,7 +232,7 @@ class TestRoutes:
             dir=".", suffix=".jpg", delete=False
         ) as tmp_file:
             app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
-                prevent_thread_lock=True, blocked_files=[os.path.abspath(tmp_file.name)]
+                prevent_thread_lock=True, blocked_paths=[os.path.abspath(tmp_file.name)]
             )
             client = TestClient(app)
 
@@ -245,7 +245,7 @@ class TestRoutes:
             dir=".", suffix=".jpg", delete=False
         ) as tmp_file:
             app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
-                prevent_thread_lock=True, blocked_files=[os.path.abspath(tmp_file.name)]
+                prevent_thread_lock=True, blocked_paths=[os.path.abspath(tmp_file.name)]
             )
             client = TestClient(app)
 
@@ -257,8 +257,8 @@ class TestRoutes:
         with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
             app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
                 prevent_thread_lock=True,
-                allowed_files=[os.path.dirname(tmp_file.name)],
-                blocked_files=[os.path.dirname(tmp_file.name)],
+                allowed_paths=[os.path.dirname(tmp_file.name)],
+                blocked_paths=[os.path.dirname(tmp_file.name)],
             )
             client = TestClient(app)
             file_response = client.get(f"/file={tmp_file.name}")

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -215,6 +215,18 @@ class TestRoutes:
         assert file_response.status_code == 200
         assert len(file_response.text) == len(media_data.BASE64_IMAGE)
 
+        app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
+            prevent_thread_lock=True,
+            allowed_paths=[os.path.abspath(allowed_file.name)],
+        )
+        client = TestClient(app)
+
+        file_response = client.get(f"/file={allowed_file.name}")
+        assert file_response.status_code == 200
+        assert len(file_response.text) == len(media_data.BASE64_IMAGE)
+        
+        os.remove(allowed_file.name)
+
     def test_get_blocked_paths(self):
         # Test that blocking a default Gradio file path works
         with tempfile.NamedTemporaryFile(

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -225,8 +225,6 @@ class TestRoutes:
         assert file_response.status_code == 200
         assert len(file_response.text) == len(media_data.BASE64_IMAGE)
 
-        os.remove(allowed_file.name)
-
     def test_get_blocked_paths(self):
         # Test that blocking a default Gradio file path works
         with tempfile.NamedTemporaryFile(

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -217,7 +217,9 @@ class TestRoutes:
 
     def test_get_blocked_files(self):
         # Test that blocking a default Gradio file path works
-        with tempfile.NamedTemporaryFile(dir='.', suffix=".jpg", delete=False) as tmp_file:
+        with tempfile.NamedTemporaryFile(
+            dir=".", suffix=".jpg", delete=False
+        ) as tmp_file:
             app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
                 prevent_thread_lock=True,
             )
@@ -225,8 +227,10 @@ class TestRoutes:
             file_response = client.get(f"/file={tmp_file.name}")
             assert file_response.status_code == 200
         os.remove(tmp_file.name)
-        
-        with tempfile.NamedTemporaryFile(dir='.', suffix=".jpg", delete=False) as tmp_file:
+
+        with tempfile.NamedTemporaryFile(
+            dir=".", suffix=".jpg", delete=False
+        ) as tmp_file:
             app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
                 prevent_thread_lock=True, blocked_files=[os.path.abspath(tmp_file.name)]
             )
@@ -237,7 +241,9 @@ class TestRoutes:
         os.remove(tmp_file.name)
 
         # Test that blocking a default Gradio directory works
-        with tempfile.NamedTemporaryFile(dir='.', suffix=".jpg", delete=False) as tmp_file:
+        with tempfile.NamedTemporaryFile(
+            dir=".", suffix=".jpg", delete=False
+        ) as tmp_file:
             app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
                 prevent_thread_lock=True, blocked_files=[os.path.abspath(tmp_file.name)]
             )
@@ -246,7 +252,7 @@ class TestRoutes:
             file_response = client.get(f"/file={tmp_file.name}")
             assert file_response.status_code == 403
         os.remove(tmp_file.name)
-            
+
         # Test that blocking a directory works even if it's also allowed
         with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
             app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -192,7 +192,7 @@ class TestRoutes:
         output = dict(response.json())
         assert output["data"] == ["testtest", None]
 
-    def test_get_file_allowed_by_file_directories(self):
+    def test_get_allowed_files(self):
         allowed_file = tempfile.NamedTemporaryFile(mode="w", delete=False)
         allowed_file.write(media_data.BASE64_IMAGE)
         allowed_file.flush()
@@ -207,13 +207,57 @@ class TestRoutes:
 
         app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
             prevent_thread_lock=True,
-            file_directories=[os.path.dirname(allowed_file.name)],
+            allowed_files=[os.path.dirname(allowed_file.name)],
         )
         client = TestClient(app)
 
         file_response = client.get(f"/file={allowed_file.name}")
         assert file_response.status_code == 200
         assert len(file_response.text) == len(media_data.BASE64_IMAGE)
+
+    def test_get_blocked_files(self):
+        # Test that blocking a default Gradio file path works
+        with tempfile.NamedTemporaryFile(dir='.', suffix=".jpg", delete=False) as tmp_file:
+            app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
+                prevent_thread_lock=True,
+            )
+            client = TestClient(app)
+            file_response = client.get(f"/file={tmp_file.name}")
+            assert file_response.status_code == 200
+        os.remove(tmp_file.name)
+        
+        with tempfile.NamedTemporaryFile(dir='.', suffix=".jpg", delete=False) as tmp_file:
+            app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
+                prevent_thread_lock=True, blocked_files=[os.path.abspath(tmp_file.name)]
+            )
+            client = TestClient(app)
+
+            file_response = client.get(f"/file={tmp_file.name}")
+            assert file_response.status_code == 403
+        os.remove(tmp_file.name)
+
+        # Test that blocking a default Gradio directory works
+        with tempfile.NamedTemporaryFile(dir='.', suffix=".jpg", delete=False) as tmp_file:
+            app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
+                prevent_thread_lock=True, blocked_files=[os.path.abspath(tmp_file.name)]
+            )
+            client = TestClient(app)
+
+            file_response = client.get(f"/file={tmp_file.name}")
+            assert file_response.status_code == 403
+        os.remove(tmp_file.name)
+            
+        # Test that blocking a directory works even if it's also allowed
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
+            app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
+                prevent_thread_lock=True,
+                allowed_files=[os.path.dirname(tmp_file.name)],
+                blocked_files=[os.path.dirname(tmp_file.name)],
+            )
+            client = TestClient(app)
+            file_response = client.get(f"/file={tmp_file.name}")
+            assert file_response.status_code == 403
+        os.remove(tmp_file.name)
 
     def test_get_file_created_by_app(self):
         app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -218,75 +218,81 @@ class TestRoutes:
         allowed_file.write(media_data.BASE64_IMAGE)
         allowed_file.flush()
 
-        app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
-            prevent_thread_lock=True,
-        )
+        io = gr.Interface(lambda s: s.name, gr.File(), gr.File())
+        app, _, _ = io.launch(prevent_thread_lock=True)
         client = TestClient(app)
-
         file_response = client.get(f"/file={allowed_file.name}")
         assert file_response.status_code == 403
+        io.close()
 
-        app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
+        io = gr.Interface(lambda s: s.name, gr.File(), gr.File())
+        app, _, _ = io.launch(
             prevent_thread_lock=True,
             allowed_paths=[os.path.dirname(allowed_file.name)],
         )
         client = TestClient(app)
-
         file_response = client.get(f"/file={allowed_file.name}")
         assert file_response.status_code == 200
         assert len(file_response.text) == len(media_data.BASE64_IMAGE)
+        io.close()
 
-        app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
+        io = gr.Interface(lambda s: s.name, gr.File(), gr.File())
+        app, _, _ = io.launch(
             prevent_thread_lock=True,
             allowed_paths=[os.path.abspath(allowed_file.name)],
         )
         client = TestClient(app)
-
         file_response = client.get(f"/file={allowed_file.name}")
         assert file_response.status_code == 200
         assert len(file_response.text) == len(media_data.BASE64_IMAGE)
+        io.close()
 
     def test_get_blocked_paths(self):
         # Test that blocking a default Gradio file path works
         with tempfile.NamedTemporaryFile(
             dir=".", suffix=".jpg", delete=False
         ) as tmp_file:
-            app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
+            io = gr.Interface(lambda s: s.name, gr.File(), gr.File())
+            app, _, _ = io.launch(
                 prevent_thread_lock=True,
             )
             client = TestClient(app)
             file_response = client.get(f"/file={tmp_file.name}")
             assert file_response.status_code == 200
+        io.close()
         os.remove(tmp_file.name)
 
         with tempfile.NamedTemporaryFile(
             dir=".", suffix=".jpg", delete=False
         ) as tmp_file:
-            app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
+            io = gr.Interface(lambda s: s.name, gr.File(), gr.File())
+            app, _, _ = io.launch(
                 prevent_thread_lock=True, blocked_paths=[os.path.abspath(tmp_file.name)]
             )
             client = TestClient(app)
-
             file_response = client.get(f"/file={tmp_file.name}")
             assert file_response.status_code == 403
+        io.close()
         os.remove(tmp_file.name)
 
         # Test that blocking a default Gradio directory works
         with tempfile.NamedTemporaryFile(
             dir=".", suffix=".jpg", delete=False
         ) as tmp_file:
-            app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
+            io = gr.Interface(lambda s: s.name, gr.File(), gr.File())
+            app, _, _ = io.launch(
                 prevent_thread_lock=True, blocked_paths=[os.path.abspath(tmp_file.name)]
             )
             client = TestClient(app)
-
             file_response = client.get(f"/file={tmp_file.name}")
             assert file_response.status_code == 403
+        io.close()
         os.remove(tmp_file.name)
 
         # Test that blocking a directory works even if it's also allowed
         with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
-            app, _, _ = gr.Interface(lambda s: s.name, gr.File(), gr.File()).launch(
+            io = gr.Interface(lambda s: s.name, gr.File(), gr.File())
+            app, _, _ = io.launch(
                 prevent_thread_lock=True,
                 allowed_paths=[os.path.dirname(tmp_file.name)],
                 blocked_paths=[os.path.dirname(tmp_file.name)],
@@ -294,6 +300,7 @@ class TestRoutes:
             client = TestClient(app)
             file_response = client.get(f"/file={tmp_file.name}")
             assert file_response.status_code == 403
+        io.close()
         os.remove(tmp_file.name)
 
     def test_get_file_created_by_app(self):


### PR DESCRIPTION
Security around filepaths that Gradio exposes has been something that's come up frequently. This PR adds the ability to blocklist filepaths (and also improves the allowlist mechanism). 

Closes: #3939

Edit: I just merged in #4053, which further adds the ability to specify a location where all temporary files created by Gradio are saved using an environmental variable. I considered also making this a parameter in `launch()` but the problem is that Gradio components are the ones that save temporary files and they are not aware of the `Blocks` instance. Furthermore, the Gradio temporary file location should actually *not* be a parameter in code because it could lead to code breaking if it is uploaded from e.g. a Windows local system to a Linux system like Spaces

Closes: #3597
