### PR TITLE
Empty gallery fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ No changes to highlight.
 
 ## Bug Fixes:
 
-No changes to highlight.
+- Fix dropdown default value not appearing by [@aliabid94](https://github.com/aliabid94) in [PR 4072](https://github.com/gradio-app/gradio/pull/4072).
 
 ## Documentation Changes:
 

--- a/js/gallery/src/Gallery.svelte
+++ b/js/gallery/src/Gallery.svelte
@@ -48,7 +48,7 @@
 		// When value is falsy (clear button or first load),
 		// style.preview determines the selected image
 		if (was_reset) {
-			selected_image = style.preview ? 0 : null;
+			selected_image = style.preview && value?.length ? 0 : null;
 			was_reset = false;
 			// Otherwise we keep the selected_image the same if the
 			// gallery has at least as many elements as it did before


### PR DESCRIPTION
Setting a gallery to empty caused an error, fixed now.

Fixes: #3944 #3737 