### PR TITLE
Fixes to view API page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix dropdown default value not appearing by [@aliabid94](https://github.com/aliabid94) in [PR 4072](https://github.com/gradio-app/gradio/pull/4072).
 - Soft theme label color fix by [@aliabid94](https://github.com/aliabid94) in [PR 4070](https://github.com/gradio-app/gradio/pull/4070) 
 - Removes extraneous `State` component info from the `/info` route by [@abidlabs](https://github.com/freddyaboulton) in [PR 4107](https://github.com/gradio-app/gradio/pull/4107)
+- Fixes to view API page by [@abidlabs](https://github.com/abidlabs) and [@aliabd](https://github.com/aliabd) in [PR 4112](https://github.com/gradio-app/gradio/pull/4112)
 
 ## Documentation Changes:
 

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -22,7 +22,7 @@
 	import type { ThemeMode } from "./components/types";
 
 	import logo from "./images/logo.svg";
-	import api_logo from "/static/img/api-logo.svg";
+	import api_logo from "/api_docs/img/api-logo.svg";
 
 	setupi18n();
 

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -22,7 +22,7 @@
 	import type { ThemeMode } from "./components/types";
 
 	import logo from "./images/logo.svg";
-	import api_logo from "/api_docs/img/api-logo.svg";
+	import api_logo from "./api_docs/img/api-logo.svg";
 
 	setupi18n();
 

--- a/js/app/src/api_docs/CodeSnippets.svelte
+++ b/js/app/src/api_docs/CodeSnippets.svelte
@@ -40,11 +40,11 @@
 
 client = Client(<span class="token string">"{root}"</span>)
 result = client.predict(<!--
--->{#each endpoint_parameters as { label, type_python, type_description, component, example_input }, i}<!--
+-->{#each endpoint_parameters as { label, type, python_type, component, example_input, serializer }, i}<!--
         -->
 				<span
 								class="example-inputs"
-								>{represent_value(example_input, type_python, "py")}</span
+								>{represent_value(example_input, python_type.type, "py")}</span
 							>,<!--
 			-->{#if dependency_failures[dependency_index][i]}<!--
 			--><span
@@ -53,8 +53,8 @@ result = client.predict(<!--
 				-->{/if}<!--
 			--><span class="desc"
 								><!--
-			-->	# {type_python} <!--
-			-->representing {type_description} in '{label}' <!--
+			-->	# {python_type.type} <!--
+			-->representing input in '{label}' <!--
 			-->{component} component<!--
 			--></span
 							><!--

--- a/js/app/src/api_docs/ResponseObject.svelte
+++ b/js/app/src/api_docs/ResponseObject.svelte
@@ -33,7 +33,7 @@
 	<div class="response-wrap">
 		<div class:hide={is_running}>
 			{#if endpoint_returns.length > 1}({/if}
-			{#each endpoint_returns as { label, type, python_type, component, example_input, serializer }}
+			{#each endpoint_returns as { label, type, python_type, component, serializer }}
 				<div class:second-level={endpoint_returns.length > 1}>
 					<span class="desc"
 						><!--

--- a/js/app/src/api_docs/ResponseObject.svelte
+++ b/js/app/src/api_docs/ResponseObject.svelte
@@ -33,13 +33,13 @@
 	<div class="response-wrap">
 		<div class:hide={is_running}>
 			{#if endpoint_returns.length > 1}({/if}
-			{#each endpoint_returns as { label, type_python, type_description, component }}
+			{#each endpoint_returns as { label, type, python_type, component, example_input, serializer }}
 				<div class:second-level={endpoint_returns.length > 1}>
 					<span class="desc"
 						><!--
-					--> # {type_python}
+					--> # {python_type.type}
 						<!--
-					-->representing {type_description} in '{label}' <!--
+					-->representing output in '{label}' <!--
 					-->{component}
 						component<!--
 					--></span


### PR DESCRIPTION
Makes two fixes to the view API page:

1. The logo next to "view API" was not showing correctly. There was a 403 error on the console log.
2. The "view API" page was showing "undefined" for some properties because we changed the format of the `/info` route

Both are now fixed