### PR TITLE
Fix then logic to work after failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix dropdown default value not appearing by [@aliabid94](https://github.com/aliabid94) in [PR 4072](https://github.com/gradio-app/gradio/pull/4072).
 - Soft theme label color fix by [@aliabid94](https://github.com/aliabid94) in [PR 4070](https://github.com/gradio-app/gradio/pull/4070) 
 - Removes extraneous `State` component info from the `/info` route by [@abidlabs](https://github.com/freddyaboulton) in [PR 4107](https://github.com/gradio-app/gradio/pull/4107)
+- Make .then() work even if first event fails by [@aliabid94](https://github.com/aliabid94) in [PR 4115](https://github.com/gradio-app/gradio/pull/4115).
 
 ## Documentation Changes:
 

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -236,6 +236,7 @@
 		handle_update(data, fn_index);
 		let status = loading_status.get_status_for_fn(fn_index);
 		if (status === "complete") {
+			// handle .success and successful .then here, after data has updated
 			dependencies.forEach((dep, i) => {
 				if (dep.trigger_after === fn_index) {
 					trigger_api_call(i, null);
@@ -247,6 +248,7 @@
 	app.on("status", ({ fn_index, ...status }) => {
 		loading_status.update({ ...status, fn_index });
 		if (status.status === "error") {
+			// handle failed .then here, since "data" listener won't trigger
 			dependencies.forEach((dep, i) => {
 				if (dep.trigger_after === fn_index && !dep.trigger_only_on_success) {
 					trigger_api_call(i, null);

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -235,12 +235,9 @@
 	app.on("data", ({ data, fn_index }) => {
 		handle_update(data, fn_index);
 		let status = loading_status.get_status_for_fn(fn_index);
-		if (status === "complete" || status === "error") {
+		if (status === "complete") {
 			dependencies.forEach((dep, i) => {
-				if (
-					dep.trigger_after === fn_index &&
-					(!dep.trigger_only_on_success || status === "complete")
-				) {
+				if (dep.trigger_after === fn_index) {
 					trigger_api_call(i, null);
 				}
 			});
@@ -249,6 +246,13 @@
 
 	app.on("status", ({ fn_index, ...status }) => {
 		loading_status.update({ ...status, fn_index });
+		if (status.status === "error") {
+			dependencies.forEach((dep, i) => {
+				if (dep.trigger_after === fn_index && !dep.trigger_only_on_success) {
+					trigger_api_call(i, null);
+				}
+			});
+		}
 	});
 
 	function set_prop<T extends ComponentMeta>(obj: T, prop: string, val: any) {


### PR DESCRIPTION
Not sure if this was always broken or broke as a result of changes in client behaviour. Now should handle `.then` if first event fails. 

Fixes: #4113 