### PR TITLE
Record username when flagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,11 @@
 
 ## New Features:
 
-- Support for asynchronous iterators by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 3821](https://github.com/gradio-app/gradio/pull/3821)
-- Returning language agnostic types in the `/info` route by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4039](https://github.com/gradio-app/gradio/pull/4039)
+No changes to highlight.
 
 ## Bug Fixes:
 
-- Allow users to upload audio files in Audio component on iOS by by [@aliabid94](https://github.com/aliabid94) in [PR 4071](https://github.com/gradio-app/gradio/pull/4071). 
-- Fixes the gradio theme builder error that appeared on launch by [@aliabid94](https://github.com/aliabid94) and [@abidlabs](https://github.com/abidlabs) in [PR 4080](https://github.com/gradio-app/gradio/pull/4080) 
-- Keep Accordion content in DOM by [@aliabid94](https://github.com/aliabid94) in [PR 4070](https://github.com/gradio-app/gradio/pull/4073) 
-- Fixed bug where type hints in functions caused the event handler to crash by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4068](https://github.com/gradio-app/gradio/pull/4068)
-- Fix dropdown default value not appearing by [@aliabid94](https://github.com/aliabid94) in [PR 4072](https://github.com/gradio-app/gradio/pull/4072).
-- Soft theme label color fix by [@aliabid94](https://github.com/aliabid94) in [PR 4070](https://github.com/gradio-app/gradio/pull/4070) 
-- Fix `gr.Slider` `release` event not triggering on mobile by [@space-nuko](https://github.com/space-nuko) in [PR 4098](https://github.com/gradio-app/gradio/pull/4098) 
-- Removes extraneous `State` component info from the `/info` route by [@abidlabs](https://github.com/freddyaboulton) in [PR 4107](https://github.com/gradio-app/gradio/pull/4107)
-- Fixes to view API page by [@abidlabs](https://github.com/abidlabs) and [@aliabd](https://github.com/aliabd) in [PR 4112](https://github.com/gradio-app/gradio/pull/4112)
-- Make .then() work even if first event fails by [@aliabid94](https://github.com/aliabid94) in [PR 4115](https://github.com/gradio-app/gradio/pull/4115).
+- Records username when flagging by [@abidlabs](https://github.com/abidlabs) in [PR 4135](https://github.com/gradio-app/gradio/pull/4135)
 
 ## Documentation Changes:
 
@@ -32,11 +22,7 @@ No changes to highlight.
 
 ## Full Changelog:
 
-- Allow users to submit with enter in Interfaces with textbox / number inputs [@aliabid94](https://github.com/aliabid94) in [PR 4090](https://github.com/gradio-app/gradio/pull/4090).
-- Updates gradio's requirements.txt to requires uvicorn>=0.14.0 by [@abidlabs](https://github.com/abidlabs) in [PR 4086](https://github.com/gradio-app/gradio/pull/4086) 
-- Updates some error messaging by [@abidlabs](https://github.com/abidlabs) in [PR 4086](https://github.com/gradio-app/gradio/pull/4086) 
-- Renames simplified Chinese translation file from `zh-cn.json` to `zh-CN.json` by [@abidlabs](https://github.com/abidlabs) in [PR 4086](https://github.com/gradio-app/gradio/pull/4086) 
-- Move `.config/README.md` to `js/README.md` and link it from `CONTRIBUTING.md` by [@whitphx](https://github.com/whitphx) in [PR 4132](https://github.com/gradio-app/gradio/pull/4132).
+No changes to highlight.
 
 ## Contributors Shoutout:
 

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -286,7 +286,12 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
             except huggingface_hub.utils.EntryNotFoundError:
                 pass
 
-    def flag(self, flag_data: list[Any], flag_option: str = "") -> int:
+    def flag(
+        self,
+        flag_data: list[Any],
+        flag_option: str = "",
+        username: str | None = None,
+    ) -> int:
         if self.separate_dirs:
             # JSONL files to support dataset preview on the Hub
             unique_id = str(uuid.uuid4())
@@ -305,6 +310,7 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
             path_in_repo=path_in_repo,
             flag_data=flag_data,
             flag_option=flag_option,
+            username=username or "",
         )
 
     def _flag_in_dir(
@@ -314,10 +320,11 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
         path_in_repo: str | None,
         flag_data: list[Any],
         flag_option: str = "",
+        username: str = "",
     ) -> int:
         # Deserialize components (write images/audio to files)
         features, row = self._deserialize_components(
-            components_dir, flag_data, flag_option
+            components_dir, flag_data, flag_option, username
         )
 
         # Write generic info to dataset_infos.json + upload
@@ -394,7 +401,11 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
         return data_file.parent.name
 
     def _deserialize_components(
-        self, data_dir: Path, flag_data: list[Any], flag_option: str = ""
+        self,
+        data_dir: Path,
+        flag_data: list[Any],
+        flag_option: str = "",
+        username: str = "",
     ) -> tuple[dict[Any, Any], list[Any]]:
         """Deserialize components and return the corresponding row for the flagged sample.
 
@@ -437,6 +448,7 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
                 )
         features["flag"] = {"dtype": "string", "_type": "Value"}
         row.append(flag_option)
+        row.append(username)
         return features, row
 
 

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -113,7 +113,7 @@ class SimpleCSVLogger(FlaggingCallback):
             writer.writerow(utils.sanitize_list_for_csv(csv_data))
 
         with open(log_filepath) as csvfile:
-            line_count = len([None for row in csv.reader(csvfile)]) - 1
+            line_count = len(list(csv.reader(csvfile))) - 1
         return line_count
 
 
@@ -187,7 +187,7 @@ class CSVLogger(FlaggingCallback):
             writer.writerow(utils.sanitize_list_for_csv(csv_data))
 
         with open(log_filepath, encoding="utf-8") as csvfile:
-            line_count = len([None for row in csv.reader(csvfile)]) - 1
+            line_count = len(list(csv.reader(csvfile))) - 1
         return line_count
 
 
@@ -483,9 +483,9 @@ class FlagMethod:
         self.__name__ = "Flag"
         self.visual_feedback = visual_feedback
 
-    def __call__(self, *flag_data):
+    def __call__(self, request: gr.Request, *flag_data):
         try:
-            self.flagging_callback.flag(list(flag_data), flag_option=self.value)
+            self.flagging_callback.flag(list(flag_data), flag_option=self.value, username=request.username)
         except Exception as e:
             print(f"Error while flagging: {e}")
             if self.visual_feedback:

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -412,7 +412,6 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
         Images/audio are saved to disk as individual files.
         """
         # Components that can have a preview on dataset repos
-        # NOTE: not at root level to avoid circular imports
         file_preview_types = {gr.Audio: "Audio", gr.Image: "Image"}
 
         # Generate the row corresponding to the flagged sample
@@ -426,7 +425,11 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
 
             # Add deserialized object to row
             features[label] = {"dtype": "string", "_type": "Value"}
-            row.append(Path(deserialized).name)
+            try:
+                assert Path(deserialized).exists()
+                row.append(Path(deserialized).name)
+            except (AssertionError, TypeError, ValueError):
+                row.append(str(deserialized))
 
             # If component is eligible for a preview, add the URL of the file
             if isinstance(component, tuple(file_preview_types)):  # type: ignore

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -8,6 +8,7 @@ import time
 import uuid
 import warnings
 from abc import ABC, abstractmethod
+from collections import OrderedDict
 from distutils.version import StrictVersion
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -415,7 +416,7 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
         file_preview_types = {gr.Audio: "Audio", gr.Image: "Image"}
 
         # Generate the row corresponding to the flagged sample
-        features = {}
+        features = OrderedDict()
         row = []
         for component, sample in zip(self.components, flag_data):
             # Get deserialized object (will save sample to disk if applicable -file, audio, image,...-)
@@ -450,6 +451,7 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
                     )
                 )
         features["flag"] = {"dtype": "string", "_type": "Value"}
+        features["username"] = {"dtype": "string", "_type": "Value"}
         row.append(flag_option)
         row.append(username)
         return features, row

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -485,7 +485,9 @@ class FlagMethod:
 
     def __call__(self, request: gr.Request, *flag_data):
         try:
-            self.flagging_callback.flag(list(flag_data), flag_option=self.value, username=request.username)
+            self.flagging_callback.flag(
+                list(flag_data), flag_option=self.value, username=request.username
+            )
         except Exception as e:
             print(f"Error while flagging: {e}")
             if self.visual_feedback:

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -631,7 +631,7 @@ def special_args(
         elif type_hint and issubclass(type_hint, EventData):
             event_data_index = i
             if inputs is not None and event_data is not None:
-                inputs.insert(i, param.annotation(event_data.target, event_data._data))
+                inputs.insert(i, type_hint(event_data.target, event_data._data))
         elif (
             param.default is not param.empty and inputs is not None and len(inputs) <= i
         ):

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -611,6 +611,7 @@ def special_args(
         updated inputs, progress index, event data index.
     """
     signature = inspect.signature(fn)
+    type_hints = utils.get_type_hints(fn)
     positional_args = []
     for param in signature.parameters.values():
         if param.kind not in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD):
@@ -619,16 +620,15 @@ def special_args(
     progress_index = None
     event_data_index = None
     for i, param in enumerate(positional_args):
+        type_hint = type_hints.get(param.name)
         if isinstance(param.default, Progress):
             progress_index = i
             if inputs is not None:
                 inputs.insert(i, param.default)
-        elif param.annotation == routes.Request:
+        elif type_hint == routes.Request:
             if inputs is not None:
                 inputs.insert(i, request)
-        elif isinstance(param.annotation, type) and issubclass(
-            param.annotation, EventData
-        ):
+        elif type_hint and issubclass(type_hint, EventData):
             event_data_index = i
             if inputs is not None and event_data is not None:
                 inputs.insert(i, param.annotation(event_data.target, event_data._data))

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -634,10 +634,9 @@ class Interface(Blocks):
 
                 extra_output = [submit_btn, stop_btn]
 
-                cleanup = lambda: [
-                    Button.update(visible=True),
-                    Button.update(visible=False),
-                ]
+                def cleanup():
+                    return [Button.update(visible=True), Button.update(visible=False)]
+
                 for i, trigger in enumerate(triggers):
                     predict_event = trigger(
                         lambda: (


### PR DESCRIPTION
Fixes: #4134

Learned something very interesting when I was working on this. We were using `inspect.Parameter.annotation` in several places. This is a method that returns the type hint of a parameter. In Python 3.x, this returns a _class_ if the type hint is a class. [However, in the future, Python (4.x?), this will be replaced with a string](https://peps.python.org/pep-0563/). More importantly, if a user has:

```
from __future__ import annotations
```

in their code while running Python 3.x, this will also return a string (the future behavior). This was causing a subtle bug that took some time to figure out. Anyways, this is now fixed because we are using `typing.get_type_hints()` instead, which is the recommendation in the PEP. 