### PR TITLE
Fix python client test

### DIFF
--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -14,7 +14,8 @@ No changes to highlight.
 
 ## Testing and Infrastructure Changes:
 
-No changes to highlight.
+- Fix bug in test from gradio 3.29.0 refactor by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4138](https://github.com/gradio-app/gradio/pull/4138)
+
 
 ## Breaking Changes:
 

--- a/client/python/test/test_client.py
+++ b/client/python/test/test_client.py
@@ -242,7 +242,7 @@ class TestPredictionsFromSpaces:
                 time.sleep(0.1)
             # Ran all iterations from scratch
             assert job2.status().code == Status.FINISHED
-            assert len(job2.outputs()) == 5
+            assert len(job2.outputs()) == 4
 
     @pytest.mark.flaky
     def test_upload_file_private_space(self):


### PR DESCRIPTION
# Description

Fixes python client test. Previously, the `finally` block of the interface with generator case would always return an "extra" output (turning the stop button to a submit button). The refactor of the interface generator logic to use `then` gets rid of this extra output.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.