### PR TITLE
Configure VSCode to use hard tabs on TS and Svelte files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,13 @@
 	"cssvar.extensions": ["js", "css", "html", "jsx", "tsx", "svelte"],
 	"python.analysis.extraPaths": ["./gradio/themes/utils"],
 	"prettier.configPath": ".config/.prettierrc.json",
-	"prettier.ignorePath": "./config/.prettierignore"
+	"prettier.ignorePath": "./config/.prettierignore",
+	"[typescript]": {
+		"editor.insertSpaces": false,
+		"editor.tabSize": 2
+	},
+	"[svelte]": {
+		"editor.insertSpaces": false,
+		"editor.tabSize": 2
+	},
 }


### PR DESCRIPTION
# Description

Using hard-tabs is [ensured by Prettier](https://github.com/gradio-app/gradio/blob/3227a9b703fb520bf4f8a8ee08f9027c0a5c1070/.config/.prettierrc.json#LL2C18-L2C18).
I want to configure VSCode too.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.