### PR TITLE
Fix the wildcard in .editorconfig to match files in nested directories

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 
 root = true
 
-[{js/**, client/js/**}]
+[{js/**,client/js/**}]
 end_of_line = lf
 insert_final_newline = true
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 
 root = true
 
-[{js/*, client/js/*}]
+[{js/**, client/js/**}]
 end_of_line = lf
 insert_final_newline = true
 indent_style = tab


### PR DESCRIPTION
# Description

A single `*` does not match path separators (`/`). Ref: https://editorconfig.org/#wildcards

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.