### PR TITLE
Naive fix for improperly formatted image input.

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -1772,6 +1772,8 @@ class Image(
 
         mask = ""
         if self.tool == "sketch" and self.source in ["upload", "webcam"]:
+            if isinstance(x, str):
+                x = {"image":x, "mask": x[:]}
             assert isinstance(x, dict)
             x, mask = x["image"], x["mask"]
 


### PR DESCRIPTION
# Description

Please include: 
* Motivation: See #4088 .
* Summary: Wraps base64 string (no validation) as an {image, mask}. Mask is copied from image currently. Might be preferable to set it to some blank value, but in base64 it's a drag. None causes an error down the line, in mask_im; I'd alter this as well but consequences are unclear.
* Fixes: #4088 .
* Dependencies: None.

Closes: #4088 

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.