### PR TITLE
Move mount_css() from main.ts to css.ts

### DIFF
--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -1,6 +1,6 @@
 <script context="module" lang="ts">
 	import { writable } from "svelte/store";
-	import { mount_css } from "./main";
+	import { mount_css } from "./css";
 
 	import type {
 		ComponentMeta,

--- a/js/app/src/css.ts
+++ b/js/app/src/css.ts
@@ -1,0 +1,18 @@
+export function mount_css(url: string, target: HTMLElement): Promise<void> {
+	const existing_link = document.querySelector(`link[href='${url}']`);
+
+	if (existing_link) return Promise.resolve();
+
+	const link = document.createElement("link");
+	link.rel = "stylesheet";
+	link.href = url;
+	// @ts-ignore
+	target.appendChild(link);
+
+	return new Promise((res, rej) => {
+		link.addEventListener("load", () => res());
+		link.addEventListener("error", () =>
+			rej(new Error(`Unable to preload CSS for ${url}`))
+		);
+	});
+}

--- a/js/app/src/main.ts
+++ b/js/app/src/main.ts
@@ -1,4 +1,5 @@
 import "@gradio/theme";
+import { mount_css } from "./css";
 import Index from "./Index.svelte";
 import type { ThemeMode } from "./components/types";
 
@@ -10,25 +11,6 @@ const ENTRY_CSS = "__ENTRY_CSS__";
 let FONTS: string | [];
 
 FONTS = "__FONTS_CSS__";
-
-export function mount_css(url: string, target: HTMLElement): Promise<void> {
-	const existing_link = document.querySelector(`link[href='${url}']`);
-
-	if (existing_link) return Promise.resolve();
-
-	const link = document.createElement("link");
-	link.rel = "stylesheet";
-	link.href = url;
-	// @ts-ignore
-	target.appendChild(link);
-
-	return new Promise((res, rej) => {
-		link.addEventListener("load", () => res());
-		link.addEventListener("error", () =>
-			rej(new Error(`Unable to preload CSS for ${url}`))
-		);
-	});
-}
 
 function create_custom_element() {
 	class GradioApp extends HTMLElement {


### PR DESCRIPTION
# Description

There is a circular dependency between `main.ts` and `Index.svelte` while it isn't an error in TS.
Also, splitting `mount_css()` into a separate will help the development of the Wasm version which need to mock the function.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.