### PR TITLE
Fix for `typing.get_type_hints()` on Python 3.9 or lower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 - Added `format` argument to `Audio` component by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4178](https://github.com/gradio-app/gradio/pull/4178)
 - Add JS client code snippets to use via api page by [@aliabd](https://github.com/aliabd) in [PR 3927](https://github.com/gradio-app/gradio/pull/3927).
 
+
 ## Bug Fixes:
 
 - The deprecation warnings for kwargs now show the actual stack level for the invocation, by [@akx](https://github.com/akx) in [PR 4203](https://github.com/gradio-app/gradio/pull/4203).
 - Fix "TypeError: issubclass() arg 1 must be a class" When use Optional[Types] by [@lingfengchencn](https://github.com/lingfengchencn) in [PR 4200](https://github.com/gradio-app/gradio/pull/4200). 
+- Fixes a bug with typing.get_type_hints() on Python 3.9 by [@abidlabs](https://github.com/abidlabs) in [PR 4228](https://github.com/gradio-app/gradio/pull/4228).
 
 ## Other Changes:
 

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -707,16 +707,16 @@ def get_type_hints(fn):
                 continue
             if "|" in str(param.annotation):
                 continue
-                # To convert the string annotation to a class, we use the
-                # internal typing._eval_type function. This is not ideal, but
-                # it's the only way to do it without eval-ing the string.
-                # Since the API is internal, it may change in the future.
-                try:
-                    type_hints[name] = typing._eval_type(  # type: ignore
-                        typing.ForwardRef(param.annotation), globals(), locals()
-                    )
-                except (NameError, TypeError):
-                    pass
+            # To convert the string annotation to a class, we use the
+            # internal typing._eval_type function. This is not ideal, but
+            # it's the only way to do it without eval-ing the string.
+            # Since the API is internal, it may change in the future.
+            try:
+                type_hints[name] = typing._eval_type(  # type: ignore
+                    typing.ForwardRef(param.annotation), globals(), locals()
+                )
+            except (NameError, TypeError):
+                pass
         return type_hints
 
 

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -703,9 +703,10 @@ def get_type_hints(fn):
         type_hints = {}
         sig = inspect.signature(fn)
         for name, param in sig.parameters.items():
-            if param.annotation is not inspect.Parameter.empty and "|" not in str(
-                param.annotation
-            ):
+            if param.annotation is inspect.Parameter.empty:
+                continue
+            if "|" in str(param.annotation):
+                continue
                 # To convert the string annotation to a class, we use the
                 # internal typing._eval_type function. This is not ideal, but
                 # it's the only way to do it without eval-ing the string.

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -858,11 +858,39 @@ def get_cancel_function(
 
 
 def get_type_hints(fn):
+    # Importing gradio with the canonical abbreviation. Used in typing._eval_type.
+    import gradio as gr  # noqa: F401
+
     if inspect.isfunction(fn) or inspect.ismethod(fn):
-        return typing.get_type_hints(fn)
+        pass
     elif callable(fn):
-        return typing.get_type_hints(fn.__call__)
-    return {}
+        fn = fn.__call__
+    else:
+        return {}
+
+    try:
+        return typing.get_type_hints(fn)
+    except TypeError:
+        # On Python 3.9 or earlier, get_type_hints throws a TypeError if the function
+        # has a type annotation that include "|". We resort to parsing the signature
+        # manually and returning the type hints as strings instead of classes.
+        type_hints = {}
+        sig = inspect.signature(fn)
+        for name, param in sig.parameters.items():
+            if param.annotation is not inspect.Parameter.empty and "|" not in str(
+                param.annotation
+            ):
+                # To convert the string annotation to a class, we use the
+                # internal typing._eval_type function. This is not ideal, but
+                # it's the only way to do it without eval-ing the string.
+                # Since the API is internal, it may change in the future.
+                try:
+                    type_hints[name] = typing._eval_type(  # type: ignore
+                        typing.ForwardRef(param.annotation), globals(), locals()
+                    )
+                except (NameError, TypeError):
+                    pass
+        return type_hints
 
 
 def is_special_typed_parameter(name, parameter_types):

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -860,6 +860,7 @@ def get_cancel_function(
 def get_type_hints(fn):
     # Importing gradio with the canonical abbreviation. Used in typing._eval_type.
     import gradio as gr  # noqa: F401
+    from gradio import Request  # noqa: F401
 
     if inspect.isfunction(fn) or inspect.ismethod(fn):
         pass

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -873,7 +873,7 @@ def get_type_hints(fn):
     except TypeError:
         # On Python 3.9 or earlier, get_type_hints throws a TypeError if the function
         # has a type annotation that include "|". We resort to parsing the signature
-        # manually and returning the type hints as strings instead of classes.
+        # manually using inspect.signature.
         type_hints = {}
         sig = inspect.signature(fn)
         for name, param in sig.parameters.items():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import ipaddress
 import json
@@ -5,7 +7,6 @@ import os
 import sys
 import unittest.mock as mock
 import warnings
-from typing import List
 from unittest.mock import MagicMock
 
 import pytest
@@ -635,7 +636,7 @@ class TestGetTypeHints:
         assert len(get_type_hints(GenericObject())) == 0
 
     def test_is_special_typed_parameter(self):
-        def func(a: List[str], b: Literal["a", "b"], c, d: Request):
+        def func(a: list[str], b: Literal["a", "b"], c, d: Request):
             pass
 
         hints = get_type_hints(func)
@@ -643,6 +644,15 @@ class TestGetTypeHints:
         assert not is_special_typed_parameter("b", hints)
         assert not is_special_typed_parameter("c", hints)
         assert is_special_typed_parameter("d", hints)
+
+    def test_is_special_typed_parameter_with_pipe(self):
+        def func(a: Request, b: str | int, c: list[str]):
+            pass
+
+        hints = get_type_hints(func)
+        assert is_special_typed_parameter("a", hints)
+        assert not is_special_typed_parameter("b", hints)
+        assert not is_special_typed_parameter("c", hints)
 
 
 class TestCheckFunctionInputsMatch:


### PR DESCRIPTION
A fix for the issue pointed out by @hysts which was breaking Gradio demos running `Python<=3.9`

It's not a perfect fix, as it parses type annotations as strings, so for example for `gr.Request`, the type annotation has to be `gr.Request` or `gradio.Request` or `Request` for it to be recognized correctly. But I don't believe there is any other way to do it, and this should be strictly better than what we have right now since this alternative logic is only used if an exception would be have been thrown otherwise. 

Fixes: #4216