### PR TITLE
Fix codeblock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ No changes to highlight.
 
 ## Other Changes:
 
-No changes to highlight.
+- Add a scroll bar to the codeblock to avoid the code exceeding the boundary and remove extra blank space after codeblock, by [@Keldos-Li](https://github.com/Keldos-Li) in [PR 4246](https://github.com/gradio-app/gradio/pull/4246).
 
 ## Breaking Changes:
 

--- a/js/chatbot/src/ChatBot.svelte
+++ b/js/chatbot/src/ChatBot.svelte
@@ -294,4 +294,11 @@
 	.message-wrap :global(pre) {
 		padding: var(--spacing-xl) 0px;
 	}
+
+	.message-wrap :global(pre code) {
+		display: block;
+		background: none;
+		padding: 0;
+		margin-bottom: calc( -1em - var(--spacing-xl));
+	}
 </style>

--- a/js/chatbot/src/ChatBot.svelte
+++ b/js/chatbot/src/ChatBot.svelte
@@ -253,6 +253,7 @@
 		border-radius: var(--radius-md);
 		background: var(--chatbot-code-background-color);
 		padding-left: var(--spacing-xxl);
+		overflow: auto;
 	}
 
 	/* Small screen */


### PR DESCRIPTION
# Description

Hi gradio team, what I did may fix 2 little issues related to codeblock in chatbot messages:

1. **Code may exceed codeblock boundary if message width is narrow:**
   <img width="592" alt="iShot_2023-05-17_上午11 59 06" src="https://github.com/gradio-app/gradio/assets/23137268/cb5b70d0-b48e-4769-ba24-8effb01d86b8">
   Now a scroll bar is added when there is a long code line.
   <img width="583" alt="iShot_2023-05-17_下午12 00 31" src="https://github.com/gradio-app/gradio/assets/23137268/3e894090-5f77-4d52-b9c0-df7e71058d5e">

2. **There is an extra blank space after the code block.** This is caused by `<code>` tag, which added a line in pre.
   <img width="759" alt="iShot_2023-05-17_下午12 23 14" src="https://github.com/gradio-app/gradio/assets/23137268/72195467-0d79-44fa-b2fd-8e58633f87f6">
    So I made some change in `<pre><code>` tag
   <img width="769" alt="iShot_2023-05-17_下午12 22 29" src="https://github.com/gradio-app/gradio/assets/23137268/0edf7c56-228a-4f5a-a6a0-485aafb19226">

final look:
<img width="582" alt="image" src="https://github.com/gradio-app/gradio/assets/23137268/41ac9281-02dd-4c4b-9893-86c763693556">


------

By the way, I would like to tell you that I'm also a developer using gradio to build a LLM project: [Chuanhu Chat](https://github.com/GaiZhenbiao/ChuanhuChatGPT) (10.3k stars). In fact, we have implemented the functions of code blocks and code highlighting and code copy a few months ago, so now we've come back to adapt to the new Gradio and found the problem...
<img width="48%" alt="image" src="https://github.com/gradio-app/gradio/assets/23137268/4ed72115-3d9a-41a3-be88-7f61d45e66e7"><img width="48%" alt="image" src="https://github.com/gradio-app/gradio/assets/23137268/39364fc7-a3c6-4bff-ac69-72e8f680693a">

 (_**I'd say it'll be so hard for we developers to catch up with gradio updates.**_.. And you guys don't even include any changelog in your github releases...😢)

----
<details><summary>
Oh, and do you have interest in Slider styles?
</summary>

I tried to make sliders look consistent and pretty in various web browsers in [our repo](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/734) : 

before
<img width="929" alt="image" src="https://user-images.githubusercontent.com/23137268/236452538-e4189eff-7c2d-4cf2-b64b-181f0b646054.png">
(Firefox, Chrome and Safari in turn)
after
<img width="904" alt="image" src="https://user-images.githubusercontent.com/23137268/236452453-37fbd6cd-845f-487f-8176-3146e264f79e.png">
However I am not very familiar with gradio... I don't know how to fix it in your code. Could you fix that?
</details>

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.