### PR TITLE
Ensure error modal display as expected when using the queue

### DIFF
--- a/.changeset/nice-parents-work.md
+++ b/.changeset/nice-parents-work.md
@@ -1,0 +1,5 @@
+---
+"@gradio/client": patch
+---
+
+Ensure websocket error messages are correctly handled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ No changes to highlight.
 ## Bug Fixes:
 
 - Fixed the behavior of the `run_on_click` parameter in `gr.Examples` by [@abidlabs](https://github.com/abidlabs) in [PR 4258](https://github.com/gradio-app/gradio/pull/4258). 
+- Ensure error modal displays when the queue is enabled by [@pngwn](https://github.com/pngwn) in [PR 4273](https://github.com/gradio-app/gradio/pull/4273)
 
 ## Other Changes:
 

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -399,7 +399,7 @@ export async function client(
 									type: "data",
 									endpoint: _endpoint,
 									fn_index,
-									data: output.data,
+									data: data,
 									time: new Date()
 								});
 
@@ -1226,18 +1226,32 @@ function handle_message(
 				data: data.success ? data.output : null
 			};
 		case "process_completed":
-			return {
-				type: "complete",
-				status: {
-					queue,
-					message: !data.success ? data.output.error : undefined,
-					stage: data.success ? "complete" : "error",
-					code: data.code,
-					progress_data: data.progress_data,
-					eta: data.output.average_duration
-				},
-				data: data.success ? data.output : null
-			};
+			if (data.output.error) {
+				return {
+					type: "update",
+					status: {
+						queue,
+						message: data.output.error as string,
+						stage: "error",
+						code: data.code,
+						success: data.success
+					}
+				};
+			} else {
+				return {
+					type: "complete",
+					status: {
+						queue,
+						message: !data.success ? data.output.error : undefined,
+						stage: data.success ? "complete" : "error",
+						code: data.code,
+						progress_data: data.progress_data,
+						eta: data.output.average_duration
+					},
+					data: data.success ? data.output : null
+				};
+			}
+
 		case "process_starts":
 			return {
 				type: "update",

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -1226,7 +1226,7 @@ function handle_message(
 				data: data.success ? data.output : null
 			};
 		case "process_completed":
-			if (data.output.error) {
+			if ("error" in data.output) {
 				return {
 					type: "update",
 					status: {

--- a/js/_cdn-test/package.json
+++ b/js/_cdn-test/package.json
@@ -3,8 +3,8 @@
 	"private": true,
 	"version": "0.0.0",
 	"scripts": {
-		"dev": "vite --port 3001 -c",
-		"build": "vite build -c",
+		"dev": "vite --port 3001",
+		"build": "vite build",
 		"preview": "vite preview  --port 3001"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"build:cdn": "pnpm --filter @gradio/client build && pnpm --filter @gradio/app build:cdn --emptyOutDir",
 		"build:website": "pnpm --filter @gradio/app build:website --emptyOutDir",
 		"build:cdn-local": "TEST_CDN=TRUE pnpm build:cdn",
-		"preview:cdn-server": "sirv ../gradio/templates/cdn --single --port=4321 --cors",
+		"preview:cdn-server": "sirv ./gradio/templates/cdn --single --port=4321 --cors",
 		"preview:cdn-app": "pnpm --filter @gradio/cdn-test dev",
 		"preview:cdn-local": "run-p preview:cdn-server preview:cdn-app",
 		"format:check": "prettier --ignore-path .config/.prettierignore --check --plugin-search-dir=. .",


### PR DESCRIPTION
# Description

Closes #4263.

There was an error with how `process_completed` messages were being handled causing the error modal to not display. Fixed in this PR. Run `gradio/calulator` with the queue enabled to test.



Please include: 
* relevant motivation
* a summary of the change 
* which issue is fixed. 
* any additional dependencies that are required for this change.

Closes: # (issue)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.