### PR TITLE
Remove unnecessary Promise wrapping another promise

### DIFF
--- a/.changeset/wicked-eyes-sort.md
+++ b/.changeset/wicked-eyes-sort.md
@@ -1,0 +1,5 @@
+---
+"@gradio/client": patch
+---
+
+Unwrap promise nesting.

--- a/.changeset/wicked-eyes-sort.md
+++ b/.changeset/wicked-eyes-sort.md
@@ -1,5 +1,0 @@
----
-"@gradio/client": patch
----
-
-Unwrap promise nesting.

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -363,189 +363,188 @@ export async function client(
 				data,
 				api_info,
 				hf_token
-			)
-				.then((_payload) => {
-					payload = { data: _payload || [], event_data, fn_index };
-					if (skip_queue(fn_index, config)) {
-						fire_event({
-							type: "status",
-							endpoint: _endpoint,
-							stage: "pending",
-							queue: false,
-							fn_index,
-							time: new Date()
-						});
+			).then((_payload) => {
+				payload = { data: _payload || [], event_data, fn_index };
+				if (skip_queue(fn_index, config)) {
+					fire_event({
+						type: "status",
+						endpoint: _endpoint,
+						stage: "pending",
+						queue: false,
+						fn_index,
+						time: new Date()
+					});
 
-						post_data(
-							`${http_protocol}//${host + config.path}/run${_endpoint.startsWith("/") ? _endpoint : `/${_endpoint}`
-							}`,
-							{
-								...payload,
-								session_hash
-							},
-							hf_token
-						)
-							.then(([output, status_code]) => {
-								const data = transform_files
-									? transform_output(
+					post_data(
+						`${http_protocol}//${host + config.path}/run${
+							_endpoint.startsWith("/") ? _endpoint : `/${_endpoint}`
+						}`,
+						{
+							...payload,
+							session_hash
+						},
+						hf_token
+					)
+						.then(([output, status_code]) => {
+							const data = transform_files
+								? transform_output(
 										output.data,
 										api_info,
 										config.root,
 										config.root_url
-									)
-									: output.data;
-								if (status_code == 200) {
-									fire_event({
-										type: "data",
-										endpoint: _endpoint,
-										fn_index,
-										data: data,
-										time: new Date()
-									});
-
-									fire_event({
-										type: "status",
-										endpoint: _endpoint,
-										fn_index,
-										stage: "complete",
-										eta: output.average_duration,
-										queue: false,
-										time: new Date()
-									});
-								} else {
-									fire_event({
-										type: "status",
-										stage: "error",
-										endpoint: _endpoint,
-										fn_index,
-										message: output.error,
-										queue: false,
-										time: new Date()
-									});
-								}
-							})
-							.catch((e) => {
+								  )
+								: output.data;
+							if (status_code == 200) {
 								fire_event({
-									type: "status",
-									stage: "error",
-									message: e.message,
+									type: "data",
 									endpoint: _endpoint,
 									fn_index,
+									data: data,
+									time: new Date()
+								});
+
+								fire_event({
+									type: "status",
+									endpoint: _endpoint,
+									fn_index,
+									stage: "complete",
+									eta: output.average_duration,
 									queue: false,
 									time: new Date()
 								});
-							});
-					} else {
-						fire_event({
-							type: "status",
-							stage: "pending",
-							queue: true,
-							endpoint: _endpoint,
-							fn_index,
-							time: new Date()
-						});
-
-						let url = new URL(`${ws_protocol}://${host}${config.path}
-						/queue/join`);
-
-						if (jwt) {
-							url.searchParams.set("__sign", jwt);
-						}
-
-						websocket = new WebSocket(url);
-
-						websocket.onclose = (evt) => {
-							if (!evt.wasClean) {
+							} else {
 								fire_event({
 									type: "status",
 									stage: "error",
-									message: BROKEN_CONNECTION_MSG,
-									queue: true,
 									endpoint: _endpoint,
 									fn_index,
+									message: output.error,
+									queue: false,
 									time: new Date()
 								});
 							}
-						};
+						})
+						.catch((e) => {
+							fire_event({
+								type: "status",
+								stage: "error",
+								message: e.message,
+								endpoint: _endpoint,
+								fn_index,
+								queue: false,
+								time: new Date()
+							});
+						});
+				} else {
+					fire_event({
+						type: "status",
+						stage: "pending",
+						queue: true,
+						endpoint: _endpoint,
+						fn_index,
+						time: new Date()
+					});
 
-						websocket.onmessage = function (event) {
-							const _data = JSON.parse(event.data);
-							const { type, status, data } = handle_message(
-								_data,
-								last_status[fn_index]
-							);
+					let url = new URL(`${ws_protocol}://${host}${config.path}
+						/queue/join`);
 
-							if (type === "update" && status && !complete) {
-								// call 'status' listeners
+					if (jwt) {
+						url.searchParams.set("__sign", jwt);
+					}
+
+					websocket = new WebSocket(url);
+
+					websocket.onclose = (evt) => {
+						if (!evt.wasClean) {
+							fire_event({
+								type: "status",
+								stage: "error",
+								message: BROKEN_CONNECTION_MSG,
+								queue: true,
+								endpoint: _endpoint,
+								fn_index,
+								time: new Date()
+							});
+						}
+					};
+
+					websocket.onmessage = function (event) {
+						const _data = JSON.parse(event.data);
+						const { type, status, data } = handle_message(
+							_data,
+							last_status[fn_index]
+						);
+
+						if (type === "update" && status && !complete) {
+							// call 'status' listeners
+							fire_event({
+								type: "status",
+								endpoint: _endpoint,
+								fn_index,
+								time: new Date(),
+								...status
+							});
+							if (status.stage === "error") {
+								websocket.close();
+							}
+						} else if (type === "hash") {
+							websocket.send(JSON.stringify({ fn_index, session_hash }));
+							return;
+						} else if (type === "data") {
+							websocket.send(JSON.stringify({ ...payload, session_hash }));
+						} else if (type === "complete") {
+							complete = status;
+						} else if (type === "generating") {
+							fire_event({
+								type: "status",
+								time: new Date(),
+								...status,
+								stage: status?.stage!,
+								queue: true,
+								endpoint: _endpoint,
+								fn_index
+							});
+						}
+						if (data) {
+							fire_event({
+								type: "data",
+								time: new Date(),
+								data: transform_files
+									? transform_output(
+											data.data,
+											api_info,
+											config.root,
+											config.root_url
+									  )
+									: data.data,
+								endpoint: _endpoint,
+								fn_index
+							});
+
+							if (complete) {
 								fire_event({
 									type: "status",
-									endpoint: _endpoint,
-									fn_index,
 									time: new Date(),
-									...status
-								});
-								if (status.stage === "error") {
-									websocket.close();
-								}
-							} else if (type === "hash") {
-								websocket.send(JSON.stringify({ fn_index, session_hash }));
-								return;
-							} else if (type === "data") {
-								websocket.send(JSON.stringify({ ...payload, session_hash }));
-							} else if (type === "complete") {
-								complete = status;
-							} else if (type === "generating") {
-								fire_event({
-									type: "status",
-									time: new Date(),
-									...status,
+									...complete,
 									stage: status?.stage!,
 									queue: true,
 									endpoint: _endpoint,
 									fn_index
 								});
+								websocket.close();
 							}
-							if (data) {
-								fire_event({
-									type: "data",
-									time: new Date(),
-									data: transform_files
-										? transform_output(
-											data.data,
-											api_info,
-											config.root,
-											config.root_url
-										)
-										: data.data,
-									endpoint: _endpoint,
-									fn_index
-								});
-
-								if (complete) {
-									fire_event({
-										type: "status",
-										time: new Date(),
-										...complete,
-										stage: status?.stage!,
-										queue: true,
-										endpoint: _endpoint,
-										fn_index
-									});
-									websocket.close();
-								}
-							}
-						};
-
-						// different ws contract for gradio versions older than 3.6.0
-						//@ts-ignore
-						if (semiver(config.version || "2.0.0", "3.6") < 0) {
-							addEventListener("open", () =>
-								websocket.send(JSON.stringify({ hash: session_hash }))
-							);
 						}
+					};
+
+					// different ws contract for gradio versions older than 3.6.0
+					//@ts-ignore
+					if (semiver(config.version || "2.0.0", "3.6") < 0) {
+						addEventListener("open", () =>
+							websocket.send(JSON.stringify({ hash: session_hash }))
+						);
 					}
-				})
-				.catch(console.log);
+				}
+			});
 
 			function fire_event<K extends EventType>(event: Event<K>) {
 				const narrowed_listener_map: ListenerMap<K> = listener_map;


### PR DESCRIPTION
# Description

```js
new Promise((res) => anotherPromise.then(() => { res(someResult) }));
```
is equivalent to
```js
anotherPromise.then(() => {return someResult});
```

Also, an error handler that only has `console.log` has been deleted. I think such an error should be thrown natively, or handled with loggers provided from fully-featured logging libraries to show call stacks and make it developer-friendly.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.