### PR TITLE
Add overridden type annotations on `normalise_file()` to remove @ts-i…

### DIFF
--- a/.changeset/smooth-camels-prove.md
+++ b/.changeset/smooth-camels-prove.md
@@ -1,0 +1,5 @@
+---
+"@gradio/client": patch
+---
+
+Refacor types.

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -708,10 +708,25 @@ function transform_output(
 	return transformed_data;
 }
 
-export function normalise_file(
-	file: Array<FileData> | FileData | string | null,
+function normalise_file(
+	file: Array<FileData>,
 	root: string,
 	root_url: string | null
+): Array<FileData>;
+function normalise_file(
+	file: FileData | string,
+	root: string,
+	root_url: string | null
+): FileData;
+function normalise_file(
+	file: null,
+	root: string,
+	root_url: string | null
+): null;
+function normalise_file(
+	file,
+	root,
+	root_url
 ): Array<FileData> | FileData | null {
 	if (file == null) return null;
 	if (typeof file === "string") {
@@ -726,7 +741,6 @@ export function normalise_file(
 			if (x === null) {
 				normalized_file.push(null);
 			} else {
-				//@ts-ignore
 				normalized_file.push(normalise_file(x, root, root_url));
 			}
 		}


### PR DESCRIPTION
…gnore, and remove its unnecessary export

* Looks like `normalise_file` is not used outside this module, so `export` is confusing.
* Also, to remove `//@ts-ignore`, detailed type annotations are added.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.