### PR TITLE
Optimize frontend's is_dep calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ No changes to highlight.
 
 ## Other Changes:
 
-No changes to highlight.
+- Performance optimization in the frontend's Blocks code by [@akx](https://github.com/akx) in [PR 4334](https://github.com/gradio-app/gradio/pull/4334)
 
 ## Breaking Changes:
 

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -94,22 +94,11 @@
 		type: "inputs" | "outputs",
 		deps: Array<Dependency>
 	) {
-		let dep_index = 0;
-		for (;;) {
-			const dep = deps[dep_index];
-			if (dep === undefined) break;
-
-			let dep_item_index = 0;
-			for (;;) {
-				const dep_item = dep[type][dep_item_index];
-				if (dep_item === undefined) break;
+		for (const dep of deps) {
+			for (const dep_item of dep[type]) {
 				if (dep_item === id) return true;
-				dep_item_index++;
 			}
-
-			dep_index++;
 		}
-
 		return false;
 	}
 

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -102,19 +102,18 @@
 		return false;
 	}
 
-	const dynamic_ids: Set<number> = components.reduce<Set<number>>(
-		(acc, { id, props }) => {
-			const is_input = is_dep(id, "inputs", dependencies);
-			const is_output = is_dep(id, "outputs", dependencies);
-
-			if (!is_input && !is_output && has_no_default_value(props?.value))
-				acc.add(id); // default dynamic
-			if (is_input) acc.add(id);
-
-			return acc;
-		},
-		new Set()
-	);
+	const dynamic_ids: Set<number> = new Set();
+	for (const comp of components) {
+		const { id, props } = comp;
+		const is_input = is_dep(id, "inputs", dependencies);
+		if (
+			is_input ||
+			(!is_dep(id, "outputs", dependencies) &&
+				has_no_default_value(props?.value))
+		) {
+			dynamic_ids.add(id);
+		}
+	}
 
 	function has_no_default_value(value: any) {
 		return (


### PR DESCRIPTION
# Description

## relevant motivation

Gradio is occasionally sluggish on my mobile device, so I looked at Chrome's profiler to find out that

* a lot of time is spent in Svelte's `toggle_class`, for which a PR is in: https://github.com/sveltejs/svelte/pull/8629/files
* a lot of time is spent in Gradio's `is_dep`


<img width="701" alt="Screenshot 2023-05-24 at 21 44 18" src="https://github.com/gradio-app/gradio/assets/58669/f8112c00-ca34-40d7-8fea-822f6289fdfc">

## a summary of the change

* `is_dep` used a strange infinite-for-loop-break-on-undefined method of iterating over Arrays; switching that to regular `for..of` (as I'd done in the unlucky #4277 for other loops) optimizes it from being 3.5% of my test app's (stable-diffusion-webui) JS time to 2.0%
* the only caller for `is_dep` is the `reduce` construct directly following it; changing that to a regular `for..of` loop and optimizing it to not even _call_ `is_dep` unless it needs to further optimizes `is_dep` to only being 1.5% of the JS time.

The resulting code is shorter and faster, and things do seem to work as before.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
