### PR TITLE
Wait for up to 1.5 seconds for external CSS to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ No changes to highlight.
 
 ## Bug Fixes:
 
-No changes to highlight.
+- Gradio will no longer hang forever when waiting for external CSS to load by [@akx](https://github.com/akx) in [PR 4335](https://github.com/gradio-app/gradio/pull/4335)
+
 
 ## Other Changes:
 

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -100,7 +100,7 @@
 			style.innerHTML = css_string;
 			target.appendChild(style);
 		}
-		await mount_css(config.root + "/theme.css", document.head);
+		await mount_css(config.root + "/theme.css");
 		if (!config.stylesheets) return;
 
 		await Promise.all(
@@ -109,7 +109,6 @@
 					stylesheet.startsWith("http:") || stylesheet.startsWith("https:");
 				return mount_css(
 					absolute_link ? stylesheet : config.root + "/" + stylesheet,
-					document.head
 				);
 			})
 		);

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -109,6 +109,8 @@
 					stylesheet.startsWith("http:") || stylesheet.startsWith("https:");
 				return mount_css(
 					absolute_link ? stylesheet : config.root + "/" + stylesheet,
+					// Wait up to 1.5 seconds for external stylesheets to load before continuing anyway.
+					absolute_link ? 1500 : undefined
 				);
 			})
 		);

--- a/js/app/src/css.ts
+++ b/js/app/src/css.ts
@@ -1,4 +1,4 @@
-export function mount_css(url: string, target: HTMLElement): Promise<void> {
+export function mount_css(url: string): Promise<void> {
 	const existing_link = document.querySelector(`link[href='${url}']`);
 
 	if (existing_link) return Promise.resolve();
@@ -6,8 +6,7 @@ export function mount_css(url: string, target: HTMLElement): Promise<void> {
 	const link = document.createElement("link");
 	link.rel = "stylesheet";
 	link.href = url;
-	// @ts-ignore
-	target.appendChild(link);
+	document.head.appendChild(link);
 
 	return new Promise((res, rej) => {
 		link.addEventListener("load", () => res());

--- a/js/app/src/css.ts
+++ b/js/app/src/css.ts
@@ -1,4 +1,12 @@
-export function mount_css(url: string): Promise<void> {
+/**
+ * Loads a CSS file and appends it to the document head.
+ * The optional timeout parameter will resolve the promise without error
+ * if the CSS file has not loaded after the specified time.
+ *
+ * @param url URL to load.
+ * @param timeout Optional timeout, in milliseconds.
+ */
+export function mount_css(url: string, timeout?: number): Promise<unknown> {
 	const existing_link = document.querySelector(`link[href='${url}']`);
 
 	if (existing_link) return Promise.resolve();
@@ -8,10 +16,17 @@ export function mount_css(url: string): Promise<void> {
 	link.href = url;
 	document.head.appendChild(link);
 
-	return new Promise((res, rej) => {
-		link.addEventListener("load", () => res());
-		link.addEventListener("error", () =>
-			rej(new Error(`Unable to preload CSS for ${url}`))
-		);
+	const loadPromise = new Promise((res, rej) => {
+		link.addEventListener("load", res);
+		link.addEventListener("error", (err) => {
+			console.error(`load_css: failed to load CSS`, url, err);
+			rej(err);
+		});
 	});
+
+	if (timeout) {
+		const timeoutPromise = new Promise((res) => setTimeout(res, timeout));
+		return Promise.race([loadPromise, timeoutPromise]);
+	}
+	return loadPromise;
 }

--- a/js/app/src/main.ts
+++ b/js/app/src/main.ts
@@ -20,10 +20,10 @@ function create_custom_element() {
 
 		async connectedCallback() {
 			if (typeof FONTS !== "string") {
-				FONTS.forEach((f) => mount_css(f, document.head));
+				FONTS.forEach(mount_css);
 			}
 
-			await mount_css(ENTRY_CSS, document.head);
+			await mount_css(ENTRY_CSS);
 
 			const event = new CustomEvent("domchange", {
 				bubbles: true,


### PR DESCRIPTION
# Description

* relevant motivation: #4332 – if Google Fonts doesn't respond (e.g. in a LAN), the UI hangs.
* a summary of the change: wait for up to 1.5 seconds for external CSS to load before continuing anyway.
* which issue is ~fixed~ touched upon: #4332

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
