### PR TITLE
Add pypi classifiers to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ keywords = ["machine learning", "reproducibility", "visualization"]
 classifiers = [
   'Development Status :: 5 - Production/Stable',
   'License :: OSI Approved :: Apache Software License',
+  'Operating System :: OS Independent',
   'Programming Language :: Python :: 3',
   'Programming Language :: Python :: 3 :: Only',
   'Programming Language :: Python :: 3.7',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,21 @@ authors = [
 ]
 keywords = ["machine learning", "reproducibility", "visualization"]
 
+classifiers = [
+  'Development Status :: 5 - Production/Stable',
+  'License :: OSI Approved :: Apache Software License',
+  'Programming Language :: Python :: 3',
+  'Programming Language :: Python :: 3 :: Only',
+  'Programming Language :: Python :: 3.7',
+  'Programming Language :: Python :: 3.8',
+  'Programming Language :: Python :: 3.9',
+  'Programming Language :: Python :: 3.10',
+  'Programming Language :: Python :: 3.11',
+  'Topic :: Scientific/Engineering',
+  'Topic :: Scientific/Engineering :: Artificial Intelligence',
+  'Topic :: Scientific/Engineering :: Visualization',
+]
+
 [project.scripts]
 gradio = "gradio.cli:cli"
 upload_theme = "gradio.themes.upload_theme:main"


### PR DESCRIPTION
# Description

Adds [PyPI project classifiers](https://pypi.org/classifiers/)
Classifiers are used to add information to the classifiers panel in PyPI. Example from [NumPy](https://pypi.org/project/numpy/): 
![image](https://github.com/gradio-app/gradio/assets/7910938/687c085c-7439-4470-91e4-c84d6e47e5b4)

The reason that it is very important for this information to be present is that in an enterprise environment, security tools like [Sonatype Nexus IQ](https://help.sonatype.com/iqserver) are used to manage open source software risk. Nexus IQ specifically can be configured to [classify packages according to their license](https://help.sonatype.com/iqserver/managing/policy-management/license-threat-groups). This prevents developers from inadvertently using licenses like [GNU General Public License v2.0](https://www.tldrlegal.com/license/gnu-general-public-license-v2) without realizing that they may be legally obligated to make their entire project open source. 

My understanding is that Nexus IQ uses the classifiers panel to determine a project's license.
Because Gradio does not currently have a classifiers panel, Nexus cannot determine the license and treats Gradio as a high-risk package.
![image](https://github.com/gradio-app/gradio/assets/7910938/b1dd6376-41a6-434e-99cf-d8e5b21b599c)


By adding classifiers, Gradio will have increased availability within enterprise environments.

This change does not affect the library. I noted a [comment](https://github.com/gradio-app/gradio/pull/4337#issuecomment-1567467950) in another PR that a changelog entry may not be required if the library is not affected.

# Testing/Risks
Because this change is to the build process, it's not straightforward to test this change. (e.g., you can't write a unit test)
I used the [Python Packaging Projects Tutorial](https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata) as reference when writing the classifiers.
I can't/don't know how perform a test upload of Gradio to PyPI to ensure that this works properly, so I would appreciate careful review and validation.
In addition to the License classifiers, I added a small collection of what I think are reasonable classifiers: Development Status, Programming Language, and Topics. There may be other appropriate classifiers that should be added.
If future updates to Gradio lead to Python 3.7 or other versions no longer being supported, these classifiers should be updated.

# Checklist:

- [X] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [X] My code follows the style guidelines of this project
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


