### PR TITLE
Add pypi classifiers to client pyproject.toml

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -19,6 +19,22 @@ authors = [
 ]
 keywords = ["machine learning", "client", "API"]
 
+classifiers = [
+  'Development Status :: 4 - Beta',
+  'License :: OSI Approved :: Apache Software License',
+  'Operating System :: OS Independent',
+  'Programming Language :: Python :: 3',
+  'Programming Language :: Python :: 3 :: Only',
+  'Programming Language :: Python :: 3.7',
+  'Programming Language :: Python :: 3.8',
+  'Programming Language :: Python :: 3.9',
+  'Programming Language :: Python :: 3.10',
+  'Programming Language :: Python :: 3.11',
+  'Topic :: Scientific/Engineering',
+  'Topic :: Scientific/Engineering :: Artificial Intelligence',
+  'Topic :: Software Development :: User Interfaces',
+]
+
 [project.urls]
 Homepage = "https://github.com/gradio-app/gradio"
 


### PR DESCRIPTION
# Description

Adds classifiers to [gradio-client](https://pypi.org/project/gradio-client/) as a continuation of #4383 
which added the following classifiers to the PyPI metadata for gradio:
![image](https://github.com/gradio-app/gradio/assets/7910938/71ac0afa-6856-418b-997e-4350ffb528ca)

The only difference with this is that it's for [gradio-client](https://pypi.org/project/gradio-client/), and the Scientific/Engineering :: Visualization tag has been replaced with Software Development :: User Interfaces

Previous change, #4383, was successful and can be seen at https://pypi.org/project/gradio/

No Changelog is necessary as it does not change the functionality of the library

- [X] I have performed a self-review of my own code
- [X] I have added a short summary of my change to the CHANGELOG.md
- [X] My code follows the style guidelines of this project
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
directly via drag-and-drop.