### PR TITLE
Remove obsolete run_circleci.sh

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -52,17 +52,6 @@ function pnpm_required() {
 }
 
 #######################################
-# Check for the CircleCI program.
-# Arguments:
-#   None
-# Outputs:
-#   None
-#######################################
-function circleci_required() {
-  program_required "circleci" "https://circleci.com/docs/1.0/local-cli/"
-}
-
-#######################################
 # Check for the AWS CLI program.
 # Arguments:
 #   None

--- a/scripts/run_circleci.sh
+++ b/scripts/run_circleci.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-cd "$(dirname ${0})/.."
-source scripts/helpers.sh
-
-circleci_required
-
-echo "Running CircleCI locally..."
-circleci local execute


### PR DESCRIPTION
# Description

The `scripts/run_circleci.sh` is obsolete, it doesn't work anymore because `.circleci/config.yml` was removed in January.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
