### PR TITLE
Fix Bug where File(file_count="multiple") can't be cached as example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ No changes to highlight.
 
 ## Bug Fixes:
 
-No changes to highlight.
+- Fixed bug where `gr.File(file_count='multiple')` could not be cached as output by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4421](https://github.com/gradio-app/gradio/pull/4421)
 
 ## Other Changes:
 

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -334,6 +334,7 @@ class Examples:
         output = []
         assert self.outputs is not None
         for component, value in zip(self.outputs, example):
+            is_list = False
             try:
                 value_as_dict = ast.literal_eval(value)
                 is_list = isinstance(value_as_dict, list)

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -21,7 +21,7 @@ import PIL.Image
 from gradio_client import utils as client_utils
 from gradio_client.documentation import document, set_documentation_group
 
-from gradio import processing_utils, routes, utils
+from gradio import components, processing_utils, routes, utils
 from gradio.context import Context
 from gradio.flagging import CSVLogger
 
@@ -334,19 +334,23 @@ class Examples:
         output = []
         assert self.outputs is not None
         for component, value in zip(self.outputs, example):
-            is_list = False
+            value_to_use = value
             try:
                 value_as_dict = ast.literal_eval(value)
-                is_list = isinstance(value_as_dict, list)
-                assert utils.is_update(value_as_dict)
-                output.append(value_as_dict)
-            except (ValueError, TypeError, SyntaxError, AssertionError):
                 # File components that output multiple files get saved as a python list
                 # need to pass the parsed list to serialize
                 # TODO: Better file serialization in 4.0
+                if isinstance(value_as_dict, list) and isinstance(
+                    component, components.File
+                ):
+                    value_to_use = value_as_dict
+                assert utils.is_update(value_as_dict)
+                output.append(value_as_dict)
+            except (ValueError, TypeError, SyntaxError, AssertionError):
                 output.append(
                     component.serialize(
-                        value_as_dict if is_list else value, self.cached_folder
+                        value_to_use,
+                        self.cached_folder,
                     )
                 )
         return output

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -336,10 +336,18 @@ class Examples:
         for component, value in zip(self.outputs, example):
             try:
                 value_as_dict = ast.literal_eval(value)
+                is_list = isinstance(value_as_dict, list)
                 assert utils.is_update(value_as_dict)
                 output.append(value_as_dict)
             except (ValueError, TypeError, SyntaxError, AssertionError):
-                output.append(component.serialize(value, self.cached_folder))
+                # File components that output multiple files get saved as a python list
+                # need to pass the parsed list to serialize
+                # TODO: Better file serialization in 4.0
+                output.append(
+                    component.serialize(
+                        value_as_dict if is_list else value, self.cached_folder
+                    )
+                )
         return output
 
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -353,3 +353,22 @@ class TestProcessExamples:
 
         response = client.post("/api/predict/", json={"fn_index": 7, "data": [1]})
         assert response.json()["data"] == ["Michael", "Jordan", "Michael Jordan"]
+
+
+@pytest.mark.asyncio
+async def test_multiple_file_flagging(tmp_path):
+    with patch("gradio.helpers.CACHED_FOLDER", str(tmp_path)):
+        io = gr.Interface(
+            fn=lambda *x: list(x),
+            inputs=[
+                gr.Image(source="upload", type="filepath", label="frame 1"),
+                gr.Image(source="upload", type="filepath", label="frame 2"),
+            ],
+            outputs=[gr.Files()],
+            examples=[["test/test_files/cheetah1.jpg", "test/test_files/bus.png"]],
+            cache_examples=True,
+        )
+        prediction = await io.examples_handler.load_from_cache(0)
+
+        assert len(prediction[0]) == 2
+        assert all(isinstance(d, dict) for d in prediction[0])


### PR DESCRIPTION
# Description

Closes: #3672

To test, run reproducer from the issue. Also added a unit test.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.