### PR TITLE
fix  get_continuous_fn bug when having every

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ No changes to highlight.
 
 ## Bug Fixes:
 
-- Fix bug for get_continuous_fn by [@dkjshk](https://github.com/hannahblair) in [PR 4434](https://github.com/gradio-app/gradio/pull/4434)
+- Fix bug for get_continuous_fn by [@dkjshk](https://github.com/dkjshk) in [PR 4434](https://github.com/gradio-app/gradio/pull/4434)
 - Fix z-index of status component by [@hannahblair](https://github.com/hannahblair) in [PR 4429](https://github.com/gradio-app/gradio/pull/4429)
 - Allow gradio to work offline, by [@aliabid94](https://github.com/aliabid94) in [PR 4398](https://github.com/gradio-app/gradio/pull/4398).  
 - Fixed `validate_url` to check for 403 errors and use a GET request in place of a HEAD by [@alvindaiyan](https://github.com/alvindaiyan) in [PR 4388](https://github.com/gradio-app/gradio/pull/4388).  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ No changes to highlight.
 
 ## Bug Fixes:
 
+- Fix bug for get_continuous_fn by [@dkjshk](https://github.com/hannahblair) in [PR 4434](https://github.com/gradio-app/gradio/pull/4434)
 - Fix z-index of status component by [@hannahblair](https://github.com/hannahblair) in [PR 4429](https://github.com/gradio-app/gradio/pull/4429)
 - Allow gradio to work offline, by [@aliabid94](https://github.com/aliabid94) in [PR 4398](https://github.com/gradio-app/gradio/pull/4398).  
 - Fixed `validate_url` to check for 403 errors and use a GET request in place of a HEAD by [@alvindaiyan](https://github.com/alvindaiyan) in [PR 4388](https://github.com/gradio-app/gradio/pull/4388).  

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -6,7 +6,7 @@ import sys
 import time
 from asyncio import TimeoutError as AsyncTimeOutError
 from collections import deque
-from typing import Any, Deque
+from typing import Any
 
 import fastapi
 import httpx
@@ -46,7 +46,7 @@ class Queue:
         max_size: int | None,
         blocks_dependencies: list,
     ):
-        self.event_queue: Deque[Event] = deque()
+        self.event_queue: deque[Event] = deque()
         self.events_pending_reconnection = []
         self.stopped = False
         self.max_thread_count = concurrency_count

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -29,6 +29,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from types import GeneratorType
 
 import anyio
 import httpx
@@ -636,7 +637,10 @@ def get_continuous_fn(fn: Callable, every: float) -> Callable:
     def continuous_fn(*args):
         while True:
             output = fn(*args)
-            yield output
+            if isinstance(output,types.GeneratorType):
+                yield from output
+            else:
+                yield output
             time.sleep(every)
 
     return continuous_fn

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -637,7 +637,7 @@ def get_continuous_fn(fn: Callable, every: float) -> Callable:
     def continuous_fn(*args):
         while True:
             output = fn(*args)
-            if isinstance(output,types.GeneratorType):
+            if isinstance(output,GeneratorType):
                 yield from output
             else:
                 yield output

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -21,6 +21,7 @@ from enum import Enum
 from io import BytesIO
 from numbers import Number
 from pathlib import Path
+from types import GeneratorType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -29,7 +30,6 @@ from typing import (
     TypeVar,
     Union,
 )
-from types import GeneratorType
 
 import anyio
 import httpx
@@ -637,7 +637,7 @@ def get_continuous_fn(fn: Callable, every: float) -> Callable:
     def continuous_fn(*args):
         while True:
             output = fn(*args)
-            if isinstance(output,GeneratorType):
+            if isinstance(output, GeneratorType):
                 yield from output
             else:
                 yield output

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -29,6 +29,7 @@ from gradio.utils import (
     colab_check,
     delete_none,
     format_ner_list,
+    get_continuous_fn,
     get_type_hints,
     ipython_check,
     is_in_or_equal,
@@ -40,7 +41,6 @@ from gradio.utils import (
     sanitize_value_for_csv,
     tex2svg,
     validate_url,
-    get_continuous_fn,
 )
 
 os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
@@ -616,33 +616,33 @@ class TestCheckFunctionInputsMatch:
 
 class TestGetContinuousFn:
     def test_get_continuous_fn(self):
-        def int_return(x):#for origin condition
-            return x+1
+        def int_return(x):  # for origin condition
+            return x + 1
 
-        def int_yield(x):#new condition
-            for i in range(2):
+        def int_yield(x):  # new condition
+            for _i in range(2):
                 yield x
                 x += 1
 
-        def list_yield(x):#new condition
-            for i in range(2):
+        def list_yield(x):  # new condition
+            for _i in range(2):
                 yield x
                 x += [1]
 
-        gen_int_return=get_continuous_fn(fn=int_return,every=0.01)
-        gen_int_yield=get_continuous_fn(fn=int_yield,every=0.01)
+        gen_int_return = get_continuous_fn(fn=int_return, every=0.01)
+        gen_int_yield = get_continuous_fn(fn=int_yield, every=0.01)
         gen_list_yield = get_continuous_fn(fn=list_yield, every=0.01)
-        gener_int_return=gen_int_return(1)
-        gener_int=gen_int_yield(1)#Primitive
-        gener_list=gen_list_yield([1])#Reference
-        assert 2==next(gener_int_return)
-        assert 2 == next(gener_int_return)
-        assert 1==next(gener_int)
-        assert 2 == next(gener_int)
-        assert 1 == next(gener_int)
-        assert [1]==next(gener_list)
-        assert [1,1]==next(gener_list)
-        assert [1,1,1] == next(gener_list)
+        gener_int_return = gen_int_return(1)
+        gener_int = gen_int_yield(1)  # Primitive
+        gener_list = gen_list_yield([1])  # Reference
+        assert next(gener_int_return) == 2
+        assert next(gener_int_return) == 2
+        assert next(gener_int) == 1
+        assert next(gener_int) == 2
+        assert next(gener_int) == 1
+        assert [1] == next(gener_list)
+        assert [1, 1] == next(gener_list)
+        assert [1, 1, 1] == next(gener_list)
 
 
 def test_tex2svg_preserves_matplotlib_backend():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -40,6 +40,7 @@ from gradio.utils import (
     sanitize_value_for_csv,
     tex2svg,
     validate_url,
+    get_continuous_fn,
 )
 
 os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
@@ -611,6 +612,37 @@ class TestCheckFunctionInputsMatch:
 
             for x in test_objs:
                 check_function_inputs_match(x, [None], False)
+
+
+class TestGetContinuousFn:
+    def test_get_continuous_fn(self):
+        def int_return(x):#for origin condition
+            return x+1
+
+        def int_yield(x):#new condition
+            for i in range(2):
+                yield x
+                x += 1
+
+        def list_yield(x):#new condition
+            for i in range(2):
+                yield x
+                x += [1]
+
+        gen_int_return=get_continuous_fn(fn=int_return,every=0.01)
+        gen_int_yield=get_continuous_fn(fn=int_yield,every=0.01)
+        gen_list_yield = get_continuous_fn(fn=list_yield, every=0.01)
+        gener_int_return=gen_int_return(1)
+        gener_int=gen_int_yield(1)#Primitive
+        gener_list=gen_list_yield([1])#Reference
+        assert 2==next(gener_int_return)
+        assert 2 == next(gener_int_return)
+        assert 1==next(gener_int)
+        assert 2 == next(gener_int)
+        assert 1 == next(gener_int)
+        assert [1]==next(gener_list)
+        assert [1,1]==next(gener_list)
+        assert [1,1,1] == next(gener_list)
 
 
 def test_tex2svg_preserves_matplotlib_backend():


### PR DESCRIPTION
# Description

For user experience, some times we need to use 'yield' in func to output part of results immediately instead of waiting for all.
And there is a bug if we use parameters every based on this condition, since in get_continuous_fn, yield a genertor dont match the output.

# Demo
```
import gradio as gr
import time

def iterative(chatbot,state):
    for i in range(10):
        chatbot.append((str(i),str(i)))
        state+="ok"
        time.sleep(0.5)
        yield chatbot,state

demo = gr.Blocks()
with demo:
    state=gr.State("")
    with gr.Row():
        bt5 = gr.Button(value='method')
    bt6 = gr.Button(value='cancel')
    with gr.Row():
        chatbot = gr.Chatbot(label='chatbot')
    event = bt5.click(iterative, [chatbot,state], [chatbot,state], every=1)
    bt6.click(lambda:None , [], [], cancels=[event])
demo.queue()
demo.launch()
```

# Before Fix
```
Traceback (most recent call last):
  File "F:\Anaconda\lib\site-packages\gradio\routes.py", line 414, in run_predict
    output = await app.get_blocks().process_api(
  File "F:\Anaconda\lib\site-packages\gradio\blocks.py", line 1323, in process_api
    data = self.postprocess_data(fn_index, result["prediction"], state)
  File "F:\Anaconda\lib\site-packages\gradio\blocks.py", line 1226, in postprocess_data
    self.validate_outputs(fn_index, predictions)  # type: ignore
  File "F:\Anaconda\lib\site-packages\gradio\blocks.py", line 1201, in validate_outputs
    raise ValueError(
ValueError: An event handler (continuous_fn) didn't receive enough output values (needed: 2, received: 1).
Wanted outputs:
    [chatbot, state]
Received outputs:
    [<generator object iterative at 0x00000174A4764660>]
Task exception was never retrieved
future: <Task finished name='s1dg2k3c67_0' coro=<Queue.process_events() done, defined at F:\Anaconda\lib\site-packages\gradio\queueing.py:343> exception=ValueError('[<gradio.queueing.Event object at 0x00000174A46F96A0>] is not in list')>
Traceback (most recent call last):
  File "F:\Anaconda\lib\site-packages\gradio\queueing.py", line 432, in process_events
    self.active_jobs[self.active_jobs.index(events)] = None
ValueError: [<gradio.queueing.Event object at 0x00000174A46F96A0>] is not in list
```
# After Fix

https://github.com/gradio-app/gradio/assets/5206014/991ded72-1de3-4f18-82a7-d3d55f80f77c




# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added a short summary of my change to the CHANGELOG.md
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.