### PR TITLE
Call mounted gradio app via api

### DIFF
--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Bug Fixes:
 - Fixes parameter names not showing underscores by [@abidlabs](https://github.com/abidlabs) in [PR 4230](https://github.com/gradio-app/gradio/pull/4230)
 - Fixes issue in which state was not handled correctly if `serialize=False` by [@abidlabs](https://github.com/abidlabs) in [PR 4230](https://github.com/gradio-app/gradio/pull/4230)
+- Fixed bug where mounted apps could not be called via the client by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4435](https://github.com/gradio-app/gradio/pull/4435)
 
 ## Breaking Changes:
 

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -85,7 +85,7 @@ class Client:
         self.space_id = None
 
         if src.startswith("http://") or src.startswith("https://"):
-            _src = src
+            _src = src if src.endswith("/") else src + "/"
         else:
             _src = self._space_name_to_src(src)
             if _src is None:

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -23,14 +23,14 @@ import requests
 from huggingface_hub import SpaceStage
 from websockets.legacy.protocol import WebSocketCommonProtocol
 
-API_URL = "/api/predict/"
-WS_URL = "/queue/join"
-UPLOAD_URL = "/upload"
-CONFIG_URL = "/config"
-API_INFO_URL = "/info"
-RAW_API_INFO_URL = "/info?serialize=False"
+API_URL = "api/predict/"
+WS_URL = "queue/join"
+UPLOAD_URL = "upload"
+CONFIG_URL = "config"
+API_INFO_URL = "info"
+RAW_API_INFO_URL = "info?serialize=False"
 SPACE_FETCHER_URL = "https://gradio-space-api-fetcher-v2.hf.space/api"
-RESET_URL = "/reset"
+RESET_URL = "reset"
 SPACE_URL = "https://hf.space/{}"
 
 STATE_COMPONENT = "state"


### PR DESCRIPTION
# Description

Closes: #4340 

The problem is that the urls in `utils.py` are absolute so `urllib` will not construct the path we expect

<img width="791" alt="image" src="https://github.com/gradio-app/gradio/assets/41651716/6ccf7c02-b5f2-49f8-816c-ee3cdab7d921">

Fix is to make the urls relative and to make sure the src ends with `/`

Added a unit test for this case and all unit tests are passing locally

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.