### PR TITLE
UI hotfixes for Examples and Dataframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ## Other Changes:
 
 - Clean up unnecessary `new Promise()`s by [@akx](https://github.com/akx) in [PR 4442](https://github.com/gradio-app/gradio/pull/4442).
+- Minor UI cleanup for Examples and Dataframe components [@aliabid94](https://github.com/aliabid94) in [PR 4455](https://github.com/gradio-app/gradio/pull/4455). 
+
 ## Breaking Changes:
 
 No changes to highlight.

--- a/js/app/src/components/Dataset/Dataset.svelte
+++ b/js/app/src/components/Dataset/Dataset.svelte
@@ -88,6 +88,7 @@
 	{scale}
 	{min_width}
 	allow_overflow={false}
+	container={false}
 >
 	<div class="label">
 		<svg

--- a/js/table/src/Table.svelte
+++ b/js/table/src/Table.svelte
@@ -658,9 +658,6 @@
 		margin-right: var(--size-1);
 		margin-left: -5px;
 	}
-	.label {
-		margin-top: var(--size-6);
-	}
 
 	.label p {
 		position: relative;


### PR DESCRIPTION
Examples had picked up an ugly container from the styles deprecation PR:
![Screen Shot 2023-06-08 at 2 12 53 PM](https://github.com/gradio-app/gradio/assets/7870876/ebd3f29c-82b0-4adb-a7d7-30f68d13b970)
Dataframe had a margin top that made alignment weird - we use Row/Column padding and flex gaps for spacing between components everywhere else.