### PR TITLE
Fix docstrings in HTML Component and missing @document 

### DIFF
--- a/gradio/components.py
+++ b/gradio/components.py
@@ -4645,8 +4645,6 @@ class HTML(Changeable, IOComponent, StringSerializable):
             label: component name in interface.
             every: If `value` is a callable, run the function 'every' number of seconds while the client connection is open. Has no effect otherwise. Queue must be enabled. The event can be accessed (e.g. to cancel it) via this component's .load_event attribute.
             show_label: if True, will display label.
-            scale: relative width compared to adjacent Components in a Row. For example, if Component A has scale=2, and Component B has scale=1, A will be twice as wide as B. Should be an integer.
-            min_width: minimum pixel width, will wrap if not sufficient screen space to satisfy this value. If a certain scale value results in this Component being narrower than min_width, the min_width parameter will be respected first.
             visible: If False, component will be hidden.
             elem_id: An optional string that is assigned as the id of this component in the HTML DOM. Can be used for targeting CSS styles.
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.

--- a/gradio/components.py
+++ b/gradio/components.py
@@ -414,6 +414,7 @@ class FormComponent:
         return Form
 
 
+@document()
 class Textbox(
     FormComponent,
     Changeable,
@@ -652,6 +653,7 @@ class Textbox(
         return self
 
 
+@document()
 class Number(
     FormComponent,
     Changeable,
@@ -864,6 +866,7 @@ class Number(
         return interpretation
 
 
+@document()
 class Slider(
     FormComponent,
     Changeable,
@@ -1056,6 +1059,7 @@ class Slider(
         return self
 
 
+@document()
 class Checkbox(
     FormComponent,
     Changeable,
@@ -1173,6 +1177,7 @@ class Checkbox(
             return None, scores[0]
 
 
+@document()
 class CheckboxGroup(
     FormComponent,
     Changeable,
@@ -1371,6 +1376,7 @@ class CheckboxGroup(
         return self
 
 
+@document()
 class Radio(
     FormComponent,
     Selectable,
@@ -1549,6 +1555,7 @@ class Radio(
         return self
 
 
+@document()
 class Dropdown(
     Changeable,
     Inputable,
@@ -1771,6 +1778,7 @@ class Dropdown(
         return self
 
 
+@document()
 class Image(
     Editable,
     Clearable,
@@ -2149,6 +2157,7 @@ class Image(
         return str(utils.abspath(input_data))
 
 
+@document()
 class Video(
     Changeable,
     Clearable,
@@ -2503,6 +2512,7 @@ class Video(
         return self
 
 
+@document()
 class Audio(
     Changeable,
     Clearable,
@@ -2806,6 +2816,7 @@ class Audio(
         return Path(input_data).name if input_data else ""
 
 
+@document()
 class File(
     Changeable,
     Selectable,
@@ -3061,6 +3072,7 @@ class File(
             return self._multiple_file_example_inputs()
 
 
+@document()
 class Dataframe(Changeable, Inputable, Selectable, IOComponent, JSONSerializable):
     """
     Accepts or displays 2D input through a spreadsheet-like component for dataframes.
@@ -3335,6 +3347,7 @@ class Dataframe(Changeable, Inputable, Selectable, IOComponent, JSONSerializable
         return input_data
 
 
+@document()
 class Timeseries(Changeable, IOComponent, JSONSerializable):
     """
     Creates a component that can be used to upload/preview timeseries csv files or display a dataframe consisting of a time series graphically.
@@ -3513,6 +3526,7 @@ class Variable(State):
         return "state"
 
 
+@document()
 class Button(Clickable, IOComponent, StringSerializable):
     """
     Used to create a button, that can be assigned arbitrary click() events. The label (value) of the button can be used as an input or set via the output of a function.
@@ -3620,6 +3634,7 @@ class Button(Clickable, IOComponent, StringSerializable):
         return self
 
 
+@document()
 class UploadButton(Clickable, Uploadable, IOComponent, FileSerializable):
     """
     Used to create an upload button, when cicked allows a user to upload files that satisfy the specified file type or generic files (if file_type not set).
@@ -3813,6 +3828,7 @@ class UploadButton(Clickable, Uploadable, IOComponent, FileSerializable):
         return self
 
 
+@document()
 class ColorPicker(
     Changeable, Inputable, Submittable, Blurrable, IOComponent, StringSerializable
 ):
@@ -3941,6 +3957,7 @@ class ColorPicker(
 ############################
 
 
+@document()
 class Label(Changeable, Selectable, IOComponent, JSONSerializable):
     """
     Displays a classification label, along with confidence scores of top categories, if provided.
@@ -4102,6 +4119,7 @@ class Label(Changeable, Selectable, IOComponent, JSONSerializable):
         return self
 
 
+@document()
 class HighlightedText(Changeable, Selectable, IOComponent, JSONSerializable):
     """
     Displays text that contains spans that are highlighted by category or numerical value.
@@ -4288,6 +4306,7 @@ class HighlightedText(Changeable, Selectable, IOComponent, JSONSerializable):
         return self
 
 
+@document()
 class AnnotatedImage(Selectable, IOComponent, JSONSerializable):
     """
     Displays a base image and colored subsections on top of that image. Subsections can take the from of rectangles (e.g. object detection) or masks (e.g. image segmentation).
@@ -4510,6 +4529,7 @@ class AnnotatedImage(Selectable, IOComponent, JSONSerializable):
         return self
 
 
+@document()
 class JSON(Changeable, IOComponent, JSONSerializable):
     """
     Used to display arbitrary JSON output prettily.
@@ -4684,6 +4704,7 @@ class HTML(Changeable, IOComponent, StringSerializable):
         return updated_config
 
 
+@document()
 class Gallery(IOComponent, GallerySerializable, Selectable):
     """
     Used to display a list of images as a gallery that can be scrolled through.
@@ -4882,6 +4903,7 @@ class Gallery(IOComponent, GallerySerializable, Selectable):
         return self
 
 
+@document()
 class Carousel(IOComponent, Changeable, SimpleSerializable):
     """
     Deprecated Component
@@ -4898,6 +4920,7 @@ class Carousel(IOComponent, Changeable, SimpleSerializable):
         )
 
 
+@document()
 class Chatbot(Changeable, Selectable, IOComponent, JSONSerializable):
     """
     Displays a chatbot output showing both user submitted messages and responses. Supports a subset of Markdown including bold, italics, code, and images.
@@ -5103,6 +5126,7 @@ class Chatbot(Changeable, Selectable, IOComponent, JSONSerializable):
         return self
 
 
+@document()
 class Model3D(
     Changeable, Uploadable, Editable, Clearable, IOComponent, FileSerializable
 ):
@@ -6611,6 +6635,7 @@ class Code(Changeable, Inputable, IOComponent, StringSerializable):
 ############################
 
 
+@document()
 class Dataset(Clickable, Selectable, Component, StringSerializable):
     """
     Used to create an output widget for showing datasets. Used to render the examples


### PR DESCRIPTION
@aliabid94 this PR added `scale` and `min_width` to the docstrings for the `HTML` `__init__`, which doesn't have those params and it broke docs on the website: https://github.com/gradio-app/gradio/pull/4374