### PR TITLE
Fix JS call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Ensure components have the correct empty sizes to prevent empty containers from collapsing by [@pngwn](https://github.com/pngwn) in [PR 4447](https://github.com/gradio-app/gradio/pull/4447).
 - Frontend code no longer crashes when there is a relative URL in an `<a>` element, by [@akx](https://github.com/akx) in [PR 4449](https://github.com/gradio-app/gradio/pull/4449).
 - Fix bug where setting `format='mp4'` on a video component would cause the function to error out if the uploaded video was not playable by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4467](https://github.com/gradio-app/gradio/pull/4467)
+- Fix `_js` parameter to work even without backend function, by [@aliabid94](https://github.com/aliabid94) in [PR 4486](https://github.com/gradio-app/gradio/pull/4486). 
 
 ## Other Changes:
 

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -215,7 +215,7 @@
 				}
 			} else {
 				output.props.value = value;
-			}			
+			}
 		});
 		rootNode = rootNode;
 	}
@@ -259,7 +259,7 @@
 		};
 
 		if (dep.frontend_fn) {
-			console.log("running frontend fn")
+			console.log("running frontend fn");
 			dep
 				.frontend_fn(
 					payload.data.concat(
@@ -267,7 +267,7 @@
 					)
 				)
 				.then((v: []) => {
-					console.log("got frontend fn result:", v)
+					console.log("got frontend fn result:", v);
 					if (dep.backend_fn) {
 						payload.data = v;
 						make_prediction();

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -213,11 +213,11 @@
 						output.props[update_key] = update_value;
 					}
 				}
-				rootNode = rootNode;
 			} else {
 				output.props.value = value;
-			}
+			}			
 		});
+		rootNode = rootNode;
 	}
 
 	let submit_map: Map<number, ReturnType<typeof app.submit>> = new Map();
@@ -259,6 +259,7 @@
 		};
 
 		if (dep.frontend_fn) {
+			console.log("running frontend fn")
 			dep
 				.frontend_fn(
 					payload.data.concat(
@@ -266,6 +267,7 @@
 					)
 				)
 				.then((v: []) => {
+					console.log("got frontend fn result:", v)
 					if (dep.backend_fn) {
 						payload.data = v;
 						make_prediction();


### PR DESCRIPTION
the `_js` parameter would not show updates to components in the cases where both:
- there was no accompanying backend python function
- all updated values were values only, and not `gr.update` JSONs

The reason for this is the line to cause svelte to re-render (`root_node = root_node`) was for some reason only in the code when `gr.update` were loaded, or there was an update to a status-tracker. All backend python functions make status-tracker updates, so if there's any python function then it always updates. Simply moving the re-render line to run after any update should fix this. Test with

```python
import gradio as gr

with gr.Blocks() as demo:
    a = gr.Textbox()
    c = gr.Button()
    c.click(None, None, a, _js="() => {console.log('abc'); return ['abc'];}")

demo.launch()
``` 

Closes: #4485 