### PR TITLE
Fix gallery select event with custom height and allow_preview=False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ No changes to highlight.
 
 ## Bug Fixes:
 
-No changes to highlight.
+- Fix bug where `select` event was not triggered in `gr.Gallery` if `height` was set to be large with `allow_preview=False` by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4551](https://github.com/gradio-app/gradio/pull/4551)
 
 ## Other Changes:
 

--- a/js/gallery/src/Gallery.svelte
+++ b/js/gallery/src/Gallery.svelte
@@ -130,7 +130,8 @@
 		});
 	}
 
-	$: can_zoom = window_height >= client_height;
+	// If you don't allow preview, assume can always zoom to trigger select event
+	$: can_zoom = !allow_preview ? true : window_height >= client_height;
 
 	let client_height = 0;
 	let window_height = 0;


### PR DESCRIPTION
# Description

Closes: #4543

When setting a height on the gallery, the select event is not being triggered when `allow_preview=False` because `can_zoom` is being calculated as `False`. 

Not too familiar with the gallery code but I assumed the `can_zoom` logic is correct. Since the gallery won't zoom with `allow_preview=False`, my fix is to set `can_zoom=true` in that case to trigger the event. But please check me @pngwn @hannahblair @aliabid94  @dawoodkhan82 



# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.