### PR TITLE
Send component data on stop_recording event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Restored missing imports in `gr.components` by [@abidlabs](https://github.com/abidlabs) in [PR 4566](https://github.com/gradio-app/gradio/pull/4566)
 - Fix bug where `select` event was not triggered in `gr.Gallery` if `height` was set to be large with `allow_preview=False` by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4551](https://github.com/gradio-app/gradio/pull/4551)
 - Fix bug where setting `visible=False` in `gr.Group` event did not work by [@abidlabs](https://github.com/abidlabs) in [PR 4567](https://github.com/gradio-app/gradio/pull/4567)
+- Send captured data in `stop_recording` event for `gr.Audio` and `gr.Video` components by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4554](https://github.com/gradio-app/gradio/pull/4554)
 
 ## Other Changes:
 

--- a/js/audio/src/Audio.svelte
+++ b/js/audio/src/Audio.svelte
@@ -86,7 +86,7 @@
 
 	const dispatch_blob = async (
 		blobs: Array<Uint8Array> | Blob[],
-		event: "stream" | "change"
+		event: "stream" | "change" | "stop_recording"
 	) => {
 		let audio_blob = new Blob(blobs, { type: "audio/wav" });
 		value = {
@@ -150,6 +150,7 @@
 			recorder.addEventListener("stop", async () => {
 				recording = false;
 				await dispatch_blob(audio_chunks, "change");
+				await dispatch_blob(audio_chunks, "stop_recording");
 				audio_chunks = [];
 			});
 		}
@@ -185,7 +186,6 @@
 	});
 
 	const stop = async () => {
-		dispatch("stop_recording");
 		recorder.stop();
 		if (streaming) {
 			recording = false;

--- a/js/image/src/Webcam.svelte
+++ b/js/image/src/Webcam.svelte
@@ -23,7 +23,11 @@
 			| string;
 		error: string;
 		start_recording: undefined;
-		stop_recording: undefined;
+		stop_recording: {
+			data: FileReader["result"];
+			name: string;
+			is_example?: boolean;
+		};
 	}>();
 
 	onMount(() => (canvas = document.createElement("canvas")));
@@ -74,13 +78,17 @@
 
 	function take_recording() {
 		if (recording) {
-			dispatch("stop_recording");
 			media_recorder.stop();
 			let video_blob = new Blob(recorded_blobs, { type: mimeType });
 			let ReaderObj = new FileReader();
 			ReaderObj.onload = function (e) {
 				if (e.target) {
 					dispatch("capture", {
+						data: e.target.result,
+						name: "sample." + mimeType.substring(6),
+						is_example: false
+					});
+					dispatch("stop_recording", {
 						data: e.target.result,
 						name: "sample." + mimeType.substring(6),
 						is_example: false

--- a/js/image/src/Webcam.svelte
+++ b/js/image/src/Webcam.svelte
@@ -23,11 +23,7 @@
 			| string;
 		error: string;
 		start_recording: undefined;
-		stop_recording: {
-			data: FileReader["result"];
-			name: string;
-			is_example?: boolean;
-		};
+		stop_recording: undefined;
 	}>();
 
 	onMount(() => (canvas = document.createElement("canvas")));
@@ -88,11 +84,7 @@
 						name: "sample." + mimeType.substring(6),
 						is_example: false
 					});
-					dispatch("stop_recording", {
-						data: e.target.result,
-						name: "sample." + mimeType.substring(6),
-						is_example: false
-					});
+					dispatch("stop_recording");
 				}
 			};
 			ReaderObj.readAsDataURL(video_blob);


### PR DESCRIPTION
# Description

Closes: #4547 

The stop_recording event does not send the microphone data when the event is triggered. This PR fixes that. I think the same thing is happening on video, will investigate.

To test, run this demo and observe that the output audio and video components are populated correctly.

```python
import gradio as gr

def test(ori):
    ori
    
with gr.Blocks() as demo:
    with gr.Row():
        audio = gr.Audio(source='microphone')
        video = gr.Video(source='webcam')
        audio_output = gr.Audio()
        video_output = gr.Video()
    audio.stop_recording(lambda x: x, inputs=audio, outputs=audio_output)
    video.stop_recording(lambda x: x, inputs=video, outputs =video_output)


if __name__ == "__main__":
    demo.launch()
```
This repro from the original PR that introduced this PR still works as expected

```python
import gradio as gr

def start_recording():
    print("Recording has started")

def stop_recording():
    print("Recording has stopped")

def start_playing():
    print("Playing has started")

def stop_playing():
    print("Playing has stopped")

def pause_playing():
    print("Playing has paused")


with gr.Blocks() as demo:
    stream_input = gr.Video(source="webcam")

    stream_input.play(start_playing)
    stream_input.pause(pause_playing)
    stream_input.stop(stop_playing)
    stream_input.start_recording(start_recording)
    stream_input.stop_recording(stop_recording)
        
demo.launch()
```


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added a short summary of my change to the CHANGELOG.md
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# A note about the CHANGELOG

Hello 👋 and thank you for contributing to Gradio!

All pull requests must update the change log located in CHANGELOG.md, unless the pull request is labeled with the "no-changelog-update" label.

Please add a brief summary of the change to the Upcoming Release > Full Changelog section of the CHANGELOG.md file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".

If you would like to elaborate on your change further, feel free to include a longer explanation in the other sections.
If you would like an image/gif/video showcasing your feature, it may be best to edit the CHANGELOG file using the 
GitHub web UI since that lets you upload files directly via drag-and-drop.