### PR TITLE
setting `visible=False` to `gr.Group` hides it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ No changes to highlight.
 ## Bug Fixes:
 
 - Fix bug where `select` event was not triggered in `gr.Gallery` if `height` was set to be large with `allow_preview=False` by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4551](https://github.com/gradio-app/gradio/pull/4551)
-
+- Fix bug where setting `visible=False` in `gr.Group` event did not work by [@abidlabs](https://github.com/abidlabs) in [PR 4567](https://github.com/gradio-app/gradio/pull/4567)
 ## Other Changes:
 
 No changes to highlight.

--- a/gradio/components/__init__.py
+++ b/gradio/components/__init__.py
@@ -2,8 +2,12 @@ from gradio.components.annotated_image import AnnotatedImage
 from gradio.components.audio import Audio
 from gradio.components.bar_plot import BarPlot
 from gradio.components.base import (
+    Column,
     Component,
+    Form,
+    FormComponent,
     IOComponent,
+    Row,
     _Keywords,
     component,
     get_component_instance,
@@ -66,9 +70,12 @@ __all__ = [
     "CheckboxGroup",
     "Code",
     "ColorPicker",
+    "Column",
     "Dataframe",
     "DataFrame",
     "Dataset",
+    "Form",
+    "FormComponent",
     "Gallery",
     "HTML",
     "Image",
@@ -96,6 +103,7 @@ __all__ = [
     "Number",
     "Plot",
     "Radio",
+    "Row,"
     "ScatterPlot",
     "Slider",
     "State",

--- a/gradio/components/__init__.py
+++ b/gradio/components/__init__.py
@@ -2,12 +2,8 @@ from gradio.components.annotated_image import AnnotatedImage
 from gradio.components.audio import Audio
 from gradio.components.bar_plot import BarPlot
 from gradio.components.base import (
-    Column,
     Component,
-    Form,
-    FormComponent,
     IOComponent,
-    Row,
     _Keywords,
     component,
     get_component_instance,
@@ -70,12 +66,9 @@ __all__ = [
     "CheckboxGroup",
     "Code",
     "ColorPicker",
-    "Column",
     "Dataframe",
     "DataFrame",
     "Dataset",
-    "Form",
-    "FormComponent",
     "Gallery",
     "HTML",
     "Image",
@@ -103,7 +96,6 @@ __all__ = [
     "Number",
     "Plot",
     "Radio",
-    "Row,"
     "ScatterPlot",
     "Slider",
     "State",

--- a/js/app/src/components/Group/Group.svelte
+++ b/js/app/src/components/Group/Group.svelte
@@ -4,7 +4,7 @@
 	export let visible: boolean = true;
 </script>
 
-<div id={elem_id} class={elem_classes.join(" ")} class:hidden={!visible}>
+<div id={elem_id} class={elem_classes.join(" ")} class:hide={!visible}>
 	<slot />
 </div>
 
@@ -25,5 +25,9 @@
 
 	div > :global(* + *:not(.absolute)) {
 		border-top: none !important;
+	}
+
+	.hide {
+		display: none;
 	}
 </style>

--- a/js/app/src/components/Group/Group.test.ts
+++ b/js/app/src/components/Group/Group.test.ts
@@ -1,0 +1,26 @@
+import { test, describe, assert, afterEach, vi } from "vitest";
+import { cleanup, render } from "@gradio/tootils";
+
+import Group from "./Group.svelte";
+
+describe("Group", () => {
+	afterEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+	});
+
+	test("setting visible to false hides the Group", async () => {
+		render(Group, {
+			elem_id: "group",
+			visible: false
+		});
+
+		const groupElement = document.getElementById("group");
+
+		assert(groupElement !== null, "Group element not found.");
+		assert(
+			groupElement.classList.contains("hide"),
+			"Group element is not hidden."
+		);
+	});
+});

--- a/js/app/src/components/Group/Group.test.ts
+++ b/js/app/src/components/Group/Group.test.ts
@@ -6,7 +6,6 @@ import Group from "./Group.svelte";
 describe("Group", () => {
 	afterEach(() => {
 		cleanup();
-		vi.restoreAllMocks();
 	});
 
 	test("setting visible to false hides the Group", async () => {


### PR DESCRIPTION
Closes: #4505

In order to make sure this regression does not happen again, I wrote a TS test. However, I'm not happy with this test, as it tests implementation (the presence of a class name) instead of behavior (checking to see if the CSS display is actually set to "none"). 

I tried adding these lines of JS to the test but it wouldn't work for me:

at the beginning of the test:

```js
// Wait for any potential reactivity updates in the component
await waitFor(() => {});
```

and at the end of the test:

```js
const computedStyles = window.getComputedStyle(groupElement);
assert(computedStyles.display === 'none', "Group element is not hidden.");
```

If we can get this to work, that'd be much better!