### PR TITLE
Test improve

### DIFF
--- a/.config/eslint.config.js
+++ b/.config/eslint.config.js
@@ -40,7 +40,7 @@ const rules = {
 	"@typescript-eslint/no-inferrable-types": "error"
 };
 
-const { browser, es2021 } = globals;
+const { browser, es2021, node } = globals;
 
 export default [
 	{
@@ -66,7 +66,8 @@ export default [
 			},
 			globals: {
 				...browser,
-				...es2021
+				...es2021,
+				...node
 			}
 		},
 

--- a/.config/playwright-setup.js
+++ b/.config/playwright-setup.js
@@ -2,6 +2,8 @@ import { spawn } from "node:child_process";
 import { join, basename } from "path";
 import { fileURLToPath } from "url";
 import { readdirSync, writeFileSync } from "fs";
+import net from "net";
+
 import kl from "kleur";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
@@ -15,9 +17,13 @@ const test_files = readdirSync(TEST_FILES_PATH)
 
 export default async function global_setup() {
 	const verbose = process.env.GRADIO_TEST_VERBOSE;
+
+	const port = await find_free_port(7860, 8860);
+	process.env.GRADIO_E2E_TEST_PORT = port;
+
 	process.stdout.write(kl.yellow("\nCreating test gradio app.\n\n"));
 
-	const test_app = make_app(test_files);
+	const test_app = make_app(test_files, port);
 	process.stdout.write(kl.yellow("App created. Starting test server.\n\n"));
 
 	process.stdout.write(kl.bgBlue(" =========================== \n"));
@@ -26,10 +32,10 @@ export default async function global_setup() {
 
 	writeFileSync(TEST_APP_PATH, test_app);
 
-	const app = await spawn_gradio_app(TEST_APP_PATH, verbose);
+	const app = await spawn_gradio_app(TEST_APP_PATH, port, verbose);
 
 	process.stdout.write(
-		kl.green(`\n\nServer started. Running tests on port ${"7879"}.\n`)
+		kl.green(`\n\nServer started. Running tests on port ${port}.\n`)
 	);
 
 	return () => {
@@ -38,11 +44,11 @@ export default async function global_setup() {
 		kill_process(app);
 	};
 }
-const PORT_RE = new RegExp(`:7879`);
 const INFO_RE = /^INFO:/;
 
-function spawn_gradio_app(app, verbose) {
-	let launched = false;
+function spawn_gradio_app(app, port, verbose) {
+	const PORT_RE = new RegExp(`:${port}`);
+
 	return new Promise((res, rej) => {
 		const _process = spawn(`python`, [app], {
 			shell: true,
@@ -112,7 +118,7 @@ function kill_process(process) {
 	});
 }
 
-function make_app(demos) {
+function make_app(demos, port) {
 	return `import gradio as gr
 import uvicorn
 from fastapi import FastAPI
@@ -124,7 +130,37 @@ ${demos
 	.map((d) => `app = gr.mount_gradio_app(app, ${d}, path="/${d}")`)
 	.join("\n")}
 
-config = uvicorn.Config(app, port=7879, log_level="info")
+config = uvicorn.Config(app, port=${port}, log_level="info")
 server = uvicorn.Server(config=config)
 server.run()`;
+}
+
+export async function find_free_port(start_port, end_port) {
+	for (let port = start_port; port < end_port; port++) {
+		if (await is_free_port(port)) {
+			return port;
+		}
+	}
+
+	throw new Error(
+		`Could not find free ports: there were not enough ports available.`
+	);
+}
+
+export function is_free_port(port) {
+	return new Promise((accept, reject) => {
+		const sock = net.createConnection(port, "127.0.0.1");
+		sock.once("connect", () => {
+			sock.end();
+			accept(false);
+		});
+		sock.once("error", (e) => {
+			sock.destroy();
+			if (e.code === "ECONNREFUSED") {
+				accept(true);
+			} else {
+				reject(e);
+			}
+		});
+	});
 }

--- a/js/tootils/src/index.ts
+++ b/js/tootils/src/index.ts
@@ -1,21 +1,22 @@
 import { test as base } from "@playwright/test";
 import { basename } from "path";
 
-export function get_text<T extends HTMLElement>(el: T) {
+export function get_text<T extends HTMLElement>(el: T): string {
 	return el.innerText.trim();
 }
 
-export function wait(n: number) {
+export function wait(n: number): Promise<void> {
 	return new Promise((r) => setTimeout(r, n));
 }
 
 export const test = base.extend<{ setup: void }>({
 	setup: [
-		async ({ page }, use, testInfo) => {
+		async ({ page }, use, testInfo): Promise<void> => {
+			const port = process.env.GRADIO_E2E_TEST_PORT;
 			const { file } = testInfo;
-			const test = basename(file, ".spec.ts");
+			const test_name = basename(file, ".spec.ts");
 
-			await page.goto(`localhost:7879/${test}`);
+			await page.goto(`localhost:${port}/${test_name}`);
 
 			await use();
 		},

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"eslint-plugin-svelte": "^2.31.0",
 		"globals": "^13.20.0",
 		"happy-dom": "^9.20.3",
+		"kleur": "^4.1.5",
 		"msw": "^1.0.0",
 		"node-html-parser": "^6.0.0",
 		"npm-run-all": "^4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       happy-dom:
         specifier: ^9.20.3
         version: 9.20.3
+      kleur:
+        specifier: ^4.1.5
+        version: 4.1.5
       msw:
         specifier: ^1.0.0
         version: 1.0.0(typescript@5.1.3)
@@ -4635,11 +4638,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /kleur@4.1.4:
-    resolution: {integrity: sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==}
-    engines: {node: '>=6'}
-    dev: false
-
   /kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
@@ -6043,7 +6041,7 @@ packages:
     dependencies:
       console-clear: 1.1.1
       get-port: 3.2.0
-      kleur: 4.1.4
+      kleur: 4.1.5
       local-access: 1.1.0
       sade: 1.8.1
       semiver: 1.1.0


### PR DESCRIPTION
## Description

I have made some improvements the browser tests setup.

**Better logging**

When you run `pnpm test:browser` the runner will _always_ print the python startup logs. Previously most logs were suppressed because they interfere with the test runner logs but when something goes running with starting up the python process, it usually happens before the test have run. Logging at this point will not interfere with the test runner because the test runner hasn't really started yet.  

Logs after the test has started will still be suppressed.

To view all logs you can run `pnpm test:browser:verbose`, this dopes interfere with the test runner logs but it is useful to see them if something isn't working correctly.

I also added some pretty colours. When you run the tests, it now looks like this:

<img width="896" alt="Screenshot 2023-06-23 at 11 56 43" src="https://github.com/gradio-app/gradio/assets/12937446/aa4c8f94-21d5-4c3b-a370-71d0c9991295">

**Better port handling**

Previously, we started on port 7879 which is relatively safe, but if that port was occupied then the process wouldn't start correctly and would hang without any logs. The above fix helps with that but I've also implemented a port scan to find the next free port from `7860` to `8860`. This port is setup as an environment variables, so it can be used elsewhere. This should prevent too many issues, regardless of what else is running on the machine. The port we connect the app to and the port wee navigate to in tests are automatically kept in sync.

**To test**

To test this occupy a port, or a few, build the frontend and run the tests.

`pnpm test:browser:full` will build the app and run the browser tests.

