### PR TITLE
Remove cleared_value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Use `typing.Literal` where possible in gradio library and client by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4608](https://github.com/gradio-app/gradio/pull/4608)
 - Remove unnecessary mock json files for frontend E2E tests by [@dawoodkhan82](https://github.com/dawoodkhan82) in [PR 4625](https://github.com/gradio-app/gradio/pull/4625)
 - Update depedencies by [@pngwn](https://github.com/pngwn) in [PR 4643](https://github.com/gradio-app/gradio/pull/4643)
+- Remove `cleared_value` from some components as its no longer used internally by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4685](https://github.com/gradio-app/gradio/pull/4685)
 
 ## Breaking Changes:
 

--- a/gradio/components/checkboxgroup.py
+++ b/gradio/components/checkboxgroup.py
@@ -70,7 +70,6 @@ class CheckboxGroup(
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
         """
         self.choices = choices or []
-        self.cleared_value = []
         valid_types = ["value", "index"]
         if type not in valid_types:
             raise ValueError(

--- a/gradio/components/color_picker.py
+++ b/gradio/components/color_picker.py
@@ -62,7 +62,6 @@ class ColorPicker(
             elem_id: An optional string that is assigned as the id of this component in the HTML DOM. Can be used for targeting CSS styles.
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
         """
-        self.cleared_value = "#000000"
         IOComponent.__init__(
             self,
             label=label,

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -124,8 +124,6 @@ class Dropdown(
             **kwargs,
         )
 
-        self.cleared_value = self.value or ([] if multiselect else "")
-
     def api_info(self) -> dict[str, dict | bool]:
         if self.multiselect:
             type = {

--- a/gradio/components/radio.py
+++ b/gradio/components/radio.py
@@ -100,7 +100,6 @@ class Radio(
             **kwargs,
         )
         NeighborInterpretable.__init__(self)
-        self.cleared_value = self.value
 
     def get_config(self):
         return {

--- a/gradio/components/slider.py
+++ b/gradio/components/slider.py
@@ -105,7 +105,6 @@ class Slider(
             **kwargs,
         )
         NeighborInterpretable.__init__(self)
-        self.cleared_value = self.value
 
     def api_info(self) -> dict[str, dict | bool]:
         return {

--- a/gradio/components/textbox.py
+++ b/gradio/components/textbox.py
@@ -124,7 +124,6 @@ class Textbox(
             **kwargs,
         )
         TokenInterpretable.__init__(self)
-        self.cleared_value = ""
         self.type = type
 
     def get_config(self):


### PR DESCRIPTION
## Description

After #4456, we no longer make use of `cleared_value`

The only references to `cleared_value` on spaces are a couple of spaces implementing their own clear button running older versions of gradio:

https://huggingface.co/search/full-text?q=cleared_value&type=space

Not used in Auto1111 either so I think its safe to remove: https://github.com/search?q=repo%3AAUTOMATIC1111%2Fstable-diffusion-webui+cleared_value&type=code

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests & Changelog

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

1. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
1. Unless the pull request is labeled with the "no-changelog-update" label by a maintainer of the repo, all pull requests must update the changelog located in `CHANGELOG.md`:

Please add a brief summary of the change to the Upcoming Release section of the `CHANGELOG.md` file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".
