### PR TITLE
Form min_width guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix double upload bug that caused lag in file uploads by [@aliabid94](https://github.com/aliabid94) in [PR 4661](https://github.com/gradio-app/gradio/pull/4661)
 - `Progress` component now appears even when no `iterable` is specified in `tqdm` constructor by [@itrushkin](https://github.com/itrushkin) in [PR 4475](https://github.com/gradio-app/gradio/pull/4475)
 - Deprecation warnings now point at the user code using those deprecated features, instead of Gradio internals, by (https://github.com/akx) in [PR 4694](https://github.com/gradio-app/gradio/pull/4694)
+- Ensure `Form` nestled in a `Row` does not crash when a subcomponent hasn't set `min_width`, by [@akx](https://github.com/akx) in [PR 4693](https://github.com/gradio-app/gradio/pull/4693)
 
 ## Other Changes:
 

--- a/gradio/layouts.py
+++ b/gradio/layouts.py
@@ -328,8 +328,9 @@ class Form(BlockContext):
     def add_child(self, child: Block):
         if isinstance(self.parent, Row):
             scale = getattr(child, "scale", None)
+            min_width = getattr(child, "min_width", None)
             self.scale += 1 if scale is None else scale
-            self.min_width += getattr(child, "min_width", 0) or 0
+            self.min_width += 0 if min_width is None else min_width
         super().add_child(child)
 
     def get_config(self):

--- a/gradio/layouts.py
+++ b/gradio/layouts.py
@@ -321,8 +321,8 @@ class Form(BlockContext):
             scale: relative width compared to adjacent Columns. For example, if Column A has scale=2, and Column B has scale=1, A will be twice as wide as B.
             min_width: minimum pixel width of Column, will wrap if not sufficient screen space to satisfy this value. If a certain scale value results in a column narrower than min_width, the min_width parameter will be respected first.
         """
-        self.scale = scale
-        self.min_width = min_width
+        self.scale = int(scale)
+        self.min_width = int(min_width)
         super().__init__(**kwargs)
 
     def add_child(self, child: Block):

--- a/test/test_layouts.py
+++ b/test/test_layouts.py
@@ -1,0 +1,14 @@
+from gradio.components import Button
+from gradio.layouts import Form, Row
+
+
+def test_form_min_width_guard():
+    """
+    Test that `Form.add_child` does not crash with a component whose `min_width` is `None`.
+    """
+    r = Row()
+    f = Form()
+    f.parent = r
+    b = Button()
+    f.add_child(b)
+    assert f.min_width == 0


### PR DESCRIPTION
## Description

This PR ensures no weird algebra is being attempted between integers and Nones for `max_width`, as was already done for `scale`, in `Form.add_child` (ref https://github.com/gradio-app/gradio/pull/4374).

On a similar note, it ensures an user attempting to do `Form(min_width=None)` will get an error immediately rather than at a later stage.

I don't have a great standalone repro for this, but the symptom is 

```
  File "modules/ui.py", line 311, in create_toprow
    with gr.Row(elem_id=f"{id_part}_tools"):
  File "gradio/blocks.py", line 366, in __exit__
    self.fill_expected_parents()
  File "gradio/blocks.py", line 358, in fill_expected_parents
    pseudo_parent.add_child(child)
  File "gradio/layouts.py", line 334, in add_child
    self.min_width += getattr(child, "min_width", 0)
TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'
```
