### PR TITLE
URL validation/access fixes

### DIFF
--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -7,7 +7,7 @@ No changes to highlight.
 ## Bug Fixes:
 
 - Fix bug where space duplication would error if the demo has cpu-basic hardware by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4583](https://github.com/gradio-app/gradio/pull/4583)
-
+- Fixes and optimizations to URL/download functions by [@akx](https://github.com/akx) in [PR 4695](https://github.com/gradio-app/gradio/pull/4695)
 
 ## Breaking Changes:
 

--- a/client/python/gradio_client/serializing.py
+++ b/client/python/gradio_client/serializing.py
@@ -171,11 +171,11 @@ class ImgSerializable(Serializable):
             x: String path to file to serialize
             load_dir: Path to directory containing x
         """
-        if x is None or x == "":
+        if not x:
             return None
-        is_url = utils.is_valid_url(x)
-        path = x if is_url else Path(load_dir) / x
-        return utils.encode_url_or_file_to_base64(path)
+        if utils.is_http_url_like(x):
+            return utils.encode_url_to_base64(x)
+        return utils.encode_file_to_base64(Path(load_dir) / x)
 
     def deserialize(
         self,
@@ -252,7 +252,7 @@ class FileSerializable(Serializable):
     ) -> FileData | None:
         if x is None or isinstance(x, dict):
             return x
-        if utils.is_valid_url(x):
+        if utils.is_http_url_like(x):
             filename = x
             size = None
         else:

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -196,10 +196,11 @@ class Communicator:
 def is_valid_url(possible_url: str) -> bool:
     headers = {"User-Agent": "gradio (https://gradio.app/; team@gradio.app)"}
     try:
-        head_request = requests.head(possible_url, headers=headers)
-        if head_request.status_code == 405:
-            return requests.get(possible_url, headers=headers).ok
-        return head_request.ok
+        with requests.session() as sess:
+            head_request = sess.head(possible_url, headers=headers)
+            if head_request.status_code == 405:
+                return sess.get(possible_url, headers=headers).ok
+            return head_request.ok
     except Exception:
         return False
 

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -305,10 +305,10 @@ def download_tmp_copy_of_file(
     directory.mkdir(exist_ok=True, parents=True)
     file_path = directory / Path(url_path).name
 
-    with requests.get(url_path, headers=headers, stream=True) as r, open(
-        file_path, "wb"
-    ) as f:
-        shutil.copyfileobj(r.raw, f)
+    with requests.get(url_path, headers=headers, stream=True) as r:
+        r.raise_for_status()
+        with open(file_path, "wb") as f:
+            shutil.copyfileobj(r.raw, f)
     return str(file_path.resolve())
 
 

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -356,7 +356,9 @@ def encode_file_to_base64(f: str | Path):
 
 
 def encode_url_to_base64(url: str):
-    encoded_string = base64.b64encode(requests.get(url).content)
+    resp = requests.get(url)
+    resp.raise_for_status()
+    encoded_string = base64.b64encode(resp.content)
     base64_str = str(encoded_string, "utf-8")
     mimetype = get_mimetype(url)
     return (

--- a/client/python/test/test_utils.py
+++ b/client/python/test/test_utils.py
@@ -73,6 +73,15 @@ def test_download_private_file():
     assert Path(file).name.endswith(".jpg")
 
 
+def test_download_tmp_copy_of_file_does_not_save_errors(monkeypatch):
+    error_response = requests.Response()
+    error_response.status_code = 404
+    error_response.close = lambda: 0  # Mock close method to avoid unrelated exception
+    monkeypatch.setattr(requests, "get", lambda *args, **kwargs: error_response)
+    with pytest.raises(requests.RequestException):
+        utils.download_tmp_copy_of_file("https://example.com/foo")
+
+
 @pytest.mark.parametrize(
     "orig_filename, new_filename",
     [


### PR DESCRIPTION
## Description

I was profiling things and noticed a whole lot of time was spent in `is_valid_url` and was pretty surprised that that function actually does HTTP requests if it can.

This PR:

* makes that function share a `requests` session if it needs to do both HEAD + GET
* renames that function to `probe_url` because that's more what it does, with a deprecation trampoline for possible external users
* changes uses where `is_valid_url` was only used to check whether another function that does a `requests` request should be called to the new `is_http_url_like` function.

While working on that I realized there were small bugs in `encode_url_to_base64` and `download_tmp_copy_of_file` where they didn't check for the response status, and would thus happily end up writing e.g. an error page out.

These changes are in the `gradio_client` library, but these functions are gratuitously used by `gradio` itself.

## 🎯 PRs Should Target Issues

This PR does not target an issue right now, sorry; this was just another small papercut sort of problem I could easily fix.
