### PR TITLE
Introduce CrossOriginWorker class to load the WebWorker file from a different domain

### DIFF
--- a/.changeset/nasty-crabs-teach.md
+++ b/.changeset/nasty-crabs-teach.md
@@ -1,0 +1,5 @@
+---
+"@gradio/lite": patch
+---
+
+Load the worker file from a different origin, e.g. CDN

--- a/js/app/src/lite/index.ts
+++ b/js/app/src/lite/index.ts
@@ -51,8 +51,8 @@ export async function create(options: Options) {
 	observer.observe(options.target, { childList: true });
 
 	const worker_proxy = new WorkerProxy({
-		gradioWheelUrl: gradioWheel,
-		gradioClientWheelUrl: gradioClientWheel,
+		gradioWheelUrl: new URL(gradioWheel, import.meta.url).href,
+		gradioClientWheelUrl: new URL(gradioClientWheel, import.meta.url).href,
 		requirements: []
 	});
 

--- a/js/wasm/src/cross-origin-worker.ts
+++ b/js/wasm/src/cross-origin-worker.ts
@@ -1,0 +1,30 @@
+// A hack to load a worker script from a different origin.
+// Vite's built-in Web Workers feature does not support inlining the worker code
+// into the main bundle and always emits it to a separate file,
+// which is not compatible with the cross-origin worker.
+// So we use this hack to load the separate worker code from a domain different from the parent page.
+// Vite deals with the special syntax `new Worker(new URL("worker.ts", import.meta.url))` for the worker build,
+// so this `CrossOriginWorkerMaker` class must be defined in a separate file and
+// be imported as the `Worker` alias into the file where the syntax is used to load the worker.
+// This implementation was based on https://github.com/whitphx/stlite/blob/v0.34.0/packages/kernel/src/kernel.ts,
+// and this technique was introduced originally for Webpack at https://github.com/webpack/webpack/discussions/14648#discussioncomment-1589272
+export class CrossOriginWorkerMaker {
+	public readonly worker: Worker;
+
+	constructor(url: URL) {
+		try {
+			// This is the normal way to load a worker script, which is the best straightforward if possible.
+			this.worker = new Worker(url);
+		} catch (e) {
+			console.debug(
+				`Failed to load a worker script from ${url.toString()}. Trying to load a cross-origin worker...`
+			);
+			const workerBlob = new Blob([`importScripts("${url.toString()}");`], {
+				type: "text/javascript",
+			});
+			const workerBlobUrl = URL.createObjectURL(workerBlob);
+			this.worker = new Worker(workerBlobUrl);
+			URL.revokeObjectURL(workerBlobUrl);
+		}
+	}
+}

--- a/js/wasm/src/worker-proxy.ts
+++ b/js/wasm/src/worker-proxy.ts
@@ -1,3 +1,4 @@
+import { CrossOriginWorkerMaker as Worker } from "./cross-origin-worker";
 import type {
 	HttpRequest,
 	HttpResponse,
@@ -12,13 +13,16 @@ export interface WorkerProxyOptions {
 }
 
 export class WorkerProxy {
-	private worker: Worker;
+	private worker: globalThis.Worker;
 
 	constructor(options: WorkerProxyOptions) {
 		console.debug("WorkerProxy.constructor(): Create a new worker.");
 		// Loading a worker here relies on Vite's support for WebWorkers (https://vitejs.dev/guide/features.html#web-workers),
 		// assuming that this module is imported from the Gradio frontend (`@gradio/app`), which is bundled with Vite.
-		this.worker = new Worker(new URL("./webworker.js", import.meta.url));
+		// HACK: Use `CrossOriginWorkerMaker` imported as `Worker` here.
+		// Read the comment in `cross-origin-worker.ts` for the detail.
+		const workerMaker = new Worker(new URL("./webworker.js", import.meta.url));
+		this.worker = workerMaker.worker;
 
 		this.postMessageAsync({
 			type: "init",


### PR DESCRIPTION
## Description

[`@gradio/lite`](https://www.npmjs.com/package/@gradio/lite)@0.1.0 is now on NPM and can be loaded through CDN such as jsdelivr.
However, the execution fails because WebWorker initialization (`new Worker(<url>)`) doesn't work when the worker file is served from a different origin. To reproduce the error, use the HTML file below. The error is like:
```
DOMException: Failed to construct 'Worker': Script at 'https://cdn.jsdelivr.net/npm/@gradio/lite@0.1.0/dist/assets/webworker-d0ef9a1b.js' cannot be accessed from origin 'http://localhost:8080'.
```

To workaround it, I would introduce a technique I introduced to [stlite](https://github.com/whitphx/stlite) at https://github.com/whitphx/stlite/pull/482/commits/94502a0970b788d1f6dea4a6e826a73dea4fb506:
We use the `CrossOriginWorker` class to initiate the worker, which downloads the worker source file even from a different origin and initialize worker with it.

---

### A sample HTML code

```html
<!DOCTYPE html>
<!-- A demo HTML file to test the bundled JS and CSS files -->
<html
	lang="en"
	style="
		margin: 0;
		padding: 0;
		min-height: 100%;
		display: flex;
		flex-direction: column;
	"
>
	<head>
		<meta charset="utf-8" />
		<meta
			name="viewport"
			content="width=device-width, initial-scale=1, shrink-to-fit=no, maximum-scale=1"
		/>

		<script type="module" crossorigin src="https://cdn.jsdelivr.net/npm/@gradio/lite@0.1.0/dist/lite.js"></script>
		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gradio/lite@0.1.0/dist/lite.css" />

		<link rel="preconnect" href="https://fonts.googleapis.com" />
		<link
			rel="preconnect"
			href="https://fonts.gstatic.com"
			crossorigin="anonymous"
		/>
		<script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.6/iframeResizer.contentWindow.min.js"></script>
	</head>

	<body
		style="
			width: 100%;
			margin: 0;
			padding: 0;
			display: flex;
			flex-direction: column;
			flex-grow: 1;
		"
	>
		<div id="gradio-app"></div>
	</body>

	<script>
		window.addEventListener("DOMContentLoaded", function () {
			// <script type="module" /> is loaded asynchronously, so we need to wait for it to load before we can use it.
			createGradioApp({
				target: document.getElementById("gradio-app"),
				pyCode: `
import gradio as gr

def greet(name):
		return "Hello " + name + "!"

demo = gr.Interface(fn=greet, inputs="text", outputs="text")

demo.launch()
`,
				info: true,
				container: true,
				isEmbed: false,
				initialHeight: "300px",
				eager: false,
				themeMode: null,
				autoScroll: false,
				controlPageTitle: false,
				appMode: true
			});
		});
	</script>
</html>
```

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests & Changelog

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

1. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
1. Unless the pull request is labeled with the "no-changelog-update" label by a maintainer of the repo, all pull requests must update the changelog located in `CHANGELOG.md`:

Please add a brief summary of the change to the Upcoming Release section of the `CHANGELOG.md` file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".
