### PR TITLE
kill process properly in test teardown

### DIFF
--- a/.config/playwright-setup.js
+++ b/.config/playwright-setup.js
@@ -43,10 +43,10 @@ export default async function global_setup() {
 		kl.green(`\n\nServer started. Running tests on port ${port}.\n`)
 	);
 
-	return () => {
+	return async () => {
 		process.stdout.write(kl.green(`\nTests complete, cleaning up!\n`));
 
-		kill_process(app);
+		await kill_process(app);
 	};
 }
 const INFO_RE = /^INFO:/;
@@ -132,8 +132,8 @@ ${demos.map((d) => `from demo.${d}.run import demo as ${d}`).join("\n")}
 
 app = FastAPI()
 ${demos
-			.map((d) => `app = gr.mount_gradio_app(app, ${d}, path="/${d}")`)
-			.join("\n")}
+	.map((d) => `app = gr.mount_gradio_app(app, ${d}, path="/${d}")`)
+	.join("\n")}
 
 config = uvicorn.Config(app, port=${port}, log_level="info")
 server = uvicorn.Server(config=config)

--- a/.config/playwright-setup.js
+++ b/.config/playwright-setup.js
@@ -43,10 +43,10 @@ export default async function global_setup() {
 		kl.green(`\n\nServer started. Running tests on port ${port}.\n`)
 	);
 
-	return async () => {
+	return () => {
 		process.stdout.write(kl.green(`\nTests complete, cleaning up!\n`));
 
-		await kill_process(app);
+		kill_process(app);
 	};
 }
 const INFO_RE = /^INFO:/;
@@ -92,6 +92,10 @@ function spawn_gradio_app(app, port, verbose) {
 			}
 		});
 
+		_process.on("exit", () => kill_process(_process));
+		_process.on("close", () => kill_process(_process));
+		_process.on("disconnect", () => kill_process(_process));
+
 		_process.stderr.on("data", (data) => {
 			const _data = data.toString();
 			const is_info = INFO_RE.test(_data);
@@ -117,10 +121,7 @@ function spawn_gradio_app(app, port, verbose) {
 }
 
 function kill_process(process) {
-	return new Promise((res, rej) => {
-		process.on("close", res);
-		process.kill("SIGTERM");
-	});
+	process.kill("SIGKILL");
 }
 
 function make_app(demos, port) {


### PR DESCRIPTION
It seem the port was being freed up but the python process was running in the background. It seem it wasn't responding to SIGTERM. I've changed this to SIGKILL and it seems to clean things up as expected. 