### PR TITLE
Install gradio from source for chromatic

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -65,7 +65,7 @@ jobs:
         with:
             fetch-depth: 0
       - name: install gradio
-        run: python -m pip install gradio==$(cat gradio/version.txt)
+        run: python -m pip install -e .
       - name: generate theme.css
         run: python scripts/generate_theme.py --outfile js/storybook/theme.css
       - name: install dependencies

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -70,7 +70,9 @@ jobs:
           always-install-pnpm: true
           skip_build: 'true'
       - name: generate theme.css
-        run: python scripts/generate_theme.py --outfile js/storybook/theme.css
+        run: | 
+          . venv/bin/activate
+          python scripts/generate_theme.py --outfile js/storybook/theme.css
       - name: build storybook
         run: pnpm build-storybook --quiet
       - name: publish to chromatic

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -64,15 +64,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
             fetch-depth: 0
-      - name: install gradio
-        run: python -m pip install -e .
-      - name: generate theme.css
-        run: python scripts/generate_theme.py --outfile js/storybook/theme.css
       - name: install dependencies
         uses: "./.github/actions/install-all-deps"
         with:
           always-install-pnpm: true
           skip_build: 'true'
+      - name: generate theme.css
+        run: python scripts/generate_theme.py --outfile js/storybook/theme.css
       - name: build storybook
         run: pnpm build-storybook --quiet
       - name: publish to chromatic


### PR DESCRIPTION
Noticed that Chromatic [job was failing here](https://github.com/gradio-app/gradio/pull/4815) because it was looking for a non-existent version of `gradio`. We should be installing `gradio` from source to test the latest changes on the PR instead of the version of `gradio` that is already released to pypi