### PR TITLE
Lite: Fix the markdown-it package name spec on the Wasm worker

### DIFF
--- a/.changeset/spicy-fishes-taste.md
+++ b/.changeset/spicy-fishes-taste.md
@@ -1,0 +1,5 @@
+---
+"@gradio/lite": patch
+---
+
+Fix the package name spec of markdown-it on the Wasm worker

--- a/js/wasm/src/webworker/index.ts
+++ b/js/wasm/src/webworker/index.ts
@@ -73,7 +73,7 @@ async function loadPyodideAndPackages(
 	await micropip.add_mock_package("aiohttp", "3.8.4");
 	await micropip.add_mock_package("multidict", "4.7.6");
 	await pyodide.loadPackage(["ssl", "distutils", "setuptools"]);
-	await micropip.install(["markdown-it-py~=2.2.0"]); // On 3rd June 2023, markdown-it-py 3.0.0 has been released. The `gradio` package depends on its `>=2.0.0` version so its 3.x will be resolved. However, it conflicts with `mdit-py-plugins`'s dependency `markdown-it-py >=1.0.0,<3.0.0` and micropip currently can't resolve it. So we explicitly install the compatible version of the library here.
+	await micropip.install(["markdown-it-py[linkify]~=2.2.0"]); // On 3rd June 2023, markdown-it-py 3.0.0 has been released. The `gradio` package depends on its `>=2.0.0` version so its 3.x will be resolved. However, it conflicts with `mdit-py-plugins`'s dependency `markdown-it-py >=1.0.0,<3.0.0` and micropip currently can't resolve it. So we explicitly install the compatible version of the library here.
 	await micropip.install.callKwargs(gradioWheelUrls, {
 		keep_going: true
 	});


### PR DESCRIPTION
## Description

The package name `markdown-it` passed to the package manager should be `markdown-it[linkify]` to work on Gradio and to make `gr.Markdown()` work, same as
https://github.com/gradio-app/gradio/blob/1c9ebdea5b288bd7358ba6e0d72d8069c021e44a/requirements.txt#L10

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests & Changelog

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

1. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
1. Unless the pull request is labeled with the "no-changelog-update" label by a maintainer of the repo, all pull requests must update the changelog located in `CHANGELOG.md`:

Please add a brief summary of the change to the Upcoming Release section of the `CHANGELOG.md` file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".
