### PR TITLE
Lite: Make the Examples component display media files correctly

### DIFF
--- a/.changeset/quick-horses-leave.md
+++ b/.changeset/quick-horses-leave.md
@@ -1,0 +1,5 @@
+---
+"@gradio/lite": patch
+---
+
+Make the Examples component work on Wasm

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -89,7 +89,7 @@
 	export let mount_css: typeof default_mount_css = default_mount_css;
 	export let client: ReturnType<typeof api_factory>["client"];
 	export let upload_files: ReturnType<typeof api_factory>["upload_files"];
-	export let get_file_from_wasm: ((pathname: string) => Promise<Blob>) | undefined;
+	export let get_file_from_wasm: ((pathname: string) => Promise<Blob>) | undefined = undefined;
 
 	export let space: string | null;
 	export let host: string | null;

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -89,10 +89,13 @@
 	export let mount_css: typeof default_mount_css = default_mount_css;
 	export let client: ReturnType<typeof api_factory>["client"];
 	export let upload_files: ReturnType<typeof api_factory>["upload_files"];
+	export let get_file_from_wasm: ((pathname: string) => Promise<Blob>) | undefined;
 
 	export let space: string | null;
 	export let host: string | null;
 	export let src: string | null;
+
+	setContext("get_file_from_wasm", get_file_from_wasm);
 
 	let _id = id++;
 

--- a/js/app/src/lite/index.ts
+++ b/js/app/src/lite/index.ts
@@ -95,6 +95,22 @@ export function create(options: Options): GradioAppController {
 	const overridden_mount_css: typeof mount_css = async (url, target) => {
 		return wasm_proxied_mount_css(worker_proxy, url, target);
 	};
+	function get_file_from_wasm(path: string): Promise<Blob> {
+		return worker_proxy.httpRequest({
+			method: "GET",
+			path,
+			query_string: "",
+			headers: {},
+		}).then((res) => {
+			if (res.status !== 200) {
+				throw new Error(`Failed to get file ${path} from the Wasm worker.`)
+			}
+
+			const blob = new Blob([res.body], { type: res.headers["Content-Type"] });
+
+			return blob;
+		})
+	}
 
 	let app: Index;
 	function launchNewApp(): void {
@@ -127,7 +143,8 @@ export function create(options: Options): GradioAppController {
 				// For Wasm mode
 				client,
 				upload_files,
-				mount_css: overridden_mount_css
+				mount_css: overridden_mount_css,
+				get_file_from_wasm,
 			}
 		});
 	}

--- a/js/image/example/Image.svelte
+++ b/js/image/example/Image.svelte
@@ -1,18 +1,36 @@
 <script lang="ts">
+	import { getContext } from "svelte";
+
 	export let value: string;
 	export let samples_dir: string;
 	export let type: "gallery" | "table";
 	export let selected = false;
+
+	let src = samples_dir + value;
+	let ready = true;
+
+	// For Wasm version, we need to fetch the file from the server running in the Wasm worker.
+	const get_file_from_wasm = getContext<((pathname: string) => Promise<Blob>) | undefined>("get_file_from_wasm");
+	$: if (get_file_from_wasm) {
+		ready = false;
+		const path = new URL(samples_dir + value).pathname;
+		get_file_from_wasm(path).then((blob) => {
+			src = URL.createObjectURL(blob);
+			ready = true;
+		})
+	}
 </script>
 
 <!-- TODO: fix -->
 <!-- svelte-ignore a11y-missing-attribute -->
+{#if ready}
 <img
-	src={samples_dir + value}
+	src={src}
 	class:table={type === "table"}
 	class:gallery={type === "gallery"}
 	class:selected
 />
+{/if}
 
 <style>
 	img {


### PR DESCRIPTION
## Description

`gr.Examples` or the `examples` option have not been working for the following reasons, and this PR addresses them:
* It's Python code internally uses `fsspec.asyn.get_loop()` and `fsspec.asyn.sync()` but they don't work on the Wasm env where the `threading` module is not supported.
    * To address it, `fsspec.asyn.get_loop()` and `fsspec.asyn.sync()` are mocked with the Wasm-compatible implementations: https://github.com/gradio-app/gradio/pull/4849/files#diff-875f331b75840f48b6d0c3c36e8e6a394bae0e152d3e4ec7842c9048b3109925R156-R176
* It's frontend components uses the `<img>` and `<video>` tags to display the media files, but they don't work for the Wasm version. For example, `<img src="...">` is for HTTP-accessible resources but the Gradio server running in a WebWorker can't serve the resources through HTTP.
    * To address it, a special method to load the resources from the server running in a WebWorker (https://github.com/gradio-app/gradio/pull/4849/files#diff-5ca8aa298aaa3f175747debafd686b0270764ffc62793997deff716496c27a75R82) and use it in the components. The loaded resources are [converted to an object URL](https://github.com/gradio-app/gradio/pull/4849/files#diff-b2c0603d28e882fd56c1223022d74938e734a567ba62f95867eb421c35c09c18R109) and it's passed to the `src` attr of the media tags.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests & Changelog

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

1. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
1. Unless the pull request is labeled with the "no-changelog-update" label by a maintainer of the repo, all pull requests must update the changelog located in `CHANGELOG.md`:

Please add a brief summary of the change to the Upcoming Release section of the `CHANGELOG.md` file and include
a link to the PR (formatted in markdown) and a link to your github profile (if you like). For example, "* Added a cool new feature by `[@myusername](link-to-your-github-profile)` in `[PR 11111](https://github.com/gradio-app/gradio/pull/11111)`".
