### PR TITLE
Fix API page code snippets in safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * The `.change()` event is fixed in `Video` and `Image` so that it only fires once by [@abidlabs](https://github.com/abidlabs) in [PR 4793](https://github.com/gradio-app/gradio/pull/4793)
 * The `.change()` event is fixed in `Audio` so that fires when the component value is programmatically updated by [@abidlabs](https://github.com/abidlabs) in [PR 4793](https://github.com/gradio-app/gradio/pull/4793)
 - Fixed bug where `gr.Video` could not preprocess urls by [@freddyaboulton](https://github.com/freddyaboulton) in [PR 4904](https://github.com/gradio-app/gradio/pull/4904)
+- Fixed copy button rendering in API page on Safari by [@aliabid94](https://github.com/aliabid94) in [PR 4924](https://github.com/gradio-app/gradio/pull/4924)
 
 ## Other Changes:
 

--- a/js/app/src/api_docs/CodeSnippets.svelte
+++ b/js/app/src/api_docs/CodeSnippets.svelte
@@ -69,8 +69,8 @@ result = client.predict(<!--
 				-->{/if}<!--
 			--><span class="desc"
 								><!--
-			-->	# {python_type.type} {#if python_type.description}({python_type.description}){/if}<!--
-			--> in '{label}' <!--
+			-->	# {python_type.type} {#if python_type.description}({python_type.description}) {/if}<!--
+			-->in '{label}' <!--
 			-->{component} component<!--
 			--></span
 							><!--
@@ -156,6 +156,7 @@ console.log(result.data);
 
 	code {
 		position: relative;
+		display: block;
 	}
 
 	.copy {

--- a/js/app/src/api_docs/InstallSnippet.svelte
+++ b/js/app/src/api_docs/InstallSnippet.svelte
@@ -38,6 +38,7 @@
 
 	code {
 		position: relative;
+		display: block;
 	}
 
 	.copy {


### PR DESCRIPTION
API page used to render copy buttons weird on safari. Fixed. Also quick fix to spacing in code snippet.
