### PR TITLE
Fixes `cancels` for generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ No changes to highlight.
 
 ## Bug Fixes:
 
-No changes to highlight.
+- Fixes `cancels` for generators so that if a generator is canceled before it is complete, subsequent runs of the event do not continue from the previous iteration, but rather start from the beginning. By [@abidlabs](https://github.com/abidlabs) in [PR 4969](https://github.com/gradio-app/gradio/pull/4969).
 
 ## Breaking Changes:
 

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -110,6 +110,7 @@ class App(FastAPI):
         self.blocks: gradio.Blocks | None = None
         self.state_holder = {}
         self.iterators = defaultdict(dict)
+        self.iterators_to_reset = defaultdict(set)
         self.lock = asyncio.Lock()
         self.queue_token = secrets.token_urlsafe(32)
         self.startup_events_triggered = False
@@ -389,14 +390,11 @@ class App(FastAPI):
         @app.post("/reset/")
         @app.post("/reset")
         async def reset_iterator(body: ResetBody):
-            print("iterators", app.iterators)
-            print("body", body)
             if body.session_hash not in app.iterators:
                 return {"success": False}
             async with app.lock:
                 app.iterators[body.session_hash][body.fn_index] = None
-                app.iterators[body.session_hash]["should_reset"].add(body.fn_index)
-            print("iterators", app.iterators)
+                app.iterators_to_reset[body.session_hash].add(body.fn_index)
             return {"success": True}
 
         async def run_predict(
@@ -404,6 +402,7 @@ class App(FastAPI):
             request: Request | List[Request],
             fn_index_inferred: int,
         ):
+            fn_index = body.fn_index
             if hasattr(body, "session_hash"):
                 if body.session_hash not in app.state_holder:
                     app.state_holder[body.session_hash] = {
@@ -412,21 +411,22 @@ class App(FastAPI):
                         if getattr(block, "stateful", False)
                     }
                 session_state = app.state_holder[body.session_hash]
-                iterators = app.iterators[body.session_hash]
                 # The should_reset set keeps track of the fn_indices
                 # that have been cancelled. When a job is cancelled,
                 # the /reset route will mark the jobs as having been reset.
                 # That way if the cancel job finishes BEFORE the job being cancelled
                 # the job being cancelled will not overwrite the state of the iterator.
-                # In all cases, should_reset will be the empty set the next time
-                # the fn_index is run.
-                app.iterators[body.session_hash]["should_reset"] = set()
+                if fn_index in app.iterators_to_reset[body.session_hash]:
+                    iterators = {}
+                    app.iterators_to_reset[body.session_hash].remove(fn_index)
+                else:
+                    iterators = app.iterators[body.session_hash]
             else:
                 session_state = {}
                 iterators = {}
+
             event_id = getattr(body, "event_id", None)
             raw_input = body.data
-            fn_index = body.fn_index
 
             dependency = app.get_blocks().dependencies[fn_index_inferred]
             target = dependency["targets"][0] if len(dependency["targets"]) else None
@@ -450,11 +450,7 @@ class App(FastAPI):
                     )
                 iterator = output.pop("iterator", None)
                 if hasattr(body, "session_hash"):
-                    print(">>", fn_index, ">>", app.iterators[body.session_hash]["should_reset"])
-                    if fn_index in app.iterators[body.session_hash]["should_reset"]:
-                        app.iterators[body.session_hash][fn_index] = None
-                    else:
-                        app.iterators[body.session_hash][fn_index] = iterator
+                    app.iterators[body.session_hash][fn_index] = iterator
                 if isinstance(output, Error):
                     raise output
             except BaseException as error:

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -389,11 +389,14 @@ class App(FastAPI):
         @app.post("/reset/")
         @app.post("/reset")
         async def reset_iterator(body: ResetBody):
+            print("iterators", app.iterators)
+            print("body", body)
             if body.session_hash not in app.iterators:
                 return {"success": False}
             async with app.lock:
                 app.iterators[body.session_hash][body.fn_index] = None
                 app.iterators[body.session_hash]["should_reset"].add(body.fn_index)
+            print("iterators", app.iterators)
             return {"success": True}
 
         async def run_predict(
@@ -447,6 +450,7 @@ class App(FastAPI):
                     )
                 iterator = output.pop("iterator", None)
                 if hasattr(body, "session_hash"):
+                    print(">>", fn_index, ">>", app.iterators[body.session_hash]["should_reset"])
                     if fn_index in app.iterators[body.session_hash]["should_reset"]:
                         app.iterators[body.session_hash][fn_index] = None
                     else:

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -12,7 +12,6 @@ import os
 import pkgutil
 import random
 import re
-import sys
 import time
 import typing
 import warnings

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -720,9 +720,6 @@ def get_function_with_locals(fn: Callable, blocks: Blocks, event_id: str | None)
 
 
 async def cancel_tasks(task_ids: set[str]):
-    if sys.version_info < (3, 8):
-        return None
-
     matching_tasks = [
         task for task in asyncio.all_tasks() if task.get_name() in task_ids
     ]
@@ -732,9 +729,7 @@ async def cancel_tasks(task_ids: set[str]):
 
 
 def set_task_name(task, session_hash: str, fn_index: int, batch: bool):
-    if sys.version_info >= (3, 8) and not (
-        batch
-    ):  # You shouldn't be able to cancel a task if it's part of a batch
+    if not batch:
         task.set_name(f"{session_hash}_{fn_index}")
 
 

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1260,26 +1260,6 @@ class TestCancel:
         captured = capsys.readouterr()
         assert "HELLO FROM LONG JOB" not in captured.out
 
-    async def test_cancel_function_with_generators(self, capsys):
-        async def long_job():
-            await asyncio.sleep(10)
-            print("HELLO FROM LONG JOB")
-
-        with gr.Blocks() as demo:
-            button = gr.Button(value="Start")
-            click = button.click(long_job, None, None)
-            cancel = gr.Button(value="Cancel")
-            cancel.click(None, None, None, cancels=[click])
-
-        cancel_fun = demo.fns[-1].fn
-        task = asyncio.create_task(long_job())
-        task.set_name("foo_0")
-        # If cancel_fun didn't cancel long_job the message would be printed to the console
-        # The test would also take 10 seconds
-        await asyncio.gather(task, cancel_fun("foo"), return_exceptions=True)
-        captured = capsys.readouterr()
-        assert "HELLO FROM LONG JOB" not in captured.out
-
     @pytest.mark.asyncio
     async def test_cancel_function_with_multiple_blocks(self, capsys):
         async def long_job():

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1239,10 +1239,6 @@ class TestRender:
 
 
 class TestCancel:
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8),
-        reason="Tasks dont have names in 3.7",
-    )
     @pytest.mark.asyncio
     async def test_cancel_function(self, capsys):
         async def long_job():
@@ -1264,10 +1260,6 @@ class TestCancel:
         captured = capsys.readouterr()
         assert "HELLO FROM LONG JOB" not in captured.out
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8),
-        reason="Tasks dont have names in 3.7",
-    )
     @pytest.mark.asyncio
     async def test_cancel_function_with_multiple_blocks(self, capsys):
         async def long_job():

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1336,6 +1336,7 @@ class TestCancel:
                 cancel.click(None, None, None, cancels=[click])
             demo.queue().launch(prevent_thread_lock=True)
 
+
 class TestEvery:
     def test_raise_exception_if_parameters_invalid(self):
         with pytest.raises(

--- a/test/test_queueing.py
+++ b/test/test_queueing.py
@@ -168,10 +168,6 @@ class TestQueueEstimation:
 
 
 class TestQueueProcessEvents:
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8),
-        reason="Mocks of async context manager don't work for 3.7",
-    )
     @pytest.mark.asyncio
     @patch("gradio.queueing.AsyncRequest", new_callable=AsyncMock)
     async def test_process_event(self, mock_request, queue: Queue, mock_event: Event):
@@ -314,10 +310,6 @@ class TestQueueProcessEvents:
         mock_event.disconnect.assert_called_once()
         assert queue.clean_event.call_count >= 1
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8),
-        reason="Mocks of async context manager don't work for 3.7",
-    )
     @pytest.mark.asyncio
     @patch("gradio.queueing.AsyncRequest", new_callable=AsyncMock)
     async def test_process_event_handles_exception_during_disconnect(

--- a/test/test_queueing.py
+++ b/test/test_queueing.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import sys
 from collections import deque
 from unittest.mock import MagicMock, patch
 

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -469,10 +469,6 @@ class TestAuthenticatedRoutes:
 
 class TestQueueRoutes:
     @pytest.mark.asyncio
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8),
-        reason="Mocks don't work with async context managers in 3.7",
-    )
     @patch("gradio.routes.get_server_url_from_ws_url", return_value="foo_url")
     async def test_queue_join_routes_sets_url_if_none_set(self, mock_get_url):
         io = Interface(lambda x: x, "text", "text").queue()

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1,7 +1,6 @@
 """Contains tests for networking.py and app.py"""
 import json
 import os
-import sys
 import tempfile
 from contextlib import closing
 from unittest.mock import patch


### PR DESCRIPTION
There was a bug in `cancels` where if a generator function was canceled, then subsequent runs of that function would continue iterating from where the previous iterator left off. Did some related cleanup of the code

I spent a lot of time trying to write an e2e test for this, but wasn't able to get it to work (see below). If anyone knows how to get it to work, I'm open to suggestions or feel free to push to this PR. But in the meantime, you can test by running the `cancel_events` demo or the test code below:

```py
import gradio as gr
import time

def test_streaming(message):
    for i in range(len(message)):
        time.sleep(1)
        yield message[: i+1]

with gr.Blocks() as demo:
    a = gr.Textbox()
    b = gr.Textbox()
    btn = gr.Button("Stop")
    ev = a.submit(test_streaming, a, b)
    btn.click(None, None, None, cancels=ev)
    
demo.queue().launch()
```

Steps to reproduce:
1. Run demo code
2. Start generator
3. Before generator completes, cancel it
4. Re-run generator (notice where it starts)

(Observed this while working on #4962)