### PR TITLE
Add CSS resets and specifiers to play nice with HF blog

### DIFF
--- a/.changeset/evil-mirrors-switch.md
+++ b/.changeset/evil-mirrors-switch.md
@@ -1,0 +1,6 @@
+---
+"@gradio/theme": patch
+"gradio": patch
+---
+
+fix:Add CSS resets and specifiers to play nice with HF blog

--- a/js/theme/src/reset.css
+++ b/js/theme/src/reset.css
@@ -213,6 +213,7 @@ img,
 video {
 	max-width: 100%;
 	height: auto;
+	margin: 0;
 }
 
 [hidden] {

--- a/js/theme/src/typography.css
+++ b/js/theme/src/typography.css
@@ -23,6 +23,7 @@
 	margin: var(--spacing-xxl) 0 var(--spacing-lg);
 	font-weight: var(--prose-header-text-weight);
 	line-height: 1.3;
+	color: var(--body-text-color);
 }
 
 .prose > *:first-child {


### PR DESCRIPTION
footer img was inheriting margin, and h1 was inheriting color.

Fixes: #4963