### PR TITLE
fix `deploy-pr-to-spaces` wheel link

### DIFF
--- a/.github/workflows/deploy-pr-to-spaces.yml
+++ b/.github/workflows/deploy-pr-to-spaces.yml
@@ -51,8 +51,6 @@ jobs:
         ${{ secrets.SPACES_DEPLOY_TOKEN }} \
         --gradio-version ${{ env.gradio_version }} > url.txt
         echo "SPACE_URL=$(cat url.txt)" >> $GITHUB_ENV
-    - name: test
-      run: echo ${{ env.gh_sha }} ${{ github.sha }}
     - name: Comment On Release PR
       uses: thollander/actions-comment-pull-request@v2
       with:


### PR DESCRIPTION
## Description

We were using the wrong github SHA variable in the wheel install link. This PR fixes that link posted in the `deploy-pr-to-spaces` workflow.

Closes: #4914 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
