### PR TITLE
JS Client: Fixes cannot read properties of null (reading 'is_file')

### DIFF
--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -395,7 +395,8 @@ export function api_factory(fetch_implementation: typeof fetch) {
 						});
 
 						post_data(
-							`${http_protocol}//${host + config.path}/run${_endpoint.startsWith("/") ? _endpoint : `/${_endpoint}`
+							`${http_protocol}//${host + config.path}/run${
+								_endpoint.startsWith("/") ? _endpoint : `/${_endpoint}`
 							}`,
 							{
 								...payload,
@@ -406,11 +407,11 @@ export function api_factory(fetch_implementation: typeof fetch) {
 							.then(([output, status_code]) => {
 								const data = transform_files
 									? transform_output(
-										output.data,
-										api_info,
-										config.root,
-										config.root_url
-									)
+											output.data,
+											api_info,
+											config.root,
+											config.root_url
+									  )
 									: output.data;
 								if (status_code == 200) {
 									fire_event({
@@ -538,11 +539,11 @@ export function api_factory(fetch_implementation: typeof fetch) {
 									time: new Date(),
 									data: transform_files
 										? transform_output(
-											data.data,
-											api_info,
-											config.root,
-											config.root_url
-										)
+												data.data,
+												api_info,
+												config.root,
+												config.root_url
+										  )
 										: data.data,
 									endpoint: _endpoint,
 									fn_index

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -395,8 +395,7 @@ export function api_factory(fetch_implementation: typeof fetch) {
 						});
 
 						post_data(
-							`${http_protocol}//${host + config.path}/run${
-								_endpoint.startsWith("/") ? _endpoint : `/${_endpoint}`
+							`${http_protocol}//${host + config.path}/run${_endpoint.startsWith("/") ? _endpoint : `/${_endpoint}`
 							}`,
 							{
 								...payload,
@@ -407,11 +406,11 @@ export function api_factory(fetch_implementation: typeof fetch) {
 							.then(([output, status_code]) => {
 								const data = transform_files
 									? transform_output(
-											output.data,
-											api_info,
-											config.root,
-											config.root_url
-									  )
+										output.data,
+										api_info,
+										config.root,
+										config.root_url
+									)
 									: output.data;
 								if (status_code == 200) {
 									fire_event({
@@ -539,11 +538,11 @@ export function api_factory(fetch_implementation: typeof fetch) {
 									time: new Date(),
 									data: transform_files
 										? transform_output(
-												data.data,
-												api_info,
-												config.root,
-												config.root_url
-										  )
+											data.data,
+											api_info,
+											config.root,
+											config.root_url
+										)
 										: data.data,
 									endpoint: _endpoint,
 									fn_index
@@ -776,7 +775,7 @@ function transform_output(
 					? [normalise_file(img[0], root_url, remote_url), img[1]]
 					: [normalise_file(img, root_url, remote_url), null];
 			});
-		} else if (typeof d === "object" && d.is_file) {
+		} else if (typeof d === "object" && d?.is_file) {
 			return normalise_file(d, root_url, remote_url);
 		} else {
 			return d;


### PR DESCRIPTION
## Description

In transform_output, typeof d can be an object even if the property is_file doesn't exist on d. Therefore attempting to access d.is_file will error out. This commit fixes that by failing quietly if the is_file property doesn't exist on d.

Closes: (no issue, the fix is very small)

## 🎯 PRs Should Target Issues

> Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

The fix is very small.