### PR TITLE
Dont format on save for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,6 @@
 	"cssvar.extensions": ["js", "css", "html", "jsx", "tsx", "svelte"],
 	"python.analysis.extraPaths": ["./gradio/themes/utils"],
 	"prettier.useTabs": true,
-	"editor.formatOnSave": false,
 	"svelte.plugin.svelte.format.enable": true,
 	"svelte.plugin.svelte.diagnostics.enable": false,
 	"prettier.configPath": ".config/.prettierrc.json",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,6 @@
 	"cssvar.disableSort": true,
 	"cssvar.extensions": ["js", "css", "html", "jsx", "tsx", "svelte"],
 	"python.analysis.extraPaths": ["./gradio/themes/utils"],
-	"prettier.useTabs": true,
 	"svelte.plugin.svelte.format.enable": true,
 	"svelte.plugin.svelte.diagnostics.enable": false,
 	"prettier.configPath": ".config/.prettierrc.json",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
 	"cssvar.extensions": ["js", "css", "html", "jsx", "tsx", "svelte"],
 	"python.analysis.extraPaths": ["./gradio/themes/utils"],
 	"prettier.useTabs": true,
-	"editor.formatOnSave": true,
+	"editor.formatOnSave": false,
 	"svelte.plugin.svelte.format.enable": true,
 	"svelte.plugin.svelte.diagnostics.enable": false,
 	"prettier.configPath": ".config/.prettierrc.json",


### PR DESCRIPTION
## Description
Whenever I update a `.svelte`, `.json` or `.ts` file, vs code will do some autoformatting that introduces a lot of additional changes irrelevant to my PR and doesn't conform to our standard lint commands anyways.

So I'm deleting it so that global user preferences takeover.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
