### PR TITLE
`gr.Dropdown` now has correct behavior in static mode as well as when an option is selected

### DIFF
--- a/.changeset/eight-humans-sniff.md
+++ b/.changeset/eight-humans-sniff.md
@@ -1,0 +1,6 @@
+---
+"@gradio/form": patch
+"gradio": patch
+---
+
+fix:`gr.Dropdown` now has correct behavior in static mode as well as when an option is selected

--- a/guides/03_building-with-blocks/01_blocks-and-event-listeners.md
+++ b/guides/03_building-with-blocks/01_blocks-and-event-listeners.md
@@ -15,13 +15,13 @@ $demo_hello_blocks
 
 ## Event Listeners and Interactivity
 
-In the example above, you'll notice that you are able to edit Textbox `name`, but not Textbox `output`. This is because any Component that acts as an input to an event listener is made interactive. However, since Textbox `output` acts only as an output, Gradio determines that it should not be made interactive. You can override the default behavior and directly configure the interactivity of a Component with the `interactive=` keyword argument. 
+In the example above, you'll notice that you are able to edit Textbox `name`, but not Textbox `output`. This is because any Component that acts as an input to an event listener is made interactive. However, since Textbox `output` acts only as an output, Gradio determines that it should not be made interactive. You can override the default behavior and directly configure the interactivity of a Component with the boolean `interactive` keyword argument. 
 
 ```python
 output = gr.Textbox(label="Output", interactive=True)
 ```
 
-_Note_: What happens if a Gradio component is neither an input nor an output? If a component is constructed with a default value, then it is presumed to be displaying content and is rendered non-interactive. Otherwise, it is rendered interactive. Again, this behavior can be overridden by specifying a value for the `interactive` property.
+_Note_: What happens if a Gradio component is neither an input nor an output? If a component is constructed with a default value, then it is presumed to be displaying content and is rendered non-interactive. Otherwise, it is rendered interactive. Again, this behavior can be overridden by specifying a value for the `interactive` argument.
 
 ## Types of Event Listeners
 

--- a/guides/03_building-with-blocks/01_blocks-and-event-listeners.md
+++ b/guides/03_building-with-blocks/01_blocks-and-event-listeners.md
@@ -21,7 +21,7 @@ In the example above, you'll notice that you are able to edit Textbox `name`, bu
 output = gr.Textbox(label="Output", interactive=True)
 ```
 
-_Note_: You might ask what happens if a Gradio component is neither an input nor an output. If a component is constructed with a default value, then it is presumed to be displaying content and is rendered non-interactive. Otherwise, it is rendered interactive. 
+_Note_: What happens if a Gradio component is neither an input nor an output? If a component is constructed with a default value, then it is presumed to be displaying content and is rendered non-interactive. Otherwise, it is rendered interactive. Again, this behavior can be overridden by specifying a value for the `interactive` property.
 
 ## Types of Event Listeners
 

--- a/guides/03_building-with-blocks/01_blocks-and-event-listeners.md
+++ b/guides/03_building-with-blocks/01_blocks-and-event-listeners.md
@@ -15,11 +15,13 @@ $demo_hello_blocks
 
 ## Event Listeners and Interactivity
 
-In the example above, you'll notice that you are able to edit Textbox `name`, but not Textbox `output`. This is because any Component that acts as an input to an event listener is made interactive. However, since Textbox `output` acts only as an output, it is not interactive. You can directly configure the interactivity of a Component with the `interactive=` keyword argument. 
+In the example above, you'll notice that you are able to edit Textbox `name`, but not Textbox `output`. This is because any Component that acts as an input to an event listener is made interactive. However, since Textbox `output` acts only as an output, Gradio determines that it should not be made interactive. You can override the default behavior and directly configure the interactivity of a Component with the `interactive=` keyword argument. 
 
 ```python
 output = gr.Textbox(label="Output", interactive=True)
 ```
+
+_Note_: You might ask what happens if a Gradio component is neither an input nor an output. If a component is constructed with a default value, then it is presumed to be displaying content and is rendered non-interactive. Otherwise, it is rendered interactive. 
 
 ## Types of Event Listeners
 

--- a/js/form/src/Dropdown.stories.svelte
+++ b/js/form/src/Dropdown.stories.svelte
@@ -1,0 +1,26 @@
+<script>
+	import { Meta, Template, Story } from "@storybook/addon-svelte-csf";
+	import Dropdown from "./Dropdown.svelte";
+</script>
+
+<Meta
+	title="Components/Dropdown"
+	component={Dropdown}
+	argTypes={{
+        multiselect: {
+            control: [true, false],
+            description: "Whether to autoplay the video on load",
+			name: "multiselect",
+			value: false
+        }
+     }}
+/>
+
+<Template let:args>
+	<Dropdown {...args} />
+</Template>
+
+<Story name="Default" args={{ value:"swim", choices:["run", "swim", "jump"], label:"Dropdown"}} />
+<Story name="Multiselect" args={{ value:["swim", "run"], choices:["run", "swim", "jump"], label:"Multiselect Dropdown", multiselect:true}} />
+<Story name="Multiselect Static" args={{ value:["swim", "run"], choices:["run", "swim", "jump"], label:"Multiselect Dropdown", multiselect:true, disabled:true}} />
+

--- a/js/form/src/Dropdown.svelte
+++ b/js/form/src/Dropdown.svelte
@@ -72,8 +72,11 @@
 	}
 
 	function remove(option: string): void {
-		value = value as string[];
-		value = value.filter((v: string) => v !== option);
+		if (!disabled)
+		{
+			value = value as string[];
+			value = value.filter((v: string) => v !== option);
+		}
 		dispatch("select", {
 			index: choices.indexOf(option),
 			value: option,
@@ -87,7 +90,7 @@
 		e.preventDefault();
 	}
 
-	function handle_blur(e: FocusEvent) {
+	function handle_blur(e: FocusEvent): void {
 		if (multiselect) {
 			inputValue = "";
 		} else if (!allow_custom_value) {
@@ -104,14 +107,10 @@
 		dispatch("blur");
 	}
 
-	function handle_focus(e: FocusEvent){
+	function handle_focus(e: FocusEvent): void{
 		dispatch("focus");
-		showOptions = !showOptions;
-		if (showOptions) {
-			filtered = choices;
-		} else {
-			filterInput.blur();
-		}
+		showOptions = true;
+		filtered = choices;
 	}
 
 	function handleOptionMousedown(e: any): void {
@@ -137,6 +136,7 @@
 					value: option,
 					selected: true
 				});
+				filterInput.blur();
 			}
 		}
 	}
@@ -154,6 +154,7 @@
 				}
 				inputValue = activeOption;
 				showOptions = false;
+				filterInput.blur();
 			} else if (multiselect && Array.isArray(value)) {
 				value.includes(activeOption) ? remove(activeOption) : add(activeOption);
 				inputValue = "";
@@ -209,13 +210,15 @@
 					<!-- svelte-ignore a11y-click-events-have-key-events -->
 					<div on:click|preventDefault={() => remove(s)} class="token">
 						<span>{s}</span>
+						{#if !disabled}
 						<div
 							class:hidden={disabled}
 							class="token-remove"
 							title="Remove {s}"
 						>
-							<Remove />
-						</div>
+						<Remove />
+					</div>
+					{/if}
 					</div>
 				{/each}
 			{/if}


### PR DESCRIPTION
2 more fixes to `gr.Dropdown()`:

1. In static mode, the `gr.Dropdown(multiselect=True)` still had the X icons, and clicking on an option would remove it. This behavior has been disabled in static mode. Test with:

```py
import gradio as gr

with gr.Blocks() as gr_training_zoo:
    d2 = gr.Dropdown(
        ["ran", "swam", "ate", "slept"],
        value=["swam"],
        multiselect=True,
        label="Initialized",
        info="Only value removal allowed, no adding",
    )

gr_training_zoo.launch()
``` 

Also we had never really documented how Gradio determines the interactivity of a component if `interactive` was not specified and the component was neither an input nor an output. I've added that to the relevant Guide. Together, this closes: #4280. 

2. Clicking on a dropdown option `gr.Dropdown(multiselect=False)` would select it, yet it would keep the focus on the Dropdown and in particular would keep the cursor typing. This led to an interesting bug described in #4269. I've changed the behavior so that clicking on a choice actually unfocuses from the dropdown. This is a more satisfying UX, more similar to the native select element's UX, and closes: #4269.

Also added a few `gr.Dropdown` stories to prevent regression of the former issue. 