### PR TITLE
Reset textbox value to empty string when value is None

### DIFF
--- a/.changeset/good-years-ask.md
+++ b/.changeset/good-years-ask.md
@@ -1,0 +1,6 @@
+---
+"@gradio/textbox": patch
+"gradio": patch
+---
+
+fix:Reset textbox value to empty string when value is None

--- a/js/textbox/shared/Textbox.svelte
+++ b/js/textbox/shared/Textbox.svelte
@@ -28,6 +28,8 @@
 
 	$: value, el && lines !== max_lines && resize({ target: el });
 
+	$: if (value === null) value = "";
+
 	const dispatch = createEventDispatcher<{
 		change: string;
 		submit: undefined;
@@ -70,7 +72,7 @@
 		const text = target.value;
 		const index: [number, number] = [
 			target.selectionStart as number,
-			target.selectionEnd as number
+			target.selectionEnd as number,
 		];
 		dispatch("select", { value: text.substring(...index), index: index });
 	}
@@ -132,7 +134,7 @@
 		resize({ target: _el });
 
 		return {
-			destroy: () => _el.removeEventListener("input", resize)
+			destroy: () => _el.removeEventListener("input", resize),
 		};
 	}
 </script>


### PR DESCRIPTION
## Description

When the textbox value is cleared, it's set to `None` on the backend. When the value is set to None in the backend, this PR adds a func set it to `""` in the frontend. 

Closes: #5103

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
