### PR TITLE
Update typing info for `gr.CheckboxGroup` and `gr.Radio`

### DIFF
--- a/.changeset/gold-radios-train.md
+++ b/.changeset/gold-radios-train.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Update typing info for `gr.CheckboxGroup` and `gr.Radio`

--- a/.changeset/gold-radios-train.md
+++ b/.changeset/gold-radios-train.md
@@ -1,5 +1,4 @@
 ---
-"gradio": patch
 ---
 
 fix:Update typing info for `gr.CheckboxGroup` and `gr.Radio`

--- a/.changeset/quick-toes-teach.md
+++ b/.changeset/quick-toes-teach.md
@@ -1,5 +1,0 @@
----
-"gradio": patch
----
-
-fix:Update typing info for `gr.CheckboxGroup` and `gr.Radio`

--- a/gradio/components/checkboxgroup.py
+++ b/gradio/components/checkboxgroup.py
@@ -159,7 +159,9 @@ class CheckboxGroup(
                 f"Unknown type: {self.type}. Please choose from: 'value', 'index'."
             )
 
-    def postprocess(self, y: list[str | int | float] | str | int | float | None) -> list[str | int | float]:
+    def postprocess(
+        self, y: list[str | int | float] | str | int | float | None
+    ) -> list[str | int | float]:
         """
         Any postprocessing needed to be performed on function output.
         Parameters:

--- a/gradio/components/checkboxgroup.py
+++ b/gradio/components/checkboxgroup.py
@@ -27,17 +27,17 @@ class CheckboxGroup(
 ):
     """
     Creates a set of checkboxes of which a subset can be checked.
-    Preprocessing: passes the list of checked checkboxes as a {List[str]} or their indices as a {List[int]} into the function, depending on `type`.
-    Postprocessing: expects a {List[str]}, each element of which becomes a checked checkbox.
-    Examples-format: a {List[str]} representing the values to be checked.
+    Preprocessing: passes the list of checked checkboxes as a {List[str | int | float]} or their indices as a {List[int]} into the function, depending on `type`.
+    Postprocessing: expects a {List[str | int | float]}, each element of which becomes a checked checkbox.
+    Examples-format: a {List[str | int | float]} representing the values to be checked.
     Demos: sentence_builder, titanic_survival
     """
 
     def __init__(
         self,
-        choices: list[str] | None = None,
+        choices: list[str | float | int] | None = None,
         *,
-        value: list[str] | str | Callable | None = None,
+        value: list[str | float | int] | str | float | int | Callable | None = None,
         type: Literal["value", "index"] = "value",
         label: str | None = None,
         info: str | None = None,
@@ -54,8 +54,8 @@ class CheckboxGroup(
     ):
         """
         Parameters:
-            choices: list of options to select from.
-            value: default selected list of options. If callable, the function will be called whenever the app loads to set the initial value of the component.
+            choices: list of (string or numeric) options to select from.
+            value: default selected list of options. If a single choice is selected, it can be passed in as a string or numeric type. If callable, the function will be called whenever the app loads to set the initial value of the component.
             type: Type of value to be returned by component. "value" returns the list of strings of the choices selected, "index" returns the list of indices of the choices selected.
             label: component name in interface.
             info: additional component description.
@@ -115,7 +115,7 @@ class CheckboxGroup(
 
     @staticmethod
     def update(
-        value: list[str]
+        value: list[str | int | float]
         | str
         | Literal[_Keywords.NO_VALUE]
         | None = _Keywords.NO_VALUE,
@@ -143,7 +143,7 @@ class CheckboxGroup(
             "__type__": "update",
         }
 
-    def preprocess(self, x: list[str]) -> list[str] | list[int]:
+    def preprocess(self, x: list[str | int | float]) -> list[str | int | float]:
         """
         Parameters:
             x: list of selected choices
@@ -159,7 +159,7 @@ class CheckboxGroup(
                 f"Unknown type: {self.type}. Please choose from: 'value', 'index'."
             )
 
-    def postprocess(self, y: list[str] | str | None) -> list[str]:
+    def postprocess(self, y: list[str | int | float] | str | int | float | None) -> list[str | int | float]:
         """
         Any postprocessing needed to be performed on function output.
         Parameters:

--- a/gradio/components/radio.py
+++ b/gradio/components/radio.py
@@ -116,7 +116,11 @@ class Radio(
 
     @staticmethod
     def update(
-        value: str | int | float | Literal[_Keywords.NO_VALUE] | None = _Keywords.NO_VALUE,
+        value: str
+        | int
+        | float
+        | Literal[_Keywords.NO_VALUE]
+        | None = _Keywords.NO_VALUE,
         choices: list[str | int | float] | None = None,
         label: str | None = None,
         info: str | None = None,

--- a/gradio/components/radio.py
+++ b/gradio/components/radio.py
@@ -26,9 +26,9 @@ class Radio(
     NeighborInterpretable,
 ):
     """
-    Creates a set of radio buttons of which only one can be selected.
-    Preprocessing: passes the value of the selected radio button as a {str} or its index as an {int} into the function, depending on `type`.
-    Postprocessing: expects a {str} corresponding to the value of the radio button to be selected.
+    Creates a set of (string or numeric type) radio buttons of which only one can be selected.
+    Preprocessing: passes the value of the selected radio button as a {str} or {int} or {float} or its index as an {int} into the function, depending on `type`.
+    Postprocessing: expects a {str} or {int} or {float} corresponding to the value of the radio button to be selected.
     Examples-format: a {str} representing the radio option to select.
 
     Demos: sentence_builder, titanic_survival, blocks_essay
@@ -36,9 +36,9 @@ class Radio(
 
     def __init__(
         self,
-        choices: list[str] | None = None,
+        choices: list[str | int | float] | None = None,
         *,
-        value: str | Callable | None = None,
+        value: str | int | float | Callable | None = None,
         type: str = "value",
         label: str | None = None,
         info: str | None = None,
@@ -116,8 +116,8 @@ class Radio(
 
     @staticmethod
     def update(
-        value: Any | Literal[_Keywords.NO_VALUE] | None = _Keywords.NO_VALUE,
-        choices: list[str] | None = None,
+        value: str | int | float | Literal[_Keywords.NO_VALUE] | None = _Keywords.NO_VALUE,
+        choices: list[str | int | float] | None = None,
         label: str | None = None,
         info: str | None = None,
         show_label: bool | None = None,
@@ -141,7 +141,7 @@ class Radio(
             "__type__": "update",
         }
 
-    def preprocess(self, x: str | None) -> str | int | None:
+    def preprocess(self, x: str | int | float | None) -> str | int | float | None:
         """
         Parameters:
             x: selected choice


### PR DESCRIPTION
Updates the docstrings for `gr.CheckboxGroup` and `gr.Radio` to include the fact that the components can pass in and return numeric types, not just strings.

Closes: #4859 -- I decided against changing `gr.Dropdown()` to preserve numeric types. Currently `gr.Dropdown` casts everything to a string, the inconsistency is annoying, but changing it would be a breaking change -- it would, in all likelihood, break some demos. Since the community hasn't raised any issues, I've decided to leave as is