### PR TITLE
Fix dataset features and dataset preview for HuggingFaceDatasetSaver

### DIFF
--- a/.changeset/new-icons-refuse.md
+++ b/.changeset/new-icons-refuse.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-fix:WIP: Fix dataset features and dataset preview for HuggingFaceDatasetSaver
+fix:Fix dataset features and dataset preview for HuggingFaceDatasetSaver

--- a/.changeset/new-icons-refuse.md
+++ b/.changeset/new-icons-refuse.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+fix:WIP: Fix dataset features and dataset preview for HuggingFaceDatasetSaver

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -261,6 +261,7 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
                 ]
             },
             overwrite=True,
+            token=self.hf_token
         )
 
         # Setup flagging dir

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -433,7 +433,8 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
                 assert Path(deserialized).exists()
                 row.append(str(Path(deserialized).relative_to(self.dataset_dir)))
             except (AssertionError, TypeError, ValueError):
-                row.append(str(deserialized))
+                deserialized = "" if deserialized is None else str(deserialized)
+                row.append(deserialized)
 
             # If component is eligible for a preview, add the URL of the file
             # Be mindful that images and audio can be None

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -261,7 +261,7 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
                 ]
             },
             overwrite=True,
-            token=self.hf_token
+            token=self.hf_token,
         )
 
         # Setup flagging dir

--- a/test/test_flagging.py
+++ b/test/test_flagging.py
@@ -46,7 +46,8 @@ class TestHuggingFaceDatasetSaver:
         return_value=MagicMock(repo_id="gradio-tests/test"),
     )
     @patch("huggingface_hub.hf_hub_download")
-    def test_saver_setup(self, mock_download, mock_create):
+    @patch("huggingface_hub.metadata_update")
+    def test_saver_setup(self, metadata_update, mock_download, mock_create):
         flagger = flagging.HuggingFaceDatasetSaver("test_token", "test")
         with tempfile.TemporaryDirectory() as tmpdirname:
             flagger.setup([gr.Audio, gr.Textbox], tmpdirname)
@@ -60,8 +61,9 @@ class TestHuggingFaceDatasetSaver:
     @patch("huggingface_hub.hf_hub_download")
     @patch("huggingface_hub.upload_folder")
     @patch("huggingface_hub.upload_file")
+    @patch("huggingface_hub.metadata_update")
     def test_saver_flag_same_dir(
-        self, mock_upload_file, mock_upload, mock_download, mock_create
+        self, metadata_update, mock_upload_file, mock_upload, mock_download, mock_create
     ):
         with tempfile.TemporaryDirectory() as tmpdirname:
             io = gr.Interface(
@@ -89,8 +91,9 @@ class TestHuggingFaceDatasetSaver:
     @patch("huggingface_hub.hf_hub_download")
     @patch("huggingface_hub.upload_folder")
     @patch("huggingface_hub.upload_file")
+    @patch("huggingface_hub.metadata_update")
     def test_saver_flag_separate_dirs(
-        self, mock_upload_file, mock_upload, mock_download, mock_create
+        self, metadata_update, mock_upload_file, mock_upload, mock_download, mock_create
     ):
         with tempfile.TemporaryDirectory() as tmpdirname:
             io = gr.Interface(


### PR DESCRIPTION
## Description

Fixes:
- If a media file (Image/Audio) was None, flagging would fail
- Jsonl dataset format was not compatible with datasets library
- Paths in json files now include the full path relative to the root of the dataset dir. This helps loading to HuggingFace datasets library.


Internal thread where this came up: https://huggingface.slack.com/archives/C02QZLG8GMN/p1691444822924499

To test:

Set up a demo with flagging
```python
import gradio as gr

def echo(msg, history, img):
    return msg

with gr.Blocks() as demo:
    image = gr.Image(label='Image')
    chat = gr.ChatInterface(echo, additional_inputs=[image])
    flagger = gr.Button("Flag")

    flagging = gr.HuggingFaceDatasetSaver(
        dataset_name="chatinterface_with_image_csv",
        hf_token="<your token>",
        separate_dirs=True)
    flagging.setup([chat.chatbot, image], "chatinterface_with_image_csv_2")
    flagger.click(lambda *args: flagging.flag(flag_data=args), inputs=[chat.chatbot , image], outputs=None, preprocess=False)

demo.launch()
```

Flag a couple with and without the image as None, then check out the dataset:
https://huggingface.co/datasets/freddyaboulton/chatinterface_with_image_json

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
