### PR TITLE
Fixes the display of minutes in the video player

### DIFF
--- a/.changeset/wide-bars-train.md
+++ b/.changeset/wide-bars-train.md
@@ -1,0 +1,6 @@
+---
+"@gradio/video": patch
+"gradio": patch
+---
+
+fix:Fixes the display of minutes in the video player

--- a/js/video/shared/Player.svelte
+++ b/js/video/shared/Player.svelte
@@ -67,7 +67,7 @@
 
 		const minutes = Math.floor(seconds / 60);
 		let _seconds: number | string = Math.floor(seconds % 60);
-		if (seconds < 10) _seconds = `0${_seconds}`;
+		if (_seconds < 10) _seconds = `0${_seconds}`;
 
 		return `${minutes}:${_seconds}`;
 	}


### PR DESCRIPTION
Tiniest PR ever, just to fix: #5132 

Test with:

```py
import gradio as gr

with gr.Blocks() as demo:
    gr.Video("https://kevinqhlin-univtg.hf.space/file=/tmp/gradio/a4dc9029d4e7eb3a2ae7bba8316a4a10ade920a0/youtube.mp4")
    
demo.launch()
```

Or if you want to create longer local video files:

```py
from moviepy.editor import *

def color_clip(size, duration, fps=25, color=(0,0,0), output='color.mp4'):
    ColorClip(size, color, duration=duration).write_videofile(output, fps=fps)

size = (200, 100)
duration = 2*60*60

color_clip(size, duration)

import gradio as gr

with gr.Blocks() as demo:
    gr.Video("color.mp4")
    
demo.launch()
```