### PR TITLE
Fix Add row_count and col_count to Dataframe.update

### DIFF
--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -11,6 +11,7 @@ from gradio_client.serializing import JSONSerializable
 
 from gradio import utils
 from gradio.components.base import IOComponent, _Keywords
+from gradio.deprecation import warn_deprecation
 from gradio.events import (
     Changeable,
     EventListenerMethod,
@@ -166,7 +167,9 @@ class Dataframe(Changeable, Inputable, Selectable, IOComponent, JSONSerializable
     def update(
         value: Any | Literal[_Keywords.NO_VALUE] | None = _Keywords.NO_VALUE,
         max_rows: int | None = None,
-        max_cols: str | None = None,
+        max_cols: int | None = None,
+        row_count: int | None | tuple[int, str] = None,
+        col_count: str | None | tuple[int, str] = None,
         label: str | None = None,
         show_label: bool | None = None,
         scale: int | None = None,
@@ -174,9 +177,14 @@ class Dataframe(Changeable, Inputable, Selectable, IOComponent, JSONSerializable
         interactive: bool | None = None,
         visible: bool | None = None,
     ):
+        if max_rows or max_cols:
+            warn_deprecation(
+                "max_rows and max_cols parameters are deprecated and have no effect. "
+                "Please use row_count and col_count."
+            )
         return {
-            "max_rows": max_rows,
-            "max_cols": max_cols,
+            "row_count": row_count,
+            "col_count": col_count,
             "label": label,
             "show_label": show_label,
             "scale": scale,

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1166,6 +1166,17 @@ class TestDataframe:
             "wrap": False,
         }
 
+    def test_dataframe_update(self):
+        update = gr.DataFrame.update(row_count=(3, "fixed"), col_count=(4, "dynamic"))
+        assert update["row_count"] == (3, "fixed")
+        assert update["col_count"] == (4, "dynamic")
+
+        with pytest.warns(
+            GradioDeprecationWarning,
+            match="max_rows and max_cols parameters are deprecated",
+        ):
+            gr.DataFrame.update(max_cols=2, max_rows=4)
+
     def test_postprocess(self):
         """
         postprocess


### PR DESCRIPTION
## Description

Fixes #5182

As discussed in #5066, we can't get rid of the update method yet for backwards compatibility so we still need to add the correct parameters to the function signature.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
