### PR TITLE
Fix the images in the theme builder to use permanent URI

### DIFF
--- a/.changeset/light-mice-bake.md
+++ b/.changeset/light-mice-bake.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix the images in the theme builder to use permanent URI

--- a/.changeset/light-mice-bake.md
+++ b/.changeset/light-mice-bake.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Fix the images in the theme builder to use permanent URI

--- a/gradio/themes/app.py
+++ b/gradio/themes/app.py
@@ -63,7 +63,7 @@ with gr.Blocks(theme=gr.themes.Default()) as demo:
             check = gr.Checkbox(label="Go")
         with gr.Column(variant="panel", scale=2):
             img = gr.Image(
-                "https://raw.githubusercontent.com/gradio-app/gradio/main/js/_website/src/assets/img/header-image.jpg",
+                "https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg",
                 label="Image",
             ).style(height=320)
             with gr.Row():
@@ -74,7 +74,7 @@ with gr.Blocks(theme=gr.themes.Default()) as demo:
 
                 def go(*args):
                     time.sleep(3)
-                    return "https://raw.githubusercontent.com/gradio-app/gradio/main/js/_website/src/assets/img/header-image.jpg"
+                    return "https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpgjpg"
 
                 go_btn.click(go, [radio, drop, drop_2, check, name], img, api_name="go")
 

--- a/gradio/themes/builder_app.py
+++ b/gradio/themes/builder_app.py
@@ -351,7 +351,7 @@ with gr.Blocks(  # noqa: SIM117
                     check = gr.Checkbox(label="Go")
                 with gr.Column(variant="panel", scale=2):
                     img = gr.Image(
-                        "https://raw.githubusercontent.com/gradio-app/gradio/main/js/_website/src/assets/img/header-image.jpg",
+                        "https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg",
                         label="Image",
                         height=320,
                     )
@@ -365,7 +365,7 @@ with gr.Blocks(  # noqa: SIM117
 
                         def go(*args):
                             time.sleep(3)
-                            return "https://raw.githubusercontent.com/gradio-app/gradio/main/js/_website/src/assets/img/header-image.jpg"
+                            return "https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg"
 
                         go_btn.click(
                             go,


### PR DESCRIPTION
The header image in the theme builder was referencing a file from our GitHub repo which was moved due to recent refactoring. I've uploaded the image to the S3 bucket and updated the references.