### PR TITLE
Fix for `gr.File()` "stuck" uploading

### DIFF
--- a/.changeset/eight-cooks-admire.md
+++ b/.changeset/eight-cooks-admire.md
@@ -1,0 +1,6 @@
+---
+"@gradio/file": minor
+"gradio": minor
+---
+
+feat:Fix for `gr.File()` "stuck" uploading

--- a/js/file/shared/FilePreview.svelte
+++ b/js/file/shared/FilePreview.svelte
@@ -33,9 +33,9 @@
 					</td>
 
 					<td class="download">
-						{#if file.data}
+						{#if file.data || file.blob}
 							<a
-								href={file.data}
+								href={file.data ? file.data : URL.createObjectURL(file.blob)}
 								target="_blank"
 								download={window.__is_colab__
 									? null


### PR DESCRIPTION
## Description
Checks for file blob, and updates download url for file.

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
