### PR TITLE
Better handling of empty dataframe in `gr.DataFrame`

### DIFF
--- a/.changeset/khaki-otters-wear.md
+++ b/.changeset/khaki-otters-wear.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": patch
+"gradio": patch
+---
+
+fix:Better handling of empty dataframe in `gr.DataFrame`

--- a/js/dataframe/Dataframe.stories.svelte
+++ b/js/dataframe/Dataframe.stories.svelte
@@ -1,0 +1,63 @@
+<script>
+	import { Meta, Template, Story } from "@storybook/addon-svelte-csf";
+	import Table from "./shared/Table.svelte";
+</script>
+
+<Meta
+	title="Components/DataFrame"
+	component={Table}
+	argTypes={{
+		editable: {
+			control: [true, false],
+			description: "Whether the DataFrame is editable",
+			name: "interactive",
+			value: true
+		}
+	}}
+/>
+
+<Template let:args>
+	<Table {...args} />
+</Template>
+
+<Story
+	name="Interactive dataframe"
+	args={{
+		values: [
+			["Cat", 5],
+			["Horse", 3],
+			["Snake", 1]
+		],
+		headers: ["Animal", "Votes"],
+		label: "Animals",
+		col_count: [2, "dynamic"],
+		row_count: [3, "dynamic"]
+	}}
+/>
+
+<Story
+	name="Static dataframe"
+	args={{
+		values: [
+			["Cat", 5],
+			["Horse", 3],
+			["Snake", 1]
+		],
+		headers: ["Animal", "Votes"],
+		label: "Animals",
+		col_count: [2, "dynamic"],
+		row_count: [3, "dynamic"],
+		editable: false
+	}}
+/>
+
+<Story
+	name="Empty dataframe"
+	args={{
+		values: [[]],
+		headers: ["Animal", "Votes"],
+		label: "Animals",
+		col_count: [2, "dynamic"],
+		row_count: [0, "dynamic"]
+	}}
+/>

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -27,11 +27,9 @@
 	$: {
 		if (values && !Array.isArray(values)) {
 			headers = values.headers;
-			// values = values.data.length === 0 ? [Array(headers.length).fill("")] : values.data;
 			values = values.data;
 			selected = false;
 		} else if (values === null) {
-			// values = []
 			values = [Array(headers.length).fill("")];
 			selected = false;
 		}
@@ -318,7 +316,6 @@
 
 		if (type === "select" && typeof id == "string") {
 			const { cell } = els[id];
-			// cell?.setAttribute("tabindex", "0");
 			await tick();
 			cell?.focus();
 		}

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -100,7 +100,13 @@
 		)
 			.fill(0)
 			.map((_, i) =>
-				Array(col_count[1] === "fixed" ? col_count[0] : data_row_length > 0 ? _values[0].length : headers.length)
+				Array(
+					col_count[1] === "fixed"
+						? col_count[0]
+						: data_row_length > 0
+						? _values[0].length
+						: headers.length
+				)
 					.fill(0)
 					.map((_, j) => {
 						const id = `${i}-${j}`;
@@ -391,7 +397,7 @@
 	function add_row(index?: number): void {
 		if (row_count[1] !== "dynamic") return;
 		if (data.length === 0) {
-			values = [Array(headers.length).fill("")]
+			values = [Array(headers.length).fill("")];
 			return;
 		}
 		data.splice(
@@ -405,6 +411,7 @@
 					return { id: _id, value: "" };
 				})
 		);
+
 		data = data;
 	}
 

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -30,7 +30,7 @@
 			values = values.data;
 			selected = false;
 		} else if (values === null) {
-			values = [Array(headers.length).fill("")];
+			values = [];
 			selected = false;
 		}
 	}

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -397,7 +397,7 @@
 		data.splice(
 			index ? index + 1 : data.length,
 			0,
-			Array(data[0] ? data[0].length: 1)
+			Array(data[0].length)
 				.fill(0)
 				.map((_, i) => {
 					const _id = `${data.length}-${i}`;

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -27,12 +27,11 @@
 	$: {
 		if (values && !Array.isArray(values)) {
 			headers = values.headers;
-			values =
-				values.data.length === 0
-					? [Array(headers.length).fill("")]
-					: values.data;
+			// values = values.data.length === 0 ? [Array(headers.length).fill("")] : values.data;
+			values = values.data;
 			selected = false;
 		} else if (values === null) {
+			// values = []
 			values = [Array(headers.length).fill("")];
 			selected = false;
 		}
@@ -93,8 +92,7 @@
 		value: string | number;
 		id: string;
 	}[][] {
-		const data_row_length = _values.length > 0 ? _values.length : row_count[0];
-
+		const data_row_length = _values.length;
 		return Array(
 			row_count[1] === "fixed"
 				? row_count[0]
@@ -104,7 +102,7 @@
 		)
 			.fill(0)
 			.map((_, i) =>
-				Array(col_count[1] === "fixed" ? col_count[0] : _values[0].length)
+				Array(col_count[1] === "fixed" ? col_count[0] : data_row_length > 0 ? _values[0].length : headers.length)
 					.fill(0)
 					.map((_, j) => {
 						const id = `${i}-${j}`;
@@ -395,10 +393,14 @@
 
 	function add_row(index?: number): void {
 		if (row_count[1] !== "dynamic") return;
+		if (data.length === 0) {
+			values = [Array(headers.length).fill("")]
+			return;
+		}
 		data.splice(
 			index ? index + 1 : data.length,
 			0,
-			Array(data[0].length)
+			Array(data[0] ? data[0].length: 1)
 				.fill(0)
 				.map((_, i) => {
 					const _id = `${data.length}-${i}`;
@@ -406,7 +408,6 @@
 					return { id: _id, value: "" };
 				})
 		);
-
 		data = data;
 	}
 

--- a/js/dropdown/Dropdown.stories.svelte
+++ b/js/dropdown/Dropdown.stories.svelte
@@ -21,8 +21,21 @@
 </Template>
 
 <Story
-	name="Default"
-	args={{ value: "swim", choices: ["run", "swim", "jump"], label: "Dropdown" }}
+	name="Single-select"
+	args={{ 
+		value: "swim", 
+		choices: ["run", "swim", "jump"], 
+		multiselect: false,
+		label: "Single-select Dropdown", }}
+/>
+<Story
+	name="Single-select Static"
+	args={{ 
+		value: "swim", 
+		choices: ["run", "swim", "jump"], 
+		multiselect: false,
+		disabled: true,
+		label: "Single-select Dropdown", }}
 />
 <Story
 	name="Multiselect"

--- a/js/dropdown/Dropdown.stories.svelte
+++ b/js/dropdown/Dropdown.stories.svelte
@@ -22,20 +22,22 @@
 
 <Story
 	name="Single-select"
-	args={{ 
-		value: "swim", 
-		choices: ["run", "swim", "jump"], 
+	args={{
+		value: "swim",
+		choices: ["run", "swim", "jump"],
 		multiselect: false,
-		label: "Single-select Dropdown", }}
+		label: "Single-select Dropdown"
+	}}
 />
 <Story
 	name="Single-select Static"
-	args={{ 
-		value: "swim", 
-		choices: ["run", "swim", "jump"], 
+	args={{
+		value: "swim",
+		choices: ["run", "swim", "jump"],
 		multiselect: false,
 		disabled: true,
-		label: "Single-select Dropdown", }}
+		label: "Single-select Dropdown"
+	}}
 />
 <Story
 	name="Multiselect"


### PR DESCRIPTION
We were handling empty dataframes incorrectly in the `gr.Dataframe` --> we were turning them into single-row arrays with each cell being "".

This fixes that -- would appreciate if folks could test this out to make sure I didn't miss anything as the dataframe frontend code is quite complex.

Fixes: #5162

Test code:

```py
import gradio as gr
import pandas as pd

df_orig = pd.DataFrame([], columns=['a', 'b', 'c'])

df_fill = pd.DataFrame([[1, 2, 3]], columns=['a', 'b', 'c'])


with gr.Blocks() as demo:
    df = gr.Dataframe(value=df_orig, interactive=True, row_count=(0, "dynamic"))
    df2 = gr.Dataframe(value=df_fill, interactive=True, row_count=(0, "dynamic"))
    btn = gr.Button()
    text = gr.Textbox()
    btn.click(fn=lambda x: x.shape, inputs=df, outputs=text)
demo.queue().launch()
```

Also adds some stories for `gr.DataFrame` to prevent regressions like #5236 and some stories (unrelatedly) for `gr.Dropdown()`