### PR TITLE
Stop passing inputs and preprocessing on iterators

### DIFF
--- a/.changeset/hip-queens-grin.md
+++ b/.changeset/hip-queens-grin.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:ignore this, testing
+feat:Stop passing inputs and preprocessing on iterators

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1222,16 +1222,23 @@ Received inputs:
             )
 
     def preprocess_data(self, fn_index: int, inputs: list[Any], state: dict[int, Any]):
+        import time
+        start = time.time()
         block_fn = self.fns[fn_index]
+        print(1, time.time() - start)
         dependency = self.dependencies[fn_index]
+        print(2, time.time() - start)
 
         self.validate_inputs(fn_index, inputs)
+        print(3, time.time() - start)
 
         if block_fn.preprocess:
             processed_input = []
+            print(4, time.time() - start)
             for i, input_id in enumerate(dependency["inputs"]):
                 try:
                     block = self.blocks[input_id]
+                    print(5, time.time() - start)
                 except KeyError as e:
                     raise InvalidBlockError(
                         f"Input component with id {input_id} used in {dependency['trigger']}() event not found in this gr.Blocks context. You are allowed to nest gr.Blocks contexts, but there must be a gr.Blocks context that contains all components and events."
@@ -1239,12 +1246,16 @@ Received inputs:
                 assert isinstance(
                     block, components.Component
                 ), f"{block.__class__} Component with id {input_id} not a valid input component."
+                print(6, time.time() - start)
                 if getattr(block, "stateful", False):
                     processed_input.append(state.get(input_id))
+                    print(7, time.time() - start)
                 else:
                     processed_input.append(block.preprocess(inputs[i]))
+                    print(8, time.time() - start)
         else:
             processed_input = inputs
+            print(9, time.time() - start)
         return processed_input
 
     def validate_outputs(self, fn_index: int, predictions: Any | list[Any]):

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1061,7 +1061,7 @@ class Blocks(BlockContext):
     async def call_function(
         self,
         fn_index: int,
-        processed_input: list[Any] | None,
+        processed_input: list[Any],
         iterator: AsyncIterator[Any] | None = None,
         requests: routes.Request | list[routes.Request] | None = None,
         event_id: str | None = None,

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1088,7 +1088,6 @@ class Blocks(BlockContext):
             if block_fn.inputs_as_dict:
                 processed_input = [dict(zip(block_fn.inputs, processed_input))]
 
-
             processed_input, progress_index, _ = special_args(
                 block_fn.fn, processed_input, request, event_data
             )


### PR DESCRIPTION
There's no need to be passing inputs and preprocessing them on every generator call - this is extremely inefficient and causes slowdowns if the preprocess step is expensive. Was causing significant issues raised internally here: https://huggingface.slack.com/archives/C02QZLG8GMN/p1692350120362899?thread_ts=1692278870.837829&cid=C02QZLG8GMN

Fixed now, preprocessing only happens on the first step.