### PR TITLE
Ensure `Blocks` translation copy renders correctly

### DIFF
--- a/.changeset/young-plums-swim.md
+++ b/.changeset/young-plums-swim.md
@@ -1,0 +1,6 @@
+---
+"@gradio/app": minor
+"gradio": minor
+---
+
+feat:Ensure `Blocks` translation copy renders correctly

--- a/.changeset/young-plums-swim.md
+++ b/.changeset/young-plums-swim.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/app": minor
-"gradio": minor
+"@gradio/app": patch
+"gradio": patch
 ---
 
-feat:Ensure `Blocks` translation copy renders correctly
+fix:Ensure `Blocks` translation copy renders correctly

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -11,7 +11,6 @@
 		ComponentMeta,
 		Dependency,
 		LayoutNode,
-		Documentation,
 	} from "./components/types";
 	import { setupi18n } from "./i18n";
 	import Render from "./Render.svelte";
@@ -644,10 +643,8 @@
 					}}
 					class="show-api"
 				>
-					$_('errors.use_via_api') <img
-						src={api_logo}
-						alt={$_("common.logo")}
-					/>
+					{$_("errors.use_via_api")}
+					<img src={api_logo} alt={$_("common.logo")} />
 				</button>
 				<div>·</div>
 			{/if}
@@ -657,7 +654,7 @@
 				target="_blank"
 				rel="noreferrer"
 			>
-				$_('common.built_with_gradio')
+				{$_("common.built_with_gradio")}
 				<img src={logo} alt={$_("common.logo")} />
 			</a>
 		</footer>


### PR DESCRIPTION
## Description

`built_with_gradio` and `use_via_api` weren't rendering correctly due to missing curly braces.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
