### PR TITLE
Allow updating the label of `gr.UpdateButton`

### DIFF
--- a/.changeset/eight-things-travel.md
+++ b/.changeset/eight-things-travel.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Allow updating the label of `gr.UpdateButton`

--- a/gradio/components/upload_button.py
+++ b/gradio/components/upload_button.py
@@ -109,6 +109,7 @@ class UploadButton(Clickable, Uploadable, IOComponent, FileSerializable):
         | list[str]
         | Literal[_Keywords.NO_VALUE]
         | None = _Keywords.NO_VALUE,
+        label: str | None = None,
         size: Literal["sm", "lg"] | None = None,
         variant: Literal["primary", "secondary", "stop"] | None = None,
         interactive: bool | None = None,
@@ -124,6 +125,7 @@ class UploadButton(Clickable, Uploadable, IOComponent, FileSerializable):
             "value": value,
             "scale": scale,
             "min_width": min_width,
+            "label": label,
             "__type__": "update",
         }
 


### PR DESCRIPTION
Quick fix needed for idefics demo, cc @yvrjsharma @dawoodkhan82 

Test code:

```py
import gradio as gr

def dummy():
  return gr.update(label='🖼️', interactive=True)

def add_text(*args):
    pass

def add_file(*args):
    pass

def bot(*args):
    pass

with gr.Blocks() as demo:
    chatbot = gr.Chatbot([], elem_id="chatbot", height=750)

    with gr.Row():
        with gr.Column(scale=0.85):
            txt = gr.Textbox(
                show_label=False,
                placeholder="Enter text and press enter, or upload an image",
                container=False,
            )
        with gr.Column(scale=0.15, min_width=0):
            btn = gr.UploadButton(label="📁", file_types=["image", "video", "audio"])

    txt_msg = txt.submit(add_text, [chatbot, txt], [chatbot, txt], queue=False).then(
        bot, chatbot, chatbot
    )
    txt_msg.then(lambda: gr.update(interactive=True), None, [txt], queue=False)
    file_msg = btn.upload(add_file, [chatbot, btn], [chatbot], queue=False).then(bot, chatbot, chatbot)
    btn.upload(dummy, [], btn )
    
demo.launch()
```