### PR TITLE
Restores missing part of bottom border on file component

### DIFF
--- a/.changeset/warm-nails-brush.md
+++ b/.changeset/warm-nails-brush.md
@@ -1,0 +1,6 @@
+---
+"@gradio/file": minor
+"gradio": minor
+---
+
+feat:Restores missing part of bottom border on file component

--- a/.changeset/warm-nails-brush.md
+++ b/.changeset/warm-nails-brush.md
@@ -3,4 +3,4 @@
 "gradio": minor
 ---
 
-feat:Restores missing part of bottom border on file component
+fix:Restores missing part of bottom border on file component

--- a/js/file/static/StaticFile.svelte
+++ b/js/file/static/StaticFile.svelte
@@ -115,6 +115,7 @@
 	{container}
 	{scale}
 	{min_width}
+	allow_overflow={false}
 >
 	<StatusTracker
 		{...loading_status}


### PR DESCRIPTION
Fixes the issue @freddyaboulton found. Test with:

```py
import gradio as gr

path = "cheetah.jpg"

with gr.Blocks() as demo:
    gr.File([path]*5, interactive=False)
    gr.File([path]*5, interactive=True)
    
demo.launch()
```