### PR TITLE
fix: error byte range

### DIFF
--- a/gradio/ranged_response.py
+++ b/gradio/ranged_response.py
@@ -102,7 +102,7 @@ class RangedFileResponse(Response):
                 if not stat.S_ISREG(mode):
                     raise RuntimeError(f"File at path {self.path} is not a file.")
 
-        byte_range = self.range.clamp(0, self.stat_result.st_size)
+        byte_range = self.range.clamp(0, self.stat_result.st_size - 1)
         self.set_range_headers(byte_range)
 
         async with aiofiles.open(self.path, mode="rb") as file:


### PR DESCRIPTION
## Description

When I run the stable diffusion webui, I found it will be slower and slower and there are many threads never stop. After doing further research, I found that there will be an infinite loop at the following code：

```python
# byte_range is (0, 1000), and len(byte_range) will be 1001
remaining_bytes = len(byte_range)
if not byte_range:
    await send(
        {"type": "http.response.body", "body": b"", "more_body": False}
    )
    return

while remaining_bytes > 0:

    # assume chunksize is 1000
    chunk_size = min(self.chunk_size, remaining_bytes)
    
    # for the first time, len(chunk) will read 1000, and never can read other data from file.
    # So, it will be 0 at the second time.
    chunk = await file.read(chunk_size)

    # remaining_bytes = 1001 - 1000 = 1 and will never change again.
    remaining_bytes -= len(chunk)
    await send(
        {
            "type": "http.response.body",
            "body": chunk,
            "more_body": remaining_bytes > 0,
        }
    )
```

After reading the following information, I think we should set the range.end to the total_length - 1:
![b047686465edf99549bb5315c564610e](https://github.com/gradio-app/gradio/assets/22362311/fe720604-8bcd-4b7d-9005-0a59b3e2a9f3)


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
