### PR TITLE
Fix typo in utils.py

### DIFF
--- a/.changeset/two-nails-march.md
+++ b/.changeset/two-nails-march.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix typo in utils.py

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -860,7 +860,7 @@ def concurrency_count_warning(queue: Callable[P, T]) -> Callable[P, T]:
             len(positional) >= 1 or "concurrency_count" in kwargs
         ):
             warnings.warn(
-                "Queue concurrency_count on ZeroGPU Spaces cannot be overriden "
+                "Queue concurrency_count on ZeroGPU Spaces cannot be overridden "
                 "and is always equal to Block's max_threads. "
                 "Consider setting max_threads value on the Block instead"
             )


### PR DESCRIPTION


## Description

overriden -> overridden
