### PR TITLE
Remove stable diffusion demo from landing page

### DIFF
--- a/.changeset/clever-baboons-act.md
+++ b/.changeset/clever-baboons-act.md
@@ -1,0 +1,5 @@
+---
+"website": minor
+---
+
+feat:Remove stable diffusion demo from landing page

--- a/js/_website/src/lib/components/DemosLanding.svelte
+++ b/js/_website/src/lib/components/DemosLanding.svelte
@@ -1,16 +1,11 @@
 <script lang="ts">
-	import { stable_diffusion, sketch, chat } from "../assets/demo_code";
+	import { sketch, chat } from "../assets/demo_code";
 
 	let tabs = [
 		{
 			title: "Sketch Recognition",
 			code: sketch,
 			demo: "gradio/pictionary"
-		},
-		{
-			title: "Stable Diffusion",
-			code: stable_diffusion,
-			demo: "hysts/SD-XL"
 		},
 		{
 			title: "Time Series Forecasting",


### PR DESCRIPTION
Remove stable diffusion demo from landing page due to issues with embedding it. 