### PR TITLE
api_open does not take precedence over show_api 

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1778,7 +1778,7 @@ Received outputs:
             ssl_keyfile_password: If a password is provided, will use this with the ssl certificate for https.
             ssl_verify: If False, skips certificate validation which allows self-signed certificates to be used.
             quiet: If True, suppresses most print statements.
-            show_api: If True, shows the api docs in the footer of the app. Default True. If the queue is enabled, then api_open parameter of .queue() will determine if the api docs are shown, independent of the value of show_api.
+            show_api: If True, shows the api docs in the footer of the app. Default True.             show_api: If True, shows the api docs in the footer of the app. Default True. If the queue is enabled and api_open=True, then api docs are not shown, independent of the value of show_api.
             file_directories: This parameter has been renamed to `allowed_paths`. It will be removed in a future version.
             allowed_paths: List of complete filepaths or parent directories that gradio is allowed to serve (in addition to the directory containing the gradio python file). Must be absolute paths. Warning: if you provide directories, any files in these directories or their subdirectories are accessible to all users of your app.
             blocked_paths: List of complete filepaths or parent directories that gradio is not allowed to serve (i.e. users of your app are not allowed to access). Must be absolute paths. Warning: takes precedence over `allowed_paths` and all other directories exposed by Gradio by default.
@@ -1848,7 +1848,10 @@ Received outputs:
             self.enable_queue = self.enable_queue is True
         if self.enable_queue and not hasattr(self, "_queue"):
             self.queue()
-        self.show_api = self.api_open if self.enable_queue else show_api
+
+        self.show_api = show_api
+        if self.enable_queue and not self.api_open:
+            self.show_api = False
 
         if file_directories is not None:
             warn_deprecation(

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1850,8 +1850,6 @@ Received outputs:
             self.queue()
 
         self.show_api = show_api
-        if self.enable_queue and not self.api_open:
-            self.show_api = False
 
         if file_directories is not None:
             warn_deprecation(

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -630,7 +630,7 @@ def test_predict_route_not_blocked_if_routes_open():
     app, _, _ = demo.queue(api_open=True).launch(
         prevent_thread_lock=True, show_api=False
     )
-    assert demo.show_api
+    assert not demo.show_api
     client = TestClient(app)
 
     result = client.post(


### PR DESCRIPTION
## Description

The two parameters now operate independently. If api_open=False, then the api_page will still be shown. This is a slight change in behavior but users still have the ability to hide them if they wish. If we automatically hide the api docs, user's don't have a way to override that. 

Closes: #5434 


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
