### PR TITLE
ensure dataframe doesn't scroll unless needed

### DIFF
--- a/.changeset/chatty-socks-bow.md
+++ b/.changeset/chatty-socks-bow.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": minor
+"gradio": minor
+---
+
+feat:ensure dataframe doesn't scroll unless needed

--- a/.changeset/chatty-socks-bow.md
+++ b/.changeset/chatty-socks-bow.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/dataframe": minor
-"gradio": minor
+"@gradio/dataframe": patch
+"gradio": patch
 ---
 
-feat:ensure dataframe doesn't scroll unless needed
+fix:ensure dataframe doesn't scroll unless needed

--- a/js/dataframe/shared/VirtualTable.svelte
+++ b/js/dataframe/shared/VirtualTable.svelte
@@ -103,11 +103,14 @@
 			return "forwards";
 		}
 
+		const { top: viewport_top } = viewport.getBoundingClientRect();
 		const { top, bottom } = current.getBoundingClientRect();
-		if (top < 37) {
+
+		if (top - viewport_top < 37) {
 			return "back";
 		}
-		if (bottom > viewport_height) {
+
+		if (bottom - viewport_top > viewport_height) {
 			return "forwards";
 		}
 


### PR DESCRIPTION
## Description

There was some faulty logic when determining if a cell is on or off screen. Clicking a cell would sometimes scroll so that cell appeared at the bottom of the dataframe. This PR fixes it.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
