### PR TITLE
Remove except asyncio.CancelledError which is no longer necessary due to 53d7025

### DIFF
--- a/.changeset/deep-socks-rule.md
+++ b/.changeset/deep-socks-rule.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Remove `except asyncio.CancelledError` which is no longer necessary due to 53d7025

--- a/.changeset/deep-socks-rule.md
+++ b/.changeset/deep-socks-rule.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:Remove `except asyncio.CancelledError` which is no longer necessary due to 53d7025
+feat:Remove except asyncio.CancelledError which is no longer necessary due to 53d7025

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -391,11 +391,6 @@ class Queue:
                 gr_request=gr_request,
                 fn_index_inferred=fn_index_inferred,
             )
-        except asyncio.CancelledError:
-            # `asyncio.CancelledError` can be raised in a normal case and we don't want to show it to the user,
-            # so we catch it here before the `BaseException` handler that prints the traceback.
-            # Ref: https://github.com/gradio-app/gradio/pull/5165#discussion_r1310497840
-            raise
         except Exception as error:
             show_error = app.get_blocks().show_error or isinstance(error, Error)
             traceback.print_exc()


### PR DESCRIPTION
## Description

Ref: https://github.com/gradio-app/gradio/pull/5165#discussion_r1311215406

This `except` block is no longer necessary because the following `except` block has been changed in 53d7025 so it doesn't catch `asyncio.CancelledError`.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
