### PR TITLE
Fix queueing.call_prediction to retrieve the default response class in the same manner as FastAPI's implementation

### DIFF
--- a/.changeset/every-laws-win.md
+++ b/.changeset/every-laws-win.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix `queueing.call_prediction` to retrieve the default response class in the same manner as FastAPI's implementation

--- a/.changeset/every-laws-win.md
+++ b/.changeset/every-laws-win.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:Fix `queueing.call_prediction` to retrieve the default response class in the same manner as FastAPI's implementation
+feat:Fix queueing.call_prediction to retrieve the default response class in the same manner as FastAPI's implementation

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -406,7 +406,11 @@ class Queue:
         # This is done by FastAPI automatically in the HTTP endpoint handlers,
         # but we need to do it manually here.
         response_class = app.router.default_response_class
-        http_response = response_class(
+        if isinstance(response_class, fastapi.datastructures.DefaultPlaceholder):
+            actual_response_class = response_class.value
+        else:
+            actual_response_class = response_class
+        http_response = actual_response_class(
             output
         )  # Do the same as https://github.com/tiangolo/fastapi/blob/0.87.0/fastapi/routing.py#L264
         # Also, decode the JSON string to a Python object, emulating the HTTP client behavior e.g. the `json()` method of `httpx`.


### PR DESCRIPTION
## Description

Add the code same as https://github.com/tiangolo/fastapi/blob/0.87.0/fastapi/routing.py#L183-L186 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
