### PR TITLE
[OAuth docs] No need to install oauth dependency in Spaces

### DIFF
--- a/guides/01_getting-started/03_sharing-your-app.md
+++ b/guides/01_getting-started/03_sharing-your-app.md
@@ -195,11 +195,9 @@ If allows to add a _"Sign in with Hugging Face"_ button to your demo. Check out 
 for a live demo.
 
 To enable OAuth, you must set `hf_oauth: true` as a Space metadata in your README.md file. This will register your Space
-as an OAuth application on Hugging Face. You also need to include `itsdangerous` and `authlib` in a separate
-`requirements.txt` file. Next, you can use `gr.LoginButton` and `gr.LogoutButton` to add login and logout buttons to
-your Gradio app. Once a user is logged in with their HF account, you can retrieve their profile. To do so, you only
-have to add a parameter of type `gr.OAuthProfile` to any Gradio function. The user profile will be automatically
-injected as a parameter value.
+as an OAuth application on Hugging Face. Next, you can use `gr.LoginButton` and `gr.LogoutButton` to add login and logout buttons to
+your Gradio app. Once a user is logged in with their HF account, you can retrieve their profile by adding a parameter of type
+`gr.OAuthProfile` to any Gradio function. The user profile will be automatically injected as a parameter value.
 
 Here is a short example:
 


### PR DESCRIPTION
Related to OAuth PR (https://github.com/gradio-app/gradio/pull/4943) and Spaces PR (https://github.com/huggingface/spaces-app-manager/pull/1037 - private repo).

`gradio[oauth]` is now installed by default on Spaces so no need to add a `requirements.txt` manually. This PR updates the documentation about it.

For the record, here is a [demo Space](https://huggingface.co/spaces/Wauplin/gradio-oauth-demo) with OAuth enabled and no requiremens.txt.