### PR TITLE
Fix docstring of dropdown

### DIFF
--- a/.changeset/chubby-hats-type.md
+++ b/.changeset/chubby-hats-type.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Fix docstring of dropdown

--- a/.changeset/chubby-hats-type.md
+++ b/.changeset/chubby-hats-type.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix docstring of dropdown

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -68,7 +68,7 @@ class Dropdown(
             value: default value(s) selected in dropdown. If None, no value is selected by default. If callable, the function will be called whenever the app loads to set the initial value of the component.
             type: Type of value to be returned by component. "value" returns the string of the choice selected, "index" returns the index of the choice selected.
             multiselect: if True, multiple choices can be selected.
-            allow_custom_value: If True, allows user to enter a custom value that is not in the list of choices. Only applies if `multiselect` is False.
+            allow_custom_value: If True, allows user to enter a custom value that is not in the list of choices.
             max_choices: maximum number of choices that can be selected. If None, no limit is enforced.
             filterable: If True, user will be able to type into the dropdown and filter the choices by typing. Can only be set to False if `allow_custom_value` is False.
             label: component name in interface.


### PR DESCRIPTION
## Description

The docstring of `allow_custom_value` of `gr.Dropdown` was not updated in #5384.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
