### PR TITLE
Fix `.update()` method in `gr.Dropdown()` to handle `choices`

### DIFF
--- a/.changeset/chubby-hats-type.md
+++ b/.changeset/chubby-hats-type.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:Fix docstring of dropdown

--- a/.changeset/free-terms-follow.md
+++ b/.changeset/free-terms-follow.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix `.update()` method in `gr.Dropdown()` to handle `choices`

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -187,7 +187,7 @@ class Dropdown(
             None
             if choices is None
             else [c if isinstance(c, tuple) else (str(c), c) for c in choices]
-        )        
+        )
         return {
             "choices": choices,
             "label": label,

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -68,7 +68,7 @@ class Dropdown(
             value: default value(s) selected in dropdown. If None, no value is selected by default. If callable, the function will be called whenever the app loads to set the initial value of the component.
             type: Type of value to be returned by component. "value" returns the string of the choice selected, "index" returns the index of the choice selected.
             multiselect: if True, multiple choices can be selected.
-            allow_custom_value: If True, allows user to enter a custom value that is not in the list of choices. Only applies if `multiselect` is False.
+            allow_custom_value: If True, allows user to enter a custom value that is not in the list of choices.
             max_choices: maximum number of choices that can be selected. If None, no limit is enforced.
             filterable: If True, user will be able to type into the dropdown and filter the choices by typing. Can only be set to False if `allow_custom_value` is False.
             label: component name in interface.

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -68,7 +68,7 @@ class Dropdown(
             value: default value(s) selected in dropdown. If None, no value is selected by default. If callable, the function will be called whenever the app loads to set the initial value of the component.
             type: Type of value to be returned by component. "value" returns the string of the choice selected, "index" returns the index of the choice selected.
             multiselect: if True, multiple choices can be selected.
-            allow_custom_value: If True, allows user to enter a custom value that is not in the list of choices.
+            allow_custom_value: If True, allows user to enter a custom value that is not in the list of choices. Only applies if `multiselect` is False.
             max_choices: maximum number of choices that can be selected. If None, no limit is enforced.
             filterable: If True, user will be able to type into the dropdown and filter the choices by typing. Can only be set to False if `allow_custom_value` is False.
             label: component name in interface.
@@ -183,6 +183,11 @@ class Dropdown(
         placeholder: str | None = None,
         visible: bool | None = None,
     ):
+        choices = (
+            None
+            if choices is None
+            else [c if isinstance(c, tuple) else (str(c), c) for c in choices]
+        )        
         return {
             "choices": choices,
             "label": label,

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -650,11 +650,20 @@ class TestDropdown:
         """
         Interface, process
         """
-        checkboxes_input = gr.CheckboxGroup(["a", "b", "c"])
-        iface = gr.Interface(lambda x: "|".join(x), checkboxes_input, "textbox")
+        dropdown_input = gr.Dropdown(["a", "b", "c"])
+        iface = gr.Interface(lambda x: "|".join(x), dropdown_input, "textbox")
         assert iface(["a", "c"]) == "a|c"
         assert iface([]) == ""
-        _ = gr.CheckboxGroup(["a", "b", "c"], type="index")
+
+    def test_update(self):
+        update = gr.Dropdown.update(
+            choices=[("zeroth", ""), "first", "second"], label="ordinal"
+        )
+        assert update["choices"] == [
+            ("zeroth", ""),
+            ("first", "first"),
+            ("second", "second"),
+        ]
 
 
 class TestImage:


### PR DESCRIPTION
Fixes: #5519 

Test with original repro in issue:

```py
import gradio as gr

def update_dropdown():
  new_choices = gr.Dropdown.update(choices = ["Hyundai","Suzuki","Mclaren"],label = "Test Dropdown")
  return new_choices

def update_text(text):
  return "You have chosen: " + text

with gr.Blocks() as demo:
  with gr.Row():
    with gr.Column():
      test = gr.Dropdown(choices = ["Honda","BMW","Mercedes"], value = "Honda",label = "Test Dropdown")
      output = gr.Textbox(lines = 5, label="Details")
    with gr.Column():
      test_button = gr.Button(value = "Test",variant = "primary" )
    test.change(update_text,[test],output)
    test_button.click(update_dropdown,[] ,[test])
    
demo.launch()
```