### PR TITLE
Use Fallback component for the no template case

### DIFF
--- a/gradio/cli/commands/files/NoTemplateComponent.py
+++ b/gradio/cli/commands/files/NoTemplateComponent.py
@@ -1,6 +1,6 @@
 import gradio as gr
 
-class <<name>>(gr.components.Component):
+class NAME(gr.components.Component):
     
     def preprocess(self, x):
         return x

--- a/gradio/cli/commands/files/NoTemplateComponent.svelte
+++ b/gradio/cli/commands/files/NoTemplateComponent.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-    import { JsonView } from '@zerodevx/svelte-json-view'
-  
-    export let value: any = {}
-</script>
-  
-<JsonView json={value} />


### PR DESCRIPTION
## Description

- Use Fallback component when a template component is not specified. FYI @pngwn looks like jsonVIEW can't display a basic number/string. Might be good to fix in the frontend but otherwise we can just modify the NoTemplateComponent postprocess.
- Use `pnpm i --ignore-scripts` if installing in test dir as opposed to npm. Otherwise it's tedious to always type it out yourself.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
