### PR TITLE
allow gr.Image() examples to take urls

### DIFF
--- a/.changeset/eighty-buttons-film.md
+++ b/.changeset/eighty-buttons-film.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:allow gr.Image() examples to take urls

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -435,8 +435,7 @@ class Image(
     def as_example(self, input_data: str | None) -> str:
         if input_data is None:
             return ""
-        elif (
-            self.root_url
-        ):  # If an externally hosted image, don't convert to absolute path
+        # If an externally hosted image or a URL, don't convert to absolute path
+        elif self.root_url or client_utils.is_http_url_like(input_data):
             return input_data
         return str(utils.abspath(input_data))

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -432,10 +432,11 @@ class Image(
         if self.source != "webcam":
             raise ValueError("Image streaming only available if source is 'webcam'.")
 
-    def as_example(self, input_data: str | None) -> str:
+    def as_example(self, input_data: str | Path | None) -> str:
         if input_data is None:
             return ""
+        input_data = str(input_data)
         # If an externally hosted image or a URL, don't convert to absolute path
-        elif self.root_url or client_utils.is_http_url_like(input_data):
+        if self.root_url or client_utils.is_http_url_like(input_data):
             return input_data
         return str(utils.abspath(input_data))

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -767,6 +767,11 @@ class TestImage:
             lambda x: np.sum(x), image_input, "number", interpretation="default"
         )
 
+    def test_as_example(self):
+        # test that URLs are not converted to an absolute path
+        url = "https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg"
+        assert gr.Image().as_example(url) == url
+
     def test_in_interface_as_output(self):
         """
         Interface, process


### PR DESCRIPTION
Quick fix for: https://github.com/gradio-app/gradio/issues/5463