### PR TITLE
Fixes dropdown breaking if a user types in invalid value and presses enter

### DIFF
--- a/.changeset/sour-falcons-marry.md
+++ b/.changeset/sour-falcons-marry.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dropdown": patch
+"gradio": patch
+---
+
+fix:Fixes dropdown breaking if a user types in invalid value and presses enter

--- a/js/dropdown/dropdown.test.ts
+++ b/js/dropdown/dropdown.test.ts
@@ -258,4 +258,62 @@ describe("Dropdown", () => {
 		const options_new = getAllByTestId("dropdown-option");
 		expect(options_new).toHaveLength(3);
 	});
+
+	test("setting an invalid value when allow_custom_choice is false should revert to the first valid choice", async () => {
+		const { getByLabelText, getAllByTestId, component } = await render(
+			Dropdown,
+			{
+				show_label: true,
+				loading_status,
+				value: "",
+				allow_custom_value: false,
+				label: "Dropdown",
+				choices: [
+					["apple", "apple"],
+					["zebra", "zebra"],
+					["pony", "pony"]
+				],
+				filterable: true
+			}
+		);
+
+		const item: HTMLInputElement = getByLabelText(
+			"Dropdown"
+		) as HTMLInputElement;
+
+		await item.focus();
+		await event.keyboard("pie");
+		expect(item.value).toBe("applepie");
+		await item.blur();
+		expect(item.value).toBe("apple");
+	});
+
+	test("setting an invalid value when allow_custom_choice is true should keep the value", async () => {
+		const { getByLabelText, getAllByTestId, component } = await render(
+			Dropdown,
+			{
+				show_label: true,
+				loading_status,
+				value: "",
+				allow_custom_value: true,
+				label: "Dropdown",
+				choices: [
+					["apple", "apple"],
+					["zebra", "zebra"],
+					["pony", "pony"]
+				],
+				filterable: true
+			}
+		);
+
+		const item: HTMLInputElement = getByLabelText(
+			"Dropdown"
+		) as HTMLInputElement;
+
+		await item.focus();
+		await event.keyboard("pie");
+		expect(item.value).toBe("applepie");
+		await item.blur();
+		expect(item.value).toBe("applepie");
+	});
 });

--- a/js/dropdown/dropdown.test.ts
+++ b/js/dropdown/dropdown.test.ts
@@ -259,7 +259,7 @@ describe("Dropdown", () => {
 		expect(options_new).toHaveLength(3);
 	});
 
-	test("setting an invalid value when allow_custom_choice is false should revert to the first valid choice", async () => {
+	test("setting a custom value when allow_custom_choice is false should revert to the first valid choice", async () => {
 		const { getByLabelText, getAllByTestId, component } = await render(
 			Dropdown,
 			{
@@ -288,7 +288,7 @@ describe("Dropdown", () => {
 		expect(item.value).toBe("apple");
 	});
 
-	test("setting an invalid value when allow_custom_choice is true should keep the value", async () => {
+	test("setting a custom value when allow_custom_choice is true should keep the value", async () => {
 		const { getByLabelText, getAllByTestId, component } = await render(
 			Dropdown,
 			{

--- a/js/dropdown/shared/Dropdown.svelte
+++ b/js/dropdown/shared/Dropdown.svelte
@@ -97,7 +97,7 @@
 			filtered_indices = handle_filter(choices, input_text);
 			old_choices = choices;
 			old_input_text = input_text;
-			if (!allow_custom_value) {
+			if (!allow_custom_value && filtered_indices.length > 0) {
 				active_index = filtered_indices[0];
 			}
 		}

--- a/js/dropdown/shared/Dropdown.svelte
+++ b/js/dropdown/shared/Dropdown.svelte
@@ -74,7 +74,7 @@
 			dispatch("select", {
 				index: selected_index,
 				value: choices_values[selected_index],
-				selected: true,
+				selected: true
 			});
 		}
 	}


### PR DESCRIPTION
Fixes: #5540

Repro: 

```py
import gradio as gr

with gr.Blocks() as demo:
    with gr.Row():
        with gr.Column():
            dropdown = gr.Dropdown(
                choices=["abc", "def", "ghi"],
                value="abc",
                allow_custom_value=False,
            )
            button = gr.Button()
        with gr.Column():
            out = gr.Textbox()

    button.click(fn=lambda x: x, inputs=dropdown, outputs=out)

if __name__ == "__main__":
    demo.queue().launch()
```

Notably, the Multiselect was not experiencing this bug. 

Adds a couple of unit tests which don't actually test this exact bug (I couldn't figure out simulating the enter key -- tried keyboard("{Enter}") but it wasn't working for me), but they do test related behavior. 