### PR TITLE
Fix `.clear()` events for audio and image

### DIFF
--- a/.changeset/better-dingos-find.md
+++ b/.changeset/better-dingos-find.md
@@ -1,0 +1,7 @@
+---
+"@gradio/audio": patch
+"@gradio/image": patch
+"gradio": patch
+---
+
+fix:Fix `.clear()` events for audio and image

--- a/js/audio/interactive/InteractiveAudio.svelte
+++ b/js/audio/interactive/InteractiveAudio.svelte
@@ -44,6 +44,7 @@
 		start_recording: never;
 		stop_recording: never;
 		upload: never;
+		clear: never;
 	}>;
 
 	let old_value: null | FileData | string = null;
@@ -97,6 +98,7 @@
 		on:start_recording={() => gradio.dispatch("start_recording")}
 		on:stop_recording={() => gradio.dispatch("stop_recording")}
 		on:upload={() => gradio.dispatch("upload")}
+		on:clear={() => gradio.dispatch("clear")}
 		on:error={({ detail }) => {
 			loading_status = loading_status || {};
 			loading_status.status = "error";

--- a/js/image/interactive/Image.svelte
+++ b/js/image/interactive/Image.svelte
@@ -113,6 +113,7 @@
 	}
 
 	async function handle_sketch_clear(): Promise<void> {
+		dispatch("clear");
 		sketch.clear();
 		await tick();
 		value = null;


### PR DESCRIPTION
## Description
Adds missing `dispatch("clear")`.
Closes: #5548, Closes: #5522

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
