### PR TITLE
Allow multiple instances of Gradio with authentication to run on different ports

### DIFF
--- a/gradio/analytics.py
+++ b/gradio/analytics.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import pkgutil
 import threading
 import urllib.parse
 import warnings

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -189,9 +189,9 @@ class App(FastAPI):
         @app.get("/user")
         @app.get("/user/")
         def get_current_user(request: fastapi.Request) -> Optional[str]:
-            token = request.cookies.get(f"access-token-{app.cookie_id}") or request.cookies.get(
-                f"access-token-unsecure-{app.cookie_id}"
-            )
+            token = request.cookies.get(
+                f"access-token-{app.cookie_id}"
+            ) or request.cookies.get(f"access-token-unsecure-{app.cookie_id}")
             return app.tokens.get(token)
 
         @app.get("/login_check")
@@ -204,9 +204,9 @@ class App(FastAPI):
             )
 
         async def ws_login_check(websocket: WebSocket) -> Optional[str]:
-            token = websocket.cookies.get(f"access-token-{app.cookie_id}") or websocket.cookies.get(
-                f"access-token-unsecure-{app.cookie_id}"
-            )
+            token = websocket.cookies.get(
+                f"access-token-{app.cookie_id}"
+            ) or websocket.cookies.get(f"access-token-unsecure-{app.cookie_id}")
             return token  # token is returned to authenticate the websocket connection in the endpoint handler.
 
         @app.get("/token")
@@ -275,7 +275,9 @@ class App(FastAPI):
                     secure=True,
                 )
                 response.set_cookie(
-                    key=f"access-token-unsecure-{app.cookie_id}", value=token, httponly=True
+                    key=f"access-token-unsecure-{app.cookie_id}",
+                    value=token,
+                    httponly=True,
                 )
                 return response
             else:

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -117,6 +117,7 @@ class App(FastAPI):
         self.iterators = defaultdict(dict)
         self.iterators_to_reset = defaultdict(set)
         self.lock = utils.safe_get_lock()
+        self.cookie_id = secrets.token_urlsafe(32)
         self.queue_token = secrets.token_urlsafe(32)
         self.startup_events_triggered = False
         self.uploaded_file_dir = os.environ.get("GRADIO_TEMP_DIR") or str(
@@ -188,8 +189,8 @@ class App(FastAPI):
         @app.get("/user")
         @app.get("/user/")
         def get_current_user(request: fastapi.Request) -> Optional[str]:
-            token = request.cookies.get("access-token") or request.cookies.get(
-                "access-token-unsecure"
+            token = request.cookies.get(f"access-token-{app.cookie_id}") or request.cookies.get(
+                f"access-token-unsecure-{app.cookie_id}"
             )
             return app.tokens.get(token)
 
@@ -203,15 +204,15 @@ class App(FastAPI):
             )
 
         async def ws_login_check(websocket: WebSocket) -> Optional[str]:
-            token = websocket.cookies.get("access-token") or websocket.cookies.get(
-                "access-token-unsecure"
+            token = websocket.cookies.get(f"access-token-{app.cookie_id}") or websocket.cookies.get(
+                f"access-token-unsecure-{app.cookie_id}"
             )
             return token  # token is returned to authenticate the websocket connection in the endpoint handler.
 
         @app.get("/token")
         @app.get("/token/")
         def get_token(request: fastapi.Request) -> dict:
-            token = request.cookies.get("access-token")
+            token = request.cookies.get(f"access-token-{app.cookie_id}")
             return {"token": token, "user": app.tokens.get(token)}
 
         @app.get("/app_id")
@@ -267,14 +268,14 @@ class App(FastAPI):
                 app.tokens[token] = username
                 response = JSONResponse(content={"success": True})
                 response.set_cookie(
-                    key="access-token",
+                    key=f"access-token-{app.cookie_id}",
                     value=token,
                     httponly=True,
                     samesite="none",
                     secure=True,
                 )
                 response.set_cookie(
-                    key="access-token-unsecure", value=token, httponly=True
+                    key=f"access-token-unsecure-{app.cookie_id}", value=token, httponly=True
                 )
                 return response
             else:

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1680,7 +1680,7 @@ async def test_queue_when_using_auth():
         follow_redirects=False,
     )
     assert resp.status_code == 200
-    token = resp.cookies.get("access-token")
+    token = resp.cookies.get(f"access-token-{demo.app.cookie_id}")
     assert token
 
     with pytest.raises(Exception) as e:
@@ -1693,7 +1693,7 @@ async def test_queue_when_using_auth():
     async def run_ws(i):
         async with websockets.connect(
             f"{demo.local_url.replace('http', 'ws')}queue/join",
-            extra_headers={"Cookie": f"access-token={token}"},
+            extra_headers={"Cookie": f"access-token-{demo.app.cookie_id}={token}"},
         ) as ws:
             while True:
                 try:


### PR DESCRIPTION
Turns out that on localhost, cookies [are not port-specific](https://stackoverflow.com/questions/1612177/are-http-cookies-port-specific). This meant that if you were running Gradio w/ auth on one port, and then you logged into a second Gradio instance, the second cookie would override the first once -- since all cookies shared the same name. 

Now, we use a unique name per cookie so this does not happen. 

Closes: #5577  