### PR TITLE
Upgrade Pyodide to 0.24.0 and install the native orjson package

### DIFF
--- a/.changeset/rich-points-dance.md
+++ b/.changeset/rich-points-dance.md
@@ -1,0 +1,6 @@
+---
+"@gradio/wasm": minor
+"gradio": minor
+---
+
+feat:Upgrade Pyodide to 0.24.0 and install the native orjson package

--- a/.changeset/rich-points-dance.md
+++ b/.changeset/rich-points-dance.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/wasm": minor
-"gradio": minor
+"@gradio/wasm": patch
+"gradio": patch
 ---
 
 feat:Upgrade Pyodide to 0.24.0 and install the native orjson package

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -175,8 +175,7 @@ class App(FastAPI):
         blocks: gradio.Blocks, app_kwargs: Dict[str, Any] | None = None
     ) -> App:
         app_kwargs = app_kwargs or {}
-        if not wasm_utils.IS_WASM:
-            app_kwargs.setdefault("default_response_class", ORJSONResponse)
+        app_kwargs.setdefault("default_response_class", ORJSONResponse)
         app = App(**app_kwargs)
         app.configure_app(blocks)
 

--- a/js/wasm/src/webworker/index.ts
+++ b/js/wasm/src/webworker/index.ts
@@ -14,7 +14,7 @@ import { makeHttpRequest } from "./http";
 import scriptRunnerPySource from "./py/script_runner.py?raw";
 import unloadModulesPySource from "./py/unload_modules.py?raw";
 
-importScripts("https://cdn.jsdelivr.net/pyodide/v0.23.2/full/pyodide.js");
+importScripts("https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.js");
 
 let pyodide: PyodideInterface;
 
@@ -71,9 +71,7 @@ async function loadPyodideAndPackages(
 	];
 	console.debug("Loading Gradio wheels.", gradioWheelUrls);
 	await micropip.add_mock_package("ffmpy", "0.3.0");
-	await micropip.add_mock_package("orjson", "3.8.12");
 	await micropip.add_mock_package("aiohttp", "3.8.4");
-	await micropip.add_mock_package("multidict", "4.7.6");
 	await pyodide.loadPackage(["ssl", "distutils", "setuptools"]);
 	await micropip.install(["markdown-it-py[linkify]~=2.2.0"]); // On 3rd June 2023, markdown-it-py 3.0.0 has been released. The `gradio` package depends on its `>=2.0.0` version so its 3.x will be resolved. However, it conflicts with `mdit-py-plugins`'s dependency `markdown-it-py >=1.0.0,<3.0.0` and micropip currently can't resolve it. So we explicitly install the compatible version of the library here.
 	await micropip.install.callKwargs(gradioWheelUrls, {


### PR DESCRIPTION
## Description

Pyodide 0.24.0 started supporting `orjson` 🎉 : https://pyodide.org/en/stable/project/changelog.html#version-0-24-0

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
