### PR TITLE
Add `render_markdown` parameter to chatbot

### DIFF
--- a/.changeset/huge-steaks-juggle.md
+++ b/.changeset/huge-steaks-juggle.md
@@ -1,0 +1,7 @@
+---
+"@gradio/chatbot": patch
+"@gradio/markdown": patch
+"gradio": patch
+---
+
+fix:Add `disable_markdown` param to chatbot

--- a/.changeset/huge-steaks-juggle.md
+++ b/.changeset/huge-steaks-juggle.md
@@ -4,4 +4,4 @@
 "gradio": patch
 ---
 
-fix:Add `disable_markdown` param to chatbot
+fix:Add `render_markdown` parameter to chatbot

--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -53,12 +53,12 @@ class Chatbot(Changeable, Selectable, Likeable, IOComponent, JSONSerializable):
         elem_classes: list[str] | str | None = None,
         height: int | None = None,
         latex_delimiters: list[dict[str, str | bool]] | None = None,
-        disable_markdown: bool = False,
         rtl: bool = False,
         show_share_button: bool | None = None,
         show_copy_button: bool = False,
         avatar_images: tuple[str | Path | None, str | Path | None] | None = None,
         sanitize_html: bool = True,
+        render_markdown: bool = True,
         bubble_full_width: bool = True,
         **kwargs,
     ):
@@ -77,12 +77,12 @@ class Chatbot(Changeable, Selectable, Likeable, IOComponent, JSONSerializable):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             height: height of the component in pixels.
             latex_delimiters: A list of dicts of the form {"left": open delimiter (str), "right": close delimiter (str), "display": whether to display in newline (bool)} that will be used to render LaTeX expressions. If not provided, `latex_delimiters` is set to `[{ "left": "$$", "right": "$$", "display": True }]`, so only expressions enclosed in $$ delimiters will be rendered as LaTeX, and in a new line. Pass in an empty list to disable LaTeX rendering. For more information, see the [KaTeX documentation](https://katex.org/docs/autorender.html).
-            disable_markdown: If True, will disable Markdown rendering for chatbot messages.
             rtl: If True, sets the direction of the rendered text to right-to-left. Default is False, which renders text left-to-right.
             show_share_button: If True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
             show_copy_button: If True, will show a copy button for each chatbot message.
             avatar_images: Tuple of two avatar image paths or URLs for user and bot (in that order). Pass None for either the user or bot image to skip. Must be within the working directory of the Gradio app or an external URL.
             sanitize_html: If False, will disable HTML sanitization for chatbot messages. This is not recommended, as it can lead to security vulnerabilities.
+            render_markdown: If False, will disable Markdown rendering for chatbot messages.
             bubble_full_width: If False, the chat bubble will fit to the content of the message. If True (default), the chat bubble will be the full width of the component.
         """
         if color_map is not None:
@@ -110,7 +110,7 @@ class Chatbot(Changeable, Selectable, Likeable, IOComponent, JSONSerializable):
             if show_share_button is None
             else show_share_button
         )
-        self.disable_markdown = disable_markdown
+        self.render_markdown = render_markdown
         self.show_copy_button = show_copy_button
         self.sanitize_html = sanitize_html
         self.bubble_full_width = bubble_full_width
@@ -148,7 +148,7 @@ class Chatbot(Changeable, Selectable, Likeable, IOComponent, JSONSerializable):
         avatar_images: tuple[str | Path | None] | None = None,
         sanitize_html: bool | None = None,
         bubble_full_width: bool | None = None,
-        disable_markdown: bool | None = None,
+        render_markdown: bool | None = None,
     ):
         warnings.warn(
             "Using the update method is deprecated. Simply return a new object instead, e.g. `return gr.Chatbot(...)` instead of `return gr.Chatbot.update(...)`."
@@ -169,7 +169,7 @@ class Chatbot(Changeable, Selectable, Likeable, IOComponent, JSONSerializable):
             "avatar_images": avatar_images,
             "sanitize_html": sanitize_html,
             "bubble_full_width": bubble_full_width,
-            "disable_markdown": disable_markdown,
+            "render_markdown": render_markdown,
             "__type__": "update",
         }
         return updated_config

--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -53,6 +53,7 @@ class Chatbot(Changeable, Selectable, Likeable, IOComponent, JSONSerializable):
         elem_classes: list[str] | str | None = None,
         height: int | None = None,
         latex_delimiters: list[dict[str, str | bool]] | None = None,
+        disable_markdown: bool = False,
         rtl: bool = False,
         show_share_button: bool | None = None,
         show_copy_button: bool = False,
@@ -76,6 +77,7 @@ class Chatbot(Changeable, Selectable, Likeable, IOComponent, JSONSerializable):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             height: height of the component in pixels.
             latex_delimiters: A list of dicts of the form {"left": open delimiter (str), "right": close delimiter (str), "display": whether to display in newline (bool)} that will be used to render LaTeX expressions. If not provided, `latex_delimiters` is set to `[{ "left": "$$", "right": "$$", "display": True }]`, so only expressions enclosed in $$ delimiters will be rendered as LaTeX, and in a new line. Pass in an empty list to disable LaTeX rendering. For more information, see the [KaTeX documentation](https://katex.org/docs/autorender.html).
+            disable_markdown: If True, will disable Markdown rendering for chatbot messages.
             rtl: If True, sets the direction of the rendered text to right-to-left. Default is False, which renders text left-to-right.
             show_share_button: If True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
             show_copy_button: If True, will show a copy button for each chatbot message.
@@ -108,6 +110,7 @@ class Chatbot(Changeable, Selectable, Likeable, IOComponent, JSONSerializable):
             if show_share_button is None
             else show_share_button
         )
+        self.disable_markdown = disable_markdown
         self.show_copy_button = show_copy_button
         self.sanitize_html = sanitize_html
         self.bubble_full_width = bubble_full_width
@@ -145,6 +148,7 @@ class Chatbot(Changeable, Selectable, Likeable, IOComponent, JSONSerializable):
         avatar_images: tuple[str | Path | None] | None = None,
         sanitize_html: bool | None = None,
         bubble_full_width: bool | None = None,
+        disable_markdown: bool | None = None,
     ):
         warnings.warn(
             "Using the update method is deprecated. Simply return a new object instead, e.g. `return gr.Chatbot(...)` instead of `return gr.Chatbot.update(...)`."
@@ -165,6 +169,7 @@ class Chatbot(Changeable, Selectable, Likeable, IOComponent, JSONSerializable):
             "avatar_images": avatar_images,
             "sanitize_html": sanitize_html,
             "bubble_full_width": bubble_full_width,
+            "disable_markdown": disable_markdown,
             "__type__": "update",
         }
         return updated_config

--- a/js/chatbot/static/ChatBot.svelte
+++ b/js/chatbot/static/ChatBot.svelte
@@ -30,6 +30,7 @@
 	export let avatar_images: [string | null, string | null] = [null, null];
 	export let sanitize_html = true;
 	export let bubble_full_width = true;
+	export let disable_markdown = false;
 	export let root: string;
 	export let root_url: null | string;
 
@@ -167,6 +168,7 @@
 									{message}
 									{latex_delimiters}
 									{sanitize_html}
+									{disable_markdown}
 									on:load={scroll}
 								/>
 							{:else if message !== null && message.mime_type?.includes("audio")}

--- a/js/chatbot/static/ChatBot.svelte
+++ b/js/chatbot/static/ChatBot.svelte
@@ -137,6 +137,7 @@
 							class:latest={i === value.length - 1}
 							class="message {j == 0 ? 'user' : 'bot'}"
 							class:message-fit={!bubble_full_width}
+							class:message-markdown-disabled={!render_markdown}
 							class:selectable
 							on:click={() => handle_select(i, j, message)}
 							dir={rtl ? "rtl" : "ltr"}
@@ -276,6 +277,9 @@
 	}
 	.message-fit.user {
 		margin-left: auto;
+	}
+	.message-markdown-disabled {
+		white-space: pre-line;
 	}
 	.user {
 		align-self: flex-end;

--- a/js/chatbot/static/ChatBot.svelte
+++ b/js/chatbot/static/ChatBot.svelte
@@ -30,7 +30,7 @@
 	export let avatar_images: [string | null, string | null] = [null, null];
 	export let sanitize_html = true;
 	export let bubble_full_width = true;
-	export let disable_markdown = false;
+	export let render_markdown = true;
 	export let root: string;
 	export let root_url: null | string;
 
@@ -168,7 +168,7 @@
 									{message}
 									{latex_delimiters}
 									{sanitize_html}
-									{disable_markdown}
+									{render_markdown}
 									on:load={scroll}
 								/>
 							{:else if message !== null && message.mime_type?.includes("audio")}

--- a/js/chatbot/static/StaticChatbot.svelte
+++ b/js/chatbot/static/StaticChatbot.svelte
@@ -26,6 +26,7 @@
 	export let show_copy_button = false;
 	export let sanitize_html = true;
 	export let bubble_full_width = true;
+	export let disable_markdown = false;
 	export let latex_delimiters: {
 		left: string;
 		right: string;
@@ -93,6 +94,7 @@
 			{show_share_button}
 			value={_value}
 			{latex_delimiters}
+			{disable_markdown}
 			pending_message={loading_status?.status === "pending"}
 			{rtl}
 			{show_copy_button}

--- a/js/chatbot/static/StaticChatbot.svelte
+++ b/js/chatbot/static/StaticChatbot.svelte
@@ -26,7 +26,7 @@
 	export let show_copy_button = false;
 	export let sanitize_html = true;
 	export let bubble_full_width = true;
-	export let disable_markdown = false;
+	export let render_markdown = true;
 	export let latex_delimiters: {
 		left: string;
 		right: string;
@@ -94,7 +94,7 @@
 			{show_share_button}
 			value={_value}
 			{latex_delimiters}
-			{disable_markdown}
+			{render_markdown}
 			pending_message={loading_status?.status === "pending"}
 			{rtl}
 			{show_copy_button}

--- a/js/markdown/static/MarkdownCode.svelte
+++ b/js/markdown/static/MarkdownCode.svelte
@@ -28,10 +28,10 @@
 
 	function process_message(value: string): string {
 		if (render_markdown) {
-			value = marked.parse(value)
+			value = marked.parse(value);
 		}
 		if (sanitize_html) {
-			value = DOMPurify.sanitize(value)
+			value = DOMPurify.sanitize(value);
 		}
 		return value;
 	}

--- a/js/markdown/static/MarkdownCode.svelte
+++ b/js/markdown/static/MarkdownCode.svelte
@@ -14,7 +14,7 @@
 		right: string;
 		display: boolean;
 	}[] = [];
-	export let disable_markdown = false;
+	export let render_markdown = true;
 
 	let el: HTMLSpanElement;
 	let html: string;
@@ -27,15 +27,15 @@
 	});
 
 	function process_message(value: string): string {
-		if (sanitize_html && !disable_markdown) {
-			return DOMPurify.sanitize(marked.parse(value));
-		} else if (sanitize_html && disable_markdown) {
-			return DOMPurify.sanitize(value);
-		} else if (!sanitize_html && !disable_markdown) {
-			return marked.parse(value);
+		if (render_markdown) {
+			value = marked.parse(value)
+		}
+		if (sanitize_html) {
+			value = DOMPurify.sanitize(value)
 		}
 		return value;
 	}
+
 	$: if (message && message.trim()) {
 		html = process_message(message);
 	} else {
@@ -53,7 +53,11 @@
 </script>
 
 <span class:chatbot bind:this={el} class="md">
-	{@html html}
+	{#if render_markdown}
+		{@html html}
+	{:else}
+		{html}
+	{/if}
 </span>
 
 <style>

--- a/js/markdown/static/MarkdownCode.svelte
+++ b/js/markdown/static/MarkdownCode.svelte
@@ -14,6 +14,7 @@
 		right: string;
 		display: boolean;
 	}[] = [];
+	export let disable_markdown = false;
 
 	let el: HTMLSpanElement;
 	let html: string;
@@ -24,10 +25,19 @@
 			node.setAttribute("rel", "noopener noreferrer");
 		}
 	});
+
+	function process_message(value: string): string {
+		if (sanitize_html && !disable_markdown) {
+			return DOMPurify.sanitize(marked.parse(value));
+		} else if (sanitize_html && disable_markdown) {
+			return DOMPurify.sanitize(value);
+		} else if (!sanitize_html && !disable_markdown) {
+			return marked.parse(value);
+		}
+		return value;
+	}
 	$: if (message && message.trim()) {
-		html = sanitize_html
-			? DOMPurify.sanitize(marked.parse(message))
-			: marked.parse(message);
+		html = process_message(message);
 	} else {
 		html = "";
 	}

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -2077,6 +2077,7 @@ class TestChatbot:
             "root_url": None,
             "selectable": False,
             "latex_delimiters": [{"display": True, "left": "$$", "right": "$$"}],
+            "disable_markdown": False,
             "likeable": False,
             "rtl": False,
             "show_copy_button": False,

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -2077,12 +2077,12 @@ class TestChatbot:
             "root_url": None,
             "selectable": False,
             "latex_delimiters": [{"display": True, "left": "$$", "right": "$$"}],
-            "disable_markdown": False,
             "likeable": False,
             "rtl": False,
             "show_copy_button": False,
             "avatar_images": (None, None),
             "sanitize_html": True,
+            "render_markdown": True,
             "bubble_full_width": True,
         }
 


### PR DESCRIPTION
## Description
Allow users to `disable_markdown` for chatbot messages.

Closes: #5513

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
