### PR TITLE
Add gr.Request in ThreadData context

### DIFF
--- a/.changeset/whole-rabbits-walk.md
+++ b/.changeset/whole-rabbits-walk.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Add gr.Request in ThreadData context

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -93,7 +93,7 @@ BUILT_IN_THEMES: dict[str, Theme] = {
 def in_event_listener():
     from gradio import context
 
-    return getattr(context.thread_data, "in_event_listener", False)
+    return context.thread_data.in_event_listener
 
 
 def updateable(fn):
@@ -1135,7 +1135,11 @@ class Blocks(BlockContext):
         start = time.time()
 
         fn = utils.get_function_with_locals(
-            block_fn.fn, self, event_id, in_event_listener
+            fn=block_fn.fn,
+            blocks=self,
+            event_id=event_id,
+            in_event_listener=in_event_listener,
+            request=request,
         )
 
         if iterator is None:  # If not a generator function that has already run

--- a/gradio/context.py
+++ b/gradio/context.py
@@ -6,6 +6,7 @@ import threading
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
+    from gradio import Request
     from gradio.blocks import BlockContext, Blocks
 
 
@@ -16,5 +17,11 @@ class Context:
     ip_address: str | None = None  # The IP address of the user.
     hf_token: str | None = None  # The token provided when loading private HF repos
 
+class ThreadData(threading.local):
+    def __init__(self, **kwargs):
+        self.blocks: Blocks | None = None
+        self.event_id: str | None = None
+        self.request: Request | None = None
+        self.in_event_listener: bool = False
 
-thread_data = threading.local()
+thread_data = ThreadData()

--- a/gradio/context.py
+++ b/gradio/context.py
@@ -17,11 +17,13 @@ class Context:
     ip_address: str | None = None  # The IP address of the user.
     hf_token: str | None = None  # The token provided when loading private HF repos
 
+
 class ThreadData(threading.local):
     def __init__(self, **kwargs):
         self.blocks: Blocks | None = None
         self.event_id: str | None = None
         self.request: Request | None = None
         self.in_event_listener: bool = False
+
 
 thread_data = ThreadData()

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -1100,7 +1100,7 @@ class EventData:
 def log_message(message: str, level: Literal["info", "warning"] = "info"):
     from gradio import context
 
-    if not hasattr(context.thread_data, "blocks"):  # Function called outside of Gradio
+    if context.thread_data.blocks is None:  # Function called outside of Gradio
         if level == "info":
             print(message)
         elif level == "warning":
@@ -1111,6 +1111,7 @@ def log_message(message: str, level: Literal["info", "warning"] = "info"):
             f"Queueing must be enabled to issue {level.capitalize()}: '{message}'."
         )
         return
+    assert context.thread_data.event_id
     context.thread_data.blocks._queue.log_message(
         event_id=context.thread_data.event_id, log=message, level=level
     )

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -44,6 +44,7 @@ from gradio.context import Context
 from gradio.strings import en
 
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
+    from gradio import Request
     from gradio.blocks import Block, BlockContext, Blocks
     from gradio.components import Component
     from gradio.routes import App
@@ -660,7 +661,11 @@ def function_wrapper(
 
 
 def get_function_with_locals(
-    fn: Callable, blocks: Blocks, event_id: str | None, in_event_listener: bool
+    fn: Callable,
+    blocks: Blocks,
+    event_id: str | None,
+    in_event_listener: bool,
+    request: Request | None,
 ):
     def before_fn(blocks, event_id):
         from gradio.context import thread_data
@@ -668,6 +673,7 @@ def get_function_with_locals(
         thread_data.blocks = blocks
         thread_data.in_event_listener = in_event_listener
         thread_data.event_id = event_id
+        thread_data.request = request
 
     def after_fn():
         from gradio.context import thread_data


### PR DESCRIPTION
## PR content
- Allows accessing the `gr.Request` object with `[gradio].context.thread_data.request`
- Type the `threading.local()` class (inspired from https://github.com/python/mypy/issues/2388#issuecomment-257968459)

This can be used as an alternative to the `gr.Request` dependency injection