### PR TITLE
Fix js deps in cli and add gradio-preview artifacts to build

### DIFF
--- a/.changeset/dry-points-join.md
+++ b/.changeset/dry-points-join.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix js deps in cli and add gradio-preview artifacts to build

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"dev": "pnpm css && pnpm --filter @gradio/client build && pnpm --filter @gradio/app dev",
 		"css": "pnpm --filter @gradio/theme generate",
-		"build": "pnpm css && pnpm --filter @gradio/client build && pnpm --filter @gradio/app build:local --emptyOutDir",
+		"build": "pnpm css && pnpm --filter @gradio/client build && pnpm --filter @gradio/app build:local --emptyOutDir && pnpm --filter @gradio/gradio-preview build --emptyOutDir",
 		"build:cdn": "pnpm --filter @gradio/client build && pnpm --filter @gradio/app build:cdn --emptyOutDir",
 		"build:website": "pnpm --filter @gradio/app build:website --emptyOutDir",
 		"build:cdn-local": "TEST_CDN=TRUE pnpm build:cdn",


### PR DESCRIPTION
## Description

FYI @pngwn 

Bugs:
* We were not updating the js dependency versions because we always thought we were in the test dir 🤦 
* We were not including the gradio-preview artifacts in the wheel

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
