### PR TITLE
Fix width and height issues that would cut off content in `gr.DataFrame`

### DIFF
--- a/.changeset/honest-phones-divide.md
+++ b/.changeset/honest-phones-divide.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": patch
+"gradio": patch
+---
+
+fix:Fix width and height of `gr.DataFrame`

--- a/.changeset/honest-phones-divide.md
+++ b/.changeset/honest-phones-divide.md
@@ -3,4 +3,4 @@
 "gradio": patch
 ---
 
-fix:Fix width and height of `gr.DataFrame`
+fix:Fix width and height issues that would cut off content in `gr.DataFrame`

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -53,9 +53,9 @@ class Dataframe(Changeable, Inputable, Selectable, IOComponent, JSONSerializable
         overflow_row_behaviour: Literal["paginate", "show_ends"] = "paginate",
         latex_delimiters: list[dict[str, str | bool]] | None = None,
         label: str | None = None,
-        every: float | None = None,
         show_label: bool | None = None,
-        height: int | float | None = None,
+        every: float | None = None,
+        height: int = 500,
         scale: int | None = None,
         min_width: int = 160,
         interactive: bool | None = None,
@@ -74,14 +74,14 @@ class Dataframe(Changeable, Inputable, Selectable, IOComponent, JSONSerializable
             datatype: Datatype of values in sheet. Can be provided per column as a list of strings, or for the entire sheet as a single string. Valid datatypes are "str", "number", "bool", "date", and "markdown".
             type: Type of value to be returned by component. "pandas" for pandas dataframe, "numpy" for numpy array, or "array" for a Python array.
             label: component name in interface.
-            max_rows: Maximum number of rows to display at once. Set to None for infinite.
-            max_cols: Maximum number of columns to display at once. Set to None for infinite.
-            overflow_row_behaviour: If set to "paginate", will create pages for overflow rows. If set to "show_ends", will show initial and final rows and truncate middle rows.
+            max_rows: Deprecated and has no effect. Use `row_count` instead.
+            max_cols: Deprecated and has no effect. Use `col_count` instead.
+            overflow_row_behaviour: Deprecated and has no effect.
             latex_delimiters: A list of dicts of the form {"left": open delimiter (str), "right": close delimiter (str), "display": whether to display in newline (bool)} that will be used to render LaTeX expressions. If not provided, `latex_delimiters` is set to `[{ "left": "$", "right": "$", "display": False }]`, so only expressions enclosed in $ delimiters will be rendered as LaTeX, and in the same line. Pass in an empty list to disable LaTeX rendering. For more information, see the [KaTeX documentation](https://katex.org/docs/autorender.html). Only applies to columns whose datatype is "markdown".
             label: component name in interface.
-            every: If `value` is a callable, run the function 'every' number of seconds while the client connection is open. Has no effect otherwise. Queue must be enabled. The event can be accessed (e.g. to cancel it) via this component's .load_event attribute.
             show_label: if True, will display label.
-            height: The maximum height of the file component, in pixels. If more files are uploaded than can fit in the height, a scrollbar will appear.
+            every: If `value` is a callable, run the function 'every' number of seconds while the client connection is open. Has no effect otherwise. Queue must be enabled. The event can be accessed (e.g. to cancel it) via this component's .load_event attribute.
+            height: The maximum height of the dataframe, in pixels. If more rows are created than can fit in the height, a scrollbar will appear.
             scale: relative width compared to adjacent Components in a Row. For example, if Component A has scale=2, and Component B has scale=1, A will be twice as wide as B. Should be an integer.
             min_width: minimum pixel width, will wrap if not sufficient screen space to satisfy this value. If a certain scale value results in this Component being narrower than min_width, the min_width parameter will be respected first.
             interactive: if True, will allow users to edit the dataframe; if False, can only be used to display data. If not provided, this is inferred based on whether the component is used as an input or output.
@@ -165,7 +165,7 @@ class Dataframe(Changeable, Inputable, Selectable, IOComponent, JSONSerializable
         latex_delimiters: list[dict[str, str | bool]] | None = None,
         scale: int | None = None,
         min_width: int | None = None,
-        height: int | float | None = None,
+        height: int | None = None,
         interactive: bool | None = None,
         visible: bool | None = None,
     ):

--- a/js/dataframe/interactive/InteractiveDataframe.svelte
+++ b/js/dataframe/interactive/InteractiveDataframe.svelte
@@ -24,7 +24,7 @@
 		right: string;
 		display: boolean;
 	}[];
-	export let height: number | undefined = undefined;
+	export let height = 500;
 
 	let old_value: string = JSON.stringify(value);
 	export let value_is_output = false;

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -529,7 +529,7 @@
 
 	function set_cell_widths(): void {
 		const widths = cells.map((el, i) => {
-			return el?.clientWidth || 0;
+			return el?.offsetHeight || 0;
 		});
 
 		if (widths.length === 0) return;

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -28,7 +28,7 @@
 
 	export let editable = true;
 	export let wrap = false;
-	export let height: number | undefined;
+	export let height: number;
 	let selected: false | [number, number] = false;
 
 	$: {
@@ -541,7 +541,7 @@
 		}
 	}
 
-	let table_height: number = height || 500;
+	let table_height: number = height;
 	let scrollbar_width = 0;
 
 	function sort_data(
@@ -683,7 +683,7 @@
 			<VirtualTable
 				bind:items={data}
 				table_width={t_width}
-				max_height={height || 500}
+				max_height={height}
 				bind:actual_height={table_height}
 				bind:table_scrollbar_width={scrollbar_width}
 				selected={selected_index}

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -28,7 +28,7 @@
 
 	export let editable = true;
 	export let wrap = false;
-	export let height: number;
+	export let height = 500;
 	let selected: false | [number, number] = false;
 
 	$: {

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -526,19 +526,21 @@
 	$: cells[0] && set_cell_widths();
 	let cells: HTMLTableCellElement[] = [];
 	let parent: HTMLDivElement;
+	let table: HTMLTableElement;
+
 
 	function set_cell_widths(): void {
 		const widths = cells.map((el, i) => {
-			return el?.offsetHeight || 0;
+			return el?.clientWidth || 0;
 		});
-
 		if (widths.length === 0) return;
 		for (let i = 0; i < widths.length; i++) {
-			parent.style.setProperty(`--cell-width-${i}`, `${widths[i]}px`);
+			parent.style.setProperty(`--cell-width-${i}`, `${widths[i] - scroll_width/widths.length}px`);
 		}
 	}
 
 	let table_height: number = height || 500;
+	let scroll_width = 0;
 
 	function sort_data(
 		_data: typeof data,
@@ -610,7 +612,7 @@
 		role="grid"
 		tabindex="0"
 	>
-		<table bind:clientWidth={t_width}>
+		<table bind:clientWidth={t_width} bind:this={table}>
 			{#if label && label.length !== 0}
 				<caption class="sr-only">{label}</caption>
 			{/if}
@@ -681,6 +683,7 @@
 				table_width={t_width}
 				max_height={height || 500}
 				bind:actual_height={table_height}
+				bind:table_scroll_width={scroll_width}
 				selected={selected_index}
 			>
 				{#if label && label.length !== 0}

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -528,19 +528,21 @@
 	let parent: HTMLDivElement;
 	let table: HTMLTableElement;
 
-
 	function set_cell_widths(): void {
 		const widths = cells.map((el, i) => {
 			return el?.clientWidth || 0;
 		});
 		if (widths.length === 0) return;
 		for (let i = 0; i < widths.length; i++) {
-			parent.style.setProperty(`--cell-width-${i}`, `${widths[i] - scroll_width/widths.length}px`);
+			parent.style.setProperty(
+				`--cell-width-${i}`,
+				`${widths[i] - scrollbar_width / widths.length}px`
+			);
 		}
 	}
 
 	let table_height: number = height || 500;
-	let scroll_width = 0;
+	let scrollbar_width = 0;
 
 	function sort_data(
 		_data: typeof data,
@@ -683,7 +685,7 @@
 				table_width={t_width}
 				max_height={height || 500}
 				bind:actual_height={table_height}
-				bind:table_scroll_width={scroll_width}
+				bind:table_scrollbar_width={scrollbar_width}
 				selected={selected_index}
 			>
 				{#if label && label.length !== 0}

--- a/js/dataframe/shared/VirtualTable.svelte
+++ b/js/dataframe/shared/VirtualTable.svelte
@@ -7,6 +7,7 @@
 	export let table_width: number;
 	export let max_height: number;
 	export let actual_height: number;
+	export let table_scroll_width: number;
 	export let start = 0;
 	export let end = 0;
 	export let selected: number | false;
@@ -33,6 +34,7 @@
 			return;
 		}
 		const { scrollTop } = viewport;
+		table_scroll_width = viewport.offsetWidth - viewport.clientWidth;
 
 		content_height = top - (scrollTop - head_height);
 		let i = start;

--- a/js/dataframe/shared/VirtualTable.svelte
+++ b/js/dataframe/shared/VirtualTable.svelte
@@ -7,7 +7,7 @@
 	export let table_width: number;
 	export let max_height: number;
 	export let actual_height: number;
-	export let table_scroll_width: number;
+	export let table_scrollbar_width: number;
 	export let start = 0;
 	export let end = 0;
 	export let selected: number | false;
@@ -34,7 +34,7 @@
 			return;
 		}
 		const { scrollTop } = viewport;
-		table_scroll_width = viewport.offsetWidth - viewport.clientWidth;
+		table_scrollbar_width = viewport.offsetWidth - viewport.clientWidth;
 
 		content_height = top - (scrollTop - head_height);
 		let i = start;
@@ -217,7 +217,6 @@
 		if (scrollbarHeight > 0) {
 			distance += scrollbarHeight;
 		}
-
 
 		const _opts = {
 			top: distance,

--- a/js/dataframe/shared/VirtualTable.svelte
+++ b/js/dataframe/shared/VirtualTable.svelte
@@ -58,9 +58,9 @@
 		end = i;
 		const remaining = _items.length - end;
 
-		const scrollbarHeight = viewport.offsetHeight - viewport.clientHeight;
-		if (scrollbarHeight > 0) {
-			content_height += scrollbarHeight;
+		const scrollbar_height = viewport.offsetHeight - viewport.clientHeight;
+		if (scrollbar_height > 0) {
+			content_height += scrollbar_height;
 		}
 
 		let filtered_height_map = height_map.filter((v) => typeof v === "number");
@@ -213,9 +213,9 @@
 			distance = distance - viewport_height + _itemHeight + head_height;
 		}
 
-		const scrollbarHeight = viewport.offsetHeight - viewport.clientHeight;
-		if (scrollbarHeight > 0) {
-			distance += scrollbarHeight;
+		const scrollbar_height = viewport.offsetHeight - viewport.clientHeight;
+		if (scrollbar_height > 0) {
+			distance += scrollbar_height;
 		}
 
 		const _opts = {

--- a/js/dataframe/shared/VirtualTable.svelte
+++ b/js/dataframe/shared/VirtualTable.svelte
@@ -56,6 +56,11 @@
 		end = i;
 		const remaining = _items.length - end;
 
+		const scrollbarHeight = viewport.offsetHeight - viewport.clientHeight;
+		if (scrollbarHeight > 0) {
+			content_height += scrollbarHeight;
+		}
+
 		let filtered_height_map = height_map.filter((v) => typeof v === "number");
 		average_height =
 			filtered_height_map.reduce((a, b) => a + b, 0) /
@@ -63,7 +68,6 @@
 
 		bottom = remaining * average_height;
 		height_map.length = _items.length;
-
 		await tick();
 		if (!max_height) {
 			actual_height = content_height + 1;
@@ -206,6 +210,13 @@
 		if (align_end) {
 			distance = distance - viewport_height + _itemHeight + head_height;
 		}
+
+		const scrollbarHeight = viewport.offsetHeight - viewport.clientHeight;
+		if (scrollbarHeight > 0) {
+			distance += scrollbarHeight;
+		}
+
+
 		const _opts = {
 			top: distance,
 			behavior: "smooth" as ScrollBehavior,

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1221,7 +1221,7 @@ class TestDataframe:
             "wrap": False,
             "root_url": None,
             "name": "dataframe",
-            "height": None,
+            "height": 500,
             "latex_delimiters": [{"display": False, "left": "$", "right": "$"}],
         }
         dataframe_input = gr.Dataframe()
@@ -1253,7 +1253,7 @@ class TestDataframe:
             "wrap": False,
             "root_url": None,
             "name": "dataframe",
-            "height": None,
+            "height": 500,
             "latex_delimiters": [{"display": False, "left": "$", "right": "$"}],
         }
 


### PR DESCRIPTION
This is an attempt to fix: https://github.com/gradio-app/gradio/issues/5592. Previously, if you would run a demo like `matrix_transpose` or code like this:

```py
import gradio as gr

df = [[f"col: {i} -- row:{j}" for j in range(1, 3)] for i in range(1, 5)]

with gr.Blocks() as demo:
    gr.DataFrame(df, headers=list(range(1, 11)))
    gr.DataFrame(df, headers=list(range(1, 11)), interactive=True)

if __name__ == "__main__":
    demo.launch()
```

you'd end up with a compressed dataframe whose content was cut off and scrollbars would always be present:

<img width="1290" alt="image" src="https://github.com/gradio-app/gradio/assets/1778297/c283d77f-d865-455e-abb8-97297db1680c">

This made small dataframes frustrating to use. I think the issue was that the scrollbar width/height was not taken into account. Now, both are taken into account. The scrollbar holders are always present, but the scroll bars themselves only appear when needed:

<img width="1279" alt="image" src="https://github.com/gradio-app/gradio/assets/1778297/54c1839e-f0d7-4f18-9d2e-2aba7b28d3d6">

Would appreciate a review @pngwn to ensure that this doesn't break anything else and this is the correct approach. 