### PR TITLE
Allow Gradio apps containing `gr.Radio()`, `gr.Checkboxgroup()`, or `gr.Dropdown()` to be loaded with `gr.load()`

### DIFF
--- a/gradio/components/checkboxgroup.py
+++ b/gradio/components/checkboxgroup.py
@@ -71,7 +71,7 @@ class CheckboxGroup(
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
         """
         self.choices = (
-            [c if isinstance(c, tuple) else (str(c), c) for c in choices]
+            [c if isinstance(c, (tuple, list)) else (str(c), c) for c in choices]
             if choices
             else []
         )
@@ -133,7 +133,7 @@ class CheckboxGroup(
         choices = (
             None
             if choices is None
-            else [c if isinstance(c, tuple) else (str(c), c) for c in choices]
+            else [c if isinstance(c, (tuple, list)) else (str(c), c) for c in choices]
         )
         return {
             "choices": choices,

--- a/gradio/components/checkboxgroup.py
+++ b/gradio/components/checkboxgroup.py
@@ -71,6 +71,8 @@ class CheckboxGroup(
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
         """
         self.choices = (
+            # Although we expect choices to be a list of tuples, it can be a list of tuples if the Gradio app
+            # is loaded with gr.load() since Python tuples are converted to lists in JSON.
             [c if isinstance(c, (tuple, list)) else (str(c), c) for c in choices]
             if choices
             else []

--- a/gradio/components/checkboxgroup.py
+++ b/gradio/components/checkboxgroup.py
@@ -73,7 +73,7 @@ class CheckboxGroup(
         self.choices = (
             # Although we expect choices to be a list of tuples, it can be a list of tuples if the Gradio app
             # is loaded with gr.load() since Python tuples are converted to lists in JSON.
-            [c if isinstance(c, (tuple, list)) else (str(c), c) for c in choices]
+            [tuple(c) if isinstance(c, (tuple, list)) else (str(c), c) for c in choices]
             if choices
             else []
         )
@@ -135,7 +135,7 @@ class CheckboxGroup(
         choices = (
             None
             if choices is None
-            else [c if isinstance(c, (tuple, list)) else (str(c), c) for c in choices]
+            else [c if isinstance(c, tuple) else (str(c), c) for c in choices]
         )
         return {
             "choices": choices,

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -86,7 +86,7 @@ class Dropdown(
         self.choices = (
             # Although we expect choices to be a list of tuples, it can be a list of tuples if the Gradio app
             # is loaded with gr.load() since Python tuples are converted to lists in JSON.
-            [c if isinstance(c, (tuple, list)) else (str(c), c) for c in choices]
+            [tuple(c) if isinstance(c, (tuple, list)) else (str(c), c) for c in choices]
             if choices
             else []
         )
@@ -179,7 +179,7 @@ class Dropdown(
         choices = (
             None
             if choices is None
-            else [c if isinstance(c, (list, tuple)) else (str(c), c) for c in choices]
+            else [c if isinstance(c, tuple) else (str(c), c) for c in choices]
         )
         return {
             "choices": choices,

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -84,6 +84,8 @@ class Dropdown(
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
         """
         self.choices = (
+            # Although we expect choices to be a list of tuples, it can be a list of tuples if the Gradio app
+            # is loaded with gr.load() since Python tuples are converted to lists in JSON.
             [c if isinstance(c, (tuple, list)) else (str(c), c) for c in choices]
             if choices
             else []

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -84,7 +84,7 @@ class Dropdown(
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
         """
         self.choices = (
-            [c if isinstance(c, tuple) else (str(c), c) for c in choices]
+            [c if isinstance(c, (tuple, list)) else (str(c), c) for c in choices]
             if choices
             else []
         )
@@ -177,7 +177,7 @@ class Dropdown(
         choices = (
             None
             if choices is None
-            else [c if isinstance(c, tuple) else (str(c), c) for c in choices]
+            else [c if isinstance(c, (list, tuple)) else (str(c), c) for c in choices]
         )
         return {
             "choices": choices,

--- a/gradio/components/radio.py
+++ b/gradio/components/radio.py
@@ -72,6 +72,8 @@ class Radio(
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
         """
         self.choices = (
+            # Although we expect choices to be a list of tuples, it can be a list of tuples if the Gradio app
+            # is loaded with gr.load() since Python tuples are converted to lists in JSON.
             [c if isinstance(c, (tuple, list)) else (str(c), c) for c in choices]
             if choices
             else []

--- a/gradio/components/radio.py
+++ b/gradio/components/radio.py
@@ -72,7 +72,7 @@ class Radio(
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
         """
         self.choices = (
-            [c if isinstance(c, tuple) else (str(c), c) for c in choices]
+            [c if isinstance(c, (tuple, list)) else (str(c), c) for c in choices]
             if choices
             else []
         )
@@ -135,7 +135,7 @@ class Radio(
         choices = (
             None
             if choices is None
-            else [c if isinstance(c, tuple) else (str(c), c) for c in choices]
+            else [c if isinstance(c, (list, tuple)) else (str(c), c) for c in choices]
         )
         return {
             "choices": choices,

--- a/gradio/components/radio.py
+++ b/gradio/components/radio.py
@@ -74,7 +74,7 @@ class Radio(
         self.choices = (
             # Although we expect choices to be a list of tuples, it can be a list of tuples if the Gradio app
             # is loaded with gr.load() since Python tuples are converted to lists in JSON.
-            [c if isinstance(c, (tuple, list)) else (str(c), c) for c in choices]
+            [tuple(c) if isinstance(c, (tuple, list)) else (str(c), c) for c in choices]
             if choices
             else []
         )
@@ -137,7 +137,7 @@ class Radio(
         choices = (
             None
             if choices is None
-            else [c if isinstance(c, (list, tuple)) else (str(c), c) for c in choices]
+            else [c if isinstance(c, tuple) else (str(c), c) for c in choices]
         )
         return {
             "choices": choices,

--- a/js/dataframe/shared/VirtualTable.svelte
+++ b/js/dataframe/shared/VirtualTable.svelte
@@ -56,11 +56,6 @@
 		end = i;
 		const remaining = _items.length - end;
 
-		const scrollbarHeight = viewport.offsetHeight - viewport.clientHeight;
-		if (scrollbarHeight > 0) {
-			content_height += scrollbarHeight;
-		}
-
 		let filtered_height_map = height_map.filter((v) => typeof v === "number");
 		average_height =
 			filtered_height_map.reduce((a, b) => a + b, 0) /
@@ -68,6 +63,7 @@
 
 		bottom = remaining * average_height;
 		height_map.length = _items.length;
+
 		await tick();
 		if (!max_height) {
 			actual_height = content_height + 1;
@@ -210,13 +206,6 @@
 		if (align_end) {
 			distance = distance - viewport_height + _itemHeight + head_height;
 		}
-
-		const scrollbarHeight = viewport.offsetHeight - viewport.clientHeight;
-		if (scrollbarHeight > 0) {
-			distance += scrollbarHeight;
-		}
-
-
 		const _opts = {
 			top: distance,
 			behavior: "smooth" as ScrollBehavior,

--- a/js/dataframe/shared/VirtualTable.svelte
+++ b/js/dataframe/shared/VirtualTable.svelte
@@ -56,6 +56,11 @@
 		end = i;
 		const remaining = _items.length - end;
 
+		const scrollbarHeight = viewport.offsetHeight - viewport.clientHeight;
+		if (scrollbarHeight > 0) {
+			content_height += scrollbarHeight;
+		}
+
 		let filtered_height_map = height_map.filter((v) => typeof v === "number");
 		average_height =
 			filtered_height_map.reduce((a, b) => a + b, 0) /
@@ -63,7 +68,6 @@
 
 		bottom = remaining * average_height;
 		height_map.length = _items.length;
-
 		await tick();
 		if (!max_height) {
 			actual_height = content_height + 1;
@@ -206,6 +210,13 @@
 		if (align_end) {
 			distance = distance - viewport_height + _itemHeight + head_height;
 		}
+
+		const scrollbarHeight = viewport.offsetHeight - viewport.clientHeight;
+		if (scrollbarHeight > 0) {
+			distance += scrollbarHeight;
+		}
+
+
 		const _opts = {
 			top: distance,
 			behavior: "smooth" as ScrollBehavior,

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -512,7 +512,7 @@ class TestCheckboxGroup:
         assert checkboxes_input.preprocess(["a", "b"]) == [0, 1]
         assert checkboxes_input.preprocess(["a", "b", "c"]) == [0, 1, None]
 
-        # When a Gradio app is loaded with gr.load, the tuples are converted to lists, 
+        # When a Gradio app is loaded with gr.load, the tuples are converted to lists,
         # so we need to test that case as well
         checkboxgroup = gr.CheckboxGroup(["a", "b", ["c", "c full"]])  # type: ignore
         assert checkboxgroup.choices == [("a", "a"), ("b", "b"), ("c", "c full")]
@@ -597,7 +597,7 @@ class TestRadio:
         assert radio.preprocess("b") == 1
         assert radio.preprocess("c") is None
 
-        # When a Gradio app is loaded with gr.load, the tuples are converted to lists, 
+        # When a Gradio app is loaded with gr.load, the tuples are converted to lists,
         # so we need to test that case as well
         radio = gr.Radio(["a", "b", ["c", "c full"]])  # type: ignore
         assert radio.choices == [("a", "a"), ("b", "b"), ("c", "c full")]
@@ -643,7 +643,7 @@ class TestDropdown:
         assert dropdown_input.preprocess("c full") == "c full"
         assert dropdown_input.postprocess("c full") == "c full"
 
-        # When a Gradio app is loaded with gr.load, the tuples are converted to lists, 
+        # When a Gradio app is loaded with gr.load, the tuples are converted to lists,
         # so we need to test that case as well
         dropdown_input = gr.Dropdown(["a", "b", ["c", "c full"]])  # type: ignore
         assert dropdown_input.choices == [("a", "a"), ("b", "b"), ("c", "c full")]

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -512,6 +512,11 @@ class TestCheckboxGroup:
         assert checkboxes_input.preprocess(["a", "b"]) == [0, 1]
         assert checkboxes_input.preprocess(["a", "b", "c"]) == [0, 1, None]
 
+        # When a Gradio app is loaded with gr.load, the tuples are converted to lists, 
+        # so we need to test that case as well
+        checkboxgroup = gr.CheckboxGroup(["a", "b", ["c", "c full"]])  # type: ignore
+        assert checkboxgroup.choices == [("a", "a"), ("b", "b"), ("c", "c full")]
+
         checkboxes_input = gr.CheckboxGroup(
             value=["a", "c"],
             choices=["a", "b", "c"],
@@ -592,6 +597,11 @@ class TestRadio:
         assert radio.preprocess("b") == 1
         assert radio.preprocess("c") is None
 
+        # When a Gradio app is loaded with gr.load, the tuples are converted to lists, 
+        # so we need to test that case as well
+        radio = gr.Radio(["a", "b", ["c", "c full"]])  # type: ignore
+        assert radio.choices == [("a", "a"), ("b", "b"), ("c", "c full")]
+
         with pytest.raises(ValueError):
             gr.Radio(["a", "b"], type="unknown")
 
@@ -632,6 +642,11 @@ class TestDropdown:
         assert dropdown_input.postprocess("a") == "a"
         assert dropdown_input.preprocess("c full") == "c full"
         assert dropdown_input.postprocess("c full") == "c full"
+
+        # When a Gradio app is loaded with gr.load, the tuples are converted to lists, 
+        # so we need to test that case as well
+        dropdown_input = gr.Dropdown(["a", "b", ["c", "c full"]])  # type: ignore
+        assert dropdown_input.choices == [("a", "a"), ("b", "b"), ("c", "c full")]
 
         dropdown = gr.Dropdown(choices=["a", "b"], type="index")
         assert dropdown.preprocess("a") == 0


### PR DESCRIPTION
We allow these components to take in tuples of choices, but we when tuples are converted to javascript, they are converted to lists, so we need to handle that as well.

Test with:

```py
import gradio as gr
demo = gr.load(name="abidlabs/test-radio", src="spaces")
demo.queue(api_open=False)
demo.launch()
```

Fixes: #5632 