### PR TITLE
Fix typos in Gallery docs

### DIFF
--- a/.changeset/puny-papayas-bake.md
+++ b/.changeset/puny-papayas-bake.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Fix typos in Gallery docs

--- a/.changeset/puny-papayas-bake.md
+++ b/.changeset/puny-papayas-bake.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix typos in Gallery docs

--- a/gradio/components/gallery.py
+++ b/gradio/components/gallery.py
@@ -70,8 +70,8 @@ class Gallery(IOComponent, GallerySerializable, Selectable):
             visible: If False, component will be hidden.
             elem_id: An optional string that is assigned as the id of this component in the HTML DOM. Can be used for targeting CSS styles.
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
-            columns: Represents the number of images that should be shown in one row, for each of the six standard screen sizes (<576px, <768px, <992px, <1200px, <1400px, >1400px). if fewer that 6 are given then the last will be used for all subsequent breakpoints
-            rows: Represents the number of rows in the image grid, for each of the six standard screen sizes (<576px, <768px, <992px, <1200px, <1400px, >1400px). if fewer that 6 are given then the last will be used for all subsequent breakpoints
+            columns: Represents the number of images that should be shown in one row, for each of the six standard screen sizes (<576px, <768px, <992px, <1200px, <1400px, >1400px). If fewer than 6 are given then the last will be used for all subsequent breakpoints
+            rows: Represents the number of rows in the image grid, for each of the six standard screen sizes (<576px, <768px, <992px, <1200px, <1400px, >1400px). If fewer than 6 are given then the last will be used for all subsequent breakpoints
             height: The height of the gallery component, in pixels. If more images are displayed than can fit in the height, a scrollbar will appear.
             preview: If True, will display the Gallery in preview mode, which shows all of the images as thumbnails and allows the user to click on them to view them in full size.
             object_fit: CSS object-fit property for the thumbnail images in the gallery. Can be "contain", "cover", "fill", "none", or "scale-down".


### PR DESCRIPTION
## Description

Fixing two small typos in the `columns` and `rows` parameter documentation of the Gallery component.
