### PR TITLE
get URL query parameters from the gr.Request object

### DIFF
--- a/.changeset/fuzzy-terms-trade.md
+++ b/.changeset/fuzzy-terms-trade.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:get URL query parameters from the gr.Request object

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import fastapi
 from gradio_client.documentation import document, set_documentation_group
+from starlette.datastructures import URL, QueryParams
 
 from gradio import utils
 from gradio.data_classes import PredictBody
@@ -118,6 +119,10 @@ class Request:
                     f"'Request' object has no attribute '{name}'"
                 ) from ke
             return self.dict_to_obj(obj)
+
+    @property
+    def query_params(self):
+        return dict(QueryParams(URL(self.request.headers["referer"]).query))
 
 
 class FnIndexInferError(Exception):

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -122,7 +122,10 @@ class Request:
 
     @property
     def query_params(self):
-        return dict(QueryParams(URL(self.request.headers["referer"]).query))
+        if self.request:
+            return dict(QueryParams(URL(self.request.headers["referer"]).query))
+        else:
+            return {}
 
 
 class FnIndexInferError(Exception):


### PR DESCRIPTION
## Description

- Currently, the way to extract URL query parameters from within a Gradio app is using _js: `URLSeachParams(window.location.search)`.
- This PR adds the `query_params` property to the `gr.Request` object. This makes it easier to get URL query params without the need for custom js function.

Closes: #5485 

  
