### PR TITLE
Fix front-end imports + other misc fixes

### DIFF
--- a/.changeset/short-clouds-see.md
+++ b/.changeset/short-clouds-see.md
@@ -1,0 +1,6 @@
+---
+"@gradio/preview": minor
+"gradio": minor
+---
+
+feat:Fix front-end imports + other misc fixes

--- a/gradio/cli/commands/create.py
+++ b/gradio/cli/commands/create.py
@@ -107,9 +107,11 @@ def _create_backend(name: str, template: str, directory: pathlib.Path, package_n
 import gradio as gr
 from {package_name} import {name}
 
+example = {name}().example_inputs()
+
 with gr.Blocks() as demo:
-    {name}(interactive=True)
-    {name}(interactive=False)
+    {name}(value=example, interactive=True)
+    {name}(value=example, interactive=False)
     
 
 demo.launch()
@@ -149,11 +151,11 @@ __all__ = ['{name}']
             shutil.copy(str(source_pyi_file), str(pyi_file))
 
         content = python_file.read_text()
-        python_file.write_text(content.replace(f"class {template}", f"class {name}"))
+        python_file.write_text(content.replace(f"class {template}(", f"class {name}("))
         if pyi_file.exists():
             pyi_content = pyi_file.read_text()
             pyi_file.write_text(
-                pyi_content.replace(f"class {template}", f"class {name}")
+                pyi_content.replace(f"class {template}(", f"class {name}(")
             )
 
 
@@ -297,6 +299,10 @@ def dev(
         stderr=subprocess.STDOUT,
     )
     while True:
+        proc.poll()
+        if proc.returncode is not None:
+            print("Backend server failed to launch. Exiting.")
+            return
         text = proc.stdout.readline()
         text = (
             text.decode("utf-8")

--- a/js/preview/src/dev_server.ts
+++ b/js/preview/src/dev_server.ts
@@ -213,10 +213,13 @@ function generate_imports(component_dir: string): string {
 			static: join(component.dir, "static"),
 			example: join(component.dir, "example")
 		};
+
+		const interactive = fs.existsSync(x.interactive) ? `interactive: () => import("${x.interactive}"),\n` : ""
+		const example = fs.existsSync(x.example) ? `example: () => import("${x.example}"),\n` : ""
 		return `${acc}"${component.package_name}": {
-			interactive: () => import("${x.interactive}"),
-			static: () => import("${x.static}"),
-			example: () => import("${x.example}")
+			${interactive}
+			${example}
+			static: () => import("${x.static}")
 			},\n`;
 	}, "");
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -844,6 +844,33 @@ importers:
         specifier: workspace:^
         version: link:../utils
 
+  js/gradio-preview/test/coolslider/frontend:
+    dependencies:
+      '@gradio/atoms':
+        specifier: workspace:^
+        version: link:../../../../atoms
+      '@gradio/statustracker':
+        specifier: workspace:^
+        version: link:../../../../statustracker
+      '@gradio/utils':
+        specifier: workspace:^
+        version: link:../../../../utils
+
+  js/gradio-preview/test/newtextbox/frontend:
+    dependencies:
+      '@gradio/atoms':
+        specifier: workspace:^
+        version: link:../../../../atoms
+      '@gradio/icons':
+        specifier: workspace:^
+        version: link:../../../../icons
+      '@gradio/statustracker':
+        specifier: workspace:^
+        version: link:../../../../statustracker
+      '@gradio/utils':
+        specifier: workspace:^
+        version: link:../../../../utils
+
   js/group: {}
 
   js/highlightedtext:


### PR DESCRIPTION
## Description

* Don't try to import the interactive/example versions of a component if they don't exist
* Fix bug where console printed out infinitely if the backend server failed to launch
* Fix bug where the data_model was also being renamed
* Add example_inputs to the demo

cc @pngwn 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
