### PR TITLE
Fix secondary hue bug in gr.themes.builder()

### DIFF
--- a/.changeset/few-nights-cheer.md
+++ b/.changeset/few-nights-cheer.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:fix: builder_app.py
+feat:Fix secondary hue bug in gr.themes.builder()

--- a/.changeset/few-nights-cheer.md
+++ b/.changeset/few-nights-cheer.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:fix: builder_app.py

--- a/gradio/themes/builder_app.py
+++ b/gradio/themes/builder_app.py
@@ -878,7 +878,7 @@ with gr.Blocks(theme=theme) as demo:
         )
         attach_rerender(
             secondary_hue.select(
-                load_color, secondary_hue, secondary_hue, api_name=False
+                load_color, secondary_hue, secondary_hues, api_name=False
             ).then
         )
         attach_rerender(


### PR DESCRIPTION
## Description

When building a custom theme locally using `gr.themes.builder()`, I encountered an error while attempting to modify the `Secondary Hue` under the `CoreColor` tab. Subsequently, I discovered a spelling mistake in the `builder_app.py` file and made the necessary correction.





