### PR TITLE
Fix functional tests

### DIFF
--- a/.changeset/brave-toes-hunt.md
+++ b/.changeset/brave-toes-hunt.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": minor
+"gradio": minor
+---
+
+feat:Fix functional tests

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           . venv/bin/activate
           python -m pip install -r demo/outbreak_forecast/requirements.txt
+      - run: pnpm build
       - run: pnpm exec playwright install chromium
       - name: run browser tests
         run: |

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -399,11 +399,6 @@ export function api_factory(fetch_implementation: typeof fetch): Client {
 
 				if (typeof endpoint === "number") {
 					fn_index = endpoint;
-					if (fn_index in api.unnamed_endpoints) {
-						api_info = api.unnamed_endpoints[fn_index];
-					} else {
-						throw new Error(`Invalid function index: ${fn_index}`);
-					}
 					api_info = api.unnamed_endpoints[fn_index];
 				} else {
 					const trimmed_endpoint = endpoint.replace(/^\//, "");


### PR DESCRIPTION
The culprit was my PR from last week: https://github.com/gradio-app/gradio/pull/5653

The js client needs to be able to access routes with `api_name=False` since it is used internally by Gradio, so I've reverted those changes. 

Somehow the functional tests didn't fail in the original PR, not sure why. 

cc @aliabd @hannahblair @freddyaboulton @pngwn 