### PR TITLE
Fix for regression in rendering empty Markdown

### DIFF
--- a/.changeset/quick-streets-taste.md
+++ b/.changeset/quick-streets-taste.md
@@ -1,0 +1,6 @@
+---
+"@gradio/markdown": patch
+"gradio": patch
+---
+
+fix:Fix for regression in rendering empty Markdown

--- a/js/markdown/static/MarkdownCode.svelte
+++ b/js/markdown/static/MarkdownCode.svelte
@@ -42,7 +42,7 @@
 		html = "";
 	}
 	async function render_html(value: string): Promise<void> {
-		if (latex_delimiters.length > 0) {
+		if (latex_delimiters.length > 0 && value) {
 			render_math_in_element(el, {
 				delimiters: latex_delimiters,
 				throwOnError: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
We had a regression -- rendering an empty string / null value in Markdown broke the component. This fixes: #5700