### PR TITLE
ensure internal data has updated before dispatching `success` or `then` events

### DIFF
--- a/.changeset/rare-lines-show.md
+++ b/.changeset/rare-lines-show.md
@@ -1,0 +1,7 @@
+---
+"@gradio/app": patch
+"@gradio/client": patch
+"gradio": patch
+---
+
+fix:ensure internal data has updated before dispatching `success` or `then` events

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -379,9 +379,9 @@ export function api_factory(fetch_implementation: typeof fetch): Client {
 							if (status.stage === "error") rej(status);
 							if (status.stage === "complete") {
 								status_complete = true;
-								app.destroy();
 								// if complete message comes after data, resolve here
 								if (data_returned) {
+									app.destroy();
 									res(result);
 								}
 							}

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -436,80 +436,82 @@
 					handle_update(data, fn_index);
 				})
 				.on("status", ({ fn_index, ...status }) => {
-					//@ts-ignore
-					loading_status.update({
-						...status,
-						status: status.stage,
-						progress: status.progress_data,
-						fn_index
-					});
-					if (
-						!showed_duplicate_message &&
-						space_id !== null &&
-						status.position !== undefined &&
-						status.position >= 2 &&
-						status.eta !== undefined &&
-						status.eta > SHOW_DUPLICATE_MESSAGE_ON_ETA
-					) {
-						showed_duplicate_message = true;
-						messages = [
-							new_message(DUPLICATE_MESSAGE, fn_index, "warning"),
-							...messages
-						];
-					}
-					if (
-						!showed_mobile_warning &&
-						is_mobile_device &&
-						status.eta !== undefined &&
-						status.eta > SHOW_MOBILE_QUEUE_WARNING_ON_ETA
-					) {
-						showed_mobile_warning = true;
-						messages = [
-							new_message(MOBILE_QUEUE_WARNING, fn_index, "warning"),
-							...messages
-						];
-					}
-
-					if (status.stage === "complete") {
-						dependencies.map(async (dep, i) => {
-							if (dep.trigger_after === fn_index) {
-								trigger_api_call(i);
-							}
+					tick().then(() => {
+						//@ts-ignore
+						loading_status.update({
+							...status,
+							status: status.stage,
+							progress: status.progress_data,
+							fn_index
 						});
-
-						submission.destroy();
-					}
-					if (status.broken && is_mobile_device && user_left_page) {
-						window.setTimeout(() => {
+						if (
+							!showed_duplicate_message &&
+							space_id !== null &&
+							status.position !== undefined &&
+							status.position >= 2 &&
+							status.eta !== undefined &&
+							status.eta > SHOW_DUPLICATE_MESSAGE_ON_ETA
+						) {
+							showed_duplicate_message = true;
 							messages = [
-								new_message(MOBILE_RECONNECT_MESSAGE, fn_index, "error"),
-								...messages
-							];
-						}, 0);
-						trigger_api_call(dep_index, event_data);
-						user_left_page = false;
-					} else if (status.stage === "error") {
-						if (status.message) {
-							const _message = status.message.replace(
-								MESSAGE_QUOTE_RE,
-								(_, b) => b
-							);
-							messages = [
-								new_message(_message, fn_index, "error"),
+								new_message(DUPLICATE_MESSAGE, fn_index, "warning"),
 								...messages
 							];
 						}
-						dependencies.map(async (dep, i) => {
-							if (
-								dep.trigger_after === fn_index &&
-								!dep.trigger_only_on_success
-							) {
-								trigger_api_call(i);
-							}
-						});
+						if (
+							!showed_mobile_warning &&
+							is_mobile_device &&
+							status.eta !== undefined &&
+							status.eta > SHOW_MOBILE_QUEUE_WARNING_ON_ETA
+						) {
+							showed_mobile_warning = true;
+							messages = [
+								new_message(MOBILE_QUEUE_WARNING, fn_index, "warning"),
+								...messages
+							];
+						}
 
-						submission.destroy();
-					}
+						if (status.stage === "complete") {
+							dependencies.map(async (dep, i) => {
+								if (dep.trigger_after === fn_index) {
+									trigger_api_call(i);
+								}
+							});
+
+							submission.destroy();
+						}
+						if (status.broken && is_mobile_device && user_left_page) {
+							window.setTimeout(() => {
+								messages = [
+									new_message(MOBILE_RECONNECT_MESSAGE, fn_index, "error"),
+									...messages
+								];
+							}, 0);
+							trigger_api_call(dep_index, event_data);
+							user_left_page = false;
+						} else if (status.stage === "error") {
+							if (status.message) {
+								const _message = status.message.replace(
+									MESSAGE_QUOTE_RE,
+									(_, b) => b
+								);
+								messages = [
+									new_message(_message, fn_index, "error"),
+									...messages
+								];
+							}
+							dependencies.map(async (dep, i) => {
+								if (
+									dep.trigger_after === fn_index &&
+									!dep.trigger_only_on_success
+								) {
+									trigger_api_call(i);
+								}
+							});
+
+							submission.destroy();
+						}
+					});
 				})
 				.on("log", ({ log, fn_index, level }) => {
 					messages = [new_message(log, fn_index, level), ...messages];


### PR DESCRIPTION
## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
