### PR TITLE
ensure client is copied along with components

### DIFF
--- a/.changeset/bright-planes-divide.md
+++ b/.changeset/bright-planes-divide.md
@@ -2,4 +2,4 @@
 "gradio": patch
 ---
 
-ensure all relevant packages are available to the custom component CLI
+fix: ensure all relevant packages are available to the custom component CLI

--- a/.changeset/bright-planes-divide.md
+++ b/.changeset/bright-planes-divide.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+ensure all relevant packages are available to the custom component CLI

--- a/.config/copy_frontend.py
+++ b/.config/copy_frontend.py
@@ -6,15 +6,33 @@ from typing import Any
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
-class BuildHook(BuildHookInterface):
 
+class BuildHook(BuildHookInterface):
     def initialize(self, version: str, build_data: dict[str, Any]) -> None:
-        NOT_COMPONENT = ["app", "node_modules", "storybook", "playwright-report", "wasm", "workbench", "tooltils"]
+        NOT_COMPONENT = [
+            "app",
+            "node_modules",
+            "storybook",
+            "playwright-report",
+            "wasm",
+            "workbench",
+            "tooltils",
+        ]
         for entry in (pathlib.Path(self.root) / "js").iterdir():
-            if (entry.is_dir() and
-                not str(entry.name).startswith("_") and 
-                not str(entry.name) in NOT_COMPONENT):
-                shutil.copytree(str(entry),
-                                str(pathlib.Path("gradio") / "_frontend_code" / entry.name),
-                                ignore=lambda d, names: ["node_modules"],
-                                dirs_exist_ok=True)
+            if (
+                entry.is_dir()
+                and not str(entry.name).startswith("_")
+                and not str(entry.name) in NOT_COMPONENT
+            ):
+                shutil.copytree(
+                    str(entry),
+                    str(pathlib.Path("gradio") / "_frontend_code" / entry.name),
+                    ignore=lambda d, names: ["node_modules"],
+                    dirs_exist_ok=True,
+                )
+        shutil.copytree(
+            str(pathlib.Path(self.root) / "client" / "js"),
+            str(pathlib.Path("gradio") / "_frontend_code" / "client"),
+            ignore=lambda d, names: ["node_modules"],
+            dirs_exist_ok=True,
+        )


### PR DESCRIPTION
## Description

We weren't copying the client to the`/ _frontend_code` folder, so the CLI was erroring when trying to replace the version. Only a few components use the js client, so this hasn't come up until now.

cc @freddyaboulton 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
