### PR TITLE
Make Tab and Tabs updatable

### DIFF
--- a/.changeset/full-hornets-obey.md
+++ b/.changeset/full-hornets-obey.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Make Tab and Tabs updatable

--- a/gradio/layouts.py
+++ b/gradio/layouts.py
@@ -143,7 +143,7 @@ class Column(Updateable, BlockContext):
         }
 
 
-class Tabs(BlockContext, Changeable, Selectable):
+class Tabs(Updateable, BlockContext, Changeable, Selectable):
     """
     Tabs is a layout element within Blocks that can contain multiple "Tab" Components.
     """
@@ -182,7 +182,7 @@ class Tabs(BlockContext, Changeable, Selectable):
 
 
 @document()
-class Tab(BlockContext, Selectable):
+class Tab(Updateable, BlockContext, Selectable):
     """
     Tab (or its alias TabItem) is a layout element. Components defined within the Tab will be visible when this tab is selected tab.
     Example:


### PR DESCRIPTION
Closes: #5707 

Test with repro on issue or this more comprehensive one:

```py
import gradio as gr

css = """
.red{
    background-color:red;
}
"""

with gr.Blocks(css=css) as demo:
    button = gr.Button("Change selected tab")
    button2 = gr.Button("Color tab")
    
    def change_tab():
        return gr.Tabs(selected=1)

    def color_tab():
        return gr.Tab(elem_classes="red")
    
    with gr.Tabs() as tabs:
        with gr.Tab("a", id=0) as tab1:
            pass
        with gr.Tab("b", id=1) as tab2:
            pass
        
    button.click(change_tab, None, tabs)
    button2.click(color_tab, None, tab1)
    
demo.launch()
```