### PR TITLE
Add a bare `Component` type to the acceptable type list of `gr.load()`'s `inputs` and `outputs`

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1664,8 +1664,8 @@ Received outputs:
     def load(
         self: Blocks | None = None,
         fn: Callable | None = None,
-        inputs: list[Component] | None = None,
-        outputs: list[Component] | None = None,
+        inputs: Component | list[Component] | None = None,
+        outputs: Component | list[Component] | None = None,
         api_name: str | None | Literal[False] = None,
         scroll_to_output: bool = False,
         show_progress: str = "full",


### PR DESCRIPTION
## Description

Fixing type annotations.

With the current types, for example, [this sample code on the doc](https://www.gradio.app/guides/blocks-and-event-listeners#running-events-continuously) shows a type error as below
```
Argument of type "Plot" cannot be assigned to parameter "outputs" of type "list[Component] | None" in function "load"
  Type "Plot" cannot be assigned to type "list[Component] | None"
    "Plot" is incompatible with "list[Component]"
    Type cannot be assigned to type "None"Pylance[reportGeneralTypeIssues](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportGeneralTypeIssues)
```
at this line:
>     dep = demo.load(get_plot, None, plot, every=1)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
