### PR TITLE
Use path to npm executable in subprocess

### DIFF
--- a/.changeset/large-banks-push.md
+++ b/.changeset/large-banks-push.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Use path to npm executable in subprocess

--- a/gradio/cli/commands/components/create.py
+++ b/gradio/cli/commands/components/create.py
@@ -69,7 +69,14 @@ def _create(
 
     npm_install = npm_install.strip()
     if npm_install == "npm install":
-        npm_install = f"{shutil.which('npm')} install"
+        npm = shutil.which("npm")
+        if not npm:
+            raise ValueError(
+                "By default, the install command uses npm to install "
+                "the frontend dependencies. Please install npm or pass your own install command "
+                "via the --npm-install option."
+            )
+        npm_install = f"{npm} install"
 
     with LivePanelDisplay() as live:
         live.update(

--- a/gradio/cli/commands/components/create.py
+++ b/gradio/cli/commands/components/create.py
@@ -1,4 +1,5 @@
 import pathlib
+import shutil
 import subprocess
 from typing import Optional
 
@@ -65,6 +66,10 @@ def _create(
 
     if _create_utils._in_test_dir():
         npm_install = "pnpm i --ignore-scripts"
+
+    npm_install = npm_install.strip()
+    if npm_install == "npm install":
+        npm_install = f"{shutil.which('npm')} install"
 
     with LivePanelDisplay() as live:
         live.update(

--- a/gradio/cli/commands/components/dev.py
+++ b/gradio/cli/commands/components/dev.py
@@ -1,3 +1,4 @@
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -30,9 +31,13 @@ def _dev(
 
     print(f":recycle: [green]Launching[/] {app} in reload mode\n")
 
+    node = shutil.which("node")
+    if not node:
+        raise ValueError("node must be installed in order to run dev mode.")
+
     proc = subprocess.Popen(
         [
-            "node",
+            node,
             gradio_node_path,
             "--component-directory",
             component_directory,


### PR DESCRIPTION
## Description

Should fix the create command on windows

FYI @pngwn 

![image](https://github.com/gradio-app/gradio/assets/41651716/21ba1467-ede5-40ab-a7fb-db889f686b99)

![image](https://github.com/gradio-app/gradio/assets/41651716/2d9fd25e-ab96-457d-a8d9-760b4aee5fe7)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
