### PR TITLE
Fix template remaining components

### DIFF
--- a/.changeset/plenty-teeth-clap.md
+++ b/.changeset/plenty-teeth-clap.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix template remaining components

--- a/gradio/cli/commands/components/_create_utils.py
+++ b/gradio/cli/commands/components/_create_utils.py
@@ -39,6 +39,41 @@ class ComponentFiles:
 
 
 OVERRIDES = {
+    "AnnotatedImage": ComponentFiles(
+        template="AnnotatedImage", python_file_name="annotated_image.py"
+    ),
+    "HighlightedText": ComponentFiles(
+        template="HighlightedText", python_file_name="highlighted_text.py"
+    ),
+    "BarPlot": ComponentFiles(
+        template="BarPlot", python_file_name="bar_plot.py", js_dir="plot"
+    ),
+    "ClearButton": ComponentFiles(
+        template="ClearButton", python_file_name="clear_button.py", js_dir="button"
+    ),
+    "ColorPicker": ComponentFiles(
+        template="ColorPicker", python_file_name="color_picker.py"
+    ),
+    "DuplicateButton": ComponentFiles(
+        template="DuplicateButton",
+        python_file_name="duplicate_button.py",
+        js_dir="button",
+    ),
+    "LinePlot": ComponentFiles(
+        template="LinePlot", python_file_name="line_plot.py", js_dir="plot"
+    ),
+    "LogoutButton": ComponentFiles(
+        template="LogoutButton", python_file_name="logout_button.py", js_dir="button"
+    ),
+    "LoginButton": ComponentFiles(
+        template="LoginButton", python_file_name="login_button.py", js_dir="button"
+    ),
+    "ScatterPlot": ComponentFiles(
+        template="ScatterPlot", python_file_name="scatter_plot.py", js_dir="plot"
+    ),
+    "UploadButton": ComponentFiles(
+        template="UploadButton", python_file_name="upload_button.py"
+    ),
     "JSON": ComponentFiles(template="JSON", python_file_name="json_component.py"),
     "Row": ComponentFiles(
         template="Row",
@@ -205,7 +240,7 @@ def _create_backend(
 import gradio as gr
 from {package_name} import {name}
 
-{component.demo_code.format(name=name)} 
+{component.demo_code.format(name=name)}
 
 demo.launch()
 """

--- a/test/test_gradio_component_cli.py
+++ b/test/test_gradio_component_cli.py
@@ -1,27 +1,48 @@
+import textwrap
+
 import pytest
 
+from gradio.cli.commands.components._create_utils import OVERRIDES
 from gradio.cli.commands.components.create import _create
 
 
-def test_template_layout_component(tmp_path):
-    _create("MyRow", tmp_path, template="Row", overwrite=True)
-    assert (
-        (tmp_path / "demo" / "app.py").read_text()
-        == """
+@pytest.mark.parametrize(
+    "template",
+    [
+        "Row",
+        "Column",
+        "Tabs",
+        "Group",
+        "Accordion",
+        "AnnotatedImage",
+        "HighlightedText",
+        "BarPlot",
+        "ClearButton",
+        "ColorPicker",
+        "DuplicateButton",
+        "LinePlot",
+        "LogoutButton",
+        "LoginButton",
+        "ScatterPlot",
+        "UploadButton",
+        "JSON",
+    ],
+)
+def test_template_override_component(template, tmp_path):
+    _create("MyComponent", tmp_path, template=template, overwrite=True)
+    app = (tmp_path / "demo" / "app.py").read_text()
+    answer = textwrap.dedent(
+        f"""
 import gradio as gr
-from gradio_myrow import MyRow
+from gradio_mycomponent import MyComponent
 
-
-with gr.Blocks() as demo:
-    with MyRow():
-        gr.Textbox(value="foo", interactive=True)
-        gr.Number(value=10, interactive=True)
- 
+{OVERRIDES[template].demo_code.format(name="MyComponent")}
 
 demo.launch()
 """
     )
-    assert (tmp_path / "backend" / "gradio_myrow" / "myrow.py").exists()
+    assert app.strip() == answer.strip()
+    assert (tmp_path / "backend" / "gradio_mycomponent" / "mycomponent.py").exists()
 
 
 def test_raise_error_component_template_does_not_exist(tmp_path):


### PR DESCRIPTION
## Description
Make sure the following components can be templated

        "AnnotatedImage",
        "HighlightedText",
        "BarPlot",
        "ClearButton",
        "ColorPicker",
        "DuplicateButton",
        "LinePlot",
        "LogoutButton",
        "LoginButton",
        "ScatterPlot",
        "UploadButton",

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
