### PR TITLE
Fix Gallery `columns` and `rows` params

### DIFF
--- a/.changeset/slow-actors-tease.md
+++ b/.changeset/slow-actors-tease.md
@@ -1,0 +1,6 @@
+---
+"@gradio/gallery": patch
+"gradio": patch
+---
+
+fix:Fix Gallery `columns` and `rows` params

--- a/gradio/components/gallery.py
+++ b/gradio/components/gallery.py
@@ -80,8 +80,8 @@ class Gallery(IOComponent, GallerySerializable, Selectable):
             show_download_button: If True, will show a download button in the corner of the selected image. If False, the icon does not appear. Default is True.
 
         """
-        self.grid_cols = columns
-        self.grid_rows = rows
+        self.columns = columns
+        self.rows = rows
         self.height = height
         self.preview = preview
         self.object_fit = object_fit
@@ -147,8 +147,8 @@ class Gallery(IOComponent, GallerySerializable, Selectable):
             "min_width": min_width,
             "visible": visible,
             "value": value,
-            "grid_cols": columns,
-            "grid_rows": rows,
+            "columns": columns,
+            "rows": rows,
             "height": height,
             "preview": preview,
             "object_fit": object_fit,
@@ -223,11 +223,11 @@ class Gallery(IOComponent, GallerySerializable, Selectable):
             warn_deprecation(
                 "The 'grid' parameter will be deprecated. Please use 'columns' in the constructor instead.",
             )
-            self.grid_cols = grid
+            self.columns = grid
         if columns is not None:
-            self.grid_cols = columns
+            self.columns = columns
         if rows is not None:
-            self.grid_rows = rows
+            self.rows = rows
         if height is not None:
             self.height = height
         if preview is not None:

--- a/js/gallery/Gallery.stories.svelte
+++ b/js/gallery/Gallery.stories.svelte
@@ -19,13 +19,13 @@
 			control: { type: "boolean" },
 			defaultValue: true
 		},
-		grid_cols: {
+		columns: {
 			options: [1, 2, 3, 4],
 			description: "The number of columns to show in grid",
 			control: { type: "select" },
 			defaultValue: 2
 		},
-		grid_rows: {
+		rows: {
 			options: [1, 2, 3, 4],
 			description: "The number of rows to show in grid",
 			control: { type: "select" },
@@ -91,20 +91,20 @@
 	args={{ label: "My Cheetah Gallery", show_label: false }}
 />
 <Story
-	name="Gallery with grid_rows=3 and grid_cols=3"
+	name="Gallery with rows=3 and columns=3"
 	args={{
 		label: "My Cheetah Gallery",
 		show_label: true,
-		grid_rows: 3,
-		grid_cols: 3
+		rows: 3,
+		columns: 3
 	}}
 />
 <Story
-	name="Gallery with grid_cols=4"
+	name="Gallery with columns=4"
 	args={{
 		label: "My Cheetah Gallery",
 		show_label: true,
-		grid_cols: 4
+		columns: 4
 	}}
 />
 <Story
@@ -184,8 +184,8 @@
 	args={{
 		label: "My Cheetah Gallery",
 		show_label: true,
-		grid_rows: 2,
-		grid_cols: 2,
+		rows: 2,
+		columns: 2,
 		height: 400,
 		value: [
 			"https://gradio-builds.s3.amazonaws.com/demo-files/cheetah-002.jpg",
@@ -201,7 +201,7 @@
 	name="Gallery with download button"
 	args={{
 		label: "My Cheetah Gallery",
-		grid_rows: 2,
+		rows: 2,
 		height: 400,
 		show_download_button: true,
 		value: ["https://gradio-builds.s3.amazonaws.com/demo-files/cheetah-002.jpg"]

--- a/js/gallery/static/Gallery.svelte
+++ b/js/gallery/static/Gallery.svelte
@@ -19,8 +19,8 @@
 	export let root_url: null | string = null;
 	export let value: (FileData | string | [FileData | string, string])[] | null =
 		null;
-	export let grid_cols: number | number[] | undefined = [2];
-	export let grid_rows: number | number[] | undefined = undefined;
+	export let columns: number | number[] | undefined = [2];
+	export let rows: number | number[] | undefined = undefined;
 	export let height: number | "auto" = "auto";
 	export let preview: boolean;
 	export let allow_preview = true;
@@ -250,7 +250,7 @@
 	>
 		<div
 			class="grid-container"
-			style="--grid-cols:{grid_cols}; --grid-rows:{grid_rows}; --object-fit: {object_fit}; height: {height};"
+			style="--grid-cols:{columns}; --grid-rows:{rows}; --object-fit: {object_fit}; height: {height};"
 			class:pt-6={show_label}
 		>
 			{#if show_share_button}

--- a/js/gallery/static/Gallery.svelte
+++ b/js/gallery/static/Gallery.svelte
@@ -129,7 +129,7 @@
 			if (selected_image !== null) {
 				dispatch("select", {
 					index: selected_image,
-					value: _value?.[selected_image][1],
+					value: _value?.[selected_image][1]
 				});
 			}
 		}
@@ -162,7 +162,7 @@
 
 		container_element?.scrollTo({
 			left: pos < 0 ? 0 : pos,
-			behavior: "smooth",
+			behavior: "smooth"
 		});
 	}
 
@@ -353,7 +353,9 @@
 	.thumbnail-item {
 		--ring-color: transparent;
 		position: relative;
-		box-shadow: 0 0 0 2px var(--ring-color), var(--shadow-drop);
+		box-shadow:
+			0 0 0 2px var(--ring-color),
+			var(--shadow-drop);
 		border: 1px solid var(--border-color-primary);
 		border-radius: var(--button-small-radius);
 		background: var(--background-fill-secondary);

--- a/js/gallery/static/StaticGallery.svelte
+++ b/js/gallery/static/StaticGallery.svelte
@@ -19,8 +19,8 @@
 	export let container = true;
 	export let scale: number | null = null;
 	export let min_width: number | undefined = undefined;
-	export let grid_cols: number | number[] | undefined = [2];
-	export let grid_rows: number | number[] | undefined = undefined;
+	export let columns: number | number[] | undefined = [2];
+	export let rows: number | number[] | undefined = undefined;
 	export let height: number | "auto" = "auto";
 	export let preview: boolean;
 	export let allow_preview = true;
@@ -57,8 +57,8 @@
 		{show_label}
 		{root}
 		{root_url}
-		{grid_cols}
-		{grid_rows}
+		{columns}
+		{rows}
 		{height}
 		{preview}
 		{object_fit}


### PR DESCRIPTION
The big update PR broke the `columns` and `rows` params for `gr.Gallery` because the parameters in the constructor (`columns` and `rows`) were different than the name of the attributes of the object (`grid_cols` and `grid_row`).

This fixes the issue by using consistent parameter names. 

To confirm the fix, see the storybook or use this test code:

```py
import gradio as gr 

with gr.Blocks() as demo:
    cheetahs = [
        "https://upload.wikimedia.org/wikipedia/commons/0/09/TheCheethcat.jpg",
        "https://nationalzoo.si.edu/sites/default/files/animals/cheetah-003.jpg",
        "https://img.etimg.com/thumb/msid-50159822,width-650,imgsize-129520,,resizemode-4,quality-100/.jpg",
        "https://nationalzoo.si.edu/sites/default/files/animals/cheetah-002.jpg",
        "https://images.theconversation.com/files/375893/original/file-20201218-13-a8h8uq.jpg?ixlib=rb-1.1.0&rect=16%2C407%2C5515%2C2924&q=45&auto=format&w=496&fit=clip",
        "https://www.lifegate.com/app/uploads/ghepardo-primo-piano.jpg",
        "https://qph.cf2.quoracdn.net/main-qimg-0bbf31c18a22178cb7a8dd53640a3d05-lq"
    ]
    gr.Gallery(value=cheetahs, columns=4)

demo.launch()
```

Fixes: #5753 