### PR TITLE
Don't raise warnings when returning an updated component in a dictionary

### DIFF
--- a/.changeset/lucky-news-float.md
+++ b/.changeset/lucky-news-float.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Don't raise warnings when returning an updated component in a dictionary

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -823,7 +823,7 @@ def update(**kwargs) -> dict:
 
 
 def skip() -> dict:
-    return update()
+    return {"__type__": "generic_update"}
 
 
 @document()


### PR DESCRIPTION
We were using `gr.update()` internally which was printing a warning. This quick fix closes: #5746