### PR TITLE
Set share=True for all Gradio apps in Colab by default

### DIFF
--- a/.changeset/yummy-mice-start.md
+++ b/.changeset/yummy-mice-start.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Set share=True for all Gradio apps in Colab by default

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2080,7 +2080,7 @@ Received outputs:
         utils.launch_counter()
         self.is_sagemaker = utils.sagemaker_check()
         if share is None:
-            if self.is_colab and self.enable_queue:
+            if self.is_colab:
                 if not quiet:
                     print(
                         "Setting queue=True in a Colab notebook requires sharing enabled. Setting `share=True` (you can turn this off by setting `share=False` in `launch()` explicitly).\n"

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -65,11 +65,11 @@ class TestBlocksMethods:
         with gr.Blocks() as demo:
             # self.share is False when instantiating the class
             assert not demo.share
-            # share default is False, if share is None in colab and no queueing
+            # share default is True, if share is None in colab and queueing
             demo.launch(prevent_thread_lock=True)
-            assert not demo.share
+            assert demo.share
             demo.close()
-            # share becomes true, if share is None in colab with queueing
+            # share is also true, if share is None in colab with queueing
             demo.queue()
             demo.launch(prevent_thread_lock=True)
             assert demo.share

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -104,14 +104,6 @@ class TestInterface:
                 )
 
     @mock.patch("gradio.utils.colab_check")
-    def test_launch_colab_share(self, mock_colab_check):
-        mock_colab_check.return_value = True
-        interface = Interface(lambda x: x, "textbox", "label")
-        _, _, share_url = interface.launch(prevent_thread_lock=True)
-        assert share_url is None
-        interface.close()
-
-    @mock.patch("gradio.utils.colab_check")
     @mock.patch("gradio.networking.setup_tunnel")
     def test_launch_colab_share_error(self, mock_setup_tunnel, mock_colab_check):
         mock_setup_tunnel.side_effect = RuntimeError()


### PR DESCRIPTION
Gradio apps running without share links in Colab are acting strange. While we investigate the issue, this is workaround that sets `share=True` for all Gradio apps in Colab. 

Closes: #5762