### PR TITLE
Simplify how files are handled in components in 4.0

### DIFF
--- a/.changeset/slick-bats-study.md
+++ b/.changeset/slick-bats-study.md
@@ -1,0 +1,6 @@
+---
+"gradio": minor
+"gradio_client": minor
+---
+
+feat:Simplify how files are handled in components in 4.0

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -71,7 +71,7 @@ class Client:
         hf_token: str | None = None,
         max_workers: int = 40,
         serialize: bool = True,
-        output_dir: str | Path | None = DEFAULT_TEMP_DIR,
+        output_dir: str | Path = DEFAULT_TEMP_DIR,
         verbose: bool = True,
     ):
         """
@@ -543,39 +543,6 @@ class Client:
     def __str__(self):
         return self.view_api(print_info=False, return_format="str")
 
-    def download_file(
-        self,
-        x: str | None,
-        save_dir: str | None = None,
-        root_url: str | None = None,
-        hf_token: str | None = None,
-    ) -> str | None:
-        if x is None:
-            return None
-        if isinstance(x, str):
-            file_name = utils.decode_base64_to_file(x, dir=save_dir).name
-        elif isinstance(x, dict):
-            if x.get("is_file"):
-                filepath = x.get("name")
-                assert filepath is not None, f"The 'name' field is missing in {x}"
-                if root_url is not None:
-                    file_name = utils.download_tmp_copy_of_file(
-                        root_url + "file=" + filepath,
-                        hf_token=hf_token,
-                        dir=save_dir,
-                    )
-                else:
-                    file_name = utils.create_tmp_copy_of_file(filepath, dir=save_dir)
-            else:
-                data = x.get("data")
-                assert data is not None, f"The 'data' field is missing in {x}"
-                file_name = utils.decode_base64_to_file(data, dir=save_dir).name
-        else:
-            raise ValueError(
-                f"A FileSerializable component can only deserialize a string or a dict, not a {type(x)}: {x}"
-            )
-        return file_name
-
     def _telemetry_thread(self) -> None:
         # Disable telemetry by setting the env variable HF_HUB_DISABLE_TELEMETRY=1
         data = {
@@ -1038,8 +1005,8 @@ class Endpoint:
     @staticmethod
     def _download_file(
         x: dict,
-        save_dir: str | None = None,
-        root_url: str | None = None,
+        save_dir: str,
+        root_url: str,
         hf_token: str | None = None,
     ) -> str | None:
         if x is None:
@@ -1050,14 +1017,11 @@ class Endpoint:
             if x.get("is_file"):
                 filepath = x.get("name")
                 assert filepath is not None, f"The 'name' field is missing in {x}"
-                if root_url is not None:
-                    file_name = utils.download_tmp_copy_of_file(
-                        root_url + "file=" + filepath,
-                        hf_token=hf_token,
-                        dir=save_dir,
-                    )
-                else:
-                    file_name = utils.create_tmp_copy_of_file(filepath, dir=save_dir)
+                file_name = utils.download_file(
+                    root_url + "file=" + filepath,
+                    hf_token=hf_token,
+                    dir=save_dir,
+                )
             else:
                 data = x.get("data")
                 assert data is not None, f"The 'data' field is missing in {x}"

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -10,7 +10,6 @@ import pkgutil
 import secrets
 import shutil
 import tempfile
-import urllib.request
 import warnings
 from concurrent.futures import CancelledError
 from dataclasses import dataclass, field
@@ -308,74 +307,6 @@ async def get_pred_from_ws(
 ########################
 # Data processing utils
 ########################
-
-
-def hash_file(file_path: str | Path, chunk_num_blocks: int = 128) -> str:
-    """Returns the sha1 hash of a file.
-
-    Used to create a unique directory for a file.
-
-    Parameters:
-        file_path: path to file
-        chunk_num_blocks: number of blocks to read at a time
-    """
-    sha1 = hashlib.sha1()
-    with open(file_path, "rb") as f:
-        for chunk in iter(lambda: f.read(chunk_num_blocks * sha1.block_size), b""):
-            sha1.update(chunk)
-    return sha1.hexdigest()
-
-
-def hash_url(url: str, chunk_num_blocks: int = 128) -> str:
-    """Returns the sha1 hash of a url.
-
-    Used to create a unique directory for a url.
-
-    Parameters:
-        url: url
-        chunk_num_blocks: number of blocks to read at a time
-    """
-    sha1 = hashlib.sha1()
-    remote = urllib.request.urlopen(url)
-    max_file_size = 100 * 1024 * 1024  # 100MB
-    total_read = 0
-    while True:
-        data = remote.read(chunk_num_blocks * sha1.block_size)
-        total_read += chunk_num_blocks * sha1.block_size
-        if not data or total_read > max_file_size:
-            break
-        sha1.update(data)
-    return sha1.hexdigest()
-
-
-def hash_bytes(bytes: bytes) -> str:
-    """Returns the sha1 hash of a bytes object.
-
-    Used to create a unique directory for a bytes object.
-
-    Parameters:
-        bytes: bytes object
-    """
-
-    sha1 = hashlib.sha1()
-    sha1.update(bytes)
-    return sha1.hexdigest()
-
-
-def hash_base64(base64_encoding: str, chunk_num_blocks: int = 128) -> str:
-    """Returns the sha1 hash of a base64 encoding.
-
-    Used to create a unique directory for a base64 encoding.
-
-    Parameters:
-        base64_encoding: base64 encoding
-        chunk_num_blocks: number of blocks to read at a time
-    """
-    sha1 = hashlib.sha1()
-    for i in range(0, len(base64_encoding), chunk_num_blocks * sha1.block_size):
-        data = base64_encoding[i : i + chunk_num_blocks * sha1.block_size]
-        sha1.update(data.encode("utf-8"))
-    return sha1.hexdigest()
 
 
 def download_file(
@@ -720,15 +651,7 @@ def is_url(s):
 
 
 def is_file_obj(d):
-    return (
-        isinstance(d, dict)
-        and "name" in d
-        and "is_file" in d
-        and "data" in d
-        and "size" in d
-        and "orig_name" in d
-        and "mime_type" in d
-    )
+    return isinstance(d, dict) and "name" in d and "is_file" in d and "data" in d
 
 
 SKIP_COMPONENTS = {

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -568,6 +568,8 @@ def json_schema_to_python_type(schema: Any) -> str:
 
 def _json_schema_to_python_type(schema: Any, defs) -> str:
     """Convert the json schema into a python type hint"""
+    if schema == {}:
+        return "Any"
     type_ = get_type(schema)
     if type_ == {}:
         if "json" in schema["description"]:

--- a/client/python/test/conftest.py
+++ b/client/python/test/conftest.py
@@ -349,3 +349,12 @@ def all_components():
             subclasses.append(subclass)
 
     return subclasses
+
+
+@pytest.fixture(autouse=True)
+def gradio_temp_dir(monkeypatch, tmp_path):
+    """tmp_path is unique to each test function.
+    It will be cleared automatically according to pytest docs: https://docs.pytest.org/en/6.2.x/reference.html#tmp-path
+    """
+    monkeypatch.setenv("GRADIO_TEMP_DIR", str(tmp_path))
+    return tmp_path

--- a/client/python/test/test_client.py
+++ b/client/python/test/test_client.py
@@ -179,7 +179,9 @@ class TestClientPredictions:
     def test_job_output_video(self, video_component):
         with connect(video_component) as client:
             job = client.submit(
-                "https://huggingface.co/spaces/gradio/video_component/resolve/main/files/a.mp4",
+                {
+                    "video": "https://huggingface.co/spaces/gradio/video_component/resolve/main/files/a.mp4"
+                },
                 fn_index=0,
             )
             assert Path(job.result()["video"]).exists()
@@ -191,7 +193,9 @@ class TestClientPredictions:
         temp_dir = tempfile.mkdtemp()
         with connect(video_component, output_dir=temp_dir) as client:
             job = client.submit(
-                "https://huggingface.co/spaces/gradio/video_component/resolve/main/files/a.mp4",
+                {
+                    "video": "https://huggingface.co/spaces/gradio/video_component/resolve/main/files/a.mp4"
+                },
                 fn_index=0,
             )
             assert Path(job.result()["video"]).exists()

--- a/client/python/test/test_utils.py
+++ b/client/python/test/test_utils.py
@@ -66,20 +66,22 @@ def test_decode_base64_to_file():
     assert isinstance(temp_file, tempfile._TemporaryFileWrapper)
 
 
-def test_download_private_file():
+def test_download_private_file(gradio_temp_dir):
     url_path = "https://gradio-tests-not-actually-private-space.hf.space/file=lion.jpg"
     hf_token = "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"  # Intentionally revealing this key for testing purposes
-    file = utils.download_tmp_copy_of_file(url_path=url_path, hf_token=hf_token)
+    file = utils.download_file(
+        url_path=url_path, hf_token=hf_token, dir=str(gradio_temp_dir)
+    )
     assert Path(file).name.endswith(".jpg")
 
 
-def test_download_tmp_copy_of_file_does_not_save_errors(monkeypatch):
+def test_download_tmp_copy_of_file_does_not_save_errors(monkeypatch, gradio_temp_dir):
     error_response = requests.Response()
     error_response.status_code = 404
     error_response.close = lambda: 0  # Mock close method to avoid unrelated exception
     monkeypatch.setattr(requests, "get", lambda *args, **kwargs: error_response)
     with pytest.raises(requests.RequestException):
-        utils.download_tmp_copy_of_file("https://example.com/foo")
+        utils.download_file("https://example.com/foo", dir=str(gradio_temp_dir))
 
 
 @pytest.mark.parametrize(

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -27,6 +27,7 @@ from gradio import (
     components,
     external,
     networking,
+    processing_utils,
     queueing,
     routes,
     strings,
@@ -1162,7 +1163,10 @@ Received inputs:
                 else:
                     if input_id in state:
                         block = state[input_id]
-                    processed_input.append(block.preprocess(inputs[i]))
+                    inputs_cached = processing_utils.move_files_to_cache(
+                        inputs[i], block
+                    )
+                    processed_input.append(block.preprocess(inputs_cached))
         else:
             processed_input = inputs
         return processed_input
@@ -1281,7 +1285,8 @@ Received outputs:
                         block, components.Component
                     ), f"{block.__class__} Component with id {output_id} not a valid output component."
                     prediction_value = block.postprocess(prediction_value)
-                output.append(prediction_value)
+                outputs_cached = processing_utils.move_files_to_cache(prediction_value, block)  # type: ignore
+                output.append(outputs_cached)
 
         return output
 

--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -194,30 +194,19 @@ class Audio(
             return x
 
         payload: AudioInputData = AudioInputData(**x)
-
-        if payload.is_file:
-            assert payload.name
-            if client_utils.is_http_url_like(payload.name):
-                temp_file_path = self.download_temp_copy_if_needed(payload.name)
-            else:
-                temp_file_path = self.make_temp_copy_if_needed(payload.name)
-        else:
-            assert payload.data
-            temp_file_path = self.base64_to_temp_file_if_needed(
-                payload.data, payload.name
-            )
-
-        sample_rate, data = processing_utils.audio_from_file(
-            temp_file_path, crop_min=payload.crop_min, crop_max=payload.crop_max
-        )
+        assert payload.name
 
         # Need a unique name for the file to avoid re-using the same audio file if
         # a user submits the same audio file twice, but with different crop min/max.
-        temp_file_path = Path(temp_file_path)
+        temp_file_path = Path(payload.name)
         output_file_name = str(
             temp_file_path.with_name(
                 f"{temp_file_path.stem}-{payload.crop_min}-{payload.crop_max}{temp_file_path.suffix}"
             )
+        )
+
+        sample_rate, data = processing_utils.audio_from_file(
+            temp_file_path, crop_min=payload.crop_min, crop_max=payload.crop_max
         )
 
         if self.type == "numpy":
@@ -236,7 +225,7 @@ class Audio(
             )
 
     def postprocess(
-        self, y: tuple[int, np.ndarray] | str | Path | None
+        self, y: tuple[int, np.ndarray] | str | Path | bytes | None
     ) -> FileData | None | bytes:
         """
         Parameters:
@@ -249,19 +238,18 @@ class Audio(
         if isinstance(y, bytes):
             if self.streaming:
                 return y
-            file_path = self.file_bytes_to_file(y, "audio")
-        elif isinstance(y, str) and client_utils.is_http_url_like(y):
-            return FileData(**{"name": y, "data": None, "is_file": True})
+            file_path = processing_utils.save_bytes_to_cache(
+                y, "audio", cache_dir=self.GRADIO_CACHE
+            )
         elif isinstance(y, tuple):
             sample_rate, data = y
-            file_path = self.audio_to_temp_file(
-                data,
-                sample_rate,
-                format=self.format,
+            file_path = processing_utils.save_audio_to_cache(
+                data, sample_rate, format=self.format, cache_dir=self.GRADIO_CACHE
             )
-            self.temp_files.add(file_path)
         else:
-            file_path = self.make_temp_copy_if_needed(y)
+            if not isinstance(y, (str, Path)):
+                raise ValueError(f"Cannot process {y} as Audio")
+            file_path = str(y)
         return FileData(**{"name": file_path, "data": None, "is_file": True})
 
     def stream_output(

--- a/gradio/components/base.py
+++ b/gradio/components/base.py
@@ -5,27 +5,18 @@ each component. These demos are located in the `demo` directory."""
 from __future__ import annotations
 
 import abc
-import hashlib
 import json
 import os
-import secrets
-import shutil
 import tempfile
-import urllib.request
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
-import aiofiles
-import numpy as np
-import requests
-from fastapi import UploadFile
-from gradio_client import utils as client_utils
 from gradio_client.documentation import set_documentation_group
 from PIL import Image as _Image  # using _ to minimize namespace pollution
 
-from gradio import processing_utils, utils
+from gradio import utils
 from gradio.blocks import Block, BlockContext
 from gradio.component_meta import ComponentMeta
 from gradio.data_classes import GradioDataModel
@@ -152,7 +143,7 @@ class Component(ComponentBase, Block):
         if not hasattr(self, "data_model"):
             self.data_model: type[GradioDataModel] | None = None
         self.temp_files: set[str] = set()
-        self.DEFAULT_TEMP_DIR = os.environ.get("GRADIO_TEMP_DIR") or str(
+        self.GRADIO_CACHE = os.environ.get("GRADIO_TEMP_DIR") or str(
             Path(tempfile.gettempdir()) / "gradio"
         )
 
@@ -191,164 +182,6 @@ class Component(ComponentBase, Block):
         )
         if callable(load_fn):
             self.attach_load_event(load_fn, every)
-
-    @staticmethod
-    def hash_file(file_path: str | Path, chunk_num_blocks: int = 128) -> str:
-        sha1 = hashlib.sha1()
-        with open(file_path, "rb") as f:
-            for chunk in iter(lambda: f.read(chunk_num_blocks * sha1.block_size), b""):
-                sha1.update(chunk)
-        return sha1.hexdigest()
-
-    @staticmethod
-    def hash_url(url: str, chunk_num_blocks: int = 128) -> str:
-        sha1 = hashlib.sha1()
-        remote = urllib.request.urlopen(url)
-        max_file_size = 100 * 1024 * 1024  # 100MB
-        total_read = 0
-        while True:
-            data = remote.read(chunk_num_blocks * sha1.block_size)
-            total_read += chunk_num_blocks * sha1.block_size
-            if not data or total_read > max_file_size:
-                break
-            sha1.update(data)
-        return sha1.hexdigest()
-
-    @staticmethod
-    def hash_bytes(bytes: bytes):
-        sha1 = hashlib.sha1()
-        sha1.update(bytes)
-        return sha1.hexdigest()
-
-    @staticmethod
-    def hash_base64(base64_encoding: str, chunk_num_blocks: int = 128) -> str:
-        sha1 = hashlib.sha1()
-        for i in range(0, len(base64_encoding), chunk_num_blocks * sha1.block_size):
-            data = base64_encoding[i : i + chunk_num_blocks * sha1.block_size]
-            sha1.update(data.encode("utf-8"))
-        return sha1.hexdigest()
-
-    def make_temp_copy_if_needed(self, file_path: str | Path) -> str:
-        """Returns a temporary file path for a copy of the given file path if it does
-        not already exist. Otherwise returns the path to the existing temp file."""
-        temp_dir = self.hash_file(file_path)
-        temp_dir = Path(self.DEFAULT_TEMP_DIR) / temp_dir
-        temp_dir.mkdir(exist_ok=True, parents=True)
-
-        name = client_utils.strip_invalid_filename_characters(Path(file_path).name)
-        full_temp_file_path = str(utils.abspath(temp_dir / name))
-
-        if not Path(full_temp_file_path).exists():
-            shutil.copy2(file_path, full_temp_file_path)
-
-        self.temp_files.add(full_temp_file_path)
-        return full_temp_file_path
-
-    async def save_uploaded_file(self, file: UploadFile, upload_dir: str) -> str:
-        temp_dir = secrets.token_hex(
-            20
-        )  # Since the full file is being uploaded anyways, there is no benefit to hashing the file.
-        temp_dir = Path(upload_dir) / temp_dir
-        temp_dir.mkdir(exist_ok=True, parents=True)
-
-        sha1 = hashlib.sha1()
-
-        if file.filename:
-            file_name = Path(file.filename).name
-            name = client_utils.strip_invalid_filename_characters(file_name)
-        else:
-            name = f"tmp{secrets.token_hex(5)}"
-
-        full_temp_file_path = str(utils.abspath(temp_dir / name))
-
-        async with aiofiles.open(full_temp_file_path, "wb") as output_file:
-            while True:
-                content = await file.read(100 * 1024 * 1024)
-                if not content:
-                    break
-                sha1.update(content)
-                await output_file.write(content)
-
-        directory = Path(upload_dir) / sha1.hexdigest()
-        directory.mkdir(exist_ok=True, parents=True)
-        dest = (directory / name).resolve()
-        shutil.move(full_temp_file_path, dest)
-        return str(dest)
-
-    def download_temp_copy_if_needed(self, url: str) -> str:
-        """Downloads a file and makes a temporary file path for a copy if does not already
-        exist. Otherwise returns the path to the existing temp file."""
-        temp_dir = self.hash_url(url)
-        temp_dir = Path(self.DEFAULT_TEMP_DIR) / temp_dir
-        temp_dir.mkdir(exist_ok=True, parents=True)
-
-        name = client_utils.strip_invalid_filename_characters(Path(url).name)
-        full_temp_file_path = str(utils.abspath(temp_dir / name))
-
-        if not Path(full_temp_file_path).exists():
-            with requests.get(url, stream=True) as r, open(
-                full_temp_file_path, "wb"
-            ) as f:
-                shutil.copyfileobj(r.raw, f)
-
-        self.temp_files.add(full_temp_file_path)
-        return full_temp_file_path
-
-    def base64_to_temp_file_if_needed(
-        self, base64_encoding: str, file_name: str | None = None
-    ) -> str:
-        """Converts a base64 encoding to a file and returns the path to the file if
-        the file doesn't already exist. Otherwise returns the path to the existing file.
-        """
-        temp_dir = self.hash_base64(base64_encoding)
-        temp_dir = Path(self.DEFAULT_TEMP_DIR) / temp_dir
-        temp_dir.mkdir(exist_ok=True, parents=True)
-
-        guess_extension = client_utils.get_extension(base64_encoding)
-        if file_name:
-            file_name = client_utils.strip_invalid_filename_characters(file_name)
-        elif guess_extension:
-            file_name = f"file.{guess_extension}"
-        else:
-            file_name = "file"
-
-        full_temp_file_path = str(utils.abspath(temp_dir / file_name))  # type: ignore
-
-        if not Path(full_temp_file_path).exists():
-            data, _ = client_utils.decode_base64_to_binary(base64_encoding)
-            with open(full_temp_file_path, "wb") as fb:
-                fb.write(data)
-
-        self.temp_files.add(full_temp_file_path)
-        return full_temp_file_path
-
-    def pil_to_temp_file(self, img: _Image.Image, dir: str, format="png") -> str:
-        bytes_data = processing_utils.encode_pil_to_bytes(img, format)
-        temp_dir = Path(dir) / self.hash_bytes(bytes_data)
-        temp_dir.mkdir(exist_ok=True, parents=True)
-        filename = str(temp_dir / f"image.{format}")
-        img.save(filename, pnginfo=processing_utils.get_pil_metadata(img))
-        return filename
-
-    def img_array_to_temp_file(self, arr: np.ndarray, dir: str) -> str:
-        pil_image = _Image.fromarray(
-            processing_utils._convert(arr, np.uint8, force_copy=False)
-        )
-        return self.pil_to_temp_file(pil_image, dir, format="png")
-
-    def audio_to_temp_file(self, data: np.ndarray, sample_rate: int, format: str):
-        temp_dir = Path(self.DEFAULT_TEMP_DIR) / self.hash_bytes(data.tobytes())
-        temp_dir.mkdir(exist_ok=True, parents=True)
-        filename = str(temp_dir / f"audio.{format}")
-        processing_utils.audio_to_file(sample_rate, data, filename, format=format)
-        return filename
-
-    def file_bytes_to_file(self, data: bytes, file_name: str):
-        path = Path(self.DEFAULT_TEMP_DIR) / self.hash_bytes(data)
-        path.mkdir(exist_ok=True, parents=True)
-        path = path / Path(file_name).name
-        path.write_bytes(data)
-        return path
 
     def get_config(self):
         config = super().get_config()

--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -214,26 +214,17 @@ class Chatbot(Component):
 
     def _postprocess_chat_messages(
         self, chat_message: str | tuple | list | None
-    ) -> str | dict | None:
+    ) -> str | FileMessage | None:
         if chat_message is None:
             return None
         elif isinstance(chat_message, (tuple, list)):
-            file_uri = str(chat_message[0])
-            if utils.validate_url(file_uri):
-                filepath = file_uri
-            else:
-                filepath = self.make_temp_copy_if_needed(file_uri)
+            filepath = str(chat_message[0])
 
             mime_type = client_utils.get_mimetype(filepath)
-            return {
-                "file": {
-                    "name": filepath,
-                    "mime_type": mime_type,
-                    "data": None,  # These last two fields are filled in by the frontend
-                    "is_file": True,
-                },
-                "alt_text": chat_message[1] if len(chat_message) > 1 else None,
-            }
+            return FileMessage(
+                file=FileData(name=filepath, is_file=True, mime_type=mime_type),
+                alt_text=chat_message[1] if len(chat_message) > 1 else None,
+            )
         elif isinstance(chat_message, str):
             chat_message = inspect.cleandoc(chat_message)
             return chat_message

--- a/gradio/components/file.py
+++ b/gradio/components/file.py
@@ -153,7 +153,6 @@ class File(Component):
             f["data"],
             f.get("is_file", False),
         )
-        print(file_name)
         if type == "file":
             file = tempfile.NamedTemporaryFile(delete=False, dir=cache_dir)
             file.name = file_name

--- a/gradio/components/model3d.py
+++ b/gradio/components/model3d.py
@@ -135,17 +135,7 @@ class Model3D(Component):
         """
         if x is None:
             return x
-        file_name, file_data, is_file = (
-            x["name"],
-            x["data"],
-            x.get("is_file", False),
-        )
-        if is_file:
-            temp_file_path = self.make_temp_copy_if_needed(file_name)
-        else:
-            temp_file_path = self.base64_to_temp_file_if_needed(file_data, file_name)
-
-        return temp_file_path
+        return x["name"]
 
     def postprocess(self, y: str | Path | None) -> FileData | None:
         """
@@ -156,12 +146,7 @@ class Model3D(Component):
         """
         if y is None:
             return y
-        data = {
-            "name": self.make_temp_copy_if_needed(y),
-            "data": None,
-            "is_file": True,
-        }
-        return FileData(**data)
+        return FileData(name=str(y), is_file=True)
 
     def as_example(self, input_data: str | None) -> str:
         return Path(input_data).name if input_data else ""

--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -303,7 +303,9 @@ class Video(Component):
 
         # For cases where the video needs to be converted to another format
         if is_url:
-            video = self.download_temp_copy_if_needed(video)
+            video = processing_utils.save_url_to_cache(
+                video, cache_dir=self.GRADIO_CACHE
+            )
         if (
             processing_utils.ffmpeg_installed()
             and not processing_utils.video_is_playable(video)

--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -43,6 +43,7 @@ class Video(Component):
     """
 
     data_model = VideoData
+    input_data_model = FileData
     EVENTS = [
         Events.change,
         Events.clear,
@@ -177,7 +178,7 @@ class Video(Component):
             "__type__": "update",
         }
 
-    def preprocess(self, x: dict | FileData) -> str | None:
+    def preprocess(self, x: dict | VideoData) -> str | None:
         """
         Parameters:
             x: A tuple of (video file data, subtitle file data) or just video file data.
@@ -186,27 +187,9 @@ class Video(Component):
         """
         if x is None:
             return None
-        data: FileData = FileData(**x) if isinstance(x, dict) else x
-        # if isinstance(x, FileData):
-        #     data = x
-        # elif isinstance(x, str):
-        #     data = FileData(name=x, is_file=True)
-        # elif isinstance(x, dict):
-        #     data = FileData(**x)
-        # else:
-        #     raise Exception(f"Cannot process type as video: {type(x)}")
-
-        if data.is_file:
-            assert data.name is not None, "Received file data without a file name."
-            if client_utils.is_http_url_like(data.name):
-                fn = self.download_temp_copy_if_needed
-            else:
-                fn = self.make_temp_copy_if_needed
-            file_name = Path(fn(data.name))
-        else:
-            assert data.data
-            file_name = Path(self.base64_to_temp_file_if_needed(data.data, data.name))
-
+        data: VideoData = VideoData(**x) if isinstance(x, dict) else x
+        assert data.video.name
+        file_name = Path(data.video.name)
         uploaded_format = file_name.suffix.replace(".", "")
         needs_formatting = self.format is not None and uploaded_format != self.format
         flip = self.source == "webcam" and self.mirror_webcam
@@ -346,8 +329,6 @@ class Video(Component):
             ff.run()
             video = output_file_name
 
-        video = self.make_temp_copy_if_needed(video)
-
         return FileData(name=video, data=None, is_file=True, orig_name=Path(video).name)
 
     def _format_subtitle(self, subtitle: str | Path | None) -> FileData | None:
@@ -388,7 +369,7 @@ class Video(Component):
         # HTML5 only support vtt format
         if Path(subtitle).suffix == ".srt":
             temp_file = tempfile.NamedTemporaryFile(
-                delete=False, suffix=".vtt", dir=self.DEFAULT_TEMP_DIR
+                delete=False, suffix=".vtt", dir=self.GRADIO_CACHE
             )
 
             srt_to_vtt(subtitle, temp_file.name)

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -214,8 +214,12 @@ class Examples:
                     prediction_value = component.postprocess(sample)
                     if isinstance(prediction_value, (GradioRootModel, GradioModel)):
                         prediction_value = prediction_value.model_dump()
+                    prediction_value = processing_utils.move_files_to_cache(
+                        prediction_value, component
+                    )
                     sub.append(prediction_value)
                 self.processed_examples.append(sub)
+
         self.non_none_processed_examples = [
             [ex for (ex, keep) in zip(example, input_has_examples) if keep]
             for example in self.processed_examples

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -1,27 +1,40 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import logging
 import os
+import secrets
 import shutil
 import subprocess
 import tempfile
+import urllib.request
 import warnings
 from io import BytesIO
 from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
 
+import aiofiles
 import numpy as np
+import requests
+from fastapi import UploadFile
 from gradio_client import utils as client_utils
 from PIL import Image, ImageOps, PngImagePlugin
 
 from gradio import wasm_utils
+from gradio.data_classes import FileData
+
+from .utils import abspath, is_in_or_equal
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")  # Ignore pydub warning if ffmpeg is not installed
     from pydub import AudioSegment
 
 log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from gradio.components.base import Component
 
 #########################
 # GENERAL
@@ -102,6 +115,207 @@ def encode_array_to_base64(image_array):
         bytes_data = output_bytes.getvalue()
     base64_str = str(base64.b64encode(bytes_data), "utf-8")
     return "data:image/png;base64," + base64_str
+
+
+def hash_file(file_path: str | Path, chunk_num_blocks: int = 128) -> str:
+    sha1 = hashlib.sha1()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(chunk_num_blocks * sha1.block_size), b""):
+            sha1.update(chunk)
+    return sha1.hexdigest()
+
+
+def hash_url(url: str, chunk_num_blocks: int = 128) -> str:
+    sha1 = hashlib.sha1()
+    remote = urllib.request.urlopen(url)
+    max_file_size = 100 * 1024 * 1024  # 100MB
+    total_read = 0
+    while True:
+        data = remote.read(chunk_num_blocks * sha1.block_size)
+        total_read += chunk_num_blocks * sha1.block_size
+        if not data or total_read > max_file_size:
+            break
+        sha1.update(data)
+    return sha1.hexdigest()
+
+
+def hash_bytes(bytes: bytes):
+    sha1 = hashlib.sha1()
+    sha1.update(bytes)
+    return sha1.hexdigest()
+
+
+def hash_base64(base64_encoding: str, chunk_num_blocks: int = 128) -> str:
+    sha1 = hashlib.sha1()
+    for i in range(0, len(base64_encoding), chunk_num_blocks * sha1.block_size):
+        data = base64_encoding[i : i + chunk_num_blocks * sha1.block_size]
+        sha1.update(data.encode("utf-8"))
+    return sha1.hexdigest()
+
+
+def save_pil_to_cache(
+    img: Image.Image, cache_dir: str, format: Literal["png", "jpg"] = "png"
+) -> str:
+    bytes_data = encode_pil_to_bytes(img, format)
+    temp_dir = Path(cache_dir) / hash_bytes(bytes_data)
+    temp_dir.mkdir(exist_ok=True, parents=True)
+    filename = str((temp_dir / f"image.{format}").resolve())
+    img.save(filename, pnginfo=get_pil_metadata(img))
+    return filename
+
+
+def save_img_array_to_cache(
+    arr: np.ndarray, cache_dir: str, format: Literal["png", "jpg"] = "png"
+) -> str:
+    pil_image = Image.fromarray(_convert(arr, np.uint8, force_copy=False))
+    return save_pil_to_cache(pil_image, cache_dir, format=format)
+
+
+def save_audio_to_cache(
+    data: np.ndarray, sample_rate: int, format: str, cache_dir: str
+) -> str:
+    temp_dir = Path(cache_dir) / hash_bytes(data.tobytes())
+    temp_dir.mkdir(exist_ok=True, parents=True)
+    filename = str((temp_dir / f"audio.{format}").resolve())
+    audio_to_file(sample_rate, data, filename, format=format)
+    return filename
+
+
+def save_bytes_to_cache(data: bytes, file_name: str, cache_dir: str) -> str:
+    path = Path(cache_dir) / hash_bytes(data)
+    path.mkdir(exist_ok=True, parents=True)
+    path = path / Path(file_name).name
+    path.write_bytes(data)
+    return str(path.resolve())
+
+
+def save_file_to_cache(file_path: str | Path, cache_dir: str) -> str:
+    """Returns a temporary file path for a copy of the given file path if it does
+    not already exist. Otherwise returns the path to the existing temp file."""
+    temp_dir = hash_file(file_path)
+    temp_dir = Path(cache_dir) / temp_dir
+    temp_dir.mkdir(exist_ok=True, parents=True)
+
+    name = client_utils.strip_invalid_filename_characters(Path(file_path).name)
+    full_temp_file_path = str(abspath(temp_dir / name))
+
+    if not Path(full_temp_file_path).exists():
+        shutil.copy2(file_path, full_temp_file_path)
+
+    return full_temp_file_path
+
+
+async def save_uploaded_file(file: UploadFile, upload_dir: str) -> str:
+    temp_dir = secrets.token_hex(
+        20
+    )  # Since the full file is being uploaded anyways, there is no benefit to hashing the file.
+    temp_dir = Path(upload_dir) / temp_dir
+    temp_dir.mkdir(exist_ok=True, parents=True)
+
+    sha1 = hashlib.sha1()
+
+    if file.filename:
+        file_name = Path(file.filename).name
+        name = client_utils.strip_invalid_filename_characters(file_name)
+    else:
+        name = f"tmp{secrets.token_hex(5)}"
+
+    full_temp_file_path = str(abspath(temp_dir / name))
+
+    async with aiofiles.open(full_temp_file_path, "wb") as output_file:
+        while True:
+            content = await file.read(100 * 1024 * 1024)
+            if not content:
+                break
+            sha1.update(content)
+            await output_file.write(content)
+
+    directory = Path(upload_dir) / sha1.hexdigest()
+    directory.mkdir(exist_ok=True, parents=True)
+    dest = (directory / name).resolve()
+    shutil.move(full_temp_file_path, dest)
+    return str(dest)
+
+
+def save_url_to_cache(url: str, cache_dir: str) -> str:
+    """Downloads a file and makes a temporary file path for a copy if does not already
+    exist. Otherwise returns the path to the existing temp file."""
+    temp_dir = hash_url(url)
+    temp_dir = Path(cache_dir) / temp_dir
+    temp_dir.mkdir(exist_ok=True, parents=True)
+
+    name = client_utils.strip_invalid_filename_characters(Path(url).name)
+    full_temp_file_path = str(abspath(temp_dir / name))
+
+    if not Path(full_temp_file_path).exists():
+        with requests.get(url, stream=True) as r, open(full_temp_file_path, "wb") as f:
+            shutil.copyfileobj(r.raw, f)
+
+    return full_temp_file_path
+
+
+def save_base64_to_cache(
+    base64_encoding: str, cache_dir: str, file_name: str | None = None
+) -> str:
+    """Converts a base64 encoding to a file and returns the path to the file if
+    the file doesn't already exist. Otherwise returns the path to the existing file.
+    """
+    temp_dir = hash_base64(base64_encoding)
+    temp_dir = Path(cache_dir) / temp_dir
+    temp_dir.mkdir(exist_ok=True, parents=True)
+
+    guess_extension = client_utils.get_extension(base64_encoding)
+    if file_name:
+        file_name = client_utils.strip_invalid_filename_characters(file_name)
+    elif guess_extension:
+        file_name = f"file.{guess_extension}"
+    else:
+        file_name = "file"
+
+    full_temp_file_path = str(abspath(temp_dir / file_name))  # type: ignore
+
+    if not Path(full_temp_file_path).exists():
+        data, _ = client_utils.decode_base64_to_binary(base64_encoding)
+        with open(full_temp_file_path, "wb") as fb:
+            fb.write(data)
+
+    return full_temp_file_path
+
+
+def move_files_to_cache(data: Any, block: Component):
+    """Move files to cache and replace the file path with the cache path.
+
+    Runs after postprocess and before preprocess.
+
+    Args:
+        data: The input or output data for a component.
+        block: The component
+    """
+
+    def _move_to_cache(d: dict):
+        payload = FileData(**d)
+        if payload.name and not is_in_or_equal(payload.name, block.GRADIO_CACHE):
+            if payload.is_file:
+                if client_utils.is_http_url_like(payload.name):
+                    temp_file_path = save_url_to_cache(
+                        payload.name, cache_dir=block.GRADIO_CACHE
+                    )
+                else:
+                    temp_file_path = save_file_to_cache(
+                        payload.name, cache_dir=block.GRADIO_CACHE
+                    )
+            else:
+                assert payload.data
+                temp_file_path = save_base64_to_cache(
+                    payload.data,
+                    file_name=payload.name,
+                    cache_dir=block.GRADIO_CACHE,
+                )
+            block.temp_files.add(temp_file_path)
+            payload.name = temp_file_path
+        return payload.model_dump()
+
+    return client_utils.traverse(data, _move_to_cache, client_utils.is_file_obj)
 
 
 def resize_and_crop(img, size, crop_type="center"):

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -294,7 +294,10 @@ def move_files_to_cache(data: Any, block: Component):
 
     def _move_to_cache(d: dict):
         payload = FileData(**d)
-        if payload.name and not is_in_or_equal(payload.name, block.GRADIO_CACHE):
+        if payload.name and (
+            client_utils.is_http_url_like(payload.name)
+            or not is_in_or_equal(payload.name, block.GRADIO_CACHE)
+        ):
             if payload.is_file:
                 if client_utils.is_http_url_like(payload.name):
                     temp_file_path = save_url_to_cache(

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -46,7 +46,7 @@ from starlette.websockets import WebSocketState
 
 import gradio
 import gradio.ranged_response as ranged_response
-from gradio import route_utils, utils, wasm_utils
+from gradio import processing_utils, route_utils, utils, wasm_utils
 from gradio.context import Context
 from gradio.data_classes import PredictBody, ResetBody
 from gradio.deprecation import warn_deprecation
@@ -122,7 +122,7 @@ class App(FastAPI):
         self.queue_token = secrets.token_urlsafe(32)
         self.startup_events_triggered = False
         self.uploaded_file_dir = os.environ.get("GRADIO_TEMP_DIR") or str(
-            Path(tempfile.gettempdir()) / "gradio"
+            (Path(tempfile.gettempdir()) / "gradio").resolve()
         )
         self.change_event: None | threading.Event = None
         # Allow user to manually set `docs_url` and `redoc_url`
@@ -601,10 +601,9 @@ class App(FastAPI):
             files: List[UploadFile] = File(...),
         ):
             output_files = []
-            file_manager = gradio.File()
             for input_file in files:
                 output_files.append(
-                    await file_manager.save_uploaded_file(
+                    await processing_utils.save_uploaded_file(
                         input_file, app.uploaded_file_dir
                     )
                 )

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -468,7 +468,6 @@ class TestTempFile:
         # only three files created and in temp directory
         assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 3
 
-    @pytest.mark.xfail
     def test_no_empty_image_files(self, gradio_temp_dir, connect):
         file_dir = pathlib.Path(pathlib.Path(__file__).parent, "test_files")
         image = str(file_dir / "bus.png")
@@ -482,10 +481,9 @@ class TestTempFile:
             _ = client.predict(image)
             _ = client.predict(image)
             _ = client.predict(image)
-        # only three files created
-        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 1
+        # Upload creates a file. image preprocessing creates another one.
+        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 2
 
-    @pytest.mark.xfail
     @pytest.mark.parametrize("component", [gr.UploadButton, gr.File])
     def test_file_component_uploads(self, component, connect, gradio_temp_dir):
         code_file = str(pathlib.Path(__file__))
@@ -493,13 +491,12 @@ class TestTempFile:
         with connect(demo) as client:
             _ = client.predict(code_file)
             _ = client.predict(code_file)
-        # the upload route does not hash the file so 2 files from there
+        # the upload route hashees the files so we get 1 from there
         # We create two tempfiles (empty) because API says we return
-        # preprocess/postprocess will only create one file since we hash
-        # so 2 + 2 + 1 = 5
-        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 5
+        # preprocess/postprocess will create the same file as the upload route
+        # so 1 + 2 = 3
+        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 3
 
-    @pytest.mark.xfail
     def test_no_empty_video_files(self, gradio_temp_dir, connect):
         file_dir = pathlib.Path(pathlib.Path(__file__).parent, "test_files")
         video = str(file_dir / "video_sample.mp4")
@@ -507,11 +504,9 @@ class TestTempFile:
         with connect(demo) as client:
             _ = client.predict(video)
             _ = client.predict(video)
-        # During preprocessing we compute the hash based on base64
-        # In postprocessing we compute it based on the file
-        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 2
+        # Upload route and postprocessing return the same file
+        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 1
 
-    @pytest.mark.xfail
     def test_no_empty_audio_files(self, gradio_temp_dir, connect):
         file_dir = pathlib.Path(pathlib.Path(__file__).parent, "test_files")
         audio = str(file_dir / "audio_sample.wav")
@@ -524,8 +519,7 @@ class TestTempFile:
         with connect(demo) as client:
             _ = client.predict(audio)
             _ = client.predict(audio)
-            # During preprocessing we compute the hash based on base64
-            # In postprocessing we compute it based on the file
+            # One for upload and one for reversal
             assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 2
 
 
@@ -1059,7 +1053,6 @@ class TestBatchProcessing:
         output = demo("Abubakar")
         assert output == "Hello Abubakar"
 
-    @pytest.mark.xfail
     @pytest.mark.asyncio
     async def test_functions_multiple_parameters(self):
         def regular_fn(word1, word2):

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -502,8 +502,8 @@ class TestTempFile:
         video = str(file_dir / "video_sample.mp4")
         demo = gr.Interface(lambda x: x, gr.Video(type="file"), gr.Video())
         with connect(demo) as client:
-            _ = client.predict(video)
-            _ = client.predict(video)
+            _ = client.predict({"video": video})
+            _ = client.predict({"video": video})
         # Upload route and postprocessing return the same file
         assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 1
 

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -47,7 +47,6 @@ class TestInterface:
         with pytest.raises(TypeError):
             Interface(lambda x: x, examples=1234)
 
-    @pytest.mark.xfail
     def test_partial_functions(self):
         def greet(name, formatter):
             return formatter(f"Hello {name}!")

--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -14,7 +14,90 @@ import pytest
 from gradio_client import media_data
 from PIL import Image, ImageCms
 
-from gradio import components, processing_utils, utils
+from gradio import processing_utils, utils
+
+
+class TestTempFileManagement:
+    def test_hash_file(self):
+        h1 = processing_utils.hash_file("gradio/test_data/cheetah1.jpg")
+        h2 = processing_utils.hash_file("gradio/test_data/cheetah1-copy.jpg")
+        h3 = processing_utils.hash_file("gradio/test_data/cheetah2.jpg")
+        assert h1 == h2
+        assert h1 != h3
+
+    def test_make_temp_copy_if_needed(self, gradio_temp_dir):
+        f = processing_utils.save_file_to_cache(
+            "gradio/test_data/cheetah1.jpg", cache_dir=gradio_temp_dir
+        )
+        try:  # Delete if already exists from before this test
+            os.remove(f)
+        except OSError:
+            pass
+
+        f = processing_utils.save_file_to_cache(
+            "gradio/test_data/cheetah1.jpg", cache_dir=gradio_temp_dir
+        )
+        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 1
+
+        assert Path(f).name == "cheetah1.jpg"
+
+        f = processing_utils.save_file_to_cache(
+            "gradio/test_data/cheetah1.jpg", cache_dir=gradio_temp_dir
+        )
+        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 1
+
+        f = processing_utils.save_file_to_cache(
+            "gradio/test_data/cheetah1-copy.jpg", cache_dir=gradio_temp_dir
+        )
+        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 2
+        assert Path(f).name == "cheetah1-copy.jpg"
+
+    def test_save_b64_to_cache(self, gradio_temp_dir):
+        base64_file_1 = media_data.BASE64_IMAGE
+        base64_file_2 = media_data.BASE64_AUDIO["data"]
+
+        f = processing_utils.save_base64_to_cache(
+            base64_file_1, cache_dir=gradio_temp_dir
+        )
+        try:  # Delete if already exists from before this test
+            os.remove(f)
+        except OSError:
+            pass
+
+        f = processing_utils.save_base64_to_cache(
+            base64_file_1, cache_dir=gradio_temp_dir
+        )
+        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 1
+
+        f = processing_utils.save_base64_to_cache(
+            base64_file_1, cache_dir=gradio_temp_dir
+        )
+        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 1
+
+        f = processing_utils.save_base64_to_cache(
+            base64_file_2, cache_dir=gradio_temp_dir
+        )
+        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 2
+
+    @pytest.mark.flaky
+    def test_save_url_to_cache(self, gradio_temp_dir):
+        url1 = "https://raw.githubusercontent.com/gradio-app/gradio/main/gradio/test_data/test_image.png"
+        url2 = "https://raw.githubusercontent.com/gradio-app/gradio/main/gradio/test_data/cheetah1.jpg"
+
+        f = processing_utils.save_url_to_cache(url1, cache_dir=gradio_temp_dir)
+        try:  # Delete if already exists from before this test
+            os.remove(f)
+        except OSError:
+            pass
+
+        f = processing_utils.save_url_to_cache(url1, cache_dir=gradio_temp_dir)
+        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 1
+
+        f = processing_utils.save_url_to_cache(url1, cache_dir=gradio_temp_dir)
+        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 1
+
+        f = processing_utils.save_url_to_cache(url2, cache_dir=gradio_temp_dir)
+        assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 2
 
 
 class TestImagePreprocessing:
@@ -55,25 +138,26 @@ class TestImagePreprocessing:
         output_base64 = processing_utils.encode_pil_to_base64(img)
         assert output_base64 == deepcopy(media_data.ARRAY_TO_BASE64_IMAGE)
 
-    def test_save_pil_to_file_keeps_pnginfo(self, tmp_path):
+    def test_save_pil_to_file_keeps_pnginfo(self, gradio_temp_dir):
         input_img = Image.open("gradio/test_data/test_image.png")
         input_img = input_img.convert("RGB")
         input_img.info = {"key1": "value1", "key2": "value2"}
 
-        file_obj = components.Image().pil_to_temp_file(input_img, dir=tmp_path)
+        file_obj = processing_utils.save_pil_to_cache(
+            input_img, cache_dir=gradio_temp_dir
+        )
         output_img = Image.open(file_obj)
 
         assert output_img.info == input_img.info
 
-    def test_np_pil_encode_to_the_same(self, tmp_path):
+    def test_np_pil_encode_to_the_same(self, gradio_temp_dir):
         arr = np.random.randint(0, 255, size=(100, 100, 3), dtype=np.uint8)
         pil = Image.fromarray(arr)
-        comp = components.Image()
-        assert comp.pil_to_temp_file(pil, dir=tmp_path) == comp.img_array_to_temp_file(
-            arr, dir=tmp_path
-        )
+        assert processing_utils.save_pil_to_cache(
+            pil, cache_dir=gradio_temp_dir
+        ) == processing_utils.save_img_array_to_cache(arr, cache_dir=gradio_temp_dir)
 
-    def test_encode_pil_to_temp_file_metadata_color_profile(self, tmp_path):
+    def test_encode_pil_to_temp_file_metadata_color_profile(self, gradio_temp_dir):
         # Read image
         img = Image.open("gradio/test_data/test_image.png")
         img_metadata = Image.open("gradio/test_data/test_image.png")
@@ -82,20 +166,29 @@ class TestImagePreprocessing:
         # Creating sRGB profile
         profile = ImageCms.createProfile("sRGB")
         profile2 = ImageCms.ImageCmsProfile(profile)
-        img.save(tmp_path / "img_color_profile.png", icc_profile=profile2.tobytes())
-        img_cp1 = Image.open(str(tmp_path / "img_color_profile.png"))
+        img.save(
+            gradio_temp_dir / "img_color_profile.png", icc_profile=profile2.tobytes()
+        )
+        img_cp1 = Image.open(str(gradio_temp_dir / "img_color_profile.png"))
 
         # Creating XYZ profile
         profile = ImageCms.createProfile("XYZ")
         profile2 = ImageCms.ImageCmsProfile(profile)
-        img.save(tmp_path / "img_color_profile_2.png", icc_profile=profile2.tobytes())
-        img_cp2 = Image.open(str(tmp_path / "img_color_profile_2.png"))
+        img.save(
+            gradio_temp_dir / "img_color_profile_2.png", icc_profile=profile2.tobytes()
+        )
+        img_cp2 = Image.open(str(gradio_temp_dir / "img_color_profile_2.png"))
 
-        comp = components.Image()
-        img_path = comp.pil_to_temp_file(img, dir=tmp_path)
-        img_metadata_path = comp.pil_to_temp_file(img_metadata, dir=tmp_path)
-        img_cp1_path = comp.pil_to_temp_file(img_cp1, dir=tmp_path)
-        img_cp2_path = comp.pil_to_temp_file(img_cp2, dir=tmp_path)
+        img_path = processing_utils.save_pil_to_cache(img, cache_dir=gradio_temp_dir)
+        img_metadata_path = processing_utils.save_pil_to_cache(
+            img_metadata, cache_dir=gradio_temp_dir
+        )
+        img_cp1_path = processing_utils.save_pil_to_cache(
+            img_cp1, cache_dir=gradio_temp_dir
+        )
+        img_cp2_path = processing_utils.save_pil_to_cache(
+            img_cp2, cache_dir=gradio_temp_dir
+        )
         assert len({img_path, img_metadata_path, img_cp1_path, img_cp2_path}) == 4
 
     def test_encode_pil_to_base64_keeps_pnginfo(self):

--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -142,6 +142,7 @@ class TestImagePreprocessing:
         input_img = Image.open("gradio/test_data/test_image.png")
         input_img = input_img.convert("RGB")
         input_img.info = {"key1": "value1", "key2": "value2"}
+        input_img.save(gradio_temp_dir / "test_test_image.png")
 
         file_obj = processing_utils.save_pil_to_cache(
             input_img, cache_dir=gradio_temp_dir

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -308,6 +308,7 @@ class TestRoutes:
                     {
                         "data": media_data.BASE64_IMAGE,
                         "name": "bus.png",
+                        "is_file": False,
                         "size": len(media_data.BASE64_IMAGE),
                     }
                 ],


### PR DESCRIPTION
## Description

- There's a lot of duplicate code in the pre/post process of components that moves a file into the "temp file set" (from henceforth called "the cache"). Moving files into the cache and adding it to `temp_files` set is now handled automatically in the Blocks parent class. This should simplify implementing pre/post process for custom components as developers don't need to know anything about how gradio serves files.
- Move all file saving utils from the Component class to processing_utils. This makes each function standalone/independent and easier to use in other components and parts of the code base. 
- Get rid of "temp_file" terminology in public facing methods and use "cache" instead. The term temp_file is misleading (these files are not temporary) and the term "cache" more accurately describes what's actually being done.
- Given that all file-based components use the /upload route, the upload route now saves components to the cache to save space


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
