### PR TITLE
Adds `change()` event to `gr.Gallery`

### DIFF
--- a/.changeset/forty-hornets-share.md
+++ b/.changeset/forty-hornets-share.md
@@ -1,0 +1,6 @@
+---
+"@gradio/gallery": minor
+"gradio": minor
+---
+
+feat:Adds `change()` event to `gr.Gallery`

--- a/demo/bokeh_plot/run.py
+++ b/demo/bokeh_plot/run.py
@@ -85,7 +85,9 @@ with gr.Blocks() as demo:
     with gr.Row():
         plot_type = gr.Radio(value="scatter", choices=["scatter", "whisker", "map"])
         plot = gr.Plot()
+        plot2 = gr.Plot()
     plot_type.change(get_plot, inputs=[plot_type], outputs=[plot])
+    plot_type.change(get_plot, inputs=[plot_type], outputs=[plot2])
     demo.load(get_plot, inputs=[plot_type], outputs=[plot])
 
 

--- a/demo/bokeh_plot/run.py
+++ b/demo/bokeh_plot/run.py
@@ -85,9 +85,7 @@ with gr.Blocks() as demo:
     with gr.Row():
         plot_type = gr.Radio(value="scatter", choices=["scatter", "whisker", "map"])
         plot = gr.Plot()
-        plot2 = gr.Plot()
     plot_type.change(get_plot, inputs=[plot_type], outputs=[plot])
-    plot_type.change(get_plot, inputs=[plot_type], outputs=[plot2])
     demo.load(get_plot, inputs=[plot_type], outputs=[plot])
 
 

--- a/gradio/components/gallery.py
+++ b/gradio/components/gallery.py
@@ -15,6 +15,7 @@ from gradio import utils
 from gradio.components.base import IOComponent, _Keywords
 from gradio.deprecation import warn_deprecation, warn_style_method_deprecation
 from gradio.events import (
+    Changeable,
     EventListenerMethod,
     Selectable,
 )
@@ -23,7 +24,7 @@ set_documentation_group("component")
 
 
 @document()
-class Gallery(IOComponent, GallerySerializable, Selectable):
+class Gallery(IOComponent, GallerySerializable, Changeable, Selectable):
     """
     Used to display a list of images as a gallery that can be scrolled through.
     Preprocessing: this component does *not* accept input.

--- a/js/gallery/Gallery.test.ts
+++ b/js/gallery/Gallery.test.ts
@@ -1,0 +1,65 @@
+import { test, describe, assert, afterEach, vi } from "vitest";
+import { cleanup, render } from "@gradio/tootils";
+import { setupi18n } from "../app/src/i18n";
+
+import Gallery from "./static";
+import type { LoadingStatus } from "@gradio/statustracker";
+
+const loading_status: LoadingStatus = {
+	eta: 0,
+	queue_position: 1,
+	queue_size: 1,
+	status: "complete" as LoadingStatus["status"],
+	scroll_to_output: false,
+	visible: true,
+	fn_index: 0,
+	show_progress: "full"
+};
+
+describe("Gallery", () => {
+	afterEach(() => {
+		cleanup();
+		vi.useRealTimers();
+	});
+	beforeEach(() => {
+		setupi18n();
+	});
+	test("renders the image provided", async () => {
+		const { getByTestId } = await render(Gallery, {
+			show_label: true,
+            label: "Gallery",
+            loading_status: loading_status,
+			preview: true,
+            root: "",
+            root_url: "",
+			value: ["https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg"],
+		});
+		let item = getByTestId("detailed-image") as HTMLImageElement;
+		assert.equal(item.src, "https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg");
+	});
+
+
+	test("triggers the change event if and only if the images change", async () => {
+		const { listen, component } = await render(Gallery, {
+			show_label: true,
+            label: "Gallery",
+            loading_status: loading_status,
+			preview: true,
+            root: "",
+            root_url: "",
+			value: ["https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg"],
+		});
+		const change_event = listen("change");
+		
+        await component.$set({
+			value: ["https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg"],
+		});
+		assert.equal(change_event.callCount, 0);
+		
+        await component.$set({
+			value: ["https://gradio-static-files.s3.us-west-2.amazonaws.com/lion.jpg"],
+		});
+		assert.equal(change_event.callCount, 1);
+	});
+
+});

--- a/js/gallery/Gallery.test.ts
+++ b/js/gallery/Gallery.test.ts
@@ -27,39 +27,46 @@ describe("Gallery", () => {
 	test("renders the image provided", async () => {
 		const { getByTestId } = await render(Gallery, {
 			show_label: true,
-            label: "Gallery",
-            loading_status: loading_status,
+			label: "Gallery",
+			loading_status: loading_status,
 			preview: true,
-            root: "",
-            root_url: "",
-			value: ["https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg"],
+			root: "",
+			root_url: "",
+			value: [
+				"https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg"
+			]
 		});
 		let item = getByTestId("detailed-image") as HTMLImageElement;
-		assert.equal(item.src, "https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg");
+		assert.equal(
+			item.src,
+			"https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg"
+		);
 	});
-
 
 	test("triggers the change event if and only if the images change", async () => {
 		const { listen, component } = await render(Gallery, {
 			show_label: true,
-            label: "Gallery",
-            loading_status: loading_status,
+			label: "Gallery",
+			loading_status: loading_status,
 			preview: true,
-            root: "",
-            root_url: "",
-			value: ["https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg"],
+			root: "",
+			root_url: "",
+			value: [
+				"https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg"
+			]
 		});
 		const change_event = listen("change");
-		
-        await component.$set({
-			value: ["https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg"],
+
+		await component.$set({
+			value: [
+				"https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg"
+			]
 		});
 		assert.equal(change_event.callCount, 0);
-		
-        await component.$set({
-			value: ["https://gradio-static-files.s3.us-west-2.amazonaws.com/lion.jpg"],
+
+		await component.$set({
+			value: ["https://gradio-static-files.s3.us-west-2.amazonaws.com/lion.jpg"]
 		});
 		assert.equal(change_event.callCount, 1);
 	});
-
 });

--- a/js/gallery/package.json
+++ b/js/gallery/package.json
@@ -13,7 +13,8 @@
 		"@gradio/image": "workspace:^",
 		"@gradio/statustracker": "workspace:^",
 		"@gradio/upload": "workspace:^",
-		"@gradio/utils": "workspace:^"
+		"@gradio/utils": "workspace:^",
+		"dequal": "^2.0.2"
 	},
 	"main_changeset": true,
 	"exports": {

--- a/js/gallery/static/Gallery.svelte
+++ b/js/gallery/static/Gallery.svelte
@@ -2,7 +2,7 @@
 	import { BlockLabel, Empty, ShareButton } from "@gradio/atoms";
 	import { ModifyUpload } from "@gradio/upload";
 	import type { SelectData } from "@gradio/utils";
-
+	import { dequal } from "dequal";
 	import { createEventDispatcher } from "svelte";
 	import { tick } from "svelte";
 	import { _ } from "svelte-i18n";
@@ -54,7 +54,7 @@
 	let selected_image = preview && value?.length ? 0 : null;
 	let old_selected_image: number | null = selected_image;
 
-	$: if (prevValue !== value) {
+	$: if (!dequal(prevValue, value)) {
 		// When value is falsy (clear button or first load),
 		// preview determines the selected image
 		if (was_reset) {
@@ -162,10 +162,12 @@
 			container_width / 2 +
 			container_element.scrollLeft;
 
-		container_element?.scrollTo({
-			left: pos < 0 ? 0 : pos,
-			behavior: "smooth"
-		});
+		if (container_element && typeof container_element.scrollTo === 'function') {
+			container_element.scrollTo({
+				left: pos < 0 ? 0 : pos,
+				behavior: "smooth"
+			});
+		}
 	}
 
 	let client_height = 0;

--- a/js/gallery/static/Gallery.svelte
+++ b/js/gallery/static/Gallery.svelte
@@ -30,6 +30,7 @@
 	export let show_download_button = false;
 
 	const dispatch = createEventDispatcher<{
+		change: undefined;
 		select: SelectData;
 	}>();
 
@@ -54,6 +55,7 @@
 	let old_selected_image: number | null = selected_image;
 
 	$: if (prevValue !== value) {
+		console.log(prevValue, value)
 		// When value is falsy (clear button or first load),
 		// preview determines the selected image
 		if (was_reset) {
@@ -69,6 +71,7 @@
 					? selected_image
 					: null;
 		}
+		dispatch("change");
 		prevValue = value;
 	}
 

--- a/js/gallery/static/Gallery.svelte
+++ b/js/gallery/static/Gallery.svelte
@@ -55,7 +55,7 @@
 	let old_selected_image: number | null = selected_image;
 
 	$: if (prevValue !== value) {
-		console.log(prevValue, value)
+		console.log(prevValue, value);
 		// When value is falsy (clear button or first load),
 		// preview determines the selected image
 		if (was_reset) {

--- a/js/gallery/static/Gallery.svelte
+++ b/js/gallery/static/Gallery.svelte
@@ -162,7 +162,7 @@
 			container_width / 2 +
 			container_element.scrollLeft;
 
-		if (container_element && typeof container_element.scrollTo === 'function') {
+		if (container_element && typeof container_element.scrollTo === "function") {
 			container_element.scrollTo({
 				left: pos < 0 ? 0 : pos,
 				behavior: "smooth"

--- a/js/gallery/static/Gallery.svelte
+++ b/js/gallery/static/Gallery.svelte
@@ -55,7 +55,6 @@
 	let old_selected_image: number | null = selected_image;
 
 	$: if (prevValue !== value) {
-		console.log(prevValue, value);
 		// When value is falsy (clear button or first load),
 		// preview determines the selected image
 		if (was_reset) {

--- a/js/gallery/static/StaticGallery.svelte
+++ b/js/gallery/static/StaticGallery.svelte
@@ -29,6 +29,7 @@
 	export let show_share_button = false;
 	export let show_download_button = false;
 	export let gradio: Gradio<{
+		change: typeof value;
 		select: SelectData;
 		share: ShareData;
 		error: string;
@@ -49,6 +50,7 @@
 >
 	<StatusTracker {...loading_status} />
 	<Gallery
+		on:change={() => gradio.dispatch("change", value)}
 		on:select={(e) => gradio.dispatch("select", e.detail)}
 		on:share={(e) => gradio.dispatch("share", e.detail)}
 		on:error={(e) => gradio.dispatch("error", e.detail)}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -828,6 +828,9 @@ importers:
       '@gradio/utils':
         specifier: workspace:^
         version: link:../utils
+      dequal:
+        specifier: ^2.0.2
+        version: 2.0.2
 
   js/group: {}
 


### PR DESCRIPTION
The `gr.Gallery()` component had been missing a `.change()` event. This adds it and closes: #2123

Test code:

```py
import gradio as gr
    
with gr.Blocks() as demo:
    with gr.Row():
        t = gr.Textbox()
        b = gr.Button()
    g = gr.Gallery()
    n = gr.Number(label="change counter")
    t.submit(lambda :["cheetah.jpg", "cat.jpg"], None, g)
    b.click(lambda :["cat.jpg", "cheetah.jpg"], None, g)
    g.change(lambda x:x+1, n, n)
    
demo.launch()
```