### PR TITLE
Adds the ability to set the `selected_index` in a `gr.Gallery`

### DIFF
--- a/.changeset/thin-rivers-care.md
+++ b/.changeset/thin-rivers-care.md
@@ -1,0 +1,6 @@
+---
+"@gradio/gallery": minor
+"gradio": minor
+---
+
+feat:Adds the ability to set the `selected_index` in a `gr.Gallery`

--- a/gradio/components/gallery.py
+++ b/gradio/components/gallery.py
@@ -50,10 +50,11 @@ class Gallery(IOComponent, GallerySerializable, Selectable):
         columns: int | tuple | None = 2,
         rows: int | tuple | None = None,
         height: int | float | None = None,
+        allow_preview: bool = True,
         preview: bool | None = None,
+        selected_index: int | None = None,
         object_fit: Literal["contain", "cover", "fill", "none", "scale-down"]
         | None = None,
-        allow_preview: bool = True,
         show_share_button: bool | None = None,
         show_download_button: bool | None = True,
         **kwargs,
@@ -73,9 +74,10 @@ class Gallery(IOComponent, GallerySerializable, Selectable):
             columns: Represents the number of images that should be shown in one row, for each of the six standard screen sizes (<576px, <768px, <992px, <1200px, <1400px, >1400px). If fewer than 6 are given then the last will be used for all subsequent breakpoints
             rows: Represents the number of rows in the image grid, for each of the six standard screen sizes (<576px, <768px, <992px, <1200px, <1400px, >1400px). If fewer than 6 are given then the last will be used for all subsequent breakpoints
             height: The height of the gallery component, in pixels. If more images are displayed than can fit in the height, a scrollbar will appear.
-            preview: If True, will display the Gallery in preview mode, which shows all of the images as thumbnails and allows the user to click on them to view them in full size.
-            object_fit: CSS object-fit property for the thumbnail images in the gallery. Can be "contain", "cover", "fill", "none", or "scale-down".
             allow_preview: If True, images in the gallery will be enlarged when they are clicked. Default is True.
+            preview: If True, Gallery will start in preview mode, which shows all of the images as thumbnails and allows the user to click on them to view them in full size. Only works if allow_preview is True.
+            selected_index: The index of the image that should be initially selected. If None, no image will be selected at start.
+            object_fit: CSS object-fit property for the thumbnail images in the gallery. Can be "contain", "cover", "fill", "none", or "scale-down".
             show_share_button: If True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
             show_download_button: If True, will show a download button in the corner of the selected image. If False, the icon does not appear. Default is True.
 
@@ -92,6 +94,7 @@ class Gallery(IOComponent, GallerySerializable, Selectable):
             else show_download_button
         )
         self.select: EventListenerMethod
+        self.selected_index = selected_index
         """
         Event listener for when the user selects image within Gallery.
         Uses event data gradio.SelectData to carry `value` referring to caption of selected image, and `index` to refer to index.

--- a/gradio/components/gallery.py
+++ b/gradio/components/gallery.py
@@ -76,7 +76,7 @@ class Gallery(IOComponent, GallerySerializable, Selectable):
             height: The height of the gallery component, in pixels. If more images are displayed than can fit in the height, a scrollbar will appear.
             allow_preview: If True, images in the gallery will be enlarged when they are clicked. Default is True.
             preview: If True, Gallery will start in preview mode, which shows all of the images as thumbnails and allows the user to click on them to view them in full size. Only works if allow_preview is True.
-            selected_index: The index of the image that should be initially selected. If None, no image will be selected at start.
+            selected_index: The index of the image that should be initially selected. If None, no image will be selected at start. If provided, will set Gallery to preview mode unless allow_preview is set to False.
             object_fit: CSS object-fit property for the thumbnail images in the gallery. Can be "contain", "cover", "fill", "none", or "scale-down".
             show_share_button: If True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
             show_download_button: If True, will show a download button in the corner of the selected image. If False, the icon does not appear. Default is True.

--- a/js/gallery/static/Gallery.svelte
+++ b/js/gallery/static/Gallery.svelte
@@ -28,6 +28,7 @@
 		"cover";
 	export let show_share_button = false;
 	export let show_download_button = false;
+	export let selected_index = true;
 
 	const dispatch = createEventDispatcher<{
 		select: SelectData;

--- a/js/gallery/static/StaticGallery.svelte
+++ b/js/gallery/static/StaticGallery.svelte
@@ -24,6 +24,7 @@
 	export let height: number | "auto" = "auto";
 	export let preview: boolean;
 	export let allow_preview = true;
+	export let selected_index: number | null = null;
 	export let object_fit: "contain" | "cover" | "fill" | "none" | "scale-down" =
 		"cover";
 	export let show_share_button = false;
@@ -63,6 +64,7 @@
 		{preview}
 		{object_fit}
 		{allow_preview}
+		{selected_index}
 		{show_share_button}
 		{show_download_button}
 	/>

--- a/js/gallery/static/StaticGallery.svelte
+++ b/js/gallery/static/StaticGallery.svelte
@@ -64,7 +64,7 @@
 		{preview}
 		{object_fit}
 		{allow_preview}
-		{selected_index}
+		bind:selected_index
 		{show_share_button}
 		{show_download_button}
 	/>


### PR DESCRIPTION
Adds the ability to set the `selected_index` of a `gr.Gallery`, both at initialization as well as by returning an updated `gr.Gallery` component from a function.

Test code:

```py
import gradio as gr

images = [
    "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80",
    "https://images.unsplash.com/photo-1554151228-14d9def656e4?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=386&q=80",
    "https://images.unsplash.com/photo-1542909168-82c3e7fdca5c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8aHVtYW4lMjBmYWNlfGVufDB8fDB8fA%3D%3D&w=1000&q=80",
    "https://images.unsplash.com/photo-1546456073-92b9f0a8d413?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80",
    "https://images.unsplash.com/photo-1601412436009-d964bd02edbc?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=464&q=80",
]


with gr.Blocks() as demo:
    g = gr.Gallery(images, selected_index=1)
    b = gr.Button("Change to 0")
    b2 = gr.Button("Change to 2")
    b.click(lambda : gr.Gallery(label="changed", selected_index=0), None, g)
    b2.click(lambda : gr.Gallery(label="changed", selected_index=2), None, g)
    
demo.launch()
```

Closes: #5123 