### PR TITLE
modify url_params

### DIFF
--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -422,9 +422,12 @@ export function api_factory(
 				let payload: Payload;
 				let complete: false | Record<string, any> = false;
 				const listener_map: ListenerMap<EventType> = {};
-				const url_params = new URLSearchParams(
-					window.location.search
-				).toString();
+				let url_params = ""
+				if (typeof(window) !== "undefined") {
+					url_params = new URLSearchParams(
+						window.location.search
+					).toString();
+				}
 
 				handle_blob(
 					`${http_protocol}//${host + config.path}`,


### PR DESCRIPTION
## Description
Currently, when I send a API request in Node.js, the following problem occurs.
```js
import { client } from "@gradio/client";
const app = await client("gradio/hello_world");
const result = await app.predict("/predict", [
  "John",
]);
console.log(result.data);
```
```bash
          window.location.search
          ^

ReferenceError: window is not defined
    at submit (file:///home/oscar/source/gradio_request/node_modules/@gradio/client/dist/index.js:412:11)
    at file:///home/oscar/source/gradio_request/node_modules/@gradio/client/dist/index.js:368:23
    at new Promise (<anonymous>)
    at Object.predict (file:///home/oscar/source/gradio_request/node_modules/@gradio/client/dist/index.js:367:16)
    at file:///home/oscar/source/gradio_request/test_hello.js:3:26
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v18.17.1
```
It can be solved by modifying a small part of the code.

## 🎯 PRs Should Target Issues

There is a issue in #5774 

## Tests

My test environment is...
```bash
Node.js v18.17.1
npm 9.6.7
@gradio/client@0.4.1
```
You need to add `"type": "module"` in `package.json`.

![result](https://github.com/gradio-app/gradio/assets/37574274/1e35bad0-4256-49bb-be09-fc8af2f54cb7)