### PR TITLE
Lite: Fix Examples.create() to be a normal func so it can be called in the Wasm env

### DIFF
--- a/.changeset/eager-goats-share.md
+++ b/.changeset/eager-goats-share.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Lite: Fix Examples.create() to be a normal func so it can be called in the Wasm env

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -278,6 +278,7 @@ class Examples:
                 # In the Wasm mode, the `threading` module is not supported,
                 # so `client_utils.synchronize_async` is also not available.
                 # And `self.cache()` should be waited for to complete before this method returns,
+                # (otherwise, an error "Cannot cache examples if not in a Blocks context" will be raised anyway)
                 # so `eventloop.create_task(self.cache())` is also not an option.
                 raise wasm_utils.WasmUnsupportedError(
                     "Caching examples is not supported in the Wasm mode."

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -23,7 +23,7 @@ from gradio_client import utils as client_utils
 from gradio_client.documentation import document, set_documentation_group
 from matplotlib import animation
 
-from gradio import components, oauth, processing_utils, routes, utils
+from gradio import components, oauth, processing_utils, routes, utils, wasm_utils
 from gradio.context import Context, LocalContext
 from gradio.exceptions import Error
 from gradio.flagging import CSVLogger
@@ -72,7 +72,7 @@ def create_examples(
         batch=batch,
         _initiated_directly=False,
     )
-    client_utils.synchronize_async(examples_obj.create)
+    examples_obj.create()
     return examples_obj
 
 
@@ -246,7 +246,7 @@ class Examples:
         self.cache_examples = cache_examples
         self.run_on_click = run_on_click
 
-    async def create(self) -> None:
+    def create(self) -> None:
         """Caches the examples if self.cache_examples is True and creates the Dataset
         component to hold the examples"""
 
@@ -274,7 +274,15 @@ class Examples:
                 )
 
         if self.cache_examples:
-            await self.cache()
+            if wasm_utils.IS_WASM:
+                # In the Wasm mode, the `threading` module is not supported,
+                # so `client_utils.synchronize_async` is also not available.
+                # And `self.cache()` should be waited for to complete before this method returns,
+                # so `eventloop.create_task(self.cache())` is also not an option.
+                raise wasm_utils.WasmUnsupportedError(
+                    "Caching examples is not supported in the Wasm mode."
+                )
+            client_utils.synchronize_async(self.cache)
 
     async def cache(self) -> None:
         """


### PR DESCRIPTION
## Description

Related to #5627 or #4849, but this PR is about the Python code.

For `gr.Examples()` to work, `Examples.create()` needs to be called synchronously [here](https://github.com/gradio-app/gradio/pull/5821/files#diff-2c1920edd2b0301c69c62332fd0724dba3740d966bbddf84a5d0d0462790a1fdR75), but in the Wasm/Pyodide env, `threading` is [not supported](https://pyodide.org/en/stable/usage/wasm-constraints.html#included-but-not-working-modules), so `client_utils.synchronize_async` can't be used.
So I converted the `Examples.create()` async method to a normal synchronous one since the async part is only in `self.cache()` so that `.create()` except calling `.cache()` can be called synchronously even in the Wasm mode.

Found that this change is the right solution to make `gr.Examples` to work on Wasm instead of [the monkey-patching on the async library](https://github.com/gradio-app/gradio/pull/5627/files#diff-875f331b75840f48b6d0c3c36e8e6a394bae0e152d3e4ec7842c9048b3109925R155-R175). (Unless `.create()` is called synchronously, the added dependency is not pushed to the frontend and clicking a dataset item would be no-op.) -> I will modify #5627 after this PR is merged.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
