### PR TITLE
Mention that audio is normalized when converting to wav in docs

### DIFF
--- a/.changeset/five-showers-bet.md
+++ b/.changeset/five-showers-bet.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Mention that audio is normalized when converting to wav in docs

--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -46,7 +46,7 @@ class Audio(
     """
     Creates an audio component that can be used to upload/record audio (as an input) or display audio (as an output).
     Preprocessing: passes the uploaded audio as a {Tuple(int, numpy.array)} corresponding to (sample rate in Hz, audio data as a 16-bit int array whose values range from -32768 to 32767), or as a {str} filepath, depending on `type`.
-    Postprocessing: expects a {Tuple(int, numpy.array)} corresponding to (sample rate in Hz, audio data as a float or int numpy array) or as a {str} or {pathlib.Path} filepath or URL to an audio file, or bytes for binary content (recommended for streaming)
+    Postprocessing: expects a {Tuple(int, numpy.array)} corresponding to (sample rate in Hz, audio data as a float or int numpy array) or as a {str} or {pathlib.Path} filepath or URL to an audio file, or bytes for binary content (recommended for streaming). Note: When converting audio data from float format to WAV, the audio is normalized by its peak value to avoid distortion or clipping in the resulting audio.
     Examples-format: a {str} filepath to a local file that contains audio.
     Demos: main_note, generate_tone, reverse_audio
     Guides: real-time-speech-recognition


### PR DESCRIPTION
## Description

When converting audio data from a float format to WAV (an audio file format), the audio is being normalized by its peak value (this means the volume of the audio is being adjusted). If algorithms modify the loudness of the audio, the user might not hear these changes because the normalization alters the volume. This could be problematic when the algorithm or model is specifically manipulating loudness and the user expects to hear these changes. 

Mention this in the documentation

Closes: #5484 


  
