### PR TITLE
Lite: Convert an error object caught in the worker to be cloneable

### DIFF
--- a/.changeset/chatty-berries-flash.md
+++ b/.changeset/chatty-berries-flash.md
@@ -1,0 +1,5 @@
+---
+"@gradio/wasm": minor
+---
+
+feat:Lite: Convert an error object caught in the worker to be cloneable

--- a/js/wasm/src/webworker/index.ts
+++ b/js/wasm/src/webworker/index.ts
@@ -314,9 +314,16 @@ self.onmessage = async (event: MessageEvent<InMessage>): Promise<void> => {
 			}
 		}
 	} catch (error) {
+		console.error(error);
+
+		// The `error` object may contain non-serializable properties such as function,
+		// so it must be converted to a plain object before sending it to the main thread.
+		// Otherwise, the following error will be thrown:
+		// `Uncaught (in promise) DOMException: Failed to execute 'postMessage' on 'MessagePort': #<Object> could not be cloned.`
+		const cloneableError = JSON.parse(JSON.stringify(error));
 		const replyMessage: ReplyMessageError = {
 			type: "reply:error",
-			error: error as Error
+			error: cloneableError
 		};
 		messagePort.postMessage(replyMessage);
 	}

--- a/js/wasm/src/webworker/index.ts
+++ b/js/wasm/src/webworker/index.ts
@@ -320,7 +320,7 @@ self.onmessage = async (event: MessageEvent<InMessage>): Promise<void> => {
 		// so it must be converted to a plain object before sending it to the main thread.
 		// Otherwise, the following error will be thrown:
 		// `Uncaught (in promise) DOMException: Failed to execute 'postMessage' on 'MessagePort': #<Object> could not be cloned.`
-		const cloneableError = JSON.parse(JSON.stringify(error));
+		const cloneableError = JSON.parse(JSON.stringify(error)); // Ref: https://stackoverflow.com/a/42376465/13103190
 		const replyMessage: ReplyMessageError = {
 			type: "reply:error",
 			error: cloneableError

--- a/js/wasm/src/webworker/index.ts
+++ b/js/wasm/src/webworker/index.ts
@@ -331,9 +331,10 @@ self.onmessage = async (event: MessageEvent<InMessage>): Promise<void> => {
 		cloneableError.name = error.name;
 		cloneableError.stack = error.stack;
 
-		messagePort.postMessage({
-			type: "reply",
+		const replyMessage: ReplyMessageError = {
+			type: "reply:error",
 			error: cloneableError,
-		});
+		}
+		messagePort.postMessage(replyMessage);
 	}
 };


### PR DESCRIPTION
 so it can be delegated to the main thread properly

## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
