### PR TITLE
Fix error when scrolling dropdown with scrollbar

### DIFF
--- a/.changeset/dry-comics-lick.md
+++ b/.changeset/dry-comics-lick.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dropdown": patch
+"gradio": patch
+---
+
+fix:Fix error when scrolling dropdown with scrollbar

--- a/js/dropdown/shared/Dropdown.svelte
+++ b/js/dropdown/shared/Dropdown.svelte
@@ -117,6 +117,10 @@
 
 	function handle_option_selected(e: any): void {
 		selected_index = parseInt(e.detail.target.dataset.index);
+		if (isNaN(selected_index)) {
+			selected_index = null;
+			return;
+		}
 		show_options = false;
 		active_index = null;
 		filter_input.blur();

--- a/js/dropdown/shared/Dropdown.svelte
+++ b/js/dropdown/shared/Dropdown.svelte
@@ -118,6 +118,7 @@
 	function handle_option_selected(e: any): void {
 		selected_index = parseInt(e.detail.target.dataset.index);
 		if (isNaN(selected_index)) {
+			// This is the case when the user clicks on the scrollbar
 			selected_index = null;
 			return;
 		}


### PR DESCRIPTION
## Description

As the target index is `undefined` in the on change event caused by dragging the scrollbar inside a dropdown, it should not be treated as something is selected.

Closes: #5759
  
