### PR TITLE
Set api=False for cancel events

### DIFF
--- a/.changeset/modern-forks-march.md
+++ b/.changeset/modern-forks-march.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Set api=False for cancel events

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -30,6 +30,7 @@ def set_cancel_events(
             outputs=None,
             queue=False,
             preprocess=False,
+            api_name=False,
             cancels=fn_indices_to_cancel,
         )
 


### PR DESCRIPTION
## Description

Cancel events are not meant to be called directly. Plus they clutter the API page.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
