### PR TITLE
V4: Set cache dir for some component tests

### DIFF
--- a/.changeset/vast-terms-rhyme.md
+++ b/.changeset/vast-terms-rhyme.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:V4: Set cache dir for some component tests

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -314,6 +314,7 @@ def move_files_to_cache(data: Any, block: Component):
                     file_name=payload.name,
                     cache_dir=block.GRADIO_CACHE,
                 )
+                payload.is_file = True
             block.temp_files.add(temp_file_path)
             payload.name = temp_file_path
         return payload.model_dump()

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -744,7 +744,7 @@ class TestPlot:
 
 
 class TestAudio:
-    def test_component_functions(self):
+    def test_component_functions(self, gradio_temp_dir):
         """
         Preprocess, postprocess serialize, get_config, deserialize
         type: filepath, numpy, file
@@ -755,10 +755,12 @@ class TestAudio:
         assert output1[0] == 8000
         assert output1[1].shape == (8046,)
 
-        x_wav["is_file"] = True
+        x_wav["is_file"] = False
+        x_wav["name"] = "audio_sample.wav"
+        x_wav = processing_utils.move_files_to_cache([x_wav], audio_input)[0]
         audio_input = gr.Audio(type="filepath")
         output1 = audio_input.preprocess(x_wav)
-        assert Path(output1).name == "audio_sample-0-100.wav"
+        assert Path(output1).name.endswith("audio_sample-0-100.wav")
 
         audio_input = gr.Audio(label="Upload Your Audio")
         assert audio_input.get_config() == {
@@ -1233,8 +1235,11 @@ class TestVideo:
         """
         Preprocess, serialize, deserialize, get_config
         """
-        x_video = {"video": deepcopy(media_data.BASE64_VIDEO)}
+        x_video = {"video": deepcopy(media_data.BASE64_VIDEO), "is_file": False}
         video_input = gr.Video()
+
+        x_video = processing_utils.move_files_to_cache([x_video], video_input)[0]
+
         output1 = video_input.preprocess(x_video)
         assert isinstance(output1, str)
         output2 = video_input.preprocess(x_video)


### PR DESCRIPTION
## Description

Some components tests were not setting the output directory correctly so the results were not being deleted after the tests run. Small fix.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
