### PR TITLE
V4: Use async version of shutil in upload route

### DIFF
--- a/.changeset/two-mirrors-nail.md
+++ b/.changeset/two-mirrors-nail.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:V4: Use async version of shutil in upload route

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -16,8 +16,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import aiofiles
+import anyio
 import numpy as np
 import requests
+from anyio import CapacityLimiter
 from fastapi import UploadFile
 from gradio_client import utils as client_utils
 from PIL import Image, ImageOps, PngImagePlugin
@@ -205,7 +207,9 @@ def save_file_to_cache(file_path: str | Path, cache_dir: str) -> str:
     return full_temp_file_path
 
 
-async def save_uploaded_file(file: UploadFile, upload_dir: str) -> str:
+async def save_uploaded_file(
+    file: UploadFile, upload_dir: str, limiter: CapacityLimiter | None = None
+) -> str:
     temp_dir = secrets.token_hex(
         20
     )  # Since the full file is being uploaded anyways, there is no benefit to hashing the file.
@@ -233,7 +237,11 @@ async def save_uploaded_file(file: UploadFile, upload_dir: str) -> str:
     directory = Path(upload_dir) / sha1.hexdigest()
     directory.mkdir(exist_ok=True, parents=True)
     dest = (directory / name).resolve()
-    shutil.move(full_temp_file_path, dest)
+
+    await anyio.to_thread.run_sync(
+        shutil.move, full_temp_file_path, dest, limiter=limiter
+    )
+
     return str(dest)
 
 

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -604,7 +604,7 @@ class App(FastAPI):
             for input_file in files:
                 output_files.append(
                     await processing_utils.save_uploaded_file(
-                        input_file, app.uploaded_file_dir
+                        input_file, app.uploaded_file_dir, app.get_blocks().limiter
                     )
                 )
             return output_files


### PR DESCRIPTION
## Description

Made some changes to the upload route so that caching is respected. However, this uses possibly blocking shutil.copy code. Fixing.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
