### PR TITLE
Fix: Improved check if WebSocket polyfill is necessary

### DIFF
--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -255,11 +255,11 @@ export function api_factory(
 			};
 
 			const transform_files = normalise_files ?? true;
-			if (typeof window === "undefined" || !("WebSocket" in window)) {
+			if (!('WebSocket' in globalThis)) {
 				const ws = await import("ws");
 				NodeBlob = (await import("node:buffer")).Blob;
 				//@ts-ignore
-				global.WebSocket = ws.WebSocket;
+				globalThis.WebSocket = ws.WebSocket;
 			}
 
 			const { ws_protocol, http_protocol, host, space_id } =


### PR DESCRIPTION
Also server environments like Next.js have already a WebSocket implementation built in. So there is no window object but a global WebSocket object. Therefore the client crashes because it wants to reassign the WebSocket global object

Closes: Havent created an issue, just the PR right away

