### PR TITLE
Remove deprecated `.update()` usage from Interface internals

### DIFF
--- a/.changeset/spicy-cycles-send.md
+++ b/.changeset/spicy-cycles-send.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Remove deprecated `.update()` usage from Interface internals

--- a/.changeset/spicy-cycles-send.md
+++ b/.changeset/spicy-cycles-send.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Remove deprecated `.update()` usage from Interface internals

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -523,4 +523,4 @@ class FlagMethod:
         return self.reset()
 
     def reset(self):
-        return gr.Button.update(value=self.label, interactive=True)
+        return gr.Button(value=self.label, interactive=True)

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -661,13 +661,13 @@ class Interface(Blocks):
                 extra_output = [submit_btn, stop_btn]
 
                 def cleanup():
-                    return [Button.update(visible=True), Button.update(visible=False)]
+                    return [Button(visible=True), Button(visible=False)]
 
                 predict_event = on(
                     triggers,
                     lambda: (
-                        submit_btn.update(visible=False),
-                        stop_btn.update(visible=True),
+                        Button(visible=False),
+                        Button(visible=True),
                     ),
                     inputs=None,
                     outputs=[submit_btn, stop_btn],
@@ -728,7 +728,7 @@ class Interface(Blocks):
             ),  # type: ignore
             _js=f"""() => {json.dumps(
                 (
-                    [Column.update(visible=True)]
+                    [{'variant': None, 'visible': True, '__type__': 'update'}]
                     if self.interface_type
                         in [
                             InterfaceTypes.STANDARD,
@@ -737,7 +737,7 @@ class Interface(Blocks):
                         ]
                     else []
                 )
-                + ([Column.update(visible=False)] if self.interpretation else [])
+                + ([{'variant': None, 'visible': False, '__type__': 'update'}] if self.interpretation else [])
             )}
             """,
         )
@@ -793,7 +793,7 @@ class Interface(Blocks):
             assert isinstance(value, str)
             flag_method = FlagMethod(self.flagging_callback, label, value)
             flag_btn.click(
-                lambda: Button.update(value="Saving...", interactive=False),
+                lambda: Button(value="Saving...", interactive=False),
                 None,
                 flag_btn,
                 queue=False,
@@ -847,8 +847,8 @@ class Interface(Blocks):
 
     async def interpret_func(self, *args):
         return await self.interpret(list(args)) + [
-            Column.update(visible=False),
-            Column.update(visible=True),
+            Column(visible=False),
+            Column(visible=True),
         ]
 
     async def interpret(self, raw_input: list[Any]) -> list[Any]:

--- a/gradio/themes/builder_app.py
+++ b/gradio/themes/builder_app.py
@@ -966,7 +966,7 @@ with gr.Blocks(theme=theme) as demo:
                 )
                 space_name = "/".join(theme_url.split("/")[-2:])
                 return (
-                    gr.Markdown.update(
+                    gr.Markdown(
                         value=f"Theme uploaded [here!]({theme_url})! Load it as `gr.Blocks(theme='{space_name}')`",
                         visible=True,
                     ),
@@ -974,7 +974,7 @@ with gr.Blocks(theme=theme) as demo:
                 )
             except Exception as e:
                 return (
-                    gr.Markdown.update(
+                    gr.Markdown(
                         value=f"Error: {e}",
                         visible=True,
                     ),


### PR DESCRIPTION
We used the `.update()` logic various places inside `Interface`, which meant that a warning was raised e.g. any time you clicked on the Clear button or passed in an iterator. This replaces with modern syntax.

Test code:

```py
import gradio as gr
import time

def identity(x):
    for i in range(len(x)):
        time.sleep(0.5)
        yield x[:i+1]
        
gr.Interface(identity, "textbox", "textbox").queue().launch()
```