### PR TITLE
refactor: change to label tag where label property is accepted by com…

### DIFF
--- a/js/atoms/src/BlockLabel.svelte
+++ b/js/atoms/src/BlockLabel.svelte
@@ -17,7 +17,7 @@
 		<Icon />
 	</span>
 
-	{label}
+	<label>{label}</label>
 </div>
 
 <style>


### PR DESCRIPTION
refactor: change to label tag where label property is accepted by component

BlockLabel is being used as the main component for labels and should address the issue reported in Chat and File component

closes issue 5454

## Description

all the the components that accept label as an input used <label> tag.

Closes: #5454 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
