### PR TITLE
Keep Markdown rendered lists within dataframe cells

### DIFF
--- a/.changeset/tidy-horses-build.md
+++ b/.changeset/tidy-horses-build.md
@@ -3,4 +3,4 @@
 "gradio": patch
 ---
 
-fix:Keep Markdown rendered lists within dataframe cells, and allows links to wrap
+fix:Keep Markdown rendered lists within dataframe cells

--- a/js/markdown/static/MarkdownCode.svelte
+++ b/js/markdown/static/MarkdownCode.svelte
@@ -119,4 +119,8 @@
 	span:not(.chatbot) :global(ol) {
 		list-style-position: inside;
 	}
+
+	span :global(a) {
+		white-space: normal;
+	}
 </style>

--- a/js/markdown/static/MarkdownCode.svelte
+++ b/js/markdown/static/MarkdownCode.svelte
@@ -111,4 +111,8 @@
 	span :global(pre) {
 		position: relative;
 	}
+
+	:global(.md ul) {
+		list-style-position: inside;
+	}
 </style>

--- a/js/markdown/static/MarkdownCode.svelte
+++ b/js/markdown/static/MarkdownCode.svelte
@@ -112,7 +112,7 @@
 		position: relative;
 	}
 
-	span :global(ul) {
+	span:not(.chatbot) :global(ul) {
 		list-style-position: inside;
 	}
 </style>

--- a/js/markdown/static/MarkdownCode.svelte
+++ b/js/markdown/static/MarkdownCode.svelte
@@ -112,7 +112,7 @@
 		position: relative;
 	}
 
-	:global(.md ul) {
+	span :global(ul) {
 		list-style-position: inside;
 	}
 </style>

--- a/js/markdown/static/MarkdownCode.svelte
+++ b/js/markdown/static/MarkdownCode.svelte
@@ -119,8 +119,4 @@
 	span:not(.chatbot) :global(ol) {
 		list-style-position: inside;
 	}
-
-	span :global(a) {
-		white-space: normal;
-	}
 </style>

--- a/js/markdown/static/MarkdownCode.svelte
+++ b/js/markdown/static/MarkdownCode.svelte
@@ -115,4 +115,8 @@
 	span:not(.chatbot) :global(ul) {
 		list-style-position: inside;
 	}
+
+	span:not(.chatbot) :global(ol) {
+		list-style-position: inside;
+	}
 </style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
Fixes: #5802 for `<ul>` and `<ol>`:

Before:

<img width="1288" alt="image" src="https://github.com/gradio-app/gradio/assets/1778297/3cdd499b-c2e3-4e16-9376-6a539f9b8b77">

After:

<img width="1283" alt="image" src="https://github.com/gradio-app/gradio/assets/1778297/a0870459-1e93-4796-8d3b-95688899df87">

Note that chatbot markdown actually looks better without this change, so I excluded chatbot markdown from the css selector. 