### PR TITLE
dataframe wrap links

### DIFF
--- a/.changeset/plenty-waves-hang.md
+++ b/.changeset/plenty-waves-hang.md
@@ -1,0 +1,6 @@
+---
+"@gradio/markdown": patch
+"gradio": patch
+---
+
+fix:dataframe wrap links

--- a/js/markdown/static/MarkdownCode.svelte
+++ b/js/markdown/static/MarkdownCode.svelte
@@ -122,6 +122,6 @@
 
 	span :global(a) {
 		white-space: normal;
-		word-break: break-word;
+		overflow-wrap: break-word;
 	}
 </style>

--- a/js/markdown/static/MarkdownCode.svelte
+++ b/js/markdown/static/MarkdownCode.svelte
@@ -119,4 +119,9 @@
 	span:not(.chatbot) :global(ol) {
 		list-style-position: inside;
 	}
+
+	span :global(a) {
+		white-space: normal;
+		word-break: break-word;
+	}
 </style>


### PR DESCRIPTION
Fixes: #5523

Nvm: this is not a good solution since wrapping the links adjusts the column widths. 

I think the issue is that the column widths are set based on the length of the content of the visible rows. That means if there's a particularly wide column later on, its content will get cut off. Will see if there's a way to fix. 