### PR TITLE
Lite: Fix is_self_host() to detect `127.0.0.1` as localhost as well

### DIFF
--- a/.changeset/eager-snakes-look.md
+++ b/.changeset/eager-snakes-look.md
@@ -1,0 +1,6 @@
+---
+"@gradio/app": minor
+"gradio": minor
+---
+
+feat:Lite: Fix is_self_host() to detect `127.0.0.1` as localhost as well

--- a/.changeset/eager-snakes-look.md
+++ b/.changeset/eager-snakes-look.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/app": minor
-"gradio": minor
+"@gradio/app": patch
+"gradio": patch
 ---
 
 feat:Lite: Fix is_self_host() to detect `127.0.0.1` as localhost as well

--- a/js/app/src/lite/url.ts
+++ b/js/app/src/lite/url.ts
@@ -1,5 +1,5 @@
 export function is_self_host(url: URL): boolean {
 	return (
-		url.host === window.location.host || url.host === "localhost:7860" // Ref: https://github.com/gradio-app/gradio/blob/v3.32.0/js/app/src/Index.svelte#L194
+		url.host === window.location.host || url.host === "localhost:7860" || url.host === "127.0.0.1:7860" // Ref: https://github.com/gradio-app/gradio/blob/v3.32.0/js/app/src/Index.svelte#L194
 	);
 }


### PR DESCRIPTION
## Description

For local development convenience.
We sometimes can open the local dev server page via `127.0.0.1` instead of `localhost`.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
