### PR TITLE
Use full path to executables in CLI

### DIFF
--- a/.changeset/nasty-dryers-show.md
+++ b/.changeset/nasty-dryers-show.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Use full path to executables in CLI

--- a/gradio/cli/commands/components/create.py
+++ b/gradio/cli/commands/components/create.py
@@ -67,7 +67,7 @@ def _create(
     directory.mkdir(exist_ok=overwrite)
 
     if _create_utils._in_test_dir():
-        npm_install = "pnpm i --ignore-scripts"
+        npm_install = f"{shutil.which('pnpm')} i --ignore-scripts"
 
     npm_install = npm_install.strip()
     if npm_install == "npm install":
@@ -99,7 +99,7 @@ def _create(
         live.update(":art: Created frontend code", add_sleep=0.2)
 
         if install:
-            cmds = ["pip", "install", "-e", f"{str(directory)}"]
+            cmds = [shutil.which("pip"), "install", "-e", f"{str(directory)}"]
             live.update(
                 f":construction_worker: Installing python... [grey37]({' '.join(cmds)})[/]"
             )

--- a/gradio/cli/commands/reload.py
+++ b/gradio/cli/commands/reload.py
@@ -101,7 +101,7 @@ def main(
     )
     # extra_args = args[1:] if len(args) == 1 or args[1].startswith("--") else args[2:]
     popen = subprocess.Popen(
-        ["python", "-u", path],
+        [sys.executable, "-u", path],
         env=dict(
             os.environ,
             GRADIO_WATCH_DIRS=",".join(watch_dirs),


### PR DESCRIPTION
## Description

Closes: #5464 
Closes: #5833 

For subprocess commands use the full path to the executable so the OS can find it without having to use `shell=True`

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
