### PR TITLE
Fix Dataframe `line_breaks`

### DIFF
--- a/.changeset/thirty-planets-smash.md
+++ b/.changeset/thirty-planets-smash.md
@@ -1,0 +1,6 @@
+---
+"@gradio/markdown": patch
+"gradio": patch
+---
+
+fix:Fix Dataframe `line_breaks`

--- a/js/markdown/static/MarkdownCode.svelte
+++ b/js/markdown/static/MarkdownCode.svelte
@@ -119,4 +119,7 @@
 	span:not(.chatbot) :global(ol) {
 		list-style-position: inside;
 	}
+	span :global(p:not(:first-child)) {
+		margin-top: var(--spacing-xxl);
+	}
 </style>


### PR DESCRIPTION
## Description
`line_breaks` param actually _was_ being passed down properly. But when adding two line breaks, markdown actually creates a new `<p>` tag for the following text. In the chatbot we added padding between `<p>` tags. I added the same here for dataframe to be consistent.
<img width="1014" alt="Screenshot 2023-10-13 at 1 08 09 AM" src="https://github.com/gradio-app/gradio/assets/12725292/80843585-c45c-46f4-92c6-e6f9fcb081c6">

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
