### PR TITLE
Fix curly brackets in docstrings

### DIFF
--- a/.changeset/new-ideas-sniff.md
+++ b/.changeset/new-ideas-sniff.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix curly brackets in docstrings

--- a/gradio/components/file.py
+++ b/gradio/components/file.py
@@ -36,7 +36,7 @@ class File(
 ):
     """
     Creates a file component that allows uploading generic file (when used as an input) and or displaying generic files (output).
-    Preprocessing: passes the uploaded file as a {tempfile._TemporaryFileWrapper} or {List[tempfile._TemporaryFileWrapper]} depending on `file_count` (or a {bytes}/{List{bytes}} depending on `type`)
+    Preprocessing: passes the uploaded file as a {tempfile._TemporaryFileWrapper} or {List[tempfile._TemporaryFileWrapper]} depending on `file_count` (or a {bytes}/{List[bytes]} depending on `type`)
     Postprocessing: expects function to return a {str} path to a file, or {List[str]} consisting of paths to files.
     Examples-format: a {str} path to a local file that populates the component.
     Demos: zip_to_json, zip_files

--- a/gradio/components/file_explorer.py
+++ b/gradio/components/file_explorer.py
@@ -25,7 +25,7 @@ set_documentation_group("component")
 class FileExplorer(Changeable, IOComponent, JSONSerializable):
     """
     Creates a file explorer component that allows users to browse and select files on the machine hosting the Gradio app.
-    Preprocessing: passes the selected file or directory as a {str} path (relative to root) or {list[str}} depending on `file_count`
+    Preprocessing: passes the selected file or directory as a {str} path (relative to root) or {list[str]} depending on `file_count`
     Postprocessing: expects function to return a {str} path to a file, or {List[str]} consisting of paths to files.
     Examples-format: a {str} path to a local file that populates the component.
     Demos: zip_to_json, zip_files

--- a/gradio/components/upload_button.py
+++ b/gradio/components/upload_button.py
@@ -22,7 +22,7 @@ set_documentation_group("component")
 class UploadButton(Clickable, Uploadable, IOComponent, FileSerializable):
     """
     Used to create an upload button, when clicked allows a user to upload files that satisfy the specified file type or generic files (if file_type not set).
-    Preprocessing: passes the uploaded file as a {file-object} or {List[file-object]} depending on `file_count` (or a {bytes}/{List{bytes}} depending on `type`)
+    Preprocessing: passes the uploaded file as a {file-object} or {List[file-object]} depending on `file_count` (or a {bytes}/{List[bytes]} depending on `type`)
     Postprocessing: expects function to return a {str} path to a file, or {List[str]} consisting of paths to files.
     Examples-format: a {str} path to a local file that populates the component.
     Demos: upload_button


### PR DESCRIPTION
## Description

For example, in the [`UploadButton` doc](https://www.gradio.app/docs/uploadbutton),

Current:
![CleanShot 2023-10-13 at 16 57 26@2x](https://github.com/gradio-app/gradio/assets/3135397/b8592692-5181-482c-a821-a2f4a1dd538f)

Fixed:
![CleanShot 2023-10-13 at 16 56 49@2x](https://github.com/gradio-app/gradio/assets/3135397/1231b665-cc37-4791-b932-c8ac047e0c0c)



## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
