### PR TITLE
Define Font.__repr__() to be printed in the doc in a readable format

### DIFF
--- a/.changeset/green-forks-float.md
+++ b/.changeset/green-forks-float.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Define Font.__repr__() to be printed in the doc in a readable format

--- a/gradio/themes/utils/fonts.py
+++ b/gradio/themes/utils/fonts.py
@@ -40,6 +40,12 @@ class Font:
     def __eq__(self, other: Font) -> bool:
         return self.name == other.name and self.stylesheet() == other.stylesheet()
 
+    def __repr__(self) -> str:
+        klass = type(self)
+        class_repr = klass.__module__ + "." + klass.__qualname__
+        attrs = ", ".join([k + "=" + repr(v) for k, v in self.__dict__.items()])
+        return f"<{class_repr} ({attrs})>"
+
 
 class GoogleFont(Font):
     def __init__(self, name: str, weights: Iterable[int] = (400, 600)):


### PR DESCRIPTION
## Description

To fix the format printed in the doc:

Current (https://www.gradio.app/docs/themes):
![CleanShot 2023-10-13 at 23 37 07@2x](https://github.com/gradio-app/gradio/assets/3135397/ca9ef740-bfe8-450a-a2ae-2a0f729f16be)

Fixed:
![CleanShot 2023-10-13 at 23 36 25@2x](https://github.com/gradio-app/gradio/assets/3135397/5e57161c-6d8a-4cad-a0a8-8b748ab5566b)

Closes: #5902

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
