### PR TITLE
Fix type the docstring of the Code component

### DIFF
--- a/.changeset/tricky-spoons-slide.md
+++ b/.changeset/tricky-spoons-slide.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix type the docstring of the Code component

--- a/gradio/components/code.py
+++ b/gradio/components/code.py
@@ -19,7 +19,7 @@ class Code(Changeable, Inputable, IOComponent, StringSerializable):
     """
     Creates a Code editor for entering, editing or viewing code.
     Preprocessing: passes a {str} of code into the function.
-    Postprocessing: expects the function to return a {str} of code or a single-elment {tuple}: (string filepath,)
+    Postprocessing: expects the function to return a {str} of code or a single-element {tuple}: {(string_filepath,)}
     """
 
     languages = [


### PR DESCRIPTION
## Description

The rendered document would be:
![CleanShot 2023-10-14 at 00 20 18@2x](https://github.com/gradio-app/gradio/assets/3135397/69c7351c-1649-496e-8268-44cf8bfc53aa)


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
