### PR TITLE
Install build and twine with --install

### DIFF
--- a/gradio/cli/commands/components/create.py
+++ b/gradio/cli/commands/components/create.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Optional
 
 import typer
+from rich.markup import escape
 from typing_extensions import Annotated
 
 from gradio.cli.commands.display import LivePanelDisplay
@@ -38,7 +39,7 @@ def _create(
     install: Annotated[
         bool,
         typer.Option(
-            help="Whether to install the component in your current environment as a local install"
+            help="Whether to install the component in your current environment as a development install. Recommended for development."
         ),
     ] = False,
     npm_install: Annotated[
@@ -99,9 +100,9 @@ def _create(
         live.update(":art: Created frontend code", add_sleep=0.2)
 
         if install:
-            cmds = [shutil.which("pip"), "install", "-e", f"{str(directory)}"]
+            cmds = [shutil.which("pip"), "install", "-e", f"{str(directory)}[dev]"]
             live.update(
-                f":construction_worker: Installing python... [grey37]({' '.join(cmds)})[/]"
+                f":construction_worker: Installing python... [grey37]({escape(' '.join(cmds))})[/]"
             )
             pipe = subprocess.run(cmds, capture_output=True, text=True)
 

--- a/gradio/cli/commands/components/files/pyproject_.toml
+++ b/gradio/cli/commands/components/files/pyproject_.toml
@@ -37,6 +37,9 @@ classifiers = [
   'Topic :: Scientific/Engineering :: Visualization',
 ]
 
+[project.optional-dependencies]
+dev = ["build", "twine"]
+
 [tool.hatch.build]
 artifacts = ["/backend/<<name>>/templates", "*.pyi"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ exclude = [
   "gradio/_frontend_code/",
   "gradio/components/*_plot.py",
   "gradio/ipython_ext.py",
+  "gradio/node"
 ]
 
 [tool.ruff]
@@ -115,6 +116,7 @@ ignore = [
   "UP007",  # use X | Y for type annotations (TODO: can be enabled once Pydantic plays nice with them)
   "UP006",  # use `list` instead of `List` for type annotations (fails for 3.8)
 ]
+exclude = ["gradio/node/*.py"]
 
 [tool.ruff.per-file-ignores]
 "demo/*" = [


### PR DESCRIPTION
## Description

Introduces a set of development dependencies for custom component packages (`build` and `twine`) that are installed when `--install` is used in create. That way cc authors can run `gradio_component build` without errors.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
