### PR TITLE
fix: allow multiple flagging directories

### DIFF
--- a/.changeset/plain-berries-tap.md
+++ b/.changeset/plain-berries-tap.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:fix: allow multiple flagging directories

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -46,6 +46,7 @@ class FlaggingCallback(ABC):
     def flag(
         self,
         flag_data: list[Any],
+        flagging_dir: str,
         flag_option: str = "",
         username: str | None = None,
     ) -> int:
@@ -55,6 +56,7 @@ class FlaggingCallback(ABC):
         Parameters:
         interface: The Interface object that is being used to launch the flagging interface.
         flag_data: The data to be flagged.
+        flagging_dir: A string, typically containing the path to the directory where the flagging file should be storied
         flag_option (optional): In the case that flagging_options are provided, the flag option that is being used.
         username (optional): The username of the user that is flagging the data, if logged in.
         Returns:
@@ -88,6 +90,7 @@ class SimpleCSVLogger(FlaggingCallback):
     def flag(
         self,
         flag_data: list[Any],
+        flagging_dir: str,
         flag_option: str = "",
         username: str | None = None,
     ) -> int:
@@ -145,10 +148,10 @@ class CSVLogger(FlaggingCallback):
     def flag(
         self,
         flag_data: list[Any],
+        flagging_dir: str,
         flag_option: str = "",
         username: str | None = None,
     ) -> int:
-        flagging_dir = self.flagging_dir
         log_filepath = Path(flagging_dir) / "log.csv"
         is_new = not Path(log_filepath).exists()
         headers = [
@@ -293,6 +296,7 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
     def flag(
         self,
         flag_data: list[Any],
+        flagging_dir: str,
         flag_option: str = "",
         username: str | None = None,
     ) -> int:
@@ -498,20 +502,25 @@ class FlagMethod:
     def __init__(
         self,
         flagging_callback: FlaggingCallback,
+        flagging_dir: str,
         label: str,
         value: str,
         visual_feedback: bool = True,
     ):
         self.flagging_callback = flagging_callback
+        self.flagging_dir = flagging_dir
         self.label = label
         self.value = value
         self.__name__ = "Flag"
         self.visual_feedback = visual_feedback
 
-    def __call__(self, request: gr.Request, *flag_data):
+    def __call__(self, request: gr.Request, flagging_dir: str, *flag_data):
         try:
             self.flagging_callback.flag(
-                list(flag_data), flag_option=self.value, username=request.username
+                list(flag_data),
+                flag_option=self.value,
+                username=request.username,
+                flagging_dir=self.flagging_dir,
             )
         except Exception as e:
             print(f"Error while flagging: {e}")

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -357,7 +357,7 @@ class Examples:
 
                 if self.batch:
                     output = [value[0] for value in output]
-                cache_logger.flag(output)
+                cache_logger.flag(output, self.cached_folder)
             # Remove the "fake_event" to prevent bugs in loading interfaces from spaces
             Context.root_block.dependencies.remove(dependency)
             Context.root_block.fns.pop(fn_index)

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -773,7 +773,7 @@ class Interface(Blocks):
 
         if self.allow_flagging == "auto":
             flag_method = FlagMethod(
-                self.flagging_callback, "", "", visual_feedback=False
+                self.flagging_callback, self.flagging_dir, "", "", visual_feedback=False
             )
             flag_btns[0].click(  # flag_btns[0] is just the "Submit" button
                 flag_method,
@@ -791,7 +791,9 @@ class Interface(Blocks):
 
         for flag_btn, (label, value) in zip(flag_btns, self.flagging_options):
             assert isinstance(value, str)
-            flag_method = FlagMethod(self.flagging_callback, label, value)
+            flag_method = FlagMethod(
+                self.flagging_callback, self.flagging_dir, label, value
+            )
             flag_btn.click(
                 lambda: Button(value="Saving...", interactive=False),
                 None,

--- a/test/test_flagging.py
+++ b/test/test_flagging.py
@@ -15,9 +15,13 @@ class TestDefaultFlagging:
         with tempfile.TemporaryDirectory() as tmpdirname:
             io = gr.Interface(lambda x: x, "text", "text", flagging_dir=tmpdirname)
             io.launch(prevent_thread_lock=True)
-            row_count = io.flagging_callback.flag(["test", "test"])
+            row_count = io.flagging_callback.flag(
+                ["test", "test"], flagging_dir=tmpdirname
+            )
             assert row_count == 1  # 2 rows written including header
-            row_count = io.flagging_callback.flag(["test", "test"])
+            row_count = io.flagging_callback.flag(
+                ["test", "test"], flagging_dir=tmpdirname
+            )
             assert row_count == 2  # 3 rows written including header
         io.close()
 
@@ -33,9 +37,13 @@ class TestSimpleFlagging:
                 flagging_callback=flagging.SimpleCSVLogger(),
             )
             io.launch(prevent_thread_lock=True)
-            row_count = io.flagging_callback.flag(["test", "test"])
+            row_count = io.flagging_callback.flag(
+                ["test", "test"], flagging_dir=tmpdirname
+            )
             assert row_count == 0  # no header in SimpleCSVLogger
-            row_count = io.flagging_callback.flag(["test", "test"])
+            row_count = io.flagging_callback.flag(
+                ["test", "test"], flagging_dir=tmpdirname
+            )
             assert row_count == 1  # no header in SimpleCSVLogger
         io.close()
 
@@ -75,7 +83,9 @@ class TestHuggingFaceDatasetSaver:
             )
             row_count = io.flagging_callback.flag(["test", "test"], "")
             assert row_count == 1  # 2 rows written including header
-            row_count = io.flagging_callback.flag(["test", "test"])
+            row_count = io.flagging_callback.flag(
+                ["test", "test"], flagging_dir=tmpdirname
+            )
             assert row_count == 2  # 3 rows written including header
             for _, _, filenames in os.walk(tmpdirname):
                 for f in filenames:
@@ -107,7 +117,9 @@ class TestHuggingFaceDatasetSaver:
             )
             row_count = io.flagging_callback.flag(["test", "test"], "")
             assert row_count == 1  # 2 rows written including header
-            row_count = io.flagging_callback.flag(["test", "test"])
+            row_count = io.flagging_callback.flag(
+                ["test", "test"], flagging_dir=tmpdirname
+            )
             assert row_count == 2  # 3 rows written including header
             for _, _, filenames in os.walk(tmpdirname):
                 for f in filenames:


### PR DESCRIPTION
## Description

In order to solve the issue grant the possibility to link different flagging directories to different interfaces in the case of multiple interfaces like gr.TabbedInterface, I tried moving flagging_dir also as a parameter of flag(), and so as a parameter of __call__ in FlagMethod (all in flagging.py).
Subsequently, I adapted some code in interface.py, helpers.py, and tests to make it all work. 

This is my first public PR, I tried my best to do everything right but if not please tell me what could be done better. 

## 🎯 Target Issue

Closes: #5692

## Tests

1. I followed the guidelines to contribute (https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and ran the tests: `bash scripts/run_all_tests.sh`. All test passed except sum test linked to hugging face that were not related with the addressed issue, and broke also before my changes (for unloadable spaces or hugginface API limit reach).

2. I ran `bash scripts/format_backend.sh` to lint my code.
  
