### PR TITLE
Fix dataframe `line_breaks`

### DIFF
--- a/.changeset/weak-pants-run.md
+++ b/.changeset/weak-pants-run.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": patch
+"gradio": patch
+---
+
+fix:Fix dataframe `line_breaks`

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -49,6 +49,7 @@
 		}
 	}
 
+
 	const dispatch = createEventDispatcher<{
 		change: {
 			data: (string | number)[][];
@@ -702,6 +703,7 @@
 								<EditableCell
 									{value}
 									{latex_delimiters}
+									{line_breaks}
 									datatype={Array.isArray(datatype) ? datatype[j] : datatype}
 									edit={false}
 									el={null}
@@ -743,6 +745,7 @@
 									bind:value={_headers[i].value}
 									bind:el={els[id].input}
 									{latex_delimiters}
+									{line_breaks}
 									edit={header_edit === i}
 									on:keydown={end_header_edit}
 									on:dblclick={() => edit_header(i)}
@@ -791,6 +794,7 @@
 									bind:el={els[id].input}
 									display_value={display_value?.[index]?.[j]}
 									{latex_delimiters}
+									{line_breaks}
 									{editable}
 									edit={dequal(editing, [index, j])}
 									datatype={Array.isArray(datatype) ? datatype[j] : datatype}

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -49,7 +49,6 @@
 		}
 	}
 
-
 	const dispatch = createEventDispatcher<{
 		change: {
 			data: (string | number)[][];


### PR DESCRIPTION
## Description
🤦🏽‍♂️

Adds `line_breaks` prop to missing `EditableCell` elements.
Closes: #5801

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
