### PR TITLE
BugFix: Make FileExplorer Component Templateable

### DIFF
--- a/.changeset/flat-experts-wink.md
+++ b/.changeset/flat-experts-wink.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:BugFix: Make FileExplorer Component Templateable

--- a/.config/copy_frontend.py
+++ b/.config/copy_frontend.py
@@ -14,7 +14,6 @@ class BuildHook(BuildHookInterface):
             "node_modules",
             "storybook",
             "playwright-report",
-            "wasm",
             "workbench",
             "tooltils",
         ]

--- a/gradio/cli/commands/components/_create_utils.py
+++ b/gradio/cli/commands/components/_create_utils.py
@@ -59,6 +59,19 @@ OVERRIDES = {
         python_file_name="duplicate_button.py",
         js_dir="button",
     ),
+    "FileExplorer": ComponentFiles(
+        template="FileExplorer",
+        python_file_name="file_explorer.py",
+        js_dir="fileexplorer",
+        demo_code=textwrap.dedent(
+            """
+        import os
+
+        with gr.Blocks() as demo:
+            {name}(value=os.path.dirname(__file__).split(os.sep))
+    """
+        ),
+    ),
     "LinePlot": ComponentFiles(
         template="LinePlot", python_file_name="line_plot.py", js_dir="plot"
     ),
@@ -175,8 +188,7 @@ def delete_contents(directory: str | Path) -> None:
         if child.is_file():
             child.unlink()
         elif child.is_dir():
-            delete_contents(child)
-            child.rmdir()
+            shutil.rmtree(child)
 
 
 def _create_frontend(name: str, component: ComponentFiles, directory: Path):

--- a/gradio/cli/commands/components/dev.py
+++ b/gradio/cli/commands/components/dev.py
@@ -62,7 +62,9 @@ def _dev(
     while True:
         proc.poll()
         text = proc.stdout.readline()  # type: ignore
-        err = proc.stderr.readline()  # type: ignore
+        err = None
+        if proc.stderr:
+            err = proc.stderr.readline()
 
         text = (
             text.decode("utf-8")
@@ -76,7 +78,8 @@ def _dev(
         if "To create a public link" in text:
             continue
         print(text)
-        print(err.decode("utf-8"))
+        if err:
+            print(err.decode("utf-8"))
 
         if proc.returncode is not None:
             print("Backend server failed to launch. Exiting.")

--- a/gradio/components/file_explorer.py
+++ b/gradio/components/file_explorer.py
@@ -101,7 +101,7 @@ class FileExplorer(Component):
         )
 
     def example_inputs(self) -> Any:
-        return [["Users", "gradio", "app.py"]]
+        return ["Users", "gradio", "app.py"]
 
     def preprocess(self, x: list[list[str]] | None) -> list[str] | str | None:
         """

--- a/test/test_gradio_component_cli.py
+++ b/test/test_gradio_component_cli.py
@@ -26,6 +26,7 @@ from gradio.cli.commands.components.create import _create
         "ScatterPlot",
         "UploadButton",
         "JSON",
+        "FileExplorer",
     ],
 )
 def test_template_override_component(template, tmp_path):


### PR DESCRIPTION
## Description

Make FileExplorer templateable

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
