### PR TITLE
Lite: Support the custom HTML element syntax `<gradio-lite>`

### DIFF
--- a/.changeset/brave-cats-show.md
+++ b/.changeset/brave-cats-show.md
@@ -4,4 +4,4 @@
 "gradio": minor
 ---
 
-feat:Lite: custom element
+feat:Lite: Support the custom HTML element syntax `<gradio-lite>`

--- a/.changeset/brave-cats-show.md
+++ b/.changeset/brave-cats-show.md
@@ -1,0 +1,7 @@
+---
+"@gradio/app": minor
+"@gradio/theme": minor
+"gradio": minor
+---
+
+feat:Lite: custom element

--- a/js/app/src/lite/custom-element/index.ts
+++ b/js/app/src/lite/custom-element/index.ts
@@ -1,0 +1,152 @@
+import { create, type Options } from ".."
+
+interface GradioComponentOptions {
+	info: Options["info"];
+	container: Options["container"];
+	isEmbed: Options["isEmbed"];
+	initialHeight?: Options["initialHeight"];
+	eager: Options["eager"];
+	themeMode: Options["themeMode"];
+	autoScroll: Options["autoScroll"];
+	controlPageTitle: Options["controlPageTitle"];
+	appMode: Options["appMode"];
+}
+
+interface GradioLiteAppOptions {
+	files?: Options["files"];
+	requirements?: Options["requirements"];
+	code?: Options["code"];
+	entrypoint?: Options["entrypoint"];
+}
+
+function parseRequirementsTxt(content: string): string[] {
+	return content
+		.split("\n")
+		.filter((r) => !r.startsWith("#"))
+		.map((r) => r.trim())
+		.filter((r) => r !== "");
+}
+
+export function bootstrap_custom_element(): void {
+	if (customElements.get("gradio-app")) {
+		return;
+	}
+
+	class GradioLiteAppElement extends HTMLElement {
+		constructor() {
+			super();
+
+			const gradioComponentOptions = this.parseGradioComponentOptions();
+			const gradioLiteAppOptions = this.parseGradioLiteAppOptions();
+
+			this.innerHTML = "";
+
+			create({
+				target: this,  // Same as `js/app/src/main.ts`
+				code: gradioLiteAppOptions.code,
+				requirements: gradioLiteAppOptions.requirements,
+				files: gradioLiteAppOptions.files,
+				entrypoint: gradioLiteAppOptions.entrypoint,
+				...gradioComponentOptions,
+			})
+		}
+
+		parseGradioComponentOptions(): GradioComponentOptions {
+			// Parse the options from the attributes of the <gradio-app> element.
+			// The following attributes are supported:
+			// * info: boolean
+			// * container: boolean
+			// * embed: boolean
+			// * initial-height: string
+			// * eager: boolean
+			// * theme: "light" | "dark" | null
+			// * auto-scroll: boolean
+			// * control-page-title: boolean
+			// * app-mode: boolean
+
+			const info = this.hasAttribute("info");
+			const container = this.hasAttribute("container");
+			const isEmbed = this.hasAttribute("embed");
+			const initialHeight = this.getAttribute("initial-height");
+			const eager = this.hasAttribute("eager");
+			const themeMode = this.getAttribute("theme");
+			const autoScroll = this.hasAttribute("auto-scroll");
+			const controlPageTitle = this.hasAttribute("control-page-title");
+			const appMode = this.hasAttribute("app-mode");
+
+			return {
+				info,
+				container,
+				isEmbed,
+				initialHeight: initialHeight ?? undefined,
+				eager,
+				themeMode: (themeMode != null && ["light", "dark"].includes(themeMode)) ? themeMode as GradioComponentOptions["themeMode"] : null,
+				autoScroll,
+				controlPageTitle,
+				appMode,
+			};
+		}
+
+		parseGradioLiteAppOptions(): GradioLiteAppOptions {
+			// When gradioLiteAppElement only contains text content, it is treated as the Python code.
+			if (this.childElementCount === 0) {
+				return { code: this.textContent ?? "" };
+			}
+
+			// When it contains child elements, parse them as options. Available child elements are:
+			// * <gradio-file />
+			//   Represents a file to be mounted in the virtual file system of the Wasm worker.
+			//   At least 1 <gradio-file> element must have the `entrypoint` attribute.
+			//   The following 2 forms are supported:
+			//   * <gradio-file name="{file name}" >{file content}</gradio-file>
+			//   * <gradio-file name="{file name}" url="{remote URL}" />
+			// * <gradio-requirements>{requirements.txt}</gradio-requirements>
+			// * <gradio-code>{Python code}</gradio-code>
+			const options: GradioLiteAppOptions = {};
+
+			const fileElements = this.getElementsByTagName("gradio-file");
+			for (const fileElement of fileElements) {
+				const name = fileElement.getAttribute("name");
+				if (name == null) {
+					throw new Error("<gradio-file> must have the name attribute.");
+				}
+
+				const entrypoint = fileElement.hasAttribute("entrypoint");
+				const url = fileElement.getAttribute("url");
+
+				options.files ??= {};
+				if (url != null) {
+					options.files[name] = { url }
+				} else {
+					options.files[name] = { data: fileElement.textContent ?? "" }
+				}
+
+				if (entrypoint) {
+					if (options.entrypoint != null) {
+						throw new Error("Multiple entrypoints are not allowed.");
+					}
+					options.entrypoint = name;
+				}
+			}
+
+			const codeElements = this.getElementsByTagName("gradio-code");
+			if (codeElements.length > 1) {
+				console.warn("Multiple <gradio-code> elements are found. Only the first one will be used.")
+			}
+			const firstCodeElement = codeElements[0];
+			options.code = firstCodeElement?.textContent ?? undefined;
+
+			const requirementsElements = this.getElementsByTagName("gradio-requirements");
+			if (requirementsElements.length > 1) {
+				console.warn("Multiple <gradio-requirements> elements are found. Only the first one will be used.")
+			}
+			const firstRequirementsElement = requirementsElements[0];
+			const requirementsTxt = firstRequirementsElement?.textContent ?? "";
+			options.requirements = parseRequirementsTxt(requirementsTxt);
+
+			return options;
+		}
+	}
+
+	customElements.define("gradio-app", GradioLiteAppElement);
+}

--- a/js/app/src/lite/custom-element/index.ts
+++ b/js/app/src/lite/custom-element/index.ts
@@ -28,7 +28,9 @@ function parseRequirementsTxt(content: string): string[] {
 }
 
 export function bootstrap_custom_element(): void {
-	if (customElements.get("gradio-app")) {
+	const CUSTOM_ELEMENT_NAME = "gradio-lite";
+
+	if (customElements.get(CUSTOM_ELEMENT_NAME)) {
 		return;
 	}
 
@@ -52,7 +54,7 @@ export function bootstrap_custom_element(): void {
 		}
 
 		parseGradioComponentOptions(): GradioComponentOptions {
-			// Parse the options from the attributes of the <gradio-app> element.
+			// Parse the options from the attributes of the <gradio-lite> element.
 			// The following attributes are supported:
 			// * info: boolean
 			// * container: boolean
@@ -157,5 +159,5 @@ export function bootstrap_custom_element(): void {
 		}
 	}
 
-	customElements.define("gradio-app", GradioLiteAppElement);
+	customElements.define(CUSTOM_ELEMENT_NAME, GradioLiteAppElement);
 }

--- a/js/app/src/lite/custom-element/index.ts
+++ b/js/app/src/lite/custom-element/index.ts
@@ -1,4 +1,4 @@
-import { create, type Options } from ".."
+import { create, type Options } from "..";
 
 interface GradioComponentOptions {
 	info: Options["info"];
@@ -42,13 +42,13 @@ export function bootstrap_custom_element(): void {
 			this.innerHTML = "";
 
 			create({
-				target: this,  // Same as `js/app/src/main.ts`
+				target: this, // Same as `js/app/src/main.ts`
 				code: gradioLiteAppOptions.code,
 				requirements: gradioLiteAppOptions.requirements,
 				files: gradioLiteAppOptions.files,
 				entrypoint: gradioLiteAppOptions.entrypoint,
-				...gradioComponentOptions,
-			})
+				...gradioComponentOptions
+			});
 		}
 
 		parseGradioComponentOptions(): GradioComponentOptions {
@@ -80,10 +80,13 @@ export function bootstrap_custom_element(): void {
 				isEmbed,
 				initialHeight: initialHeight ?? undefined,
 				eager,
-				themeMode: (themeMode != null && ["light", "dark"].includes(themeMode)) ? themeMode as GradioComponentOptions["themeMode"] : null,
+				themeMode:
+					themeMode != null && ["light", "dark"].includes(themeMode)
+						? (themeMode as GradioComponentOptions["themeMode"])
+						: null,
 				autoScroll,
 				controlPageTitle,
-				appMode,
+				appMode
 			};
 		}
 
@@ -116,9 +119,9 @@ export function bootstrap_custom_element(): void {
 
 				options.files ??= {};
 				if (url != null) {
-					options.files[name] = { url }
+					options.files[name] = { url };
 				} else {
-					options.files[name] = { data: fileElement.textContent ?? "" }
+					options.files[name] = { data: fileElement.textContent ?? "" };
 				}
 
 				if (entrypoint) {
@@ -131,14 +134,20 @@ export function bootstrap_custom_element(): void {
 
 			const codeElements = this.getElementsByTagName("gradio-code");
 			if (codeElements.length > 1) {
-				console.warn("Multiple <gradio-code> elements are found. Only the first one will be used.")
+				console.warn(
+					"Multiple <gradio-code> elements are found. Only the first one will be used."
+				);
 			}
 			const firstCodeElement = codeElements[0];
 			options.code = firstCodeElement?.textContent ?? undefined;
 
-			const requirementsElements = this.getElementsByTagName("gradio-requirements");
+			const requirementsElements = this.getElementsByTagName(
+				"gradio-requirements"
+			);
 			if (requirementsElements.length > 1) {
-				console.warn("Multiple <gradio-requirements> elements are found. Only the first one will be used.")
+				console.warn(
+					"Multiple <gradio-requirements> elements are found. Only the first one will be used."
+				);
 			}
 			const firstRequirementsElement = requirementsElements[0];
 			const requirementsTxt = firstRequirementsElement?.textContent ?? "";

--- a/js/app/src/lite/index.ts
+++ b/js/app/src/lite/index.ts
@@ -170,6 +170,53 @@ export function create(options: Options): GradioAppController {
 	};
 }
 
+interface GradioComponentOptions {
+	info: boolean;
+	container: boolean;
+	isEmbed: boolean;
+	initialHeight?: string;
+	eager: boolean;
+	themeMode: ThemeMode | null;
+	autoScroll: boolean;
+	controlPageTitle: boolean;
+	appMode: boolean;
+}
+function parseGradioComponentOptions(gradioLiteAppElement: GradioLiteAppElement): GradioComponentOptions {
+	// Parse the options from the attributes of the <gradio-app> element.
+	// The following attributes are supported:
+	// * info: boolean
+	// * container: boolean
+	// * embed: boolean
+	// * initial-height: string
+	// * eager: boolean
+	// * theme: "light" | "dark" | null
+	// * auto-scroll: boolean
+	// * control-page-title: boolean
+	// * app-mode: boolean
+
+	const info = gradioLiteAppElement.hasAttribute("info");
+	const container = gradioLiteAppElement.hasAttribute("container");
+	const isEmbed = gradioLiteAppElement.hasAttribute("embed");
+	const initialHeight = gradioLiteAppElement.getAttribute("initial-height");
+	const eager = gradioLiteAppElement.hasAttribute("eager");
+	const themeMode = gradioLiteAppElement.getAttribute("theme");
+	const autoScroll = gradioLiteAppElement.hasAttribute("auto-scroll");
+	const controlPageTitle = gradioLiteAppElement.hasAttribute("control-page-title");
+	const appMode = gradioLiteAppElement.hasAttribute("app-mode");
+
+	return {
+		info,
+		container,
+		isEmbed,
+		initialHeight: initialHeight ?? undefined,
+		eager,
+		themeMode: (themeMode != null && ["light", "dark"].includes(themeMode)) ? themeMode as ThemeMode : null,
+		autoScroll,
+		controlPageTitle,
+		appMode,
+	};
+}
+
 interface GradioLiteAppOptions {
 	files?: WorkerProxyOptions["files"];
 	requirements?: WorkerProxyOptions["requirements"];
@@ -249,25 +296,18 @@ class GradioLiteAppElement extends HTMLElement {
 	constructor() {
 		super();
 
-		const options = parseGradioLiteAppOptions(this);
+		const gradioComponentOptions = parseGradioComponentOptions(this);
+		const gradioLiteAppOptions = parseGradioLiteAppOptions(this);
 
 		this.innerHTML = "";
 
 		create({
 			target: this,  // Same as `js/app/src/main.ts`
-			code: options.code,
-			requirements: options.requirements,
-			files: options.files,
-			entrypoint: options.entrypoint,
-			info: true,
-			container: true,
-			isEmbed: false,
-			initialHeight: "300px",
-			eager: false,
-			themeMode: null,
-			autoScroll: false,
-			controlPageTitle: false,
-			appMode: true,
+			code: gradioLiteAppOptions.code,
+			requirements: gradioLiteAppOptions.requirements,
+			files: gradioLiteAppOptions.files,
+			entrypoint: gradioLiteAppOptions.entrypoint,
+			...gradioComponentOptions,
 		})
 	}
 }

--- a/js/app/vite.config.ts
+++ b/js/app/vite.config.ts
@@ -108,6 +108,11 @@ export default defineConfig(({ mode }) => {
 								fileName.indexOf(".svelte") > -1
 							) {
 								return selector;
+							} else if (
+								// For the custom element <gradio-app>. See theme/src/global.css for the details.
+								/^gradio-app(\:[^\:]+)?/.test(selector)
+							) {
+								return selector;
 							}
 							return prefixedSelector;
 						}

--- a/js/app/vite.config.ts
+++ b/js/app/vite.config.ts
@@ -109,8 +109,8 @@ export default defineConfig(({ mode }) => {
 							) {
 								return selector;
 							} else if (
-								// For the custom element <gradio-app>. See theme/src/global.css for the details.
-								/^gradio-app(\:[^\:]+)?/.test(selector)
+								// For the custom element <gradio-lite>. See theme/src/global.css for the details.
+								/^gradio-lite(\:[^\:]+)?/.test(selector)
 							) {
 								return selector;
 							}

--- a/js/theme/src/global.css
+++ b/js/theme/src/global.css
@@ -1,7 +1,7 @@
 /*
  Custom element styles
  */
-gradio-app {
+gradio-lite {
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;
@@ -13,7 +13,7 @@ gradio-app {
 	https://www.abeautifulsite.net/posts/flash-of-undefined-custom-elements/#the-%3Adefined-selector
 	https://github.com/pyscript/pypercard/blob/66d3550abd8e478f9389e6b87790d5985e55ef7f/static/pyscript.css#L6-L8
 	*/
-gradio-app:not(:defined) {
+gradio-lite:not(:defined) {
 	display: none;
 }
 

--- a/js/theme/src/global.css
+++ b/js/theme/src/global.css
@@ -3,8 +3,6 @@
  */
 gradio-lite {
 	display: flex;
-	flex-direction: column;
-	flex-grow: 1;
 }
 
 /*

--- a/js/theme/src/global.css
+++ b/js/theme/src/global.css
@@ -1,3 +1,22 @@
+/*
+ Custom element styles
+ */
+gradio-app {
+	display: flex;
+	flex-direction: column;
+	flex-grow: 1;
+}
+
+/*
+	To avoid FOUC of custom elements
+	Refs:
+	https://www.abeautifulsite.net/posts/flash-of-undefined-custom-elements/#the-%3Adefined-selector
+	https://github.com/pyscript/pypercard/blob/66d3550abd8e478f9389e6b87790d5985e55ef7f/static/pyscript.css#L6-L8
+	*/
+gradio-app:not(:defined) {
+	display: none;
+}
+
 .scroll-hide {
 	-ms-overflow-style: none;
 	scrollbar-width: none;


### PR DESCRIPTION
## Description

### Custom element API
A custom element `<gradio-app>` will be registered by importing the `@gradio/lite` script, and users can use it to mount a Gradio app with various configs.

### Simplest API with a single script
When `<gradio-app>` doesn't have any child elements, its text content is directly interpreted as a script to execute.
```html
<gradio-app>
import gradio as gr

def greet(name):
    return "Hello " + name + "!"

demo = gr.Interface(fn=greet, inputs="text", outputs="text")

demo.launch()
</gradio-app>
```
### Attributes
Setting attributes on the `<gradio-app>` tag affects the component configs listed as https://github.com/gradio-app/gradio/blob/fee3d527e83a615109cf937f6ca0a37662af2bb6/js/app/src/lite/index.ts#L52-L60
```html
<gradio-app theme="dark">
...
</gradio-app>
```

### Multi files and requirements
This API style is used to
* mount multiple files to the virtual file system
* download and mount files from remote hosts
* install packages

In this API style,
* The `<gradio-file>` tag represents a file to be mounted on the file system
* The `<gradio-requirements>` should contain the requirement list like `requirements.txt`.

```html
<gradio-app>

<gradio-file name="app.py" entrypoint>
import gradio as gr
from utils import add

def greet(name):
    return "Hello " + name + "!"

demo = gr.Interface(fn=greet, inputs="text", outputs="text")

demo.launch()
</gradio-file>

<gradio-file name="utils.py" >
def add(a, b):
    return a + b
</gradio-file>

<gradio-file
    name="images/lion.jpg"
    url="<remote file URL to download>"
/>

<gradio-requirements>
# requirements.txt syntax
numpy
scipy
</gradio-requirements>

</gradio-app>
```

#### Fully-featured example
This is an example mounting multiple files, downloading binary images from a remote host, and installing packages.
```html
<!doctype html>
<!-- A demo HTML file to test the bundled JS and CSS files -->
<html style="margin: 0; padding: 0; height: 100%">
	<head>
		<meta charset="utf-8" />
		<meta
			name="viewport"
			content="width=device-width, initial-scale=1, shrink-to-fit=no, maximum-scale=1"
		/>

		<link rel="preconnect" href="https://fonts.googleapis.com" />
		<link
			rel="preconnect"
			href="https://fonts.gstatic.com"
			crossorigin="anonymous"
		/>

		<script type="module" crossorigin src="./dist/lite.js"></script>
		<link rel="stylesheet" href="./dist/lite.css" />
	</head>

	<body style="margin: 0; padding: 0; height: 100%">
		<gradio-app initial-height="100%" style="height: 100%">
			<gradio-file name="run.py" entrypoint>
import gradio as gr
import os

from utils import image_mod


demo = gr.Interface(
    image_mod,
    gr.Image(type="numpy"),
    "image",
    flagging_options=["blurry", "incorrect", "other"],
    examples=[
        os.path.join(os.path.dirname(__file__), "images/cheetah1.jpg"),
        os.path.join(os.path.dirname(__file__), "images/lion.jpg"),
        os.path.join(os.path.dirname(__file__), "images/logo.png"),
        os.path.join(os.path.dirname(__file__), "images/tower.jpg"),
    ],
)

if __name__ == "__main__":
    demo.launch()
			</gradio-file>
			<gradio-file name="utils.py">
from skimage import filters


def image_mod(image):
    return filters.sobel(image)
			</gradio-file>

			<gradio-requirements>
scikit-image
			</gradio-requirements>

			<gradio-file name="images/cheetah1.jpg" url="https://huggingface.co/spaces/gradio/image_mod/resolve/main/images/cheetah1.jpg" />
			<gradio-file name="images/lion.jpg" url="https://huggingface.co/spaces/gradio/image_mod/resolve/main/images/lion.jpg" />
			<gradio-file name="images/logo.png" url="https://huggingface.co/spaces/gradio/image_mod/resolve/main/images/logo.png" />
			<gradio-file name="images/tower.jpg" url="https://huggingface.co/spaces/gradio/image_mod/resolve/main/images/tower.jpg" />
		</gradio-app>
	</body>
</html>
```
![CleanShot 2023-10-17 at 23 13 23@2x](https://github.com/gradio-app/gradio/assets/3135397/b8e82fb5-e41b-46c0-9d0e-15a3803aec27)



## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
