### PR TITLE
Apply formatter (and small refactoring) to the Lite-related frontend code

### DIFF
--- a/.changeset/green-tips-read.md
+++ b/.changeset/green-tips-read.md
@@ -1,0 +1,7 @@
+---
+"@gradio/app": minor
+"@gradio/wasm": minor
+"gradio": minor
+---
+
+feat:Apply formatter (and small refactoring) to the Lite-related frontend code

--- a/js/app/src/lite/css.ts
+++ b/js/app/src/lite/css.ts
@@ -8,7 +8,9 @@ import { mount_css as default_mount_css } from "../css";
 const PREBUILT_CSS_URL = new URL("./theme.css", import.meta.url).href;
 const DYNAMIC_THEME_CSS_URL_PATH = "/theme.css";
 
-export async function mount_prebuilt_css(target: HTMLElement): Promise<void> {
+export function mount_prebuilt_css(
+	target: Parameters<typeof default_mount_css>[1]
+): Promise<void> {
 	return default_mount_css(PREBUILT_CSS_URL, target);
 }
 

--- a/js/app/src/lite/url.ts
+++ b/js/app/src/lite/url.ts
@@ -1,5 +1,7 @@
 export function is_self_host(url: URL): boolean {
 	return (
-		url.host === window.location.host || url.host === "localhost:7860" || url.host === "127.0.0.1:7860" // Ref: https://github.com/gradio-app/gradio/blob/v3.32.0/js/app/src/Index.svelte#L194
+		url.host === window.location.host ||
+		url.host === "localhost:7860" ||
+		url.host === "127.0.0.1:7860" // Ref: https://github.com/gradio-app/gradio/blob/v3.32.0/js/app/src/Index.svelte#L194
 	);
 }

--- a/js/wasm/src/webworker/index.ts
+++ b/js/wasm/src/webworker/index.ts
@@ -334,8 +334,8 @@ self.onmessage = async (event: MessageEvent<InMessage>): Promise<void> => {
 
 		const replyMessage: ReplyMessageError = {
 			type: "reply:error",
-			error: cloneableError,
-		}
+			error: cloneableError
+		};
 		messagePort.postMessage(replyMessage);
 	}
 };

--- a/js/wasm/svelte/file-url.ts
+++ b/js/wasm/svelte/file-url.ts
@@ -9,7 +9,9 @@ export async function resolve_wasm_src(src: MediaSrc): Promise<MediaSrc> {
 
 	const url = new URL(src);
 	if (
-		url.host !== window.location.host && url.host !== "localhost:7860" && url.host !== "127.0.0.1:7860" // Ref: https://github.com/gradio-app/gradio/blob/v3.32.0/js/app/src/Index.svelte#L194
+		url.host !== window.location.host &&
+		url.host !== "localhost:7860" &&
+		url.host !== "127.0.0.1:7860" // Ref: https://github.com/gradio-app/gradio/blob/v3.32.0/js/app/src/Index.svelte#L194
 	) {
 		// `src` is not accessing a local server resource, so we don't need to proxy this request to the Wasm worker.
 		return src;


### PR DESCRIPTION
## Description

Just caught up with the `format_frontend.sh` behavior.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
