### PR TITLE
Lite: Consider the `file:` protocol in URL as localhost

### DIFF
--- a/.changeset/angry-walls-say.md
+++ b/.changeset/angry-walls-say.md
@@ -1,0 +1,7 @@
+---
+"@gradio/app": minor
+"@gradio/wasm": minor
+"gradio": minor
+---
+
+feat:Lite: Consider the `file:` protocol in URL as localhost

--- a/js/app/src/lite/url.ts
+++ b/js/app/src/lite/url.ts
@@ -1,6 +1,7 @@
 export function is_self_host(url: URL): boolean {
 	return (
 		url.host === window.location.host ||
+		url.protocol === "file:" || // Ref: https://github.com/gradio-app/gradio/issues/5942
 		url.host === "localhost:7860" ||
 		url.host === "127.0.0.1:7860" // Ref: https://github.com/gradio-app/gradio/blob/v3.32.0/js/app/src/Index.svelte#L194
 	);

--- a/js/wasm/svelte/file-url.ts
+++ b/js/wasm/svelte/file-url.ts
@@ -10,6 +10,7 @@ export async function resolve_wasm_src(src: MediaSrc): Promise<MediaSrc> {
 	const url = new URL(src);
 	if (
 		url.host !== window.location.host &&
+		url.protocol !== "file:" && // Ref: https://github.com/gradio-app/gradio/issues/5942
 		url.host !== "localhost:7860" &&
 		url.host !== "127.0.0.1:7860" // Ref: https://github.com/gradio-app/gradio/blob/v3.32.0/js/app/src/Index.svelte#L194
 	) {


### PR DESCRIPTION
## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #5942

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
