### PR TITLE
Strip vite import warning

### DIFF
--- a/js/preview/src/dev.ts
+++ b/js/preview/src/dev.ts
@@ -12,8 +12,6 @@ const vite_messages_to_ignore = [
 const logger = createLogger();
 const originalWarning = logger.warn;
 logger.warn = (msg, options) => {
-	// console.log(`msg: ${msg}`);
-	// console.log(options);
 	if (vite_messages_to_ignore.some((m) => msg.includes(m))) return;
 
 	originalWarning(msg, options);

--- a/js/preview/src/dev.ts
+++ b/js/preview/src/dev.ts
@@ -5,12 +5,15 @@ import { plugins, make_gradio_plugin } from "./plugins";
 import { examine_module } from "./index";
 
 const vite_messages_to_ignore = [
-	"Default and named imports from CSS files are deprecated."
+	"Default and named imports from CSS files are deprecated.",
+	"The above dynamic import cannot be analyzed by Vite."
 ];
 
 const logger = createLogger();
 const originalWarning = logger.warn;
 logger.warn = (msg, options) => {
+	// console.log(`msg: ${msg}`);
+	// console.log(options);
 	if (vite_messages_to_ignore.some((m) => msg.includes(m))) return;
 
 	originalWarning(msg, options);


### PR DESCRIPTION
## Description

Removes warning about vite not being able to analyze dynamic imports

<img width="791" alt="image" src="https://github.com/gradio-app/gradio/assets/41651716/2979fee0-087e-4355-93c7-b1dc250ab9dd">


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
