### PR TITLE
Lite: Fix error handling on the ASGI app

### DIFF
--- a/.changeset/warm-chefs-trade.md
+++ b/.changeset/warm-chefs-trade.md
@@ -2,4 +2,4 @@
 "@gradio/wasm": minor
 ---
 
-feat:Lite: Error handling
+feat:Lite: Fix error handling on the ASGI app

--- a/.changeset/warm-chefs-trade.md
+++ b/.changeset/warm-chefs-trade.md
@@ -1,0 +1,5 @@
+---
+"@gradio/wasm": minor
+---
+
+feat:Lite: Error handling

--- a/js/wasm/src/webworker/http.ts
+++ b/js/wasm/src/webworker/http.ts
@@ -129,5 +129,5 @@ export const makeHttpRequest = (
 			headers: headersToASGI(request.headers)
 		};
 
-		asgiApp(scope, receiveFromJs, sendToJs);
+		asgiApp(scope, receiveFromJs, sendToJs).catch(reject);
 	});


### PR DESCRIPTION
## Description

For example, when the user runs a script that doesn't call `Blocks.launch()`, the HTTP request would fail because no HTTP server has started.

Such errors thrown from the ASGI app (=HTTP handler) has not been handled properly so in the example case above, the app silently dies with ever-running "loading..." message.
With this PR, such error will be properly propagated to the main thread.
