### PR TITLE
Relax pin on typing_extensions

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -238,13 +238,6 @@ traitlets==5.3.0
     #   matplotlib-inline
 transformers==4.20.1
     # via -r requirements.in
-typing-extensions==4.3.0
-    # via
-    #   black
-    #   huggingface-hub
-    #   pydantic
-    #   starlette
-    #   torch
 urllib3==1.26.10
     # via
     #   botocore


### PR DESCRIPTION
## Description

CI was breaking because new FastAPI release needs typing_extensions>4.8.0 but we had version 4.7.1. We should not be pinning in this case since we deliberately have a relaxed pin for typing_extensions in our requirements.txt to avoid this kind of situation.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
