### PR TITLE
Specify FastAPI version for the Wasm runtime as a workaround

### DIFF
--- a/.changeset/red-terms-rest.md
+++ b/.changeset/red-terms-rest.md
@@ -1,0 +1,5 @@
+---
+"@gradio/wasm": minor
+---
+
+feat:Specify FastAPI version for the Wasm runtime as a workaround

--- a/js/wasm/src/webworker/index.ts
+++ b/js/wasm/src/webworker/index.ts
@@ -76,6 +76,7 @@ async function loadPyodideAndPackages(
 	await pyodide.loadPackage(["ssl", "distutils", "setuptools"]);
 	await micropip.install(["markdown-it-py[linkify]~=2.2.0"]); // On 3rd June 2023, markdown-it-py 3.0.0 has been released. The `gradio` package depends on its `>=2.0.0` version so its 3.x will be resolved. However, it conflicts with `mdit-py-plugins`'s dependency `markdown-it-py >=1.0.0,<3.0.0` and micropip currently can't resolve it. So we explicitly install the compatible version of the library here.
 	await micropip.install(["anyio==3.*"]); // `fastapi` depends on `anyio>=3.4.0,<5` so its 4.* can be installed, but it conflicts with the anyio version `httpx` depends on, `==3.*`. Seems like micropip can't resolve it for now, so we explicitly install the compatible version of the library here.
+	await micropip.install(["fastapi<0.104.0"]);  // XXX: Workaround for #5986.
 	await micropip.install.callKwargs(gradioWheelUrls, {
 		keep_going: true
 	});


### PR DESCRIPTION
## Description

Workaround for #5986
