### PR TITLE
Update static/AudioPlayerto use ../shared/Audio instead of the native `<audio>` for Wasm support

### DIFF
--- a/.changeset/wise-hands-dress.md
+++ b/.changeset/wise-hands-dress.md
@@ -1,0 +1,6 @@
+---
+"@gradio/audio": patch
+"gradio": patch
+---
+
+fix:Update static/AudioPlayerto use ../shared/Audio instead of the native `<audio>` for Wasm support

--- a/js/audio/shared/Audio.svelte
+++ b/js/audio/shared/Audio.svelte
@@ -32,7 +32,6 @@
 	<p style="color: red;">{error.message}</p>
 {/await}
 
-
 <style>
 	audio {
 		padding: var(--size-2);

--- a/js/audio/static/AudioPlayer.svelte
+++ b/js/audio/static/AudioPlayer.svelte
@@ -82,24 +82,21 @@
 		<Music />
 	</Empty>
 {:else}
-	<Audio
-		{autoplay}
-		controls
-		preload="metadata"
-		src={value?.data}
-		on:play
-		on:pause
-		on:ended={handle_ended}
-		data-testid={`${label}-audio`}
-	/>
+	<div class="container">
+		<Audio
+			{autoplay}
+			controls
+			preload="metadata"
+			src={value?.data}
+			on:play
+			on:pause
+			on:ended={handle_ended}
+			data-testid={`${label}-audio`}
+		/>
+	</div>
 {/if}
 
 <style>
-	audio {
-		padding: var(--size-2);
-		width: var(--size-full);
-		height: var(--size-14);
-	}
 	.icon-buttons {
 		display: flex;
 		position: absolute;

--- a/js/audio/static/AudioPlayer.svelte
+++ b/js/audio/static/AudioPlayer.svelte
@@ -14,6 +14,7 @@
 	import { BlockLabel, ShareButton, IconButton } from "@gradio/atoms";
 	import { Music, Download } from "@gradio/icons";
 
+	import Audio from "../shared/Audio.svelte";
 	import { loaded } from "../shared/utils";
 
 	export let value: null | { name: string; data: string } = null;
@@ -81,8 +82,8 @@
 		<Music />
 	</Empty>
 {:else}
-	<audio
-		use:loaded={{ autoplay }}
+	<Audio
+		{autoplay}
 		controls
 		preload="metadata"
 		src={value?.data}


### PR DESCRIPTION
## Description

I missed `js/audio/static/AudioPlayer.svelte` in #5627 which also should be converted to be Wasm-compatible.

Closes: #5999
