### PR TITLE
Lite: Error handling after initialization

### DIFF
--- a/.changeset/chatty-laws-drop.md
+++ b/.changeset/chatty-laws-drop.md
@@ -1,0 +1,7 @@
+---
+"@gradio/app": minor
+"@gradio/wasm": minor
+"gradio": minor
+---
+
+feat:Lite: Error handling after initialization

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -98,7 +98,15 @@
 		worker_proxy.addEventListener("progress-update", (event) => {
 			loading_text = (event as CustomEvent).detail + "...";
 		});
-		worker_proxy.addEventListener("initialization-error", (event) => {
+		worker_proxy.addEventListener("run-start", (event) => {
+			status = {
+				message: "",
+				load_status: "pending",
+				status: "sleeping",
+				detail: "SLEEPING"
+			}
+		});
+		worker_proxy.addEventListener("error", (event) => {
 			const error: Error = (event as CustomEvent).detail;
 
 			// XXX: Although `status` is expected to store Space status info,

--- a/js/wasm/src/worker-proxy.ts
+++ b/js/wasm/src/worker-proxy.ts
@@ -57,7 +57,7 @@ export class WorkerProxy extends EventTarget {
 					error
 				);
 				this.dispatchEvent(
-					new CustomEvent("initialization-error", {
+					new CustomEvent("error", {
 						detail: error
 					})
 				);
@@ -65,23 +65,43 @@ export class WorkerProxy extends EventTarget {
 	}
 
 	public async runPythonCode(code: string): Promise<void> {
-		await this.postMessageAsync({
-			type: "run-python-code",
-			data: {
-				code
-			}
-		});
-		this.firstRunPromiseDelegate.resolve();
+		this.dispatchEvent(new Event("run-start"));
+		try {
+			await this.postMessageAsync({
+				type: "run-python-code",
+				data: {
+					code
+				}
+			});
+			this.firstRunPromiseDelegate.resolve();
+		} catch (error) {
+			this.dispatchEvent(
+				new CustomEvent("error", {
+					detail: error
+				})
+			);
+			throw error;
+		}
 	}
 
 	public async runPythonFile(path: string): Promise<void> {
-		await this.postMessageAsync({
-			type: "run-python-file",
-			data: {
-				path
-			}
-		});
-		this.firstRunPromiseDelegate.resolve();
+		this.dispatchEvent(new Event("run-start"));
+		try {
+			await this.postMessageAsync({
+				type: "run-python-file",
+				data: {
+					path
+				}
+			});
+			this.firstRunPromiseDelegate.resolve();
+		} catch (error) {
+			this.dispatchEvent(
+				new CustomEvent("error", {
+					detail: error
+				})
+			);
+			throw error;
+		}
 	}
 
 	// A wrapper for this.worker.postMessage(). Unlike that function, which
@@ -186,6 +206,13 @@ export class WorkerProxy extends EventTarget {
 				data,
 				opts
 			}
+		}).catch((error) => {
+			this.dispatchEvent(
+				new CustomEvent("error", {
+					detail: error
+				})
+			);
+			throw error;
 		}) as Promise<void>;
 	}
 
@@ -196,6 +223,13 @@ export class WorkerProxy extends EventTarget {
 				oldPath,
 				newPath
 			}
+		}).catch((error) => {
+			this.dispatchEvent(
+				new CustomEvent("error", {
+					detail: error
+				})
+			);
+			throw error;
 		}) as Promise<void>;
 	}
 
@@ -205,6 +239,13 @@ export class WorkerProxy extends EventTarget {
 			data: {
 				path
 			}
+		}).catch((error) => {
+			this.dispatchEvent(
+				new CustomEvent("error", {
+					detail: error
+				})
+			);
+			throw error;
 		}) as Promise<void>;
 	}
 
@@ -214,6 +255,13 @@ export class WorkerProxy extends EventTarget {
 			data: {
 				requirements
 			}
+		}).catch((error) => {
+			this.dispatchEvent(
+				new CustomEvent("error", {
+					detail: error
+				})
+			);
+			throw error;
 		}) as Promise<void>;
 	}
 


### PR DESCRIPTION
## Description

#5983 was only about the errors emitted at the initialization.
This PR will add event emitters covering `run_file()`, `run_code()`, `write()`, `rename()`, `unlink()`, and `install()`, and add event handlers in `Index.svelte` to handle these errors to print on the app screen.

Closes: #6003


### Example1
Invalid syntax when `run_file()` is called.

This is the case of https://huggingface.co/spaces/abidlabs/gradio-lite-classify-error

![CleanShot 2023-10-19 at 15 07 09@2x](https://github.com/gradio-app/gradio/assets/3135397/4ffec276-0a4d-4179-b654-ab0073fb4b16)

### Example2
Installing packages that are not available on Pyodide/Wasm.

For example, when `controller.install(["torch"])` is called:
![CleanShot 2023-10-19 at 15 16 36@2x](https://github.com/gradio-app/gradio/assets/3135397/0d002a28-617f-4e68-9c8f-8482baa89352)
