### PR TITLE
Lite: Set `wasClean: true` on the `CloseEvent` emitted by `WebSocket.close()`

### DIFF
--- a/js/wasm/src/messageportwebsocket.ts
+++ b/js/wasm/src/messageportwebsocket.ts
@@ -104,7 +104,7 @@ export class MessagePortWebSocket extends EventTarget {
 		this.readyState = 2;
 		this._port.postMessage({ type: "close", value: { code, reason } });
 		this.readyState = 3;
-		this.dispatchEvent(new CloseEvent("close", { code, reason }));
+		this.dispatchEvent(new CloseEvent("close", { code, reason, wasClean: true }));
 	}
 
 	private _onMessage(e: MessageEvent): void {
@@ -127,7 +127,7 @@ export class MessagePortWebSocket extends EventTarget {
 			case "close":
 				if (this.readyState < 3) {
 					this.readyState = 3;
-					this.dispatchEvent(new CloseEvent("close", { ...event.value }));
+					this.dispatchEvent(new CloseEvent("close", { ...event.value, wasClean: true }));
 					return;
 				}
 				break;


### PR DESCRIPTION
## Description

Closes: #6001
