### PR TITLE
fix: allow multiple flagging directories

### DIFF
--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -142,7 +142,7 @@ class Interface(Blocks):
         allow_flagging: str | None = None,
         flagging_options: list[str] | list[tuple[str, str]] | None = None,
         flagging_dir: str = "flagged",
-        flagging_callback: FlaggingCallback = CSVLogger(),
+        flagging_callback: FlaggingCallback | None = None,
         analytics_enabled: bool | None = None,
         batch: bool = False,
         max_batch_size: int = 4,
@@ -171,7 +171,7 @@ class Interface(Blocks):
             allow_flagging: one of "never", "auto", or "manual". If "never" or "auto", users will not see a button to flag an input and output. If "manual", users will see a button to flag. If "auto", every input the user submits will be automatically flagged (outputs are not flagged). If "manual", both the input and outputs are flagged when the user clicks flag button. This parameter can be set with environmental variable GRADIO_ALLOW_FLAGGING; otherwise defaults to "manual".
             flagging_options: if provided, allows user to select from the list of options when flagging. Only applies if allow_flagging is "manual". Can either be a list of tuples of the form (label, value), where label is the string that will be displayed on the button and value is the string that will be stored in the flagging CSV; or it can be a list of strings ["X", "Y"], in which case the values will be the list of strings and the labels will ["Flag as X", "Flag as Y"], etc.
             flagging_dir: what to name the directory where flagged data is stored.
-            flagging_callback: An instance of a subclass of FlaggingCallback which will be called when a sample is flagged. By default logs to a local CSV file.
+            flagging_callback: None or an instance of a subclass of FlaggingCallback which will be called when a sample is flagged. If set to None, an instance of gradio.flagging.CSVLogger will be created and logs will be saved to a local CSV file in flagging_dir. Default to None.
             analytics_enabled: Whether to allow basic telemetry. If None, will use GRADIO_ANALYTICS_ENABLED environment variable if defined, or default to True.
             batch: If True, then the function should process a batch of inputs, meaning that it should accept a list of input values for each parameter. The lists should be of equal length (and be up to length `max_batch_size`). The function is then *required* to return a tuple of lists (even if there is only 1 output component), with each list in the tuple corresponding to one output component.
             max_batch_size: Maximum number of inputs to batch together if this is called from the queue (only relevant if batch=True)
@@ -358,6 +358,9 @@ class Interface(Blocks):
             raise ValueError(
                 "flagging_options must be a list of strings or list of (string, string) tuples."
             )
+
+        if flagging_callback is None:
+            flagging_callback = CSVLogger()
 
         self.flagging_callback = flagging_callback
         self.flagging_dir = flagging_dir
@@ -730,11 +733,11 @@ class Interface(Blocks):
                 (
                     [{'variant': None, 'visible': True, '__type__': 'update'}]
                     if self.interface_type
-                        in [
-                            InterfaceTypes.STANDARD,
-                            InterfaceTypes.INPUT_ONLY,
-                            InterfaceTypes.UNIFIED,
-                        ]
+                       in [
+                           InterfaceTypes.STANDARD,
+                           InterfaceTypes.INPUT_ONLY,
+                           InterfaceTypes.UNIFIED,
+                       ]
                     else []
                 )
                 + ([{'variant': None, 'visible': False, '__type__': 'update'}] if self.interpretation else [])
@@ -753,7 +756,9 @@ class Interface(Blocks):
             interpretation_btn.click(
                 self.interpret_func,
                 inputs=self.input_components + self.output_components,
-                outputs=(interpretation_set or []) + [input_component_column, interpret_component_column],  # type: ignore
+                outputs=(interpretation_set or [])
+                + [input_component_column, interpret_component_column],
+                # type: ignore
                 preprocess=False,
             )
 


### PR DESCRIPTION

  
## Description

Solves the issue of a bug impeding linking different flagging directories to different interfaces in the case of multiple interfaces like gr.TabbedInterface, as discussed with @abidlabs and @harry-urek in pull request [5928](https://github.com/gradio-app/gradio/pull/5928), and in issue #5692.

The cause of the bug was residing in the fact that even if each interface, in theory, should have its proper FlaggingCallback, which in theory should have its own `self.flagging_dir`, both FlaggingCallaback pointed to the same `CSVLogger()` because the argument flagging_callback of `Interface` class in `interface.py` created a FlaggingCallback that pointed to the `CSVLogger()` class and not, as it should, provide to create instance of this class.

 I fixed the problem by changing the default value of flagging_callback to None, and moving the flagging_callback build  in the constructor of Interface like:

```
    if flagging_callback is None:
        flagging_callback = CSVLogger()
```


## 🎯 PRs Should Target Issues

Closes: #5692

## Tests

1. I followed the guidelines to contribute (https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and ran the tests: `bash scripts/run_all_tests.sh`. All tests passed except for some tests linked to hugging face that were not related to the addressed issue and were already broken before my changes (for unloadable spaces or hugginface API limit reach).

2. I ran `bash scripts/format_backend.sh` to lint my code.
  