### PR TITLE
Add a message at the end of the Wasm worker initialization

### DIFF
--- a/.changeset/big-dogs-chew.md
+++ b/.changeset/big-dogs-chew.md
@@ -1,0 +1,5 @@
+---
+"@gradio/wasm": minor
+---
+
+feat:Add a message at the end of the Wasm worker initialization

--- a/js/wasm/src/webworker/index.ts
+++ b/js/wasm/src/webworker/index.ts
@@ -192,6 +192,8 @@ matplotlib.use("agg")
 	await pyodide.runPythonAsync(unloadModulesPySource);
 	unload_local_modules = pyodide.globals.get("unload_local_modules");
 	console.debug("Python utility functions are set up.");
+
+	updateProgress("Initialization completed");
 }
 
 self.onmessage = async (event: MessageEvent<InMessage>): Promise<void> => {


### PR DESCRIPTION
## Description

Related to #5983 .
Showing the progress and error handling during the initialization should be covered by #5983 , so this PR shouldn't be mandatory but is intended to be a defensive improvement.
With this PR, even when some error occurs after the initialization and the app screen unexpectedly gets frozen, users can know at least the initialization has finished. It would be helpful for bug reports as well.



