### PR TITLE
feat: added output flagging to "auto"-mode

### DIFF
--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 set_documentation_group("flagging")
 
-
+@document()
 class FlaggingCallback(ABC):
     """
     An abstract class for defining the methods that any FlaggingCallback should have.

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -168,7 +168,7 @@ class Interface(Blocks):
             thumbnail: path or url to image to use as display image when the web demo is shared on social media.
             theme: Theme to use, loaded from gradio.themes.
             css: custom css or path to custom css file to use with interface.
-            allow_flagging: one of "never", "auto", or "manual". If "never" or "auto", users will not see a button to flag an input and output. If "manual", users will see a button to flag. If "auto", every input the user submits will be automatically flagged (outputs are not flagged). If "manual", both the input and outputs are flagged when the user clicks flag button. This parameter can be set with environmental variable GRADIO_ALLOW_FLAGGING; otherwise defaults to "manual".
+            allow_flagging: one of "never", "auto", or "manual". If "never" or "auto", users will not see a button to flag an input and output. If "manual", users will see a button to flag. If "auto", every input and output the user submits will be automatically flagged. If "manual", both the input and outputs are flagged when the user clicks flag button. This parameter can be set with environmental variable GRADIO_ALLOW_FLAGGING; otherwise defaults to "manual".
             flagging_options: if provided, allows user to select from the list of options when flagging. Only applies if allow_flagging is "manual". Can either be a list of tuples of the form (label, value), where label is the string that will be displayed on the button and value is the string that will be stored in the flagging CSV; or it can be a list of strings ["X", "Y"], in which case the values will be the list of strings and the labels will ["Flag as X", "Flag as Y"], etc.
             flagging_dir: what to name the directory where flagged data is stored.
             flagging_callback: None or an instance of a subclass of FlaggingCallback which will be called when a sample is flagged. If set to None, an instance of gradio.flagging.CSVLogger will be created and logs will be saved to a local CSV file in flagging_dir. Default to None.
@@ -395,12 +395,7 @@ class Interface(Blocks):
                     component.label = f"output {i}"
 
         if self.allow_flagging != "never":
-            if (
-                self.interface_type == InterfaceTypes.UNIFIED
-                or self.allow_flagging == "auto"
-            ):
-                self.flagging_callback.setup(self.input_components, self.flagging_dir)  # type: ignore
-            elif self.interface_type == InterfaceTypes.INPUT_ONLY:
+            if self.interface_type == InterfaceTypes.INPUT_ONLY:
                 pass
             else:
                 self.flagging_callback.setup(


### PR DESCRIPTION
## Description

I chose to default the "auto"-flagging to include input and output component info

Closes: #3441

## 🎯 PRs Should Target Issues

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
