### PR TITLE
lite: install typing-extensions to avoid capping fastapi versions

### DIFF
--- a/.changeset/bitter-mirrors-dance.md
+++ b/.changeset/bitter-mirrors-dance.md
@@ -1,0 +1,5 @@
+---
+"@gradio/wasm": minor
+---
+
+feat:lite: install typing-extensions to avoid capping fastapi versions

--- a/js/wasm/src/webworker/index.ts
+++ b/js/wasm/src/webworker/index.ts
@@ -89,9 +89,9 @@ async function loadPyodideAndPackages(
 	await micropip.add_mock_package("ffmpy", "0.3.0");
 	await micropip.add_mock_package("aiohttp", "3.8.4");
 	await pyodide.loadPackage(["ssl", "distutils", "setuptools"]);
+	await micropip.install(["typing-extensions>=4.8.0"]); // Typing extensions needs to be installed first otherwise the versions from the pyodide lockfile is used which is incompatible with the latest fastapi.
 	await micropip.install(["markdown-it-py[linkify]~=2.2.0"]); // On 3rd June 2023, markdown-it-py 3.0.0 has been released. The `gradio` package depends on its `>=2.0.0` version so its 3.x will be resolved. However, it conflicts with `mdit-py-plugins`'s dependency `markdown-it-py >=1.0.0,<3.0.0` and micropip currently can't resolve it. So we explicitly install the compatible version of the library here.
 	await micropip.install(["anyio==3.*"]); // `fastapi` depends on `anyio>=3.4.0,<5` so its 4.* can be installed, but it conflicts with the anyio version `httpx` depends on, `==3.*`. Seems like micropip can't resolve it for now, so we explicitly install the compatible version of the library here.
-	await micropip.install(["fastapi<0.104.0"]); // XXX: Workaround for #5986.
 	await micropip.install.callKwargs(gradioWheelUrls, {
 		keep_going: true
 	});


### PR DESCRIPTION
## Description

Closes: #6010

See https://github.com/pyodide/pyodide/issues/4234#issuecomment-1772115575

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
