### PR TITLE
Fix `root` when user is unauthenticated so that login page appears correctly

### DIFF
--- a/.changeset/puny-teeth-notice.md
+++ b/.changeset/puny-teeth-notice.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix `root` when user is unauthenticated so that login page appears correctly

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -325,7 +325,7 @@ class App(FastAPI):
                     "auth_required": True,
                     "auth_message": blocks.auth_message,
                     "space_id": app.get_blocks().space_id,
-                    "root": root_path,
+                    "root": route_utils.strip_url(root_path),
                 }
 
             try:


### PR DESCRIPTION
Sorry for targeting `main` but this is a pretty bad bug -- the login page css is [broken on Spaces](https://huggingface.co/spaces/abidlabs/test-auth):

<img width="577" alt="image" src="https://github.com/gradio-app/gradio/assets/1778297/14c421c2-15ee-48eb-84a6-bc689ce141bd">

This PR fixes it. Verified by installing this PR on a different Space: https://huggingface.co/spaces/abidlabs/test-auth2



Fixes: #5932 