### PR TITLE
Use str instead of repr on Error messages

### DIFF
--- a/.changeset/floppy-taxes-rule.md
+++ b/.changeset/floppy-taxes-rule.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Use str instead of repr on Error messages

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -80,4 +80,4 @@ class Error(Exception):
         super().__init__(self.message)
 
     def __str__(self):
-        return repr(self.message)
+        return str(self.message)


### PR DESCRIPTION
## Description

I believe it the `__str__` method of `gradio.Error` should call `str` instead of `repr`, otherwise newlines and whitespace does not display correctly in the error modal in browser.
  
