### PR TITLE
Fix remaining xfail tests in backend

### DIFF
--- a/.changeset/rare-hornets-take.md
+++ b/.changeset/rare-hornets-take.md
@@ -1,0 +1,6 @@
+---
+"gradio": minor
+"gradio_client": minor
+---
+
+feat:Fix remaining xfail tests in backend

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -30,8 +30,9 @@ from huggingface_hub.utils import (
 )
 from packaging import version
 
-from gradio_client import utils
+from gradio_client import serializing, utils
 from gradio_client.documentation import document, set_documentation_group
+from gradio_client.exceptions import SerializationSetupError
 from gradio_client.utils import (
     Communicator,
     JobStatus,
@@ -128,11 +129,15 @@ class Client:
         self.upload_url = urllib.parse.urljoin(self.src, utils.UPLOAD_URL)
         self.reset_url = urllib.parse.urljoin(self.src, utils.RESET_URL)
         self.config = self._get_config()
+        self.app_version = version.parse(self.config.get("version", "2.0"))
         self._info = self._get_api_info()
         self.session_hash = str(uuid.uuid4())
 
+        endpoint_class = Endpoint
+        if self.app_version < version.Version("4.0.0"):
+            endpoint_class = EndpointV3Compatibility
         self.endpoints = [
-            Endpoint(self, fn_index, dependency)
+            endpoint_class(self, fn_index, dependency)
             for fn_index, dependency in enumerate(self.config["dependencies"])
         ]
 
@@ -360,9 +365,7 @@ class Client:
         else:
             api_info_url = urllib.parse.urljoin(self.src, utils.RAW_API_INFO_URL)
 
-        # Versions of Gradio older than 3.29.0 returned format of the API info
-        # from the /info endpoint
-        if version.parse(self.config.get("version", "2.0")) > version.Version("3.36.1"):
+        if self.app_version > version.Version("3.36.1"):
             r = requests.get(api_info_url, headers=self.headers)
             if r.ok:
                 info = r.json()
@@ -1044,6 +1047,313 @@ class Endpoint:
         predictions = self.remove_skipped_components(*predictions)
         predictions = self.reduce_singleton_output(*predictions)
         return predictions
+
+    def _use_websocket(self, dependency: dict) -> bool:
+        queue_enabled = self.client.config.get("enable_queue", False)
+        queue_uses_websocket = version.parse(
+            self.client.config.get("version", "2.0")
+        ) >= version.Version("3.2")
+        dependency_uses_queue = dependency.get("queue", False) is not False
+        return queue_enabled and queue_uses_websocket and dependency_uses_queue
+
+    async def _ws_fn(self, data, hash_data, helper: Communicator):
+        async with websockets.connect(  # type: ignore
+            self.client.ws_url,
+            open_timeout=10,
+            extra_headers=self.client.headers,
+            max_size=1024 * 1024 * 1024,
+        ) as websocket:
+            return await utils.get_pred_from_ws(websocket, data, hash_data, helper)
+
+
+class EndpointV3Compatibility:
+    """Endpoint class for connecting to v3 endpoints. Backwards compatibility."""
+
+    def __init__(self, client: Client, fn_index: int, dependency: dict):
+        self.client: Client = client
+        self.fn_index = fn_index
+        self.dependency = dependency
+        api_name = dependency.get("api_name")
+        self.api_name: str | Literal[False] | None = (
+            "/" + api_name if isinstance(api_name, str) else api_name
+        )
+        self.use_ws = self._use_websocket(self.dependency)
+        self.input_component_types = []
+        self.output_component_types = []
+        self.root_url = client.src + "/" if not client.src.endswith("/") else client.src
+        self.is_continuous = dependency.get("types", {}).get("continuous", False)
+        try:
+            # Only a real API endpoint if backend_fn is True (so not just a frontend function), serializers are valid,
+            # and api_name is not False (meaning that the developer has explicitly disabled the API endpoint)
+            self.serializers, self.deserializers = self._setup_serializers()
+            self.is_valid = self.dependency["backend_fn"] and self.api_name is not False
+        except SerializationSetupError:
+            self.is_valid = False
+
+    def __repr__(self):
+        return f"Endpoint src: {self.client.src}, api_name: {self.api_name}, fn_index: {self.fn_index}"
+
+    def __str__(self):
+        return self.__repr__()
+
+    def make_end_to_end_fn(self, helper: Communicator | None = None):
+        _predict = self.make_predict(helper)
+
+        def _inner(*data):
+            if not self.is_valid:
+                raise utils.InvalidAPIEndpointError()
+            data = self.insert_state(*data)
+            if self.client.serialize:
+                data = self.serialize(*data)
+            predictions = _predict(*data)
+            predictions = self.process_predictions(*predictions)
+            # Append final output only if not already present
+            # for consistency between generators and not generators
+            if helper:
+                with helper.lock:
+                    if not helper.job.outputs:
+                        helper.job.outputs.append(predictions)
+            return predictions
+
+        return _inner
+
+    def make_predict(self, helper: Communicator | None = None):
+        def _predict(*data) -> tuple:
+            data = json.dumps(
+                {
+                    "data": data,
+                    "fn_index": self.fn_index,
+                    "session_hash": self.client.session_hash,
+                }
+            )
+            hash_data = json.dumps(
+                {
+                    "fn_index": self.fn_index,
+                    "session_hash": self.client.session_hash,
+                }
+            )
+
+            if self.use_ws:
+                result = utils.synchronize_async(self._ws_fn, data, hash_data, helper)
+                if "error" in result:
+                    raise ValueError(result["error"])
+            else:
+                response = requests.post(
+                    self.client.api_url, headers=self.client.headers, data=data
+                )
+                result = json.loads(response.content.decode("utf-8"))
+            try:
+                output = result["data"]
+            except KeyError as ke:
+                is_public_space = (
+                    self.client.space_id
+                    and not huggingface_hub.space_info(self.client.space_id).private
+                )
+                if "error" in result and "429" in result["error"] and is_public_space:
+                    raise utils.TooManyRequestsError(
+                        f"Too many requests to the API, please try again later. To avoid being rate-limited, "
+                        f"please duplicate the Space using Client.duplicate({self.client.space_id}) "
+                        f"and pass in your Hugging Face token."
+                    ) from None
+                elif "error" in result:
+                    raise ValueError(result["error"]) from None
+                raise KeyError(
+                    f"Could not find 'data' key in response. Response received: {result}"
+                ) from ke
+            return tuple(output)
+
+        return _predict
+
+    def _predict_resolve(self, *data) -> Any:
+        """Needed for gradio.load(), which has a slightly different signature for serializing/deserializing"""
+        outputs = self.make_predict()(*data)
+        if len(self.dependency["outputs"]) == 1:
+            return outputs[0]
+        return outputs
+
+    def _upload(
+        self, file_paths: list[str | list[str]]
+    ) -> list[str | list[str]] | list[dict[str, Any] | list[dict[str, Any]]]:
+        if not file_paths:
+            return []
+        # Put all the filepaths in one file
+        # but then keep track of which index in the
+        # original list they came from so we can recreate
+        # the original structure
+        files = []
+        indices = []
+        for i, fs in enumerate(file_paths):
+            if not isinstance(fs, list):
+                fs = [fs]
+            for f in fs:
+                files.append(("files", (Path(f).name, open(f, "rb"))))  # noqa: SIM115
+                indices.append(i)
+        r = requests.post(
+            self.client.upload_url, headers=self.client.headers, files=files
+        )
+        if r.status_code != 200:
+            uploaded = file_paths
+        else:
+            uploaded = []
+            result = r.json()
+            for i, fs in enumerate(file_paths):
+                if isinstance(fs, list):
+                    output = [o for ix, o in enumerate(result) if indices[ix] == i]
+                    res = [
+                        {
+                            "is_file": True,
+                            "name": o,
+                            "orig_name": Path(f).name,
+                            "data": None,
+                        }
+                        for f, o in zip(fs, output)
+                    ]
+                else:
+                    o = next(o for ix, o in enumerate(result) if indices[ix] == i)
+                    res = {
+                        "is_file": True,
+                        "name": o,
+                        "orig_name": Path(fs).name,
+                        "data": None,
+                    }
+                uploaded.append(res)
+        return uploaded
+
+    def _add_uploaded_files_to_data(
+        self,
+        files: list[str | list[str]] | list[dict[str, Any] | list[dict[str, Any]]],
+        data: list[Any],
+    ) -> None:
+        """Helper function to modify the input data with the uploaded files."""
+        file_counter = 0
+        for i, t in enumerate(self.input_component_types):
+            if t in ["file", "uploadbutton"]:
+                data[i] = files[file_counter]
+                file_counter += 1
+
+    def insert_state(self, *data) -> tuple:
+        data = list(data)
+        for i, input_component_type in enumerate(self.input_component_types):
+            if input_component_type == utils.STATE_COMPONENT:
+                data.insert(i, None)
+        return tuple(data)
+
+    def remove_skipped_components(self, *data) -> tuple:
+        data = [
+            d
+            for d, oct in zip(data, self.output_component_types)
+            if oct not in utils.SKIP_COMPONENTS
+        ]
+        return tuple(data)
+
+    def reduce_singleton_output(self, *data) -> Any:
+        if (
+            len(
+                [
+                    oct
+                    for oct in self.output_component_types
+                    if oct not in utils.SKIP_COMPONENTS
+                ]
+            )
+            == 1
+        ):
+            return data[0]
+        else:
+            return data
+
+    def serialize(self, *data) -> tuple:
+        if len(data) != len(self.serializers):
+            raise ValueError(
+                f"Expected {len(self.serializers)} arguments, got {len(data)}"
+            )
+
+        files = [
+            f
+            for f, t in zip(data, self.input_component_types)
+            if t in ["file", "uploadbutton"]
+        ]
+        uploaded_files = self._upload(files)
+        data = list(data)
+        self._add_uploaded_files_to_data(uploaded_files, data)
+        o = tuple([s.serialize(d) for s, d in zip(self.serializers, data)])
+        return o
+
+    def deserialize(self, *data) -> tuple:
+        if len(data) != len(self.deserializers):
+            raise ValueError(
+                f"Expected {len(self.deserializers)} outputs, got {len(data)}"
+            )
+        outputs = tuple(
+            [
+                s.deserialize(
+                    d,
+                    save_dir=self.client.output_dir,
+                    hf_token=self.client.hf_token,
+                    root_url=self.root_url,
+                )
+                for s, d in zip(self.deserializers, data)
+            ]
+        )
+        return outputs
+
+    def process_predictions(self, *predictions):
+        if self.client.serialize:
+            predictions = self.deserialize(*predictions)
+        predictions = self.remove_skipped_components(*predictions)
+        predictions = self.reduce_singleton_output(*predictions)
+        return predictions
+
+    def _setup_serializers(
+        self,
+    ) -> tuple[list[serializing.Serializable], list[serializing.Serializable]]:
+        inputs = self.dependency["inputs"]
+        serializers = []
+
+        for i in inputs:
+            for component in self.client.config["components"]:
+                if component["id"] == i:
+                    component_name = component["type"]
+                    self.input_component_types.append(component_name)
+                    if component.get("serializer"):
+                        serializer_name = component["serializer"]
+                        if serializer_name not in serializing.SERIALIZER_MAPPING:
+                            raise SerializationSetupError(
+                                f"Unknown serializer: {serializer_name}, you may need to update your gradio_client version."
+                            )
+                        serializer = serializing.SERIALIZER_MAPPING[serializer_name]
+                    elif component_name in serializing.COMPONENT_MAPPING:
+                        serializer = serializing.COMPONENT_MAPPING[component_name]
+                    else:
+                        raise SerializationSetupError(
+                            f"Unknown component: {component_name}, you may need to update your gradio_client version."
+                        )
+                    serializers.append(serializer())  # type: ignore
+
+        outputs = self.dependency["outputs"]
+        deserializers = []
+        for i in outputs:
+            for component in self.client.config["components"]:
+                if component["id"] == i:
+                    component_name = component["type"]
+                    self.output_component_types.append(component_name)
+                    if component.get("serializer"):
+                        serializer_name = component["serializer"]
+                        if serializer_name not in serializing.SERIALIZER_MAPPING:
+                            raise SerializationSetupError(
+                                f"Unknown serializer: {serializer_name}, you may need to update your gradio_client version."
+                            )
+                        deserializer = serializing.SERIALIZER_MAPPING[serializer_name]
+                    elif component_name in utils.SKIP_COMPONENTS:
+                        deserializer = serializing.SimpleSerializable
+                    elif component_name in serializing.COMPONENT_MAPPING:
+                        deserializer = serializing.COMPONENT_MAPPING[component_name]
+                    else:
+                        raise SerializationSetupError(
+                            f"Unknown component: {component_name}, you may need to update your gradio_client version."
+                        )
+                    deserializers.append(deserializer())  # type: ignore
+
+        return serializers, deserializers
 
     def _use_websocket(self, dependency: dict) -> bool:
         queue_enabled = self.client.config.get("enable_queue", False)

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -971,13 +971,18 @@ class Endpoint:
         file_list = []
 
         def get_file(d):
-            file_list.append(d)
+            if utils.is_file_obj(d):
+                file_list.append(d["name"])
+            else:
+                file_list.append(d)
             return ReplaceMe(len(file_list) - 1)
 
         new_data = []
         for i, d in enumerate(data):
             if self.input_component_types[i].value_is_file:
-                d = utils.traverse(d, get_file, utils.is_filepath)
+                d = utils.traverse(
+                    d, get_file, lambda s: utils.is_file_obj(s) or utils.is_filepath(s)
+                )
             new_data.append(d)
         return file_list, new_data
 
@@ -1132,7 +1137,6 @@ class EndpointV3Compatibility:
                     "session_hash": self.client.session_hash,
                 }
             )
-
             if self.use_ws:
                 result = utils.synchronize_async(self._ws_fn, data, hash_data, helper)
                 if "error" in result:

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -980,6 +980,9 @@ class Endpoint:
         new_data = []
         for i, d in enumerate(data):
             if self.input_component_types[i].value_is_file:
+                # Check file dicts and filepaths to upload
+                # file dict is a corner case but still needed for completeness
+                # most users should be using filepaths
                 d = utils.traverse(
                     d, get_file, lambda s: utils.is_file_obj(s) or utils.is_filepath(s)
                 )

--- a/client/python/gradio_client/serializing.py
+++ b/client/python/gradio_client/serializing.py
@@ -1,0 +1,599 @@
+"""Included for backwards compatibility with 3.x spaces/apps."""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any
+
+from gradio_client import media_data, utils
+from gradio_client.data_classes import FileData
+
+with open(Path(__file__).parent / "types.json") as f:
+    serializer_types = json.load(f)
+
+
+class Serializable:
+    def serialized_info(self):
+        """
+        The typing information for this component as a dictionary whose values are a list of 2 strings: [Python type, language-agnostic description].
+        Keys of the dictionary are: raw_input, raw_output, serialized_input, serialized_output
+        """
+        return self.api_info()
+
+    def api_info(self) -> dict[str, list[str]]:
+        """
+        The typing information for this component as a dictionary whose values are a list of 2 strings: [Python type, language-agnostic description].
+        Keys of the dictionary are: raw_input, raw_output, serialized_input, serialized_output
+        """
+        raise NotImplementedError()
+
+    def example_inputs(self) -> dict[str, Any]:
+        """
+        The example inputs for this component as a dictionary whose values are example inputs compatible with this component.
+        Keys of the dictionary are: raw, serialized
+        """
+        raise NotImplementedError()
+
+    # For backwards compatibility
+    def input_api_info(self) -> tuple[str, str]:
+        api_info = self.api_info()
+        types = api_info.get("serialized_input", [api_info["info"]["type"]] * 2)  # type: ignore
+        return (types[0], types[1])
+
+    # For backwards compatibility
+    def output_api_info(self) -> tuple[str, str]:
+        api_info = self.api_info()
+        types = api_info.get("serialized_output", [api_info["info"]["type"]] * 2)  # type: ignore
+        return (types[0], types[1])
+
+    def serialize(self, x: Any, load_dir: str | Path = "", allow_links: bool = False):
+        """
+        Convert data from human-readable format to serialized format for a browser.
+        """
+        return x
+
+    def deserialize(
+        self,
+        x: Any,
+        save_dir: str | Path | None = None,
+        root_url: str | None = None,
+        hf_token: str | None = None,
+    ):
+        """
+        Convert data from serialized format for a browser to human-readable format.
+        """
+        return x
+
+
+class SimpleSerializable(Serializable):
+    """General class that does not perform any serialization or deserialization."""
+
+    def api_info(self) -> dict[str, bool | dict]:
+        return {
+            "info": serializer_types["SimpleSerializable"],
+            "serialized_info": False,
+        }
+
+    def example_inputs(self) -> dict[str, Any]:
+        return {
+            "raw": None,
+            "serialized": None,
+        }
+
+
+class StringSerializable(Serializable):
+    """Expects a string as input/output but performs no serialization."""
+
+    def api_info(self) -> dict[str, bool | dict]:
+        return {
+            "info": serializer_types["StringSerializable"],
+            "serialized_info": False,
+        }
+
+    def example_inputs(self) -> dict[str, Any]:
+        return {
+            "raw": "Howdy!",
+            "serialized": "Howdy!",
+        }
+
+
+class ListStringSerializable(Serializable):
+    """Expects a list of strings as input/output but performs no serialization."""
+
+    def api_info(self) -> dict[str, bool | dict]:
+        return {
+            "info": serializer_types["ListStringSerializable"],
+            "serialized_info": False,
+        }
+
+    def example_inputs(self) -> dict[str, Any]:
+        return {
+            "raw": ["Howdy!", "Merhaba"],
+            "serialized": ["Howdy!", "Merhaba"],
+        }
+
+
+class BooleanSerializable(Serializable):
+    """Expects a boolean as input/output but performs no serialization."""
+
+    def api_info(self) -> dict[str, bool | dict]:
+        return {
+            "info": serializer_types["BooleanSerializable"],
+            "serialized_info": False,
+        }
+
+    def example_inputs(self) -> dict[str, Any]:
+        return {
+            "raw": True,
+            "serialized": True,
+        }
+
+
+class NumberSerializable(Serializable):
+    """Expects a number (int/float) as input/output but performs no serialization."""
+
+    def api_info(self) -> dict[str, bool | dict]:
+        return {
+            "info": serializer_types["NumberSerializable"],
+            "serialized_info": False,
+        }
+
+    def example_inputs(self) -> dict[str, Any]:
+        return {
+            "raw": 5,
+            "serialized": 5,
+        }
+
+
+class ImgSerializable(Serializable):
+    """Expects a base64 string as input/output which is serialized to a filepath."""
+
+    def serialized_info(self):
+        return {
+            "type": "string",
+            "description": "filepath on your computer (or URL) of image",
+        }
+
+    def api_info(self) -> dict[str, bool | dict]:
+        return {"info": serializer_types["ImgSerializable"], "serialized_info": True}
+
+    def example_inputs(self) -> dict[str, Any]:
+        return {
+            "raw": media_data.BASE64_IMAGE,
+            "serialized": "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png",
+        }
+
+    def serialize(
+        self,
+        x: str | None,
+        load_dir: str | Path = "",
+        allow_links: bool = False,
+    ) -> str | None:
+        """
+        Convert from human-friendly version of a file (string filepath) to a serialized
+        representation (base64).
+        Parameters:
+            x: String path to file to serialize
+            load_dir: Path to directory containing x
+        """
+        if not x:
+            return None
+        if utils.is_http_url_like(x):
+            return utils.encode_url_to_base64(x)
+        return utils.encode_file_to_base64(Path(load_dir) / x)
+
+    def deserialize(
+        self,
+        x: str | None,
+        save_dir: str | Path | None = None,
+        root_url: str | None = None,
+        hf_token: str | None = None,
+    ) -> str | None:
+        """
+        Convert from serialized representation of a file (base64) to a human-friendly
+        version (string filepath). Optionally, save the file to the directory specified by save_dir
+        Parameters:
+            x: Base64 representation of image to deserialize into a string filepath
+            save_dir: Path to directory to save the deserialized image to
+            root_url: Ignored
+            hf_token: Ignored
+        """
+        if x is None or x == "":
+            return None
+        file = utils.decode_base64_to_file(x, dir=save_dir)
+        return file.name
+
+
+class FileSerializable(Serializable):
+    """Expects a dict with base64 representation of object as input/output which is serialized to a filepath."""
+
+    def __init__(self) -> None:
+        self.stream = None
+        self.stream_name = None
+        super().__init__()
+
+    def serialized_info(self):
+        return self._single_file_serialized_info()
+
+    def _single_file_api_info(self):
+        return {
+            "info": serializer_types["SingleFileSerializable"],
+            "serialized_info": True,
+        }
+
+    def _single_file_serialized_info(self):
+        return {
+            "type": "string",
+            "description": "filepath on your computer (or URL) of file",
+        }
+
+    def _multiple_file_serialized_info(self):
+        return {
+            "type": "array",
+            "description": "List of filepath(s) or URL(s) to files",
+            "items": {
+                "type": "string",
+                "description": "filepath on your computer (or URL) of file",
+            },
+        }
+
+    def _multiple_file_api_info(self):
+        return {
+            "info": serializer_types["MultipleFileSerializable"],
+            "serialized_info": True,
+        }
+
+    def api_info(self) -> dict[str, dict | bool]:
+        return self._single_file_api_info()
+
+    def example_inputs(self) -> dict[str, Any]:
+        return self._single_file_example_inputs()
+
+    def _single_file_example_inputs(self) -> dict[str, Any]:
+        return {
+            "raw": {"is_file": False, "data": media_data.BASE64_FILE},
+            "serialized": "https://github.com/gradio-app/gradio/raw/main/test/test_files/sample_file.pdf",
+        }
+
+    def _multiple_file_example_inputs(self) -> dict[str, Any]:
+        return {
+            "raw": [{"is_file": False, "data": media_data.BASE64_FILE}],
+            "serialized": [
+                "https://github.com/gradio-app/gradio/raw/main/test/test_files/sample_file.pdf"
+            ],
+        }
+
+    def _serialize_single(
+        self,
+        x: str | FileData | None,
+        load_dir: str | Path = "",
+        allow_links: bool = False,
+    ) -> FileData | None:
+        if x is None or isinstance(x, dict):
+            return x
+        if utils.is_http_url_like(x):
+            filename = x
+            size = None
+        else:
+            filename = str(Path(load_dir) / x)
+            size = Path(filename).stat().st_size
+        return {
+            "name": filename,
+            "data": None
+            if allow_links
+            else utils.encode_url_or_file_to_base64(filename),
+            "orig_name": Path(filename).name,
+            "is_file": allow_links,
+            "size": size,
+        }
+
+    def _setup_stream(self, url, hf_token):
+        return utils.download_byte_stream(url, hf_token)
+
+    def _deserialize_single(
+        self,
+        x: str | FileData | None,
+        save_dir: str | None = None,
+        root_url: str | None = None,
+        hf_token: str | None = None,
+    ) -> str | None:
+        if x is None:
+            return None
+        if isinstance(x, str):
+            file_name = utils.decode_base64_to_file(x, dir=save_dir).name
+        elif isinstance(x, dict):
+            if x.get("is_file"):
+                filepath = x.get("name")
+                if filepath is None:
+                    raise ValueError(f"The 'name' field is missing in {x}")
+                if root_url is not None:
+                    file_name = utils.download_tmp_copy_of_file(
+                        root_url + "file=" + filepath,
+                        hf_token=hf_token,
+                        dir=save_dir,
+                    )
+                else:
+                    file_name = utils.create_tmp_copy_of_file(filepath, dir=save_dir)
+            elif x.get("is_stream"):
+                assert x["name"] and root_url and save_dir
+                if not self.stream or self.stream_name != x["name"]:
+                    self.stream = self._setup_stream(
+                        root_url + "stream/" + x["name"], hf_token=hf_token
+                    )
+                    self.stream_name = x["name"]
+                chunk = next(self.stream)
+                path = Path(save_dir or tempfile.gettempdir()) / secrets.token_hex(20)
+                path.mkdir(parents=True, exist_ok=True)
+                path = path / x.get("orig_name", "output")
+                path.write_bytes(chunk)
+                file_name = str(path)
+            else:
+                data = x.get("data")
+                if data is None:
+                    raise ValueError(f"The 'data' field is missing in {x}")
+                file_name = utils.decode_base64_to_file(data, dir=save_dir).name
+        else:
+            raise ValueError(
+                f"A FileSerializable component can only deserialize a string or a dict, not a {type(x)}: {x}"
+            )
+        return file_name
+
+    def serialize(
+        self,
+        x: str | FileData | None | list[str | FileData | None],
+        load_dir: str | Path = "",
+        allow_links: bool = False,
+    ) -> FileData | None | list[FileData | None]:
+        """
+        Convert from human-friendly version of a file (string filepath) to a
+        serialized representation (base64)
+        Parameters:
+            x: String path to file to serialize
+            load_dir: Path to directory containing x
+            allow_links: Will allow path returns instead of raw file content
+        """
+        if x is None or x == "":
+            return None
+        if isinstance(x, list):
+            return [self._serialize_single(f, load_dir, allow_links) for f in x]
+        else:
+            return self._serialize_single(x, load_dir, allow_links)
+
+    def deserialize(
+        self,
+        x: str | FileData | None | list[str | FileData | None],
+        save_dir: Path | str | None = None,
+        root_url: str | None = None,
+        hf_token: str | None = None,
+    ) -> str | None | list[str | None]:
+        """
+        Convert from serialized representation of a file (base64) to a human-friendly
+        version (string filepath). Optionally, save the file to the directory specified by `save_dir`
+        Parameters:
+            x: Base64 representation of file to deserialize into a string filepath
+            save_dir: Path to directory to save the deserialized file to
+            root_url: If this component is loaded from an external Space, this is the URL of the Space.
+            hf_token: If this component is loaded from an external private Space, this is the access token for the Space
+        """
+        if x is None:
+            return None
+        if isinstance(save_dir, Path):
+            save_dir = str(save_dir)
+        if isinstance(x, list):
+            return [
+                self._deserialize_single(
+                    f, save_dir=save_dir, root_url=root_url, hf_token=hf_token
+                )
+                for f in x
+            ]
+        else:
+            return self._deserialize_single(
+                x, save_dir=save_dir, root_url=root_url, hf_token=hf_token
+            )
+
+
+class VideoSerializable(FileSerializable):
+    def serialized_info(self):
+        return {
+            "type": "string",
+            "description": "filepath on your computer (or URL) of video file",
+        }
+
+    def api_info(self) -> dict[str, dict | bool]:
+        return {"info": serializer_types["FileSerializable"], "serialized_info": True}
+
+    def example_inputs(self) -> dict[str, Any]:
+        return {
+            "raw": {"is_file": False, "data": media_data.BASE64_VIDEO},
+            "serialized": "https://github.com/gradio-app/gradio/raw/main/test/test_files/video_sample.mp4",
+        }
+
+    def serialize(
+        self, x: str | None, load_dir: str | Path = "", allow_links: bool = False
+    ) -> tuple[FileData | None, None]:
+        return (super().serialize(x, load_dir, allow_links), None)  # type: ignore
+
+    def deserialize(
+        self,
+        x: tuple[FileData | None, FileData | None] | None,
+        save_dir: Path | str | None = None,
+        root_url: str | None = None,
+        hf_token: str | None = None,
+    ) -> str | tuple[str | None, str | None] | None:
+        """
+        Convert from serialized representation of a file (base64) to a human-friendly
+        version (string filepath). Optionally, save the file to the directory specified by `save_dir`
+        """
+        if isinstance(x, (tuple, list)):
+            if len(x) != 2:
+                raise ValueError(f"Expected tuple of length 2. Received: {x}")
+            x_as_list = [x[0], x[1]]
+        else:
+            raise ValueError(f"Expected tuple of length 2. Received: {x}")
+        deserialized_file = super().deserialize(x_as_list, save_dir, root_url, hf_token)  # type: ignore
+        if isinstance(deserialized_file, list):
+            return deserialized_file[0]  # ignore subtitles
+
+
+class JSONSerializable(Serializable):
+    def serialized_info(self):
+        return {"type": "string", "description": "filepath to JSON file"}
+
+    def api_info(self) -> dict[str, dict | bool]:
+        return {"info": serializer_types["JSONSerializable"], "serialized_info": True}
+
+    def example_inputs(self) -> dict[str, Any]:
+        return {
+            "raw": {"a": 1, "b": 2},
+            "serialized": None,
+        }
+
+    def serialize(
+        self,
+        x: str | None,
+        load_dir: str | Path = "",
+        allow_links: bool = False,
+    ) -> dict | list | None:
+        """
+        Convert from a a human-friendly version (string path to json file) to a
+        serialized representation (json string)
+        Parameters:
+            x: String path to json file to read to get json string
+            load_dir: Path to directory containing x
+        """
+        if x is None or x == "":
+            return None
+        return utils.file_to_json(Path(load_dir) / x)
+
+    def deserialize(
+        self,
+        x: str | dict | list,
+        save_dir: str | Path | None = None,
+        root_url: str | None = None,
+        hf_token: str | None = None,
+    ) -> str | None:
+        """
+        Convert from serialized representation (json string) to a human-friendly
+        version (string path to json file).  Optionally, save the file to the directory specified by `save_dir`
+        Parameters:
+            x: Json string
+            save_dir: Path to save the deserialized json file to
+            root_url: Ignored
+            hf_token: Ignored
+        """
+        if x is None:
+            return None
+        return utils.dict_or_str_to_json_file(x, dir=save_dir).name
+
+
+class GallerySerializable(Serializable):
+    def serialized_info(self):
+        return {
+            "type": "string",
+            "description": "path to directory with images and a file associating images with captions called captions.json",
+        }
+
+    def api_info(self) -> dict[str, dict | bool]:
+        return {
+            "info": serializer_types["GallerySerializable"],
+            "serialized_info": True,
+        }
+
+    def example_inputs(self) -> dict[str, Any]:
+        return {
+            "raw": [media_data.BASE64_IMAGE] * 2,
+            "serialized": [
+                "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png",
+            ]
+            * 2,
+        }
+
+    def serialize(
+        self, x: str | None, load_dir: str | Path = "", allow_links: bool = False
+    ) -> list[list[str | None]] | None:
+        if x is None or x == "":
+            return None
+        files = []
+        captions_file = Path(x) / "captions.json"
+        with captions_file.open("r") as captions_json:
+            captions = json.load(captions_json)
+        for file_name, caption in captions.items():
+            img = FileSerializable().serialize(file_name, allow_links=allow_links)
+            files.append([img, caption])
+        return files
+
+    def deserialize(
+        self,
+        x: list[list[str | None]] | None,
+        save_dir: str = "",
+        root_url: str | None = None,
+        hf_token: str | None = None,
+    ) -> None | str:
+        if x is None:
+            return None
+        gallery_path = Path(save_dir) / str(uuid.uuid4())
+        gallery_path.mkdir(exist_ok=True, parents=True)
+        captions = {}
+        for img_data in x:
+            if isinstance(img_data, (list, tuple)):
+                img_data, caption = img_data
+            else:
+                caption = None
+            name = FileSerializable().deserialize(
+                img_data, gallery_path, root_url=root_url, hf_token=hf_token
+            )
+            captions[name] = caption
+            captions_file = gallery_path / "captions.json"
+            with captions_file.open("w") as captions_json:
+                json.dump(captions, captions_json)
+        return os.path.abspath(gallery_path)
+
+
+SERIALIZER_MAPPING = {}
+for cls in Serializable.__subclasses__():
+    SERIALIZER_MAPPING[cls.__name__] = cls
+    for subcls in cls.__subclasses__():
+        SERIALIZER_MAPPING[subcls.__name__] = subcls
+
+SERIALIZER_MAPPING["Serializable"] = SimpleSerializable
+SERIALIZER_MAPPING["File"] = FileSerializable
+SERIALIZER_MAPPING["UploadButton"] = FileSerializable
+
+COMPONENT_MAPPING: dict[str, type] = {
+    "textbox": StringSerializable,
+    "number": NumberSerializable,
+    "slider": NumberSerializable,
+    "checkbox": BooleanSerializable,
+    "checkboxgroup": ListStringSerializable,
+    "radio": StringSerializable,
+    "dropdown": SimpleSerializable,
+    "image": ImgSerializable,
+    "video": FileSerializable,
+    "audio": FileSerializable,
+    "file": FileSerializable,
+    "dataframe": JSONSerializable,
+    "timeseries": JSONSerializable,
+    "fileexplorer": JSONSerializable,
+    "state": SimpleSerializable,
+    "button": StringSerializable,
+    "uploadbutton": FileSerializable,
+    "colorpicker": StringSerializable,
+    "label": JSONSerializable,
+    "highlightedtext": JSONSerializable,
+    "json": JSONSerializable,
+    "html": StringSerializable,
+    "gallery": GallerySerializable,
+    "chatbot": JSONSerializable,
+    "model3d": FileSerializable,
+    "plot": JSONSerializable,
+    "barplot": JSONSerializable,
+    "lineplot": JSONSerializable,
+    "scatterplot": JSONSerializable,
+    "markdown": StringSerializable,
+    "code": StringSerializable,
+    "annotatedimage": JSONSerializable,
+}

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -344,6 +344,24 @@ def create_tmp_copy_of_file(file_path: str, dir: str | None = None) -> str:
     return str(dest.resolve())
 
 
+def download_tmp_copy_of_file(
+    url_path: str, hf_token: str | None = None, dir: str | None = None
+) -> str:
+    """Kept for backwards compatibility for 3.x spaces."""
+    if dir is not None:
+        os.makedirs(dir, exist_ok=True)
+    headers = {"Authorization": "Bearer " + hf_token} if hf_token else {}
+    directory = Path(dir or tempfile.gettempdir()) / secrets.token_hex(20)
+    directory.mkdir(exist_ok=True, parents=True)
+    file_path = directory / Path(url_path).name
+
+    with requests.get(url_path, headers=headers, stream=True) as r:
+        r.raise_for_status()
+        with open(file_path, "wb") as f:
+            shutil.copyfileobj(r.raw, f)
+    return str(file_path.resolve())
+
+
 def get_mimetype(filename: str) -> str | None:
     if filename.endswith(".vtt"):
         return "text/vtt"

--- a/client/python/test/test_utils.py
+++ b/client/python/test/test_utils.py
@@ -67,7 +67,9 @@ def test_decode_base64_to_file():
 
 
 def test_download_private_file(gradio_temp_dir):
-    url_path = "https://gradio-tests-not-actually-private-space.hf.space/file=lion.jpg"
+    url_path = (
+        "https://gradio-tests-not-actually-private-space-v4.hf.space/file=lion.jpg"
+    )
     hf_token = "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"  # Intentionally revealing this key for testing purposes
     file = utils.download_file(
         url_path=url_path, hf_token=hf_token, dir=str(gradio_temp_dir)

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -700,7 +700,6 @@ class Blocks(BlockContext):
                 ]
                 blocks.__name__ = "Interface"
                 blocks.api_mode = True
-
         blocks.root_urls = root_urls
         return blocks
 

--- a/gradio/component_meta.py
+++ b/gradio/component_meta.py
@@ -123,7 +123,9 @@ def create_or_modify_pyi(
     else:
         contents = pyi_file.read_text()
         contents = contents.replace(current_interface, new_interface.strip())
-        pyi_file.write_text(contents)
+        current_contents = pyi_file.read_text()
+        if current_contents != contents:
+            pyi_file.write_text(contents)
 
 
 def in_event_listener():

--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -161,7 +161,6 @@ class Audio(
         """
         if x is None:
             return x
-
         payload: AudioInputData = AudioInputData(**x)
         assert payload.name
 

--- a/gradio/components/dataset.py
+++ b/gradio/components/dataset.py
@@ -6,7 +6,6 @@ from typing import Any, Literal
 
 from gradio_client.documentation import document, set_documentation_group
 
-import gradio.utils as utils
 from gradio.components.base import (
     Component,
     get_component_instance,
@@ -45,8 +44,6 @@ class Dataset(Component):
         container: bool = True,
         scale: int | None = None,
         min_width: int = 160,
-        component_props: dict[str, Any] | None = None,
-        component_ids: dict[str, Any] | None = None,
     ):
         """
         Parameters:
@@ -72,15 +69,16 @@ class Dataset(Component):
             elem_classes=elem_classes,
             root_url=root_url,
             _skip_init_processing=_skip_init_processing,
+            render=render,
         )
         self.container = container
         self.scale = scale
         self.min_width = min_width
         self._components = [get_component_instance(c) for c in components]
         self.component_props = [
-            utils.recover_kwargs(
+            component.recover_kwargs(
                 component.get_config(),
-                ["value", "component_props", "component_ids"],
+                ["value"],
             )
             for component in self._components
         ]

--- a/gradio/components/dataset.py
+++ b/gradio/components/dataset.py
@@ -45,6 +45,8 @@ class Dataset(Component):
         container: bool = True,
         scale: int | None = None,
         min_width: int = 160,
+        component_props: dict[str, Any] | None = None,
+        component_ids: dict[str, Any] | None = None,
     ):
         """
         Parameters:
@@ -61,8 +63,11 @@ class Dataset(Component):
             container: If True, will place the component in a container - providing some extra padding around the border.
             scale: relative width compared to adjacent Components in a Row. For example, if Component A has scale=2, and Component B has scale=1, A will be twice as wide as B. Should be an integer.
             min_width: minimum pixel width, will wrap if not sufficient screen space to satisfy this value. If a certain scale value results in this Component being narrower than min_width, the min_width parameter will be respected first.
+            component_props: This is created when the dataset is initialized. Not intended to be set manually. But we add it to init so that Datasets can be loaded from spaces with gr.load.
+            component_ids: This is created when the dataset is initialized. Not intended to be set manually. But we add it to init so that Datasets can be loaded from spaces with gr.load.
         """
-        super().__init__(visible=visible, elem_id=elem_id, elem_classes=elem_classes)
+        super().__init__(visible=visible, elem_id=elem_id, elem_classes=elem_classes, root_url=root_url,
+                        _skip_init_processing=_skip_init_processing)
         self.container = container
         self.scale = scale
         self.min_width = min_width
@@ -70,7 +75,7 @@ class Dataset(Component):
         self.component_props = [
             utils.recover_kwargs(
                 component.get_config(),
-                ["value"],
+                ["value", "component_props", "component_ids"],
             )
             for component in self._components
         ]

--- a/gradio/components/dataset.py
+++ b/gradio/components/dataset.py
@@ -60,8 +60,6 @@ class Dataset(Component):
             container: If True, will place the component in a container - providing some extra padding around the border.
             scale: relative width compared to adjacent Components in a Row. For example, if Component A has scale=2, and Component B has scale=1, A will be twice as wide as B. Should be an integer.
             min_width: minimum pixel width, will wrap if not sufficient screen space to satisfy this value. If a certain scale value results in this Component being narrower than min_width, the min_width parameter will be respected first.
-            component_props: This is created when the dataset is initialized. Not intended to be set manually. But we add it to init so that Datasets can be loaded from spaces with gr.load.
-            component_ids: This is created when the dataset is initialized. Not intended to be set manually. But we add it to init so that Datasets can be loaded from spaces with gr.load.
         """
         super().__init__(
             visible=visible,

--- a/gradio/components/dataset.py
+++ b/gradio/components/dataset.py
@@ -66,8 +66,13 @@ class Dataset(Component):
             component_props: This is created when the dataset is initialized. Not intended to be set manually. But we add it to init so that Datasets can be loaded from spaces with gr.load.
             component_ids: This is created when the dataset is initialized. Not intended to be set manually. But we add it to init so that Datasets can be loaded from spaces with gr.load.
         """
-        super().__init__(visible=visible, elem_id=elem_id, elem_classes=elem_classes, root_url=root_url,
-                        _skip_init_processing=_skip_init_processing)
+        super().__init__(
+            visible=visible,
+            elem_id=elem_id,
+            elem_classes=elem_classes,
+            root_url=root_url,
+            _skip_init_processing=_skip_init_processing,
+        )
         self.container = container
         self.scale = scale
         self.min_width = min_width

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -249,7 +249,7 @@ class Image(StreamingInput, Component):
         elif isinstance(y, _Image.Image):
             path = processing_utils.save_pil_to_cache(y, cache_dir=self.GRADIO_CACHE)
         elif isinstance(y, (str, Path)):
-            path = y if isinstance(y, str) else y.name
+            path = y if isinstance(y, str) else str(y)
         else:
             raise ValueError("Cannot process this value as an Image")
         return FileData(name=path, data=None, is_file=True)

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -53,6 +53,12 @@ class ReloadError(ValueError):
     pass
 
 
+class GradioVersionIncompatibleError(Exception):
+    """Raised when loading a 3.x space with 4.0"""
+
+    pass
+
+
 InvalidApiName = InvalidApiNameError  # backwards compatibility
 
 set_documentation_group("modals")

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -4,18 +4,26 @@ use the `gr.Blocks.load()` or `gr.load()` functions."""
 from __future__ import annotations
 
 import json
+import os
 import re
+import tempfile
 import warnings
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
 import requests
 from gradio_client import Client
+from gradio_client import utils as client_utils
 from gradio_client.documentation import document, set_documentation_group
 
 import gradio
 from gradio import components, utils
 from gradio.context import Context
-from gradio.exceptions import Error, ModelNotFoundError, TooManyRequestsError
+from gradio.exceptions import (
+    Error,
+    ModelNotFoundError,
+    TooManyRequestsError,
+)
 from gradio.external_utils import (
     cols_to_rows,
     encode_to_base64,
@@ -24,7 +32,7 @@ from gradio.external_utils import (
     rows_to_cols,
     streamline_spaces_interface,
 )
-from gradio.processing_utils import extract_base64_data, to_binary
+from gradio.processing_utils import extract_base64_data, save_base64_to_cache, to_binary
 
 if TYPE_CHECKING:
     from gradio.blocks import Blocks
@@ -141,6 +149,10 @@ def from_model(model_name: str, hf_token: str | None, alias: str | None, **kwarg
             f"Could not find model: {model_name}. If it is a private or gated model, please provide your Hugging Face access token (https://huggingface.co/settings/tokens) as the argument for the `api_key` parameter."
         )
     p = response.json().get("pipeline_tag")
+    GRADIO_CACHE = os.environ.get("GRADIO_TEMP_DIR") or str(
+        Path(tempfile.gettempdir()) / "gradio"
+    )
+
     pipelines = {
         "audio-classification": {
             # example model: ehcalabres/wav2vec2-lg-xlsr-en-speech-emotion-recognition
@@ -311,7 +323,9 @@ def from_model(model_name: str, hf_token: str | None, alias: str | None, **kwarg
             "inputs": components.Textbox(label="Input", render=False),
             "outputs": components.Image(label="Output", render=False),
             "preprocess": lambda x: {"inputs": x},
-            "postprocess": encode_to_base64,
+            "postprocess": lambda x: save_base64_to_cache(
+                encode_to_base64(x), cache_dir=GRADIO_CACHE, file_name="output.jpg"
+            ),
         },
         "token-classification": {
             # example model: huggingface-course/bert-finetuned-ner
@@ -329,7 +343,9 @@ def from_model(model_name: str, hf_token: str | None, alias: str | None, **kwarg
             "outputs": components.Label(label="Label", render=False),
             "preprocess": lambda img, q: {
                 "inputs": {
-                    "image": extract_base64_data(img),  # Extract base64 data
+                    "image": extract_base64_data(
+                        client_utils.encode_url_or_file_to_base64(img["name"])
+                    ),  # Extract base64 data
                     "question": q,
                 }
             },
@@ -346,7 +362,9 @@ def from_model(model_name: str, hf_token: str | None, alias: str | None, **kwarg
             "outputs": components.Label(label="Label", render=False),
             "preprocess": lambda img, q: {
                 "inputs": {
-                    "image": extract_base64_data(img),
+                    "image": extract_base64_data(
+                        client_utils.encode_url_or_file_to_base64(img["name"])
+                    ),
                     "question": q,
                 }
             },
@@ -498,7 +516,12 @@ def from_spaces(
 
 def from_spaces_blocks(space: str, hf_token: str | None) -> Blocks:
     client = Client(space, hf_token=hf_token)
+    # if client.app_version < version.Version("4.0.0"):
+    #     raise GradioVersionIncompatible(
+    #         f"Gradio version 4.x cannot load spaces with versions less than 4.x ({client.app_version})."
+    #         "Please downgrade to version 3 to load this space.")
     predict_fns = [endpoint._predict_resolve for endpoint in client.endpoints]
+
     return gradio.Blocks.from_config(client.config, predict_fns, client.src)
 
 

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -525,6 +525,7 @@ def from_spaces_blocks(space: str, hf_token: str | None) -> Blocks:
             f"Gradio version 4.x cannot load spaces with versions less than 4.x ({client.app_version})."
             "Please downgrade to version 3 to load this space."
         )
+    # Use end_to_end_fn here to properly upload/download all files
     predict_fns = [endpoint.make_end_to_end_fn() for endpoint in client.endpoints]
     return gradio.Blocks.from_config(client.config, predict_fns, client.src)
 

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -174,7 +174,9 @@ def from_model(model_name: str, hf_token: str | None, alias: str | None, **kwarg
             ),
             "outputs": components.Audio(label="Output", render=False),
             "preprocess": to_binary,
-            "postprocess": encode_to_base64,
+            "postprocess": lambda x: save_base64_to_cache(
+                encode_to_base64(x), cache_dir=GRADIO_CACHE, file_name="output.wav"
+            ),
         },
         "automatic-speech-recognition": {
             # example model: facebook/wav2vec2-base-960h

--- a/gradio/package.json
+++ b/gradio/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gradio",
-	"version": "3.45.0-beta.13",
+	"version": "4.0.0",
 	"description": "",
 	"python": "true"
 }

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -952,15 +952,6 @@ def find_user_stack_level() -> int:
     return n
 
 
-def recover_kwargs(config: dict, additional_keys_to_ignore: list[str] | None = None):
-    not_kwargs = ["type", "name", "selectable", "server_fns", "streamable"]
-    return {
-        k: v
-        for k, v in config.items()
-        if k not in not_kwargs and k not in (additional_keys_to_ignore or [])
-    }
-
-
 class NamedString(str):
     """
     Subclass of str that includes a .name attribute equal to the value of the string itself. This class is used when returning

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1666,3 +1666,16 @@ def test_temp_file_sets_get_extended():
         demo2.render()
 
     assert demo3.temp_file_sets == demo1.temp_file_sets + demo2.temp_file_sets
+
+
+def test_recover_kwargs():
+    audio = gr.Audio(format="wav", autoplay=True)
+    props = audio.recover_kwargs(
+        {"format": "wav", "value": "foo.wav", "autoplay": False, "foo": "bar"}
+    )
+    assert props == {"format": "wav", "value": "foo.wav", "autoplay": False}
+    props = audio.recover_kwargs(
+        {"format": "wav", "value": "foo.wav", "autoplay": False, "foo": "bar"},
+        ["value"],
+    )
+    assert props == {"format": "wav", "autoplay": False}

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -333,7 +333,9 @@ class TestLoadInterface:
         assert io.theme.name == "default"
         app, _, _ = io.launch(prevent_thread_lock=True)
         test_client = TestClient(app)
-        r = test_client.get("/proxy=https://gradio-tests-test-loading-examples-private-v4.hf.space/file=Bunny.obj")
+        r = test_client.get(
+            "/proxy=https://gradio-tests-test-loading-examples-private-v4.hf.space/file=Bunny.obj"
+        )
         assert r.status_code == 200
 
 
@@ -359,7 +361,8 @@ class TestLoadInterfaceWithExamples:
     def test_root_url(self):
         demo = gr.load("spaces/gradio/test-loading-examples-v4")
         assert all(
-            c["props"]["root_url"] == "https://gradio-test-loading-examples-v4.hf.space/"
+            c["props"]["root_url"]
+            == "https://gradio-test-loading-examples-v4.hf.space/"
             for c in demo.get_config_file()["components"]
         )
 

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -184,7 +184,6 @@ class TestLoadInterface:
         with pytest.raises(GradioVersionIncompatibleError):
             gr.load("spaces/gradio-tests/english_to_spanish", title="hi")
 
-    @pytest.mark.xfail
     def test_english_to_spanish_v4(self):
         with pytest.warns(UserWarning):
             io = gr.load("spaces/gradio-tests/english_to_spanish-v4", title="hi")
@@ -292,7 +291,6 @@ class TestLoadInterface:
         except TooManyRequestsError:
             pass
 
-    @pytest.mark.xfail
     def test_private_space(self):
         hf_token = "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"  # Intentionally revealing this key for testing purposes
         io = gr.load(
@@ -301,7 +299,7 @@ class TestLoadInterface:
         try:
             output = io("abc")
             assert output == "abc"
-            assert io.theme.name == "gradio/monochrome"
+            assert io.theme.name == "default"
         except TooManyRequestsError:
             pass
 
@@ -316,7 +314,6 @@ class TestLoadInterface:
         except TooManyRequestsError:
             pass
 
-    @pytest.mark.xfail
     def test_multiple_spaces_one_private(self):
         hf_token = "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"  # Intentionally revealing this key for testing purposes
         with gr.Blocks():
@@ -328,7 +325,6 @@ class TestLoadInterface:
             )
         assert Context.hf_token == hf_token
 
-    @pytest.mark.xfail
     def test_loading_files_via_proxy_works(self):
         hf_token = "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"  # Intentionally revealing this key for testing purposes
         io = gr.load(
@@ -337,9 +333,7 @@ class TestLoadInterface:
         assert io.theme.name == "default"
         app, _, _ = io.launch(prevent_thread_lock=True)
         test_client = TestClient(app)
-        r = test_client.get(
-            "/proxy=https://gradio-tests-test-loading-examples-private.hf.space/file=Bunny.obj"
-        )
+        r = test_client.get("/proxy=https://gradio-tests-test-loading-examples-private-v4.hf.space/file=Bunny.obj")
         assert r.status_code == 200
 
 
@@ -362,11 +356,10 @@ class TestLoadInterfaceWithExamples:
                 cache_examples=True,
             )
 
-    @pytest.mark.xfail
     def test_root_url(self):
         demo = gr.load("spaces/gradio/test-loading-examples-v4")
         assert all(
-            c["props"]["root_url"] == "https://gradio-test-loading-examples.hf.space/"
+            c["props"]["root_url"] == "https://gradio-test-loading-examples-v4.hf.space/"
             for c in demo.get_config_file()["components"]
         )
 
@@ -375,7 +368,6 @@ class TestLoadInterfaceWithExamples:
         gallery = demo("test")
         assert all("caption" in d for d in gallery)
 
-    @pytest.mark.xfail
     def test_interface_with_examples(self):
         # This demo has the "fake_event" correctly removed
         demo = gr.load("spaces/gradio-tests/test-calculator-1-v4")

--- a/test/test_mix.py
+++ b/test/test_mix.py
@@ -1,5 +1,3 @@
-import pytest
-
 import gradio as gr
 from gradio import mix
 from gradio.external import TooManyRequestsError

--- a/test/test_mix.py
+++ b/test/test_mix.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 
 import gradio as gr
@@ -19,14 +17,12 @@ class TestSeries:
         series = mix.Series(io1, io2)
         assert series("Hello") == "Hello World!"
 
-    @pytest.mark.xfail
     def test_with_external(self):
-        io1 = gr.load("spaces/gradio-tests/image-identity-new")
-        io2 = gr.load("spaces/gradio-tests/image-classifier-new")
+        io1 = gr.load("spaces/gradio-tests/image-identity-new-v4")
+        io2 = gr.load("spaces/gradio-tests/image-classifier-new-v4")
         series = mix.Series(io1, io2)
         try:
-            with open(series("gradio/test_data/lion.jpg")) as f:
-                assert json.load(f)["label"] == "lion"
+            assert series("gradio/test_data/lion.jpg")["label"] == "lion"
         except TooManyRequestsError:
             pass
 
@@ -52,8 +48,8 @@ class TestParallel:
 
     @pytest.mark.xfail
     def test_with_external(self):
-        io1 = gr.load("spaces/gradio-tests/english_to_spanish")
-        io2 = gr.load("spaces/gradio-tests/english2german")
+        io1 = gr.load("spaces/gradio-tests/english_to_spanish-v4")
+        io2 = gr.load("spaces/gradio-tests/english2german-v4")
         parallel = mix.Parallel(io1, io2)
         try:
             hello_es, hello_de = parallel("Hello")

--- a/test/test_mix.py
+++ b/test/test_mix.py
@@ -46,7 +46,6 @@ class TestParallel:
             "Hello World 2!",
         ]
 
-    @pytest.mark.xfail
     def test_with_external(self):
         io1 = gr.load("spaces/gradio-tests/english_to_spanish-v4")
         io2 = gr.load("spaces/gradio-tests/english2german-v4")


### PR DESCRIPTION
## Description

* Make `gradio_client` backwards compatible with v3 spaces
* Raise an error if someone tries to load a v3 space with gradio v4 via `gr.load`
* Fix the remaining tests that are failing in the backend. All of them related to `external.py` or `gr.load` 😓 . This uncovered some gaps/bugs in v4.

~There's still an outstanding issue - since we removed **kwargs from component init, we can't call `gr.load` on a space that has examples because the dataset component has `component_props` saved in the config but `component_props` is not a parameter of init. @abidlabs let's synch tomorrow on the best pattern to deal with this.~


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
