### PR TITLE
Fix Dropdown Example component and example processing logic

### DIFF
--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -174,13 +174,20 @@ class Dropdown(FormComponent):
         )
 
     def postprocess(self, y):
+        print("y", y, self.multiselect)
         if y is None:
             return None
         if self.multiselect:
+            print(">>>", y)
             [self._warn_if_invalid_choice(_y) for _y in y]
         else:
             self._warn_if_invalid_choice(y)
         return y
 
     def as_example(self, input_data):
+        if self.multiselect:
+            return [
+                next((c[0] for c in self.choices if c[1] == data), None)
+                for data in input_data
+            ]
         return next((c[0] for c in self.choices if c[1] == input_data), None)

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -174,11 +174,9 @@ class Dropdown(FormComponent):
         )
 
     def postprocess(self, y):
-        print("y", y, self.multiselect)
         if y is None:
             return None
         if self.multiselect:
-            print(">>>", y)
             [self._warn_if_invalid_choice(_y) for _y in y]
         else:
             self._warn_if_invalid_choice(y)

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -259,7 +259,6 @@ class Examples:
 
         async def load_example(example_id):
             processed_example = self.non_none_processed_examples[example_id]
-            # examples = utils.resolve_singleton(processed_example)
             if len(self.inputs_with_examples) == 1:
                 return update(
                     value=processed_example[0], **self.dataset.component_props[0]

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -259,16 +259,15 @@ class Examples:
 
         async def load_example(example_id):
             processed_example = self.non_none_processed_examples[example_id]
-            examples = utils.resolve_singleton(processed_example)
-
-            return (
-                update(value=examples, **self.dataset.component_props[0])
-                if not isinstance(examples, list)
-                else [
-                    update(value=ex, **self.dataset.component_props[i])
-                    for i, ex in enumerate(examples)
-                ]
-            )
+            # examples = utils.resolve_singleton(processed_example)
+            if len(self.inputs_with_examples) == 1:
+                return update(
+                    value=processed_example[0], **self.dataset.component_props[0]
+                )
+            return [
+                update(value=processed_example[i], **self.dataset.component_props[i])
+                for i in range(len(self.inputs_with_examples))
+            ]
 
         if Context.root_block:
             self.load_input_event = self.dataset.click(


### PR DESCRIPTION
Fixes: #6043 

Check by running `demo/kitchen_sink/run.py` or

```py
import gradio as gr

example_1 = [["a", "b"]]
example_2 = [["a"]]

io = gr.Interface(lambda x:x, 
                  gr.Dropdown(["a", "b"], 
                              multiselect=True), "dropdown", examples=[example_1, example_2])
io.launch()
```
