### PR TITLE
Fix selectable prop in the backend

### DIFF
--- a/.changeset/hungry-spiders-cross.md
+++ b/.changeset/hungry-spiders-cross.md
@@ -1,4 +1,9 @@
 ---
+"@gradio/chatbot": minor
+"@gradio/file": minor
+"@gradio/highlightedtext": minor
+"@gradio/image": minor
+"@gradio/label": minor
 "gradio": minor
 ---
 

--- a/.changeset/hungry-spiders-cross.md
+++ b/.changeset/hungry-spiders-cross.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix selectable prop in the backend

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -206,7 +206,7 @@ class Block:
         for e in self.events:
             to_add = e.config_data()
             if to_add:
-                config = {**config, **to_add}
+                config = {**to_add, **config}
         config.pop("_skip_init_processing", None)
         config.pop("render", None)
         return {**config, "root_url": self.root_url, "name": self.get_block_name()}

--- a/gradio/components/annotated_image.py
+++ b/gradio/components/annotated_image.py
@@ -65,6 +65,7 @@ class AnnotatedImage(Component):
         elem_classes: list[str] | str | None = None,
         render: bool = True,
         root_url: str | None = None,
+        _selectable: bool = False,
         _skip_init_processing: bool = False,
     ):
         """
@@ -85,11 +86,13 @@ class AnnotatedImage(Component):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
+            _selectable: Whether the annotated image's messages can be selected. Set automatically if the select event is used.
         """
         self.show_legend = show_legend
         self.height = height
         self.width = width
         self.color_map = color_map
+        self._selectable = _selectable
         super().__init__(
             label=label,
             every=every,

--- a/gradio/components/annotated_image.py
+++ b/gradio/components/annotated_image.py
@@ -86,7 +86,6 @@ class AnnotatedImage(Component):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
-            _selectable: Whether the annotated image's messages can be selected. Set automatically if the select event is used.
         """
         self.show_legend = show_legend
         self.height = height

--- a/gradio/components/base.py
+++ b/gradio/components/base.py
@@ -165,7 +165,7 @@ class Component(ComponentBase, Block):
             elem_classes = []
 
         # This gets overriden when `select` is called
-        self.selectable = False
+        self._selectable = False
         if not hasattr(self, "data_model"):
             self.data_model: type[GradioDataModel] | None = None
         self.temp_files: set[str] = set()

--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -24,11 +24,6 @@ class FileMessage(GradioModel):
     alt_text: Optional[str] = None
 
 
-# _Message = Annotated[List[Union[str, FileMessage, None]], Field(min_length=2, max_length=2)]
-
-# Message = TypeAdapter(_Message)
-
-
 class ChatbotData(GradioRootModel):
     root: List[Tuple[Union[str, FileMessage, None], Union[str, FileMessage, None]]]
 
@@ -76,6 +71,7 @@ class Chatbot(Component):
         bubble_full_width: bool = True,
         line_breaks: bool = True,
         layout: Literal["panel", "bubble"] | None = None,
+        selectable: bool = False,
     ):
         """
         Parameters:
@@ -102,6 +98,7 @@ class Chatbot(Component):
             bubble_full_width: If False, the chat bubble will fit to the content of the message. If True (default), the chat bubble will be the full width of the component.
             line_breaks: If True (default), will enable Github-flavored Markdown line breaks in chatbot messages. If False, single new lines will be ignored. Only applies if `render_markdown` is True.
             layout: If "panel", will display the chatbot in a llm style layout. If "bubble", will display the chatbot with message bubbles, with the user and bot messages on alterating sides. Will default to "bubble".
+            selectable: Whether the chatbot's messages can be selected. Set automatically if the select event is used.
         """
         self.likeable = False
         self.height = height

--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -71,7 +71,7 @@ class Chatbot(Component):
         bubble_full_width: bool = True,
         line_breaks: bool = True,
         layout: Literal["panel", "bubble"] | None = None,
-        selectable: bool = False,
+        _selectable: bool = False,
     ):
         """
         Parameters:
@@ -98,7 +98,7 @@ class Chatbot(Component):
             bubble_full_width: If False, the chat bubble will fit to the content of the message. If True (default), the chat bubble will be the full width of the component.
             line_breaks: If True (default), will enable Github-flavored Markdown line breaks in chatbot messages. If False, single new lines will be ignored. Only applies if `render_markdown` is True.
             layout: If "panel", will display the chatbot in a llm style layout. If "bubble", will display the chatbot with message bubbles, with the user and bot messages on alterating sides. Will default to "bubble".
-            selectable: Whether the chatbot's messages can be selected. Set automatically if the select event is used.
+            _selectable: Whether the chatbot's messages can be selected. Set automatically if the select event is used.
         """
         self.likeable = False
         self.height = height
@@ -118,6 +118,7 @@ class Chatbot(Component):
         self.bubble_full_width = bubble_full_width
         self.line_breaks = line_breaks
         self.layout = layout
+        self._selectable = _selectable
 
         super().__init__(
             label=label,

--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -98,7 +98,6 @@ class Chatbot(Component):
             bubble_full_width: If False, the chat bubble will fit to the content of the message. If True (default), the chat bubble will be the full width of the component.
             line_breaks: If True (default), will enable Github-flavored Markdown line breaks in chatbot messages. If False, single new lines will be ignored. Only applies if `render_markdown` is True.
             layout: If "panel", will display the chatbot in a llm style layout. If "bubble", will display the chatbot with message bubbles, with the user and bot messages on alterating sides. Will default to "bubble".
-            _selectable: Whether the chatbot's messages can be selected. Set automatically if the select event is used.
         """
         self.likeable = False
         self.height = height

--- a/gradio/components/checkbox.py
+++ b/gradio/components/checkbox.py
@@ -43,7 +43,7 @@ class Checkbox(FormComponent):
         render: bool = True,
         root_url: str | None = None,
         _skip_init_processing: bool = False,
-        selectable: bool = False,
+        _selectable: bool = False,
     ):
         """
         Parameters:
@@ -61,8 +61,9 @@ class Checkbox(FormComponent):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
-            selectable: Whether the checkbox emits the select event. Set automatically when the select event is used.
+            _selectable: Whether the checkbox emits the select event. Set automatically when the select event is used.
         """
+        self._selectable = _selectable
         super().__init__(
             label=label,
             info=info,

--- a/gradio/components/checkbox.py
+++ b/gradio/components/checkbox.py
@@ -61,7 +61,6 @@ class Checkbox(FormComponent):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
-            _selectable: Whether the checkbox emits the select event. Set automatically when the select event is used.
         """
         self._selectable = _selectable
         super().__init__(

--- a/gradio/components/checkbox.py
+++ b/gradio/components/checkbox.py
@@ -43,6 +43,7 @@ class Checkbox(FormComponent):
         render: bool = True,
         root_url: str | None = None,
         _skip_init_processing: bool = False,
+        selectable: bool = False,
     ):
         """
         Parameters:
@@ -60,6 +61,7 @@ class Checkbox(FormComponent):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
+            selectable: Whether the checkbox emits the select event. Set automatically when the select event is used.
         """
         super().__init__(
             label=label,

--- a/gradio/components/checkboxgroup.py
+++ b/gradio/components/checkboxgroup.py
@@ -44,7 +44,7 @@ class CheckboxGroup(FormComponent):
         render: bool = True,
         root_url: str | None = None,
         _skip_init_processing: bool = False,
-        selectable: bool = False,
+        _selectable: bool = False,
     ):
         """
         Parameters:
@@ -64,9 +64,9 @@ class CheckboxGroup(FormComponent):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
-            selectable: Whether the select event is used. Set automatically.
+            _selectable: Whether the checkbox emits the select event. Set automatically when the select event is used.
         """
-        self.selectable = selectable
+        self._selectable = _selectable
         self.choices = (
             # Although we expect choices to be a list of tuples, it can be a list of tuples if the Gradio app
             # is loaded with gr.load() since Python tuples are converted to lists in JSON.

--- a/gradio/components/checkboxgroup.py
+++ b/gradio/components/checkboxgroup.py
@@ -44,6 +44,7 @@ class CheckboxGroup(FormComponent):
         render: bool = True,
         root_url: str | None = None,
         _skip_init_processing: bool = False,
+        selectable: bool = False,
     ):
         """
         Parameters:
@@ -63,7 +64,9 @@ class CheckboxGroup(FormComponent):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
+            selectable: Whether the select event is used. Set automatically.
         """
+        self.selectable = selectable
         self.choices = (
             # Although we expect choices to be a list of tuples, it can be a list of tuples if the Gradio app
             # is loaded with gr.load() since Python tuples are converted to lists in JSON.

--- a/gradio/components/checkboxgroup.py
+++ b/gradio/components/checkboxgroup.py
@@ -64,7 +64,6 @@ class CheckboxGroup(FormComponent):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
-            _selectable: Whether the checkbox emits the select event. Set automatically when the select event is used.
         """
         self._selectable = _selectable
         self.choices = (

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -102,7 +102,6 @@ class Dataframe(Component):
             wrap: If True, the text in table cells will wrap when appropriate. If False and the `column_width` parameter is not set, the column widths will expand based on the cell contents and the table may need to be horizontally scrolled. If `column_width` is set, then any overflow text will be hidden.
             line_breaks: If True (default), will enable Github-flavored Markdown line breaks in chatbot messages. If False, single new lines will be ignored. Only applies for columns of type "markdown."
             column_widths: An optional list representing the width of each column. The elements of the list should be in the format "100px" (ints are also accepted and converted to pixel values) or "10%". If not provided, the column widths will be automatically determined based on the content of the cells. Setting this parameter will cause the browser to try to fit the table within the page width.
-            _selectable: Whether the dataframe can be selected. Set automatically if the select event is used.
         """
         self._selectable = _selectable
         self.wrap = wrap

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -75,6 +75,7 @@ class Dataframe(Component):
         wrap: bool = False,
         line_breaks: bool = True,
         column_widths: list[str | int] | None = None,
+        selectable: bool = False,
     ):
         """
         Parameters:
@@ -101,8 +102,9 @@ class Dataframe(Component):
             wrap: If True, the text in table cells will wrap when appropriate. If False and the `column_width` parameter is not set, the column widths will expand based on the cell contents and the table may need to be horizontally scrolled. If `column_width` is set, then any overflow text will be hidden.
             line_breaks: If True (default), will enable Github-flavored Markdown line breaks in chatbot messages. If False, single new lines will be ignored. Only applies for columns of type "markdown."
             column_widths: An optional list representing the width of each column. The elements of the list should be in the format "100px" (ints are also accepted and converted to pixel values) or "10%". If not provided, the column widths will be automatically determined based on the content of the cells. Setting this parameter will cause the browser to try to fit the table within the page width.
+            selectable: Whether the dataframe can be selected. Set automatically if the select event is used.
         """
-
+        self.selectable = selectable
         self.wrap = wrap
         self.row_count = self.__process_counts(row_count)
         self.col_count = self.__process_counts(

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -75,7 +75,7 @@ class Dataframe(Component):
         wrap: bool = False,
         line_breaks: bool = True,
         column_widths: list[str | int] | None = None,
-        selectable: bool = False,
+        _selectable: bool = False,
     ):
         """
         Parameters:
@@ -102,9 +102,9 @@ class Dataframe(Component):
             wrap: If True, the text in table cells will wrap when appropriate. If False and the `column_width` parameter is not set, the column widths will expand based on the cell contents and the table may need to be horizontally scrolled. If `column_width` is set, then any overflow text will be hidden.
             line_breaks: If True (default), will enable Github-flavored Markdown line breaks in chatbot messages. If False, single new lines will be ignored. Only applies for columns of type "markdown."
             column_widths: An optional list representing the width of each column. The elements of the list should be in the format "100px" (ints are also accepted and converted to pixel values) or "10%". If not provided, the column widths will be automatically determined based on the content of the cells. Setting this parameter will cause the browser to try to fit the table within the page width.
-            selectable: Whether the dataframe can be selected. Set automatically if the select event is used.
+            _selectable: Whether the dataframe can be selected. Set automatically if the select event is used.
         """
-        self.selectable = selectable
+        self._selectable = _selectable
         self.wrap = wrap
         self.row_count = self.__process_counts(row_count)
         self.col_count = self.__process_counts(

--- a/gradio/components/dataset.py
+++ b/gradio/components/dataset.py
@@ -44,6 +44,7 @@ class Dataset(Component):
         container: bool = True,
         scale: int | None = None,
         min_width: int = 160,
+        selectable: bool = False,
     ):
         """
         Parameters:
@@ -60,6 +61,7 @@ class Dataset(Component):
             container: If True, will place the component in a container - providing some extra padding around the border.
             scale: relative width compared to adjacent Components in a Row. For example, if Component A has scale=2, and Component B has scale=1, A will be twice as wide as B. Should be an integer.
             min_width: minimum pixel width, will wrap if not sufficient screen space to satisfy this value. If a certain scale value results in this Component being narrower than min_width, the min_width parameter will be respected first.
+            selectable: Whether the dataset can be selected. Set automatically if the select event is used.
         """
         super().__init__(
             visible=visible,
@@ -69,6 +71,7 @@ class Dataset(Component):
             _skip_init_processing=_skip_init_processing,
             render=render,
         )
+        self.selectable = selectable
         self.container = container
         self.scale = scale
         self.min_width = min_width

--- a/gradio/components/dataset.py
+++ b/gradio/components/dataset.py
@@ -61,7 +61,6 @@ class Dataset(Component):
             container: If True, will place the component in a container - providing some extra padding around the border.
             scale: relative width compared to adjacent Components in a Row. For example, if Component A has scale=2, and Component B has scale=1, A will be twice as wide as B. Should be an integer.
             min_width: minimum pixel width, will wrap if not sufficient screen space to satisfy this value. If a certain scale value results in this Component being narrower than min_width, the min_width parameter will be respected first.
-            _selectable: Whether the dataset can be selected. Set automatically if the select event is used.
         """
         super().__init__(
             visible=visible,

--- a/gradio/components/dataset.py
+++ b/gradio/components/dataset.py
@@ -44,7 +44,7 @@ class Dataset(Component):
         container: bool = True,
         scale: int | None = None,
         min_width: int = 160,
-        selectable: bool = False,
+        _selectable: bool = False,
     ):
         """
         Parameters:
@@ -61,7 +61,7 @@ class Dataset(Component):
             container: If True, will place the component in a container - providing some extra padding around the border.
             scale: relative width compared to adjacent Components in a Row. For example, if Component A has scale=2, and Component B has scale=1, A will be twice as wide as B. Should be an integer.
             min_width: minimum pixel width, will wrap if not sufficient screen space to satisfy this value. If a certain scale value results in this Component being narrower than min_width, the min_width parameter will be respected first.
-            selectable: Whether the dataset can be selected. Set automatically if the select event is used.
+            _selectable: Whether the dataset can be selected. Set automatically if the select event is used.
         """
         super().__init__(
             visible=visible,
@@ -71,7 +71,7 @@ class Dataset(Component):
             _skip_init_processing=_skip_init_processing,
             render=render,
         )
-        self.selectable = selectable
+        self._selectable = _selectable
         self.container = container
         self.scale = scale
         self.min_width = min_width

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -48,6 +48,7 @@ class Dropdown(FormComponent):
         elem_classes: list[str] | str | None = None,
         render: bool = True,
         root_url: str | None = None,
+        selectable: bool = False,
         _skip_init_processing: bool = False,
     ):
         """
@@ -72,7 +73,9 @@ class Dropdown(FormComponent):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
+            selectable: Whether the dropdown emits the select event. Set automatically when the select event is used.
         """
+        self.selectable = selectable
         self.choices = (
             # Although we expect choices to be a list of tuples, it can be a list of tuples if the Gradio app
             # is loaded with gr.load() since Python tuples are converted to lists in JSON.

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -48,7 +48,7 @@ class Dropdown(FormComponent):
         elem_classes: list[str] | str | None = None,
         render: bool = True,
         root_url: str | None = None,
-        selectable: bool = False,
+        _selectable: bool = False,
         _skip_init_processing: bool = False,
     ):
         """
@@ -73,9 +73,9 @@ class Dropdown(FormComponent):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
-            selectable: Whether the dropdown emits the select event. Set automatically when the select event is used.
+            _selectable: Whether the dropdown emits the select event. Set automatically when the select event is used.
         """
-        self.selectable = selectable
+        self._selectable = _selectable
         self.choices = (
             # Although we expect choices to be a list of tuples, it can be a list of tuples if the Gradio app
             # is loaded with gr.load() since Python tuples are converted to lists in JSON.

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -73,7 +73,6 @@ class Dropdown(FormComponent):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
-            _selectable: Whether the dropdown emits the select event. Set automatically when the select event is used.
         """
         self._selectable = _selectable
         self.choices = (

--- a/gradio/components/file.py
+++ b/gradio/components/file.py
@@ -53,7 +53,7 @@ class File(Component):
         elem_classes: list[str] | str | None = None,
         render: bool = True,
         root_url: str | None = None,
-        selectable: bool = False,
+        _selectable: bool = False,
         _skip_init_processing: bool = False,
     ):
         """
@@ -75,9 +75,9 @@ class File(Component):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
-            selectable: Whether the file can be selected. Set automatically if the select event is used.
+            _selectable: Whether the file can be selected. Set automatically if the select event is used.
         """
-        self.selectable = selectable
+        self._selectable = _selectable
         self.file_count = file_count
         if self.file_count == "multiple":
             self.data_model = ListFiles

--- a/gradio/components/file.py
+++ b/gradio/components/file.py
@@ -53,6 +53,7 @@ class File(Component):
         elem_classes: list[str] | str | None = None,
         render: bool = True,
         root_url: str | None = None,
+        selectable: bool = False,
         _skip_init_processing: bool = False,
     ):
         """
@@ -74,7 +75,9 @@ class File(Component):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
+            selectable: Whether the file can be selected. Set automatically if the select event is used.
         """
+        self.selectable = selectable
         self.file_count = file_count
         if self.file_count == "multiple":
             self.data_model = ListFiles

--- a/gradio/components/file.py
+++ b/gradio/components/file.py
@@ -75,7 +75,6 @@ class File(Component):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
-            _selectable: Whether the file can be selected. Set automatically if the select event is used.
         """
         self._selectable = _selectable
         self.file_count = file_count

--- a/gradio/components/gallery.py
+++ b/gradio/components/gallery.py
@@ -68,6 +68,7 @@ class Gallery(Component):
         | None = None,
         show_share_button: bool | None = None,
         show_download_button: bool | None = True,
+        selectable: bool = False,
     ):
         """
         Parameters:
@@ -92,8 +93,9 @@ class Gallery(Component):
             object_fit: CSS object-fit property for the thumbnail images in the gallery. Can be "contain", "cover", "fill", "none", or "scale-down".
             show_share_button: If True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
             show_download_button: If True, will show a download button in the corner of the selected image. If False, the icon does not appear. Default is True.
-
+            selectable: Whether the gallery can be selected. Set automatically if the select event is used.
         """
+        self.selectable = selectable
         self.columns = columns
         self.rows = rows
         self.height = height

--- a/gradio/components/gallery.py
+++ b/gradio/components/gallery.py
@@ -93,7 +93,6 @@ class Gallery(Component):
             object_fit: CSS object-fit property for the thumbnail images in the gallery. Can be "contain", "cover", "fill", "none", or "scale-down".
             show_share_button: If True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
             show_download_button: If True, will show a download button in the corner of the selected image. If False, the icon does not appear. Default is True.
-            _selectable: Whether the gallery can be selected. Set automatically if the select event is used.
         """
         self._selectable = _selectable
         self.columns = columns

--- a/gradio/components/gallery.py
+++ b/gradio/components/gallery.py
@@ -68,7 +68,7 @@ class Gallery(Component):
         | None = None,
         show_share_button: bool | None = None,
         show_download_button: bool | None = True,
-        selectable: bool = False,
+        _selectable: bool = False,
     ):
         """
         Parameters:
@@ -93,9 +93,9 @@ class Gallery(Component):
             object_fit: CSS object-fit property for the thumbnail images in the gallery. Can be "contain", "cover", "fill", "none", or "scale-down".
             show_share_button: If True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
             show_download_button: If True, will show a download button in the corner of the selected image. If False, the icon does not appear. Default is True.
-            selectable: Whether the gallery can be selected. Set automatically if the select event is used.
+            _selectable: Whether the gallery can be selected. Set automatically if the select event is used.
         """
-        self.selectable = selectable
+        self._selectable = _selectable
         self.columns = columns
         self.rows = rows
         self.height = height

--- a/gradio/components/highlighted_text.py
+++ b/gradio/components/highlighted_text.py
@@ -79,7 +79,6 @@ class HighlightedText(Component):
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
             interactive: If True, the component will be editable, and allow user to select spans of text and label them.
-            _selectable: Whether the highlighted text can be selected. Set automatically if the select event is used.
         """
         self._selectable = _selectable
         self.color_map = color_map

--- a/gradio/components/highlighted_text.py
+++ b/gradio/components/highlighted_text.py
@@ -58,6 +58,7 @@ class HighlightedText(Component):
         root_url: str | None = None,
         _skip_init_processing: bool = False,
         interactive: bool | None = None,
+        selectable: bool = False,
     ):
         """
         Parameters:
@@ -78,8 +79,9 @@ class HighlightedText(Component):
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
             interactive: If True, the component will be editable, and allow user to select spans of text and label them.
-
+            selectable: Whether the highlighted text can be selected. Set automatically if the select event is used.
         """
+        self.selectable = selectable
         self.color_map = color_map
         self.show_legend = show_legend
         self.combine_adjacent = combine_adjacent

--- a/gradio/components/highlighted_text.py
+++ b/gradio/components/highlighted_text.py
@@ -58,7 +58,7 @@ class HighlightedText(Component):
         root_url: str | None = None,
         _skip_init_processing: bool = False,
         interactive: bool | None = None,
-        selectable: bool = False,
+        _selectable: bool = False,
     ):
         """
         Parameters:
@@ -79,9 +79,9 @@ class HighlightedText(Component):
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
             interactive: If True, the component will be editable, and allow user to select spans of text and label them.
-            selectable: Whether the highlighted text can be selected. Set automatically if the select event is used.
+            _selectable: Whether the highlighted text can be selected. Set automatically if the select event is used.
         """
-        self.selectable = selectable
+        self._selectable = _selectable
         self.color_map = color_map
         self.show_legend = show_legend
         self.combine_adjacent = combine_adjacent

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -73,7 +73,7 @@ class Image(StreamingInput, Component):
         _skip_init_processing: bool = False,
         mirror_webcam: bool = True,
         show_share_button: bool | None = None,
-        selectable: bool = False,
+        _selectable: bool = False,
     ):
         """
         Parameters:
@@ -101,7 +101,7 @@ class Image(StreamingInput, Component):
             show_share_button: If True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
             _selectable: Whether the image can be selected. Set automatically if the select event is used.
         """
-        self._selectable = selectable
+        self._selectable = _selectable
         self.mirror_webcam = mirror_webcam
         valid_types = ["numpy", "pil", "filepath"]
         if type not in valid_types:

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -73,6 +73,7 @@ class Image(StreamingInput, Component):
         _skip_init_processing: bool = False,
         mirror_webcam: bool = True,
         show_share_button: bool | None = None,
+        selectable: bool = False,
     ):
         """
         Parameters:
@@ -98,8 +99,9 @@ class Image(StreamingInput, Component):
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
             mirror_webcam: If True webcam will be mirrored. Default is True.
             show_share_button: If True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
+            _selectable: Whether the image can be selected. Set automatically if the select event is used.
         """
-
+        self._selectable = selectable
         self.mirror_webcam = mirror_webcam
         valid_types = ["numpy", "pil", "filepath"]
         if type not in valid_types:

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -99,7 +99,6 @@ class Image(StreamingInput, Component):
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
             mirror_webcam: If True webcam will be mirrored. Default is True.
             show_share_button: If True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
-            _selectable: Whether the image can be selected. Set automatically if the select event is used.
         """
         self._selectable = _selectable
         self.mirror_webcam = mirror_webcam

--- a/gradio/components/label.py
+++ b/gradio/components/label.py
@@ -77,7 +77,6 @@ class Label(Component):
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
             color: The background color of the label (either a valid css color name or hexadecimal string).
-            _selectable: Whether the label can be selected. Set automatically if the select event is used.
         """
         self._selectable = _selectable
         self.num_top_classes = num_top_classes

--- a/gradio/components/label.py
+++ b/gradio/components/label.py
@@ -59,7 +59,7 @@ class Label(Component):
         root_url: str | None = None,
         _skip_init_processing: bool = False,
         color: str | None = None,
-        selectable: bool = False,
+        _selectable: bool = False,
     ):
         """
         Parameters:
@@ -77,9 +77,9 @@ class Label(Component):
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
             color: The background color of the label (either a valid css color name or hexadecimal string).
-            selectable: Whether the label can be selected. Set automatically if the select event is used.
+            _selectable: Whether the label can be selected. Set automatically if the select event is used.
         """
-        self.selectable = selectable
+        self._selectable = _selectable
         self.num_top_classes = num_top_classes
         self.color = color
         super().__init__(

--- a/gradio/components/label.py
+++ b/gradio/components/label.py
@@ -59,6 +59,7 @@ class Label(Component):
         root_url: str | None = None,
         _skip_init_processing: bool = False,
         color: str | None = None,
+        selectable: bool = False,
     ):
         """
         Parameters:
@@ -76,7 +77,9 @@ class Label(Component):
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
             color: The background color of the label (either a valid css color name or hexadecimal string).
+            selectable: Whether the label can be selected. Set automatically if the select event is used.
         """
+        self.selectable = selectable
         self.num_top_classes = num_top_classes
         self.color = color
         super().__init__(

--- a/gradio/components/radio.py
+++ b/gradio/components/radio.py
@@ -44,7 +44,7 @@ class Radio(FormComponent):
         elem_classes: list[str] | str | None = None,
         render: bool = True,
         root_url: str | None = None,
-        selectable: bool = False,
+        _selectable: bool = False,
         _skip_init_processing: bool = False,
     ):
         """
@@ -65,7 +65,7 @@ class Radio(FormComponent):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
-            selectable: Whether the radio buttons can be selected. Set automatically if the select event is used.
+            _selectable: Whether the radio buttons can be selected. Set automatically if the select event is used.
         """
         self.choices = (
             # Although we expect choices to be a list of tuples, it can be a list of tuples if the Gradio app
@@ -80,6 +80,7 @@ class Radio(FormComponent):
                 f"Invalid value for parameter `type`: {type}. Please choose from one of: {valid_types}"
             )
         self.type = type
+        self._selectable = _selectable
         super().__init__(
             label=label,
             info=info,

--- a/gradio/components/radio.py
+++ b/gradio/components/radio.py
@@ -65,7 +65,6 @@ class Radio(FormComponent):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
-            _selectable: Whether the radio buttons can be selected. Set automatically if the select event is used.
         """
         self.choices = (
             # Although we expect choices to be a list of tuples, it can be a list of tuples if the Gradio app

--- a/gradio/components/radio.py
+++ b/gradio/components/radio.py
@@ -44,6 +44,7 @@ class Radio(FormComponent):
         elem_classes: list[str] | str | None = None,
         render: bool = True,
         root_url: str | None = None,
+        selectable: bool = False,
         _skip_init_processing: bool = False,
     ):
         """
@@ -64,6 +65,7 @@ class Radio(FormComponent):
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             root_url: The remote URL that of the Gradio app that this component belongs to. Used in `gr.load()`. Should not be set manually.
+            selectable: Whether the radio buttons can be selected. Set automatically if the select event is used.
         """
         self.choices = (
             # Although we expect choices to be a list of tuples, it can be a list of tuples if the Gradio app

--- a/gradio/components/textbox.py
+++ b/gradio/components/textbox.py
@@ -62,7 +62,7 @@ class Textbox(FormComponent):
         text_align: Literal["left", "right"] | None = None,
         rtl: bool = False,
         show_copy_button: bool = False,
-        selectable: bool = False,
+        _selectable: bool = False,
     ):
         """
         Parameters:
@@ -89,9 +89,9 @@ class Textbox(FormComponent):
             rtl: If True and `type` is "text", sets the direction of the text to right-to-left (cursor appears on the left of the text). Default is False, which renders cursor on the right.
             show_copy_button: If True, includes a copy button to copy the text in the textbox. Only applies if show_label is True.
             autoscroll: If True, will automatically scroll to the bottom of the textbox when the value changes, unless the user scrolls up. If False, will not scroll to the bottom of the textbox when the value changes.
-            selectable: Whether the textbox can be selected. Set automatically if the select event is used.
+            _selectable: Whether the textbox can be selected. Set automatically if the select event is used.
         """
-        self.selectable = selectable
+        self._selectable = _selectable
         if type not in ["text", "password", "email"]:
             raise ValueError('`type` must be one of "text", "password", or "email".')
 

--- a/gradio/components/textbox.py
+++ b/gradio/components/textbox.py
@@ -89,7 +89,6 @@ class Textbox(FormComponent):
             rtl: If True and `type` is "text", sets the direction of the text to right-to-left (cursor appears on the left of the text). Default is False, which renders cursor on the right.
             show_copy_button: If True, includes a copy button to copy the text in the textbox. Only applies if show_label is True.
             autoscroll: If True, will automatically scroll to the bottom of the textbox when the value changes, unless the user scrolls up. If False, will not scroll to the bottom of the textbox when the value changes.
-            _selectable: Whether the textbox can be selected. Set automatically if the select event is used.
         """
         self._selectable = _selectable
         if type not in ["text", "password", "email"]:

--- a/gradio/components/textbox.py
+++ b/gradio/components/textbox.py
@@ -62,6 +62,7 @@ class Textbox(FormComponent):
         text_align: Literal["left", "right"] | None = None,
         rtl: bool = False,
         show_copy_button: bool = False,
+        selectable: bool = False,
     ):
         """
         Parameters:
@@ -88,7 +89,9 @@ class Textbox(FormComponent):
             rtl: If True and `type` is "text", sets the direction of the text to right-to-left (cursor appears on the left of the text). Default is False, which renders cursor on the right.
             show_copy_button: If True, includes a copy button to copy the text in the textbox. Only applies if show_label is True.
             autoscroll: If True, will automatically scroll to the bottom of the textbox when the value changes, unless the user scrolls up. If False, will not scroll to the bottom of the textbox when the value changes.
+            selectable: Whether the textbox can be selected. Set automatically if the select event is used.
         """
+        self.selectable = selectable
         if type not in ["text", "password", "email"]:
             raise ValueError('`type` must be one of "text", "password", or "email".')
 

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -28,9 +28,7 @@ def set_cancel_events(
         cancel_fn, fn_indices_to_cancel = get_cancel_function(cancels)
 
         if Context.root_block is None:
-            raise AttributeError(
-                "Cannot cancel {self.event_name} outside of a gradio.Blocks context."
-            )
+            raise AttributeError("Cannot cancel outside of a gradio.Blocks context.")
 
         Context.root_block.set_event_trigger(
             triggers,

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -117,7 +117,7 @@ class SelectData(EventData):
         """
         The value of the selected item.
         """
-        self.selected: bool = data.get("selected", True)
+        self.selected: bool = data.get("_selected", True)
         """
         True if the item was selected, False if deselected.
         """
@@ -487,7 +487,6 @@ class Events:
     )
     select = EventListener(
         "select",
-        config_data=lambda: {"selectable": False},
         callback=lambda block: setattr(block, "selectable", True),
         doc="Event listener for when the user selects or deselects the {{ component }}. Uses event data gradio.SelectData to carry `value` referring to the label of the {{ component }}, and `selected` to refer to state of the {{ component }}. See EventData documentation on how to use this event data",
     )

--- a/js/chatbot/Index.svelte
+++ b/js/chatbot/Index.svelte
@@ -22,7 +22,7 @@
 	export let show_label = true;
 	export let root: string;
 	export let root_url: null | string;
-	export let selectable = false;
+	export let _selectable = false;
 	export let likeable = false;
 	export let show_share_button = false;
 	export let rtl = false;
@@ -112,7 +112,7 @@
 		{/if}
 		<ChatBot
 			i18n={gradio.i18n}
-			{selectable}
+			selectable={_selectable}
 			{likeable}
 			{show_share_button}
 			value={_value}

--- a/js/file/Index.svelte
+++ b/js/file/Index.svelte
@@ -27,7 +27,7 @@
 	export let height: number | undefined = undefined;
 
 	export let root_url: null | string;
-	export let selectable = false;
+	export let _selectable = false;
 	export let loading_status: LoadingStatus;
 	export let container = true;
 	export let scale: number | null = null;
@@ -76,7 +76,7 @@
 	{#if mode === "static"}
 		<File
 			on:select={({ detail }) => gradio.dispatch("select", detail)}
-			{selectable}
+			selectable={_selectable}
 			value={_value}
 			{label}
 			{show_label}
@@ -90,7 +90,7 @@
 			value={_value}
 			{file_count}
 			{file_types}
-			{selectable}
+			selectable={_selectable}
 			{root}
 			{height}
 			on:change={({ detail }) => {

--- a/js/highlightedtext/Index.svelte
+++ b/js/highlightedtext/Index.svelte
@@ -118,7 +118,7 @@
 			<InteractiveHighlightedText
 				bind:value
 				on:change={() => gradio.dispatch("change")}
-				{selectable}
+				selectable={_selectable}
 				{show_legend}
 				{color_map}
 			/>

--- a/js/highlightedtext/Index.svelte
+++ b/js/highlightedtext/Index.svelte
@@ -26,7 +26,7 @@
 	export let container = true;
 	export let scale: number | null = null;
 	export let min_width: number | undefined = undefined;
-	export let selectable = false;
+	export let _selectable = false;
 	export let combine_adjacent = false;
 	export let mode: "static" | "interactive";
 
@@ -77,7 +77,7 @@
 		{#if value}
 			<StaticHighlightedText
 				on:select={({ detail }) => gradio.dispatch("select", detail)}
-				{selectable}
+				selectable={_selectable}
 				{value}
 				{show_legend}
 				{color_map}

--- a/js/image/Index.svelte
+++ b/js/image/Index.svelte
@@ -27,7 +27,7 @@
 	export let height: number | undefined;
 	export let width: number | undefined;
 
-	export let selectable = false;
+	export let _selectable = false;
 	export let container = true;
 	export let scale: number | null = null;
 	export let min_width: number | undefined = undefined;
@@ -94,7 +94,7 @@
 			{label}
 			{show_label}
 			{show_download_button}
-			{selectable}
+			selecatble={_selectable}
 			{show_share_button}
 			i18n={gradio.i18n}
 		/>
@@ -123,7 +123,7 @@
 		<ImageUploader
 			bind:active_tool
 			bind:value
-			{selectable}
+			selectable={_selectable}
 			{root}
 			{sources}
 			on:edit={() => gradio.dispatch("edit")}

--- a/js/image/Index.svelte
+++ b/js/image/Index.svelte
@@ -94,7 +94,7 @@
 			{label}
 			{show_label}
 			{show_download_button}
-			selecatble={_selectable}
+			selectable={_selectable}
 			{show_share_button}
 			i18n={gradio.i18n}
 		/>

--- a/js/label/Index.svelte
+++ b/js/label/Index.svelte
@@ -24,7 +24,7 @@
 	export let min_width: number | undefined = undefined;
 	export let loading_status: LoadingStatus;
 	export let show_label = true;
-	export let selectable = false;
+	export let _selectable = false;
 
 	$: ({ confidences, label: _label } = value);
 	$: _label, confidences, gradio.dispatch("change");
@@ -51,7 +51,7 @@
 	{#if _label !== undefined && _label !== null}
 		<Label
 			on:select={({ detail }) => gradio.dispatch("select", detail)}
-			{selectable}
+			selectable={_selectable}
 			{value}
 			{color}
 		/>

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -90,7 +90,7 @@ class TestTextbox:
             "rtl": False,
             "text_align": None,
             "autofocus": False,
-            "selectable": False,
+            "_selectable": False,
             "info": None,
             "autoscroll": True,
         }
@@ -339,7 +339,7 @@ class TestCheckbox:
             "visible": True,
             "interactive": None,
             "root_url": None,
-            "selectable": False,
+            "_selectable": False,
             "info": None,
         }
 
@@ -389,7 +389,7 @@ class TestCheckboxGroup:
             "visible": True,
             "interactive": None,
             "root_url": None,
-            "selectable": False,
+            "_selectable": False,
             "type": "value",
             "info": None,
         }
@@ -439,7 +439,7 @@ class TestRadio:
             "visible": True,
             "interactive": None,
             "root_url": None,
-            "selectable": False,
+            "_selectable": False,
             "type": "value",
             "info": None,
         }
@@ -523,7 +523,7 @@ class TestDropdown:
             "multiselect": True,
             "filterable": True,
             "max_choices": 2,
-            "selectable": False,
+            "_selectable": False,
             "type": "value",
             "info": None,
         }
@@ -582,7 +582,7 @@ class TestImage:
             "interactive": None,
             "root_url": None,
             "mirror_webcam": True,
-            "selectable": False,
+            "_selectable": False,
             "streamable": False,
             "type": "pil",
         }
@@ -873,7 +873,7 @@ class TestFile:
             "value": None,
             "interactive": None,
             "root_url": None,
-            "selectable": False,
+            "_selectable": False,
             "height": None,
             "type": "filepath",
         }
@@ -971,7 +971,7 @@ class TestDataframe:
                 "data": [["", "", ""]],
                 "metadata": None,
             },
-            "selectable": False,
+            "_selectable": False,
             "headers": ["Name", "Age", "Member"],
             "row_count": (1, "dynamic"),
             "col_count": (3, "dynamic"),
@@ -1006,7 +1006,7 @@ class TestDataframe:
                 "data": [["", "", ""]],
                 "metadata": None,
             },
-            "selectable": False,
+            "_selectable": False,
             "headers": ["1", "2", "3"],
             "row_count": (1, "dynamic"),
             "col_count": (3, "dynamic"),
@@ -1572,7 +1572,7 @@ class TestLabel:
             "visible": True,
             "root_url": None,
             "color": None,
-            "selectable": False,
+            "_selectable": False,
         }
 
     def test_color_argument(self):
@@ -1713,7 +1713,7 @@ class TestHighlightedText:
             "visible": True,
             "value": None,
             "root_url": None,
-            "selectable": False,
+            "_selectable": False,
             "combine_adjacent": False,
             "adjacent_separator": "",
             "interactive": None,
@@ -1791,7 +1791,7 @@ class TestAnnotatedImage:
             "visible": True,
             "value": None,
             "root_url": None,
-            "selectable": False,
+            "_selectable": False,
         }
 
     def test_in_interface(self):
@@ -1851,7 +1851,7 @@ class TestChatbot:
             "scale": None,
             "height": None,
             "root_url": None,
-            "selectable": False,
+            "_selectable": False,
             "latex_delimiters": [{"display": True, "left": "$$", "right": "$$"}],
             "likeable": False,
             "rtl": False,


### PR DESCRIPTION
## Description

The selectable prop was not properly being set in the config in the backend.

This fixes that. We need to add `selectable` to the init for `gr.load` to work. This is a bug on main actually. If you `gr.load("spaces/gradio/tictactoe")`, the dataframe's selectable prop will be `False`

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
