### PR TITLE
Small change to make `api_open=False` by default

### DIFF
--- a/.changeset/deep-spies-rhyme.md
+++ b/.changeset/deep-spies-rhyme.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Small change to make `api_open=False` by default

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -534,7 +534,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
         self.share_url = None
         self.width = None
         self.height = None
-        self.api_open = True
+        self.api_open = False
 
         self.space_id = utils.get_space()
         self.favicon_path = None
@@ -1586,7 +1586,7 @@ Received outputs:
         self,
         concurrency_count: int = 1,
         status_update_rate: float | Literal["auto"] = "auto",
-        api_open: bool = True,
+        api_open: bool = False,
         max_size: int | None = None,
     ):
         """

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -553,6 +553,7 @@ class App(FastAPI):
                 fn_index_inferred
             ):
                 raise HTTPException(
+                    detail="This API endpoint does not accept direct HTTP POST requests. Please join the queue to use this API.",
                     status_code=status.HTTP_404_NOT_FOUND,
                 )
 

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -170,7 +170,7 @@ class TestRoutes:
             btn = gr.Button()
             btn.click(batch_fn, inputs=text, outputs=text, batch=True, api_name="pred")
 
-        demo.queue()
+        demo.queue(api_open=True)
         app, _, _ = demo.launch(prevent_thread_lock=True)
         client = TestClient(app)
         response = client.post("/api/pred/", json={"data": ["test"]})
@@ -556,7 +556,7 @@ class TestPassingRequest:
 
         app, _, _ = (
             gr.ChatInterface(identity)
-            .queue()
+            .queue(api_open=True)
             .launch(
                 prevent_thread_lock=True,
             )


### PR DESCRIPTION
Closes: #3947

Test with (new default):

```py
import gradio as gr
import requests

_, url, _ = gr.Interface(lambda x:x, "textbox", "textbox").queue().launch(inline=False)

r = requests.post(url + "run/predict", json={ "data": [ "abc" ], "event_data":  None, "fn_index": 0, "session_hash": "nxml3nqiic9" })
r.json()
```

vs.

```py
import gradio as gr
import requests

_, url, _ = gr.Interface(lambda x:x, "textbox", "textbox").queue(api_open=True).launch(inline=False)

r = requests.post(url + "run/predict", json={ "data": [ "abc" ], "event_data":  None, "fn_index": 0, "session_hash": "nxml3nqiic9" })
r.json()

```