### PR TITLE
Moves `gradio_cached_folder` inside the gradio temp direcotry

### DIFF
--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -32,7 +32,6 @@ from huggingface_hub.utils import (
 from packaging import version
 
 from gradio_client import serializing, utils
-from gradio_client.client import DEFAULT_TEMP_DIR
 from gradio_client.documentation import document, set_documentation_group
 from gradio_client.exceptions import SerializationSetupError
 from gradio_client.utils import (
@@ -45,6 +44,9 @@ from gradio_client.utils import (
 set_documentation_group("py-client")
 
 
+DEFAULT_TEMP_DIR = os.environ.get("GRADIO_TEMP_DIR") or str(
+    Path(tempfile.gettempdir()) / "gradio"
+)
 
 
 @document("predict", "submit", "view_api", "duplicate", "deploy_discord")

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -32,6 +32,7 @@ from huggingface_hub.utils import (
 from packaging import version
 
 from gradio_client import serializing, utils
+from gradio_client.client import DEFAULT_TEMP_DIR
 from gradio_client.documentation import document, set_documentation_group
 from gradio_client.exceptions import SerializationSetupError
 from gradio_client.utils import (
@@ -44,9 +45,6 @@ from gradio_client.utils import (
 set_documentation_group("py-client")
 
 
-DEFAULT_TEMP_DIR = os.environ.get("GRADIO_TEMP_DIR") or str(
-    Path(tempfile.gettempdir()) / "gradio"
-)
 
 
 @document("predict", "submit", "view_api", "duplicate", "deploy_discord")

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -20,6 +20,7 @@ import numpy as np
 import PIL
 import PIL.Image
 from gradio_client import utils as client_utils
+from gradio_client.client import DEFAULT_TEMP_DIR
 from gradio_client.documentation import document, set_documentation_group
 from matplotlib import animation
 
@@ -33,7 +34,7 @@ from gradio.flagging import CSVLogger
 if TYPE_CHECKING:  # Only import for type checking (to avoid circular imports).
     from gradio.components import Component
 
-CACHED_FOLDER = "gradio_cached_examples"
+CACHED_FOLDER = Path(DEFAULT_TEMP_DIR) / "cached_examples"
 LOG_FILE = "log.csv"
 
 set_documentation_group("helpers")

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -20,7 +20,6 @@ import numpy as np
 import PIL
 import PIL.Image
 from gradio_client import utils as client_utils
-from gradio_client.client import DEFAULT_TEMP_DIR
 from gradio_client.documentation import document, set_documentation_group
 from matplotlib import animation
 
@@ -34,7 +33,7 @@ from gradio.flagging import CSVLogger
 if TYPE_CHECKING:  # Only import for type checking (to avoid circular imports).
     from gradio.components import Component
 
-CACHED_FOLDER = Path(DEFAULT_TEMP_DIR) / "cached_examples"
+CACHED_FOLDER = "gradio_cached_examples"
 LOG_FILE = "log.csv"
 
 set_documentation_group("helpers")

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -448,9 +448,13 @@ class App(FastAPI):
                 for allowed_path in blocks.allowed_paths
             )
             was_uploaded = utils.is_in_or_equal(abs_path, app.uploaded_file_dir)
-            is_cached_example = utils.is_in_or_equal(abs_path, utils.abspath(CACHED_FOLDER))
+            is_cached_example = utils.is_in_or_equal(
+                abs_path, utils.abspath(CACHED_FOLDER)
+            )
 
-            if not (created_by_app or in_allowlist or was_uploaded or is_cached_example):
+            if not (
+                created_by_app or in_allowlist or was_uploaded or is_cached_example
+            ):
                 raise HTTPException(403, f"File not allowed: {path_or_url}.")
 
             if not abs_path.exists():

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -53,6 +53,7 @@ from gradio import route_utils, utils, wasm_utils
 from gradio.context import Context
 from gradio.data_classes import ComponentServerBody, PredictBody, ResetBody
 from gradio.exceptions import Error
+from gradio.helpers import CACHED_FOLDER
 from gradio.oauth import attach_oauth
 from gradio.queueing import Estimation, Event
 from gradio.route_utils import (  # noqa: F401
@@ -447,8 +448,9 @@ class App(FastAPI):
                 for allowed_path in blocks.allowed_paths
             )
             was_uploaded = utils.is_in_or_equal(abs_path, app.uploaded_file_dir)
+            is_cached_example = utils.is_in_or_equal(abs_path, utils.abspath(CACHED_FOLDER))
 
-            if not (created_by_app or in_allowlist or was_uploaded):
+            if not (created_by_app or in_allowlist or was_uploaded or is_cached_example):
                 raise HTTPException(403, f"File not allowed: {path_or_url}.")
 
             if not abs_path.exists():

--- a/guides/01_getting-started/03_sharing-your-app.md
+++ b/guides/01_getting-started/03_sharing-your-app.md
@@ -8,9 +8,9 @@ How to share your Gradio app:
 4. [Embedding with web components](#embedding-with-web-components)
 5. [Using the API page](#api-page)
 6. [Adding authentication to the page](#authentication)
-7. [Accessing Network Requests](#accessing-the-network-request-directly)
+7. [Accessing network requests](#accessing-the-network-request-directly)
 8. [Mounting within FastAPI](#mounting-within-another-fast-api-app)
-9. [Security](#security-and-file-access)
+9. [Security and file access](#security-and-file-access)
 
 ## Sharing Demos
 
@@ -269,7 +269,7 @@ In particular, Gradio apps ALLOW users to access to three kinds of files:
 - **Temporary files created by Gradio.** These are files that are created by Gradio as part of running your prediction function. For example, if your prediction function returns a video file, then Gradio will save that video to a temporary cache on your device and then send the path to the file to the front end. You can customize the location of cache files created by Gradio by setting the environment variable `GRADIO_TEMP_DIR` to an absolute path, such as `/home/usr/scripts/project/temp/`.
 
 
-- **Cached examples created by Gradio.** These are files that are created by Gradio as part of caching examples for faster runtimes, if you set `cache_examples=True` in `gr.Interface()` or in `gr.Examples()`. These files are saved in the `/gradio_cached_examples/` subdirectory within your app's working directory.
+- **Cached examples created by Gradio.** These are files that are created by Gradio as part of caching examples for faster runtimes, if you set `cache_examples=True` in `gr.Interface()` or in `gr.Examples()`. These files are saved in the `gradio_cached_examples/` subdirectory within your app's working directory.
 
 - **Files that you explicitly allow via the `allowed_paths` parameter in `launch()`**. This parameter allows you to pass in a list of additional directories or exact filepaths you'd like to allow users to have access to. (By default, this parameter is an empty list).
 

--- a/guides/01_getting-started/03_sharing-your-app.md
+++ b/guides/01_getting-started/03_sharing-your-app.md
@@ -264,9 +264,12 @@ Note that this approach also allows you run your Gradio apps on custom paths (`h
 
 Sharing your Gradio app with others (by hosting it on Spaces, on your own server, or through temporary share links) **exposes** certain files on the host machine to users of your Gradio app.
 
-In particular, Gradio apps ALLOW users to access to two kinds of files:
+In particular, Gradio apps ALLOW users to access to three kinds of files:
 
-- **Cached files created by Gradio.** These are files that are created by Gradio as part of running your prediction function. For example, if your prediction function returns a video file, then Gradio will save that video to a cache on your device and then send the path to the file to the front end. You can customize the location of cache files created by Gradio by setting the environment variable `GRADIO_TEMP_DIR` to an absolute path, such as `/home/usr/scripts/project/temp/`.
+- **Temporary files created by Gradio.** These are files that are created by Gradio as part of running your prediction function. For example, if your prediction function returns a video file, then Gradio will save that video to a temporary cache on your device and then send the path to the file to the front end. You can customize the location of cache files created by Gradio by setting the environment variable `GRADIO_TEMP_DIR` to an absolute path, such as `/home/usr/scripts/project/temp/`.
+
+
+- **Cached examples created by Gradio.** These are files that are created by Gradio as part of caching examples for faster runtimes, if you set `cache_examples=True` in `gr.Interface()` or in `gr.Examples()`. These files are saved in the `/gradio_cached_examples/` subdirectory within your app's working directory.
 
 - **Files that you explicitly allow via the `allowed_paths` parameter in `launch()`**. This parameter allows you to pass in a list of additional directories or exact filepaths you'd like to allow users to have access to. (By default, this parameter is an empty list).
 


### PR DESCRIPTION
This should fix the issue where the cached example files were not showing up, and also doesn't pollute the user's working directory with cached examples, which are really an internal gradio resource. 

cc @hannahblair @freddyaboulton 

Will test in @hannahblair's PR to confirm