### PR TITLE
Make output components not editable if they are being updated

### DIFF
--- a/.changeset/shy-bugs-sneeze.md
+++ b/.changeset/shy-bugs-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@gradio/app": minor
+"gradio": minor
+---
+
+feat:Make output components not editable if they are being updated

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -429,6 +429,10 @@
 				})
 				.on("status", ({ fn_index, ...status }) => {
 					tick().then(() => {
+						const outputs = dependencies[fn_index].outputs;
+						outputs.forEach((id) => {
+							instance_map[id].props.interactive = status.stage === "pending" ? false : true;
+						});
 						//@ts-ignore
 						loading_status.update({
 							...status,


### PR DESCRIPTION
## Description
Make output components not editable if they are being updated

Closes: #4733

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
