### PR TITLE
Allow data at queue join

### DIFF
--- a/.changeset/eighty-sides-visit.md
+++ b/.changeset/eighty-sides-visit.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Allow data at queue join

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -581,14 +581,12 @@ class App(FastAPI):
             username: str = Depends(get_current_user),
             data: Optional[str] = None,
         ):
-            print("queue_join", fn_index, session_hash, data)
             blocks = app.get_blocks()
             if blocks._queue.server_app is None:
                 blocks._queue.set_server_app(app)
 
             event = Event(session_hash, fn_index, request, username)
             if data is not None:
-                print("data", data)
                 input_data = json.loads(data)
                 event.data = PredictBody(
                     session_hash=session_hash,

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -579,12 +579,23 @@ class App(FastAPI):
             session_hash: str,
             request: fastapi.Request,
             username: str = Depends(get_current_user),
+            data: Optional[str] = None,
         ):
+            print("queue_join", fn_index, session_hash, data)
             blocks = app.get_blocks()
             if blocks._queue.server_app is None:
                 blocks._queue.set_server_app(app)
 
             event = Event(session_hash, fn_index, request, username)
+            if data is not None:
+                print("data", data)
+                input_data = json.loads(data)
+                event.data = PredictBody(
+                    session_hash=session_hash,
+                    fn_index=fn_index,
+                    data=input_data,
+                    request=request,
+                )
 
             # Continuous events are not put in the queue so that they do not
             # occupy the queue's resource as they are expected to run forever


### PR DESCRIPTION
So now you can curl directly, e.g.
```
curl "http://localhost:7860/queue/join?fn_index=0&session_hash=1&data=%5B%22hello%22%5D"

data: {"msg": "estimation", "rank": 0, "queue_size": 1, "avg_event_process_time": 0.0, "avg_event_concurrent_process_time": null, "rank_eta": null, "queue_eta": 1.0}

data: {"msg": "process_starts"}

data: {"msg": "process_completed", "output": {"data": ["Hello hello!"], "is_generating": false, "duration": 0.0006520748138427734, "average_duration": 0.0006520748138427734}, "success": true}
```