### PR TITLE
Cleanup theme vars

### DIFF
--- a/.changeset/thirty-beans-type.md
+++ b/.changeset/thirty-beans-type.md
@@ -1,0 +1,6 @@
+---
+"@gradio/markdown": minor
+"gradio": minor
+---
+
+feat:Cleanup theme vars

--- a/gradio/themes/base.py
+++ b/gradio/themes/base.py
@@ -747,8 +747,8 @@ class Base(ThemeClass):
             prose_text_size: The text size used for markdown and other prose.
             prose_text_weight: The text weight used for markdown and other prose.
             prose_header_text_weight: The text weight of a header used for markdown and other prose.
-            code_background_fill: The background color of code blocks in the chatbot.
-            code_background_fill_dark: The background color of code blocks in the chatbot in dark mode.
+            code_background_fill: The background color of code blocks.
+            code_background_fill_dark: The background color of code blocks in dark mode.
             shadow_drop: Drop shadow used by other shadowed items.
             shadow_drop_lg: Larger drop shadow used by other shadowed items.
             shadow_inset: Inset shadow used by other shadowed items.

--- a/gradio/themes/base.py
+++ b/gradio/themes/base.py
@@ -506,6 +506,8 @@ class Base(ThemeClass):
         prose_text_size=None,
         prose_text_weight=None,
         prose_header_text_weight=None,
+        code_background_fill=None,
+        code_background_fill_dark=None,
         # Shadows: These set the high-level shadow rendering styles. These variables are often referenced by other component-specific shadow variables.
         shadow_drop=None,
         shadow_drop_lg=None,
@@ -566,8 +568,6 @@ class Base(ThemeClass):
         section_header_text_size=None,
         section_header_text_weight=None,
         # Component Atoms: These set the style for elements within components.
-        chatbot_code_background_color=None,
-        chatbot_code_background_color_dark=None,
         checkbox_background_color=None,
         checkbox_background_color_dark=None,
         checkbox_background_color_focus=None,
@@ -747,6 +747,8 @@ class Base(ThemeClass):
             prose_text_size: The text size used for markdown and other prose.
             prose_text_weight: The text weight used for markdown and other prose.
             prose_header_text_weight: The text weight of a header used for markdown and other prose.
+            code_background_fill: The background color of code blocks in the chatbot.
+            code_background_fill_dark: The background color of code blocks in the chatbot in dark mode.
             shadow_drop: Drop shadow used by other shadowed items.
             shadow_drop_lg: Larger drop shadow used by other shadowed items.
             shadow_inset: Inset shadow used by other shadowed items.
@@ -804,8 +806,6 @@ class Base(ThemeClass):
             panel_border_width_dark: The border width of a panel in dark mode.
             section_header_text_size: The text size of a section header (e.g. tab name).
             section_header_text_weight: The text weight of a section header (e.g. tab name).
-            chatbot_code_background_color: The background color of code blocks in the chatbot.
-            chatbot_code_background_color_dark: The background color of code blocks in the chatbot in dark mode.
             checkbox_background_color: The background of a checkbox square or radio circle.
             checkbox_background_color_dark: The background of a checkbox square or radio circle in dark mode.
             checkbox_background_color_focus: The background of a checkbox square or radio circle when focused.
@@ -1214,12 +1214,12 @@ class Base(ThemeClass):
             or getattr(self, "border_color_accent_subdued_dark", "*border_color_accent")
         )
         # Component Atoms
-        self.chatbot_code_background_color = chatbot_code_background_color or getattr(
-            self, "chatbot_code_background_color", "*neutral_100"
+        self.code_background_fill = code_background_fill or getattr(
+            self, "code_background_fill", "*neutral_100"
         )
-        self.chatbot_code_background_color_dark = (
-            chatbot_code_background_color_dark
-            or getattr(self, "chatbot_code_background_color_dark", "*neutral_800")
+        self.code_background_fill_dark = (
+            code_background_fill_dark
+            or getattr(self, "code_background_fill_dark", "*neutral_800")
         )
         self.checkbox_background_color = checkbox_background_color or getattr(
             self, "checkbox_background_color", "*background_fill_primary"

--- a/gradio/themes/base.py
+++ b/gradio/themes/base.py
@@ -1217,9 +1217,8 @@ class Base(ThemeClass):
         self.code_background_fill = code_background_fill or getattr(
             self, "code_background_fill", "*neutral_100"
         )
-        self.code_background_fill_dark = (
-            code_background_fill_dark
-            or getattr(self, "code_background_fill_dark", "*neutral_800")
+        self.code_background_fill_dark = code_background_fill_dark or getattr(
+            self, "code_background_fill_dark", "*neutral_800"
         )
         self.checkbox_background_color = checkbox_background_color or getattr(
             self, "checkbox_background_color", "*background_fill_primary"

--- a/js/markdown/shared/prism.css
+++ b/js/markdown/shared/prism.css
@@ -65,7 +65,7 @@ th {
 	box-shadow: none;
 	border: none;
 	border-radius: var(--radius-md);
-	background-color: var(--chatbot-code-background-color);
+	background: var(--code-background-fill);
 	padding: var(--spacing-lg) var(--spacing-xl);
 	font-family: var(--font-mono);
 	/* font-size: var(--text-sm) !important; */
@@ -90,7 +90,7 @@ th {
 	padding: 0.1em;
 	border-radius: var(--radius-xs);
 	white-space: normal;
-	background-color: var(--chatbot-code-background-color);
+	background: var(--code-background-fill);
 	border: 1px solid var(--panel-border-color);
 	padding: var(--spacing-xxs) var(--spacing-xs);
 }


### PR DESCRIPTION
Wasn't much to cleanup, just chatbot_code_background_color was too component specific, and  not accurate either because all markdown used this variable. Renamed to code_background_fill, (change color -> fill for background, because we always use fill for background variable names, not color, because these can also be images/gradients/etc)