### PR TITLE
fix`FileExplorer` preprocess

### DIFF
--- a/.changeset/tame-singers-join.md
+++ b/.changeset/tame-singers-join.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:fix`FileExplorer` preprocess

--- a/gradio/components/file_explorer.py
+++ b/gradio/components/file_explorer.py
@@ -104,18 +104,18 @@ class FileExplorer(Component):
     def example_inputs(self) -> Any:
         return ["Users", "gradio", "app.py"]
 
-    def preprocess(self, payload: list[list[str]] | None) -> list[str] | str | None:
+    def preprocess(self, payload: FileExplorerData | None) -> list[str] | str | None:
         if payload is None:
             return None
 
         if self.file_count == "single":
-            if len(payload) > 1:
+            if len(payload.root) > 1:
                 raise ValueError(
-                    f"Expected only one file, but {len(payload)} were selected."
+                    f"Expected only one file, but {len(payload.root)} were selected."
                 )
-            return self._safe_join(payload[0])
+            return self._safe_join(payload.root[0])
 
-        return [self._safe_join(file) for file in (payload)]
+        return [self._safe_join(file) for file in (payload.root)]
 
     def _strip_root(self, path):
         if path.startswith(self.root):


### PR DESCRIPTION
## Description

The datamodel for FileExplorer changed with a recent pr (i think #6181) but the preprocess was not modified to reflect this. The Signature for preprocess also wasn't updated which is probably what allowed this to creep in.

run `demo/file_explorer` to test.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
