### PR TITLE
Fixes: Initial message is overwrtitten in chat interface 

### DIFF
--- a/.changeset/public-banks-film.md
+++ b/.changeset/public-banks-film.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fixes: Initial message is overwrtitten in chat interface 

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -242,8 +242,9 @@ class ChatInterface(Blocks):
                 client_utils.synchronize_async(self.examples_handler.cache)
 
             self.saved_input = State()
-            self.chatbot_state = State(self.chatbot.value) if self.chatbot.value else State([])
-            
+            self.chatbot_state = (
+                State(self.chatbot.value) if self.chatbot.value else State([])
+            )
 
             self._setup_events()
             self._setup_api()

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -242,7 +242,8 @@ class ChatInterface(Blocks):
                 client_utils.synchronize_async(self.examples_handler.cache)
 
             self.saved_input = State()
-            self.chatbot_state = State([])
+            self.chatbot_state = State(self.chatbot.value) if self.chatbot.value else State([])
+            
 
             self._setup_events()
             self._setup_api()


### PR DESCRIPTION
## Description
Include initial value in chat history for chat interface.

Closes: #6194

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
