### PR TITLE
Add likeable to config for Chatbot

### DIFF
--- a/.changeset/major-bushes-ring.md
+++ b/.changeset/major-bushes-ring.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Add likeable to config for Chatbot

--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -66,6 +66,7 @@ class Chatbot(Component):
         render_markdown: bool = True,
         bubble_full_width: bool = True,
         line_breaks: bool = True,
+        likeable: bool = False,
         layout: Literal["panel", "bubble"] | None = None,
     ):
         """
@@ -91,9 +92,10 @@ class Chatbot(Component):
             render_markdown: If False, will disable Markdown rendering for chatbot messages.
             bubble_full_width: If False, the chat bubble will fit to the content of the message. If True (default), the chat bubble will be the full width of the component.
             line_breaks: If True (default), will enable Github-flavored Markdown line breaks in chatbot messages. If False, single new lines will be ignored. Only applies if `render_markdown` is True.
+            likeable: Whether the chat messages display a like or dislike button. Set automatically by the .like method but has to be present in the signature for it to show up in the config.
             layout: If "panel", will display the chatbot in a llm style layout. If "bubble", will display the chatbot with message bubbles, with the user and bot messages on alterating sides. Will default to "bubble".
         """
-        self.likeable = False
+        self.likeable = likeable
         self.height = height
         self.rtl = rtl
         if latex_delimiters is None:

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1895,6 +1895,16 @@ class TestJSON:
             "_selectable": False,
         }
 
+    def test_chatbot_selectable_in_config(self):
+        with gr.Blocks() as demo:
+            cb = gr.Chatbot(label="Chatbot")
+            cb.like(lambda: print("foo"))
+        for component in demo.config["components"]:
+            if component["props"]["label"] == "Chatbot":
+                assert component["props"]["likeable"]
+                return
+        raise AssertionError()
+
     @pytest.mark.asyncio
     async def test_in_interface(self):
         """

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -1899,11 +1899,18 @@ class TestJSON:
         with gr.Blocks() as demo:
             cb = gr.Chatbot(label="Chatbot")
             cb.like(lambda: print("foo"))
+            gr.Chatbot(label="Chatbot2")
+
+        assertion_count = 0
         for component in demo.config["components"]:
             if component["props"]["label"] == "Chatbot":
+                assertion_count += 1
                 assert component["props"]["likeable"]
-                return
-        raise AssertionError()
+            elif component["props"]["label"] == "Chatbot2":
+                assertion_count += 1
+                assert not component["props"]["likeable"]
+
+        assert assertion_count == 2
 
     @pytest.mark.asyncio
     async def test_in_interface(self):


### PR DESCRIPTION
## Description

Repro in issue.

We added some under-the-hood logic to Blocks to set `_selectable` in the config without it being present in the init signature. I don't like treating some props as privileged though. Doesn't scale for custom component authors who want to set event-based props in their custom component. So I'm adding likeable to the config.

Closes: #6230 


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
