### PR TITLE
Remove **kwargs from queue, raise warning instead of error concurrency_count

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1624,7 +1624,7 @@ Received outputs:
         status_update_rate: float | Literal["auto"] = "auto",
         api_open: bool | None = None,
         max_size: int | None = None,
-        **kwargs,
+        concurrency_count: int | None = None,
     ):
         """
         By enabling the queue you can control when users know their position in the queue, and set a limit on maximum number of events allowed.
@@ -1632,6 +1632,7 @@ Received outputs:
             status_update_rate: If "auto", Queue will send status estimations to all clients whenever a job is finished. Otherwise Queue will send status at regular intervals set by this parameter as the number of seconds.
             api_open: If True, the REST routes of the backend will be open, allowing requests made directly to those endpoints to skip the queue.
             max_size: The maximum number of events the queue will store at any given moment. If the queue is full, new events will not be added and a user will receive a message saying that the queue is full. If None, the queue size will be unlimited.
+            concurrency_count: Deprecated and has no effect. Set the concurrency_limit directly on event listeners e.g. btn.click(fn, ..., concurrency_limit=10) or gr.Interface(concurrency_limit=10). If necessary, the total number of workers can be configured via `max_threads` in launch().
         Example: (Blocks)
             with gr.Blocks() as demo:
                 button = gr.Button(label="Generate Image")
@@ -1643,12 +1644,12 @@ Received outputs:
             demo.queue(max_size=20)
             demo.launch()
         """
-        if "concurrency_count" in kwargs:
-            raise DeprecationWarning(
-                "concurrency_count has been deprecated. Set the concurrency_limit directly on event listeners e.g. btn.click(fn, ..., concurrency_limit=10) or gr.Interface(concurrency_limit=10). If necessary, the total number of workers can be configured via `max_threads` in launch()."
+        if concurrency_count:
+            warnings.warn(
+                "concurrency_count has been deprecated. Set the concurrency_limit directly on event listeners e.g. btn.click(fn, ..., concurrency_limit=10) or gr.Interface(concurrency_limit=10). If necessary, the total number of workers can be configured via `max_threads` in launch().",
+                # Deprecation warnings filtered out by default
+                UserWarning,
             )
-        if len(kwargs):
-            raise ValueError(f"Invalid arguments: {kwargs}")
         if api_open is not None:
             self.api_open = api_open
         if utils.is_zero_gpu_space():

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1536,3 +1536,10 @@ def test_recover_kwargs():
         ["value"],
     )
     assert props == {"format": "wav", "autoplay": False}
+
+
+def test_deprecation_warning_emitted_when_concurrency_count_set():
+    with pytest.warns(UserWarning):
+        gr.Interface(lambda x: x, gr.Textbox(), gr.Textbox()).queue(
+            concurrency_count=12
+        )


### PR DESCRIPTION
## Description

Don't think removing kwargs is a breaking change because we were already not allowing arbitrary kwargs. Removing them from the signature has the benefit of having your editor warn you before you run your code and reducing code for us. Also treat concurrency_count as a warning instead of an error.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
