### PR TITLE
Model3D panning, improved UX

### DIFF
--- a/.changeset/fruity-peaches-appear.md
+++ b/.changeset/fruity-peaches-appear.md
@@ -1,0 +1,6 @@
+---
+"@gradio/model3d": minor
+"gradio": minor
+---
+
+feat:Model3D panning, improved UX

--- a/gradio/components/model3d.py
+++ b/gradio/components/model3d.py
@@ -42,6 +42,7 @@ class Model3D(Component):
             None,
         ),
         zoom_speed: float = 1,
+        pan_speed: float = 1,
         height: int | None = None,
         label: str | None = None,
         show_label: bool | None = None,
@@ -61,6 +62,7 @@ class Model3D(Component):
             clear_color: background color of scene, should be a tuple of 4 floats between 0 and 1 representing RGBA values.
             camera_position: initial camera position of scene, provided as a tuple of `(alpha, beta, radius)`. Each value is optional. If provided, `alpha` and `beta` should be in degrees reflecting the angular position along the longitudinal and latitudinal axes, respectively. Radius corresponds to the distance from the center of the object to the camera.
             zoom_speed: the speed of zooming in and out of the scene when the cursor wheel is rotated or when screen is pinched on a mobile device. Should be a positive float, increase this value to make zooming faster, decrease to make it slower. Affects the wheelPrecision property of the camera.
+            pan_speed: the speed of panning the scene when the cursor is dragged or when the screen is dragged on a mobile device. Should be a positive float, increase this value to make panning faster, decrease to make it slower. Affects the panSensibility property of the camera.
             height: height of the model3D component, in pixels.
             interactive: if True, will allow users to upload a file; if False, can only be used to display files. If not provided, this is inferred based on whether the component is used as an input or output.
             label: The label for this component. Appears above the component and is also used as the header if there are a table of examples for this component. If None and used in a `gr.Interface`, the label will be the name of the parameter this component is assigned to.
@@ -78,6 +80,7 @@ class Model3D(Component):
         self.camera_position = camera_position
         self.height = height
         self.zoom_speed = zoom_speed
+        self.pan_speed = pan_speed
         super().__init__(
             label=label,
             every=every,

--- a/js/model3D/shared/Model3D.svelte
+++ b/js/model3D/shared/Model3D.svelte
@@ -14,6 +14,7 @@
 	export let show_label: boolean;
 	export let i18n: I18nFormatter;
 	export let zoom_speed = 1;
+	export let pan_speed = 1;
 
 	// alpha, beta, radius
 	export let camera_position: [number | null, number | null, number | null] = [
@@ -69,13 +70,14 @@
 				value,
 				clear_color,
 				camera_position,
-				zoom_speed
+				zoom_speed,
+				pan_speed
 			);
 		}
 	}
 
 	function handle_undo(): void {
-		reset_camera_position(scene, camera_position, zoom_speed);
+		reset_camera_position(scene, camera_position, zoom_speed, pan_speed);
 	}
 </script>
 

--- a/js/model3D/shared/Model3DUpload.svelte
+++ b/js/model3D/shared/Model3DUpload.svelte
@@ -13,6 +13,7 @@
 	export let root: string;
 	export let i18n: I18nFormatter;
 	export let zoom_speed = 1;
+	export let pan_speed = 1;
 
 	// alpha, beta, radius
 	export let camera_position: [number | null, number | null, number | null] = [
@@ -34,7 +35,8 @@
 			value,
 			clear_color,
 			camera_position,
-			zoom_speed
+			zoom_speed,
+			pan_speed
 		);
 	}
 
@@ -71,7 +73,7 @@
 	}
 
 	async function handle_undo(): Promise<void> {
-		reset_camera_position(scene, camera_position, zoom_speed);
+		reset_camera_position(scene, camera_position, zoom_speed, pan_speed);
 	}
 
 	const dispatch = createEventDispatcher<{

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -2016,6 +2016,7 @@ class TestModel3D:
             "camera_position": (None, None, None),
             "height": None,
             "zoom_speed": 1,
+            "pan_speed": 1,
             "_selectable": False,
         }
 


### PR DESCRIPTION
Improvements to the Model3D component

- Enabled panning
- Adapt pan and zoom speed to scene radius, creating a consistent experience across various model sizes
- Set lower radius limit to prevent zoom inversion (zooming in below 0)

Closes: #6119 