### PR TITLE
fix: avoid unnecessary folders creation when flagging

### DIFF
--- a/gradio/components/base.py
+++ b/gradio/components/base.py
@@ -273,6 +273,7 @@ class Component(ComponentBase, Block):
         """
         if self.data_model:
             payload = self.data_model.from_json(payload)
+            flag_dir.mkdir(exist_ok=True)
             return payload.copy_to_dir(flag_dir).model_dump_json()
         return payload
 

--- a/gradio/components/base.py
+++ b/gradio/components/base.py
@@ -273,7 +273,7 @@ class Component(ComponentBase, Block):
         """
         if self.data_model:
             payload = self.data_model.from_json(payload)
-            flag_dir.mkdir(exist_ok=True)
+            Path(flag_dir).mkdir(exist_ok=True)
             return payload.copy_to_dir(flag_dir).model_dump_json()
         return payload
 

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -166,7 +166,6 @@ class CSVLogger(FlaggingCallback):
             ) / client_utils.strip_invalid_filename_characters(
                 getattr(component, "label", None) or f"component {idx}"
             )
-            save_dir.mkdir(exist_ok=True)
             if utils.is_update(sample):
                 csv_data.append(str(sample))
             else:

--- a/test/test_flagging.py
+++ b/test/test_flagging.py
@@ -21,6 +21,13 @@ class TestDefaultFlagging:
             assert row_count == 2  # 3 rows written including header
         io.close()
 
+    def test_flagging_does_not_create_unnecessary_directories(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            io = gr.Interface(lambda x: x, "text", "text", flagging_dir=tmpdirname)
+            io.launch(prevent_thread_lock=True)
+            io.flagging_callback.flag(["test", "test"])
+            assert os.listdir(tmpdirname) == ["log.csv"]
+
 
 class TestSimpleFlagging:
     def test_simple_csv_flagging_callback(self):


### PR DESCRIPTION
## Description

As discussed with @abidlabs in #6196, fixes the issue by moving the creation of a folder for flagged components inside the `.flag()` method in `components/base.py`, making it run only when data_model is not `none` before the payload is copied inside of it.

## 🎯 PRs Should Target Issues

Closes: #6196

## Tests

1. I followed the guidelines to contribute (https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and ran the tests: `bash scripts/run_all_tests.sh`. All tests passed.

2. I ran `bash scripts/format_backend.sh` to lint my code.
  
