### PR TITLE
ensure radios have different names

### DIFF
--- a/.changeset/pretty-doodles-work.md
+++ b/.changeset/pretty-doodles-work.md
@@ -1,0 +1,7 @@
+---
+"@gradio/radio": patch
+"@gradio/tootils": patch
+"gradio": patch
+---
+
+fix:ensure radios have different names

--- a/demo/hello_blocks/run.py
+++ b/demo/hello_blocks/run.py
@@ -1,28 +1,15 @@
-# import gradio as gr
-
-
-# def greet(name):
-#     return "Hello " + name + "!"
-
-
-# with gr.Blocks() as demo:
-#     name = gr.Textbox(label="Name")
-#     output = gr.Textbox(label="Output Box")
-#     greet_btn = gr.Button("Greet")
-#     greet_btn.click(fn=greet, inputs=name, outputs=output, api_name="greet")
-
-# if __name__ == "__main__":
-#     demo.launch()
-
-
 import gradio as gr
 
+
+def greet(name):
+    return "Hello " + name + "!"
+
+
 with gr.Blocks() as demo:
-    with gr.Row():
-        with gr.Column():
-            Drug = gr.Radio(["Yes", "No"])
-            Family = gr.Radio(["Yes", "No"])
+    name = gr.Textbox(label="Name")
+    output = gr.Textbox(label="Output Box")
+    greet_btn = gr.Button("Greet")
+    greet_btn.click(fn=greet, inputs=name, outputs=output, api_name="greet")
 
 if __name__ == "__main__":
-    demo.queue()
     demo.launch()

--- a/demo/hello_blocks/run.py
+++ b/demo/hello_blocks/run.py
@@ -1,15 +1,28 @@
+# import gradio as gr
+
+
+# def greet(name):
+#     return "Hello " + name + "!"
+
+
+# with gr.Blocks() as demo:
+#     name = gr.Textbox(label="Name")
+#     output = gr.Textbox(label="Output Box")
+#     greet_btn = gr.Button("Greet")
+#     greet_btn.click(fn=greet, inputs=name, outputs=output, api_name="greet")
+
+# if __name__ == "__main__":
+#     demo.launch()
+
+
 import gradio as gr
 
-
-def greet(name):
-    return "Hello " + name + "!"
-
-
 with gr.Blocks() as demo:
-    name = gr.Textbox(label="Name")
-    output = gr.Textbox(label="Output Box")
-    greet_btn = gr.Button("Greet")
-    greet_btn.click(fn=greet, inputs=name, outputs=output, api_name="greet")
+    with gr.Row():
+        with gr.Column():
+            Drug = gr.Radio(["Yes", "No"])
+            Family = gr.Radio(["Yes", "No"])
 
 if __name__ == "__main__":
+    demo.queue()
     demo.launch()

--- a/js/radio/Index.svelte
+++ b/js/radio/Index.svelte
@@ -24,7 +24,7 @@
 	export let visible = true;
 	export let value: string | number | null = null;
 	export let value_is_output = false;
-	export let choices: [string, number | number][] = [];
+	export let choices: [string, string | number][] = [];
 	export let show_label = true;
 	export let container = false;
 	export let scale: number | null = null;

--- a/js/radio/Index.svelte
+++ b/js/radio/Index.svelte
@@ -16,6 +16,7 @@
 		select: SelectData;
 		input: never;
 	}>;
+
 	export let label = gradio.i18n("radio.radio");
 	export let info: string | undefined = undefined;
 	export let elem_id = "";
@@ -23,13 +24,13 @@
 	export let visible = true;
 	export let value: string | number | null = null;
 	export let value_is_output = false;
-	export let choices: [string, number][] = [];
-	export let show_label: boolean;
+	export let choices: [string, number | number][] = [];
+	export let show_label = true;
 	export let container = false;
 	export let scale: number | null = null;
 	export let min_width: number | undefined = undefined;
 	export let loading_status: LoadingStatus;
-	export let interactive: boolean;
+	export let interactive = true;
 
 	function handle_change(): void {
 		gradio.dispatch("change");
@@ -64,14 +65,14 @@
 	<BlockTitle {show_label} {info}>{label}</BlockTitle>
 
 	<div class="wrap">
-		{#each choices as choice, i (i)}
+		{#each choices as [display_value, internal_value], i (i)}
 			<BaseRadio
-				display_value={choice[0]}
-				internal_value={choice[1]}
+				{display_value}
+				{internal_value}
 				bind:selected={value}
 				{disabled}
 				on:input={() =>
-					gradio.dispatch("select", { value: choice[1], index: i })}
+					gradio.dispatch("select", { value: internal_value, index: i })}
 			/>
 		{/each}
 	</div>

--- a/js/radio/Index.svelte
+++ b/js/radio/Index.svelte
@@ -22,7 +22,7 @@
 	export let elem_id = "";
 	export let elem_classes: string[] = [];
 	export let visible = true;
-	export let value: string | number | null = null;
+	export let value: string | null = null;
 	export let value_is_output = false;
 	export let choices: [string, string | number][] = [];
 	export let show_label = true;

--- a/js/radio/Radio.test.ts
+++ b/js/radio/Radio.test.ts
@@ -23,16 +23,13 @@ describe("Radio", () => {
 		["dog", "dog"],
 		["cat", "cat"],
 		["turtle", "turtle"]
-	];
+	] as [string, string][];
 
 	test("renders provided value", async () => {
 		const { getAllByRole, getByTestId } = await render(Radio, {
-			show_label: true,
-			loading_status,
 			choices: choices,
 			value: "cat",
-			label: "Radio",
-			interactive: true
+			label: "Radio"
 		});
 
 		assert.equal(
@@ -52,12 +49,9 @@ describe("Radio", () => {
 
 	test("should update the value when a radio is clicked", async () => {
 		const { getByDisplayValue, getByTestId } = await render(Radio, {
-			show_label: true,
-			loading_status,
 			choices: choices,
 			value: "cat",
-			label: "Radio",
-			interactive: true
+			label: "Radio"
 		});
 
 		await event.click(getByDisplayValue("dog"));
@@ -78,5 +72,30 @@ describe("Radio", () => {
 			getByTestId("turtle-radio-label").classList.contains("selected"),
 			true
 		);
+	});
+
+	test("when multiple radios are on the screen, they should not conflict", async () => {
+		const { container } = await render(Radio, {
+			choices: choices,
+			value: "cat",
+			label: "Radio"
+		});
+
+		const { getAllByLabelText } = await render(
+			Radio,
+			{
+				choices: choices,
+				value: "dog",
+				label: "Radio"
+			},
+			container
+		);
+
+		const items = getAllByLabelText("dog") as HTMLInputElement[];
+		expect([items[0].checked, items[1].checked]).toEqual([false, true]);
+
+		await event.click(items[0]);
+
+		expect([items[0].checked, items[1].checked]).toEqual([true, true]);
 	});
 });

--- a/js/radio/shared/Radio.svelte
+++ b/js/radio/shared/Radio.svelte
@@ -7,7 +7,7 @@
 	export let display_value: string;
 	export let internal_value: string | number;
 	export let disabled = false;
-	export let selected: string | number | null = null;
+	export let selected: string | null = null;
 
 	const dispatch = createEventDispatcher<{ input: string | number }>();
 
@@ -26,7 +26,6 @@
 		value={internal_value}
 		on:input={() => dispatch("input", internal_value)}
 		bind:group={selected}
-		class={++id}
 	/>
 	<span class="ml-2">{display_value}</span>
 </label>

--- a/js/radio/shared/Radio.svelte
+++ b/js/radio/shared/Radio.svelte
@@ -1,3 +1,7 @@
+<script context="module">
+	let id = 0;
+</script>
+
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
 	export let display_value: string;
@@ -13,15 +17,16 @@
 <label
 	class:disabled
 	class:selected={is_selected}
-	data-testid={`${internal_value}-radio-label`}
+	data-testid="{display_value}-radio-label"
 >
 	<input
 		{disabled}
 		type="radio"
-		name={`radio-${internal_value}`}
+		name="radio-{++id}"
 		value={internal_value}
 		on:input={() => dispatch("input", internal_value)}
 		bind:group={selected}
+		class={++id}
 	/>
 	<span class="ml-2">{display_value}</span>
 </label>

--- a/js/tootils/src/render.ts
+++ b/js/tootils/src/render.ts
@@ -46,14 +46,21 @@ export async function render<
 	X extends Record<string, any>
 >(
 	Component: ComponentType<T, Props> | { default: ComponentType<T, Props> },
-	props?: Omit<Props, "gradio">
+	props?: Omit<Props, "gradio">,
+	_container?: HTMLElement
 ): Promise<
 	RenderResult<T> & {
 		listen: typeof listen;
 		wait_for_event: typeof wait_for_event;
 	}
 > {
-	const container = document.body;
+	let container: HTMLElement;
+	if (!_container) {
+		container = document.body;
+	} else {
+		container = _container;
+	}
+
 	const target = container.appendChild(document.createElement("div"));
 
 	const ComponentConstructor: ComponentType<


### PR DESCRIPTION
## Description

Closes #6198 

Funny issue. The `name` attribute on a Radio button has to be unique across the page or there will be conflicts. We were using the internal value (in the PR example 'Yes' and 'No'). SO when we had duplicates with the same value only one 'Yes' or one 'No' could be 'checked' at the same time (because radio inputs are xor).

Added a few defaults again to make testing easier and added a unit test for this case.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
