### PR TITLE
Fix Audio Pause/Play Issue

### DIFF
--- a/.changeset/slow-comics-act.md
+++ b/.changeset/slow-comics-act.md
@@ -1,0 +1,6 @@
+---
+"@gradio/audio": patch
+"gradio": patch
+---
+
+fix:Fix Audio Pause/Play Issue

--- a/js/audio/interactive/InteractiveAudio.svelte
+++ b/js/audio/interactive/InteractiveAudio.svelte
@@ -245,11 +245,12 @@
 		{label}
 		{autoplay}
 		{i18n}
-		{dispatch}
 		{dispatch_blob}
 		{waveform_settings}
 		{handle_reset_value}
 		interactive
+		on:play={() => dispatch("play")} 
+		on:pause={() => dispatch("pause")}
 	/>
 {/if}
 

--- a/js/audio/player/AudioPlayer.svelte
+++ b/js/audio/player/AudioPlayer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from "svelte";
+	import { onMount, createEventDispatcher } from "svelte";
 	import { Music } from "@gradio/icons";
 	import type { I18nFormatter } from "@gradio/utils";
 	import WaveSurfer from "wavesurfer.js";
@@ -13,7 +13,6 @@
 	export let label: string;
 	export let autoplay: boolean;
 	export let i18n: I18nFormatter;
-	export let dispatch: (event: any, detail?: any) => void;
 	export let dispatch_blob: (
 		blobs: Uint8Array[] | Blob[],
 		event: "stream" | "change" | "stop_recording"
@@ -22,6 +21,11 @@
 	export let waveform_settings = {};
 	export let mode = "";
 	export let handle_reset_value: () => void = () => {};
+
+	const dispatch = createEventDispatcher<{
+		play: never;
+		pause: never;
+	}>();
 
 	let container: HTMLDivElement;
 	let waveform: WaveSurfer;

--- a/js/audio/static/StaticAudio.svelte
+++ b/js/audio/static/StaticAudio.svelte
@@ -68,6 +68,8 @@
 		{i18n}
 		{dispatch}
 		{waveform_settings}
+		on:play={() => console.log('Play event received')} 
+		on:pause={() => console.log('Pause event received')}
 	/>
 {:else}
 	<Empty size="small">

--- a/js/audio/static/StaticAudio.svelte
+++ b/js/audio/static/StaticAudio.svelte
@@ -68,8 +68,6 @@
 		{i18n}
 		{dispatch}
 		{waveform_settings}
-		on:play={() => console.log('Play event received')} 
-		on:pause={() => console.log('Pause event received')}
 	/>
 {:else}
 	<Empty size="small">


### PR DESCRIPTION
## Description

Not sure why, but `dispatch("play")` and `dispatch("pause")` was causing the audio player the play/pause event triggers for the waveform to both be called in succession. 

Not sure if this PR is the best way to fix this.

Closes: #6260

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
