### PR TITLE
Provide status updates on file uploads

### DIFF
--- a/.changeset/tired-berries-tease.md
+++ b/.changeset/tired-berries-tease.md
@@ -1,0 +1,7 @@
+---
+"@gradio/client": minor
+"@gradio/upload": minor
+"gradio": minor
+---
+
+feat:Provide status updates on file uploads

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -156,7 +156,8 @@ interface Client {
 	upload_files: (
 		root: string,
 		files: File[],
-		token?: `hf_${string}`
+		token?: `hf_${string}`,
+		upload_id?: string
 	) => Promise<UploadResponse>;
 	client: (
 		app_reference: string,
@@ -208,7 +209,8 @@ export function api_factory(
 	async function upload_files(
 		root: string,
 		files: (Blob | File)[],
-		token?: `hf_${string}`
+		token?: `hf_${string}`,
+		upload_id?: string
 	): Promise<UploadResponse> {
 		const headers: {
 			Authorization?: string;
@@ -225,7 +227,10 @@ export function api_factory(
 				formData.append("files", file);
 			});
 			try {
-				var response = await fetch_implementation(`${root}/upload`, {
+				const upload_url = upload_id
+					? `${root}/upload?upload_id=${upload_id}`
+					: `${root}/upload`;
+				var response = await fetch_implementation(upload_url, {
 					method: "POST",
 					body: formData,
 					headers

--- a/client/js/src/upload.ts
+++ b/client/js/src/upload.ts
@@ -88,6 +88,7 @@ export function get_fetchable_url_or_file(
 export async function upload(
 	file_data: FileData[],
 	root: string,
+	upload_id?: string,
 	upload_fn: typeof upload_files = upload_files
 ): Promise<(FileData | null)[] | null> {
 	let files = (Array.isArray(file_data) ? file_data : [file_data]).map(
@@ -95,7 +96,7 @@ export async function upload(
 	);
 
 	return await Promise.all(
-		await upload_fn(root, files).then(
+		await upload_fn(root, files, undefined, upload_id).then(
 			async (response: { files?: string[]; error?: string }) => {
 				if (response.error) {
 					throw new Error(response.error);

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections import deque
+from dataclasses import dataclass as python_dataclass
 from tempfile import NamedTemporaryFile, _TemporaryFileWrapper
 from typing import TYPE_CHECKING, AsyncGenerator, BinaryIO, List, Optional, Tuple, Union
 
@@ -294,6 +296,42 @@ class GradioUploadFile(UploadFile):
         self.sha = hashlib.sha1()
 
 
+@python_dataclass(frozen=True)
+class FileUploadProgressUnit:
+    filename: str
+    chunk_size: int
+    is_done: bool
+
+
+class FileUploadProgress:
+    def __init__(self) -> None:
+        self._statuses: dict[str, deque[FileUploadProgressUnit]] = {}
+
+    def track(self, upload_id: str):
+        if upload_id not in self._statuses:
+            self._statuses[upload_id] = deque()
+
+    def update(self, upload_id: str, filename: str, message_bytes: bytes):
+        if upload_id not in self._statuses:
+            self._statuses[upload_id] = deque()
+        self._statuses[upload_id].append(
+            FileUploadProgressUnit(filename, len(message_bytes), is_done=False)
+        )
+
+    def set_done(self, upload_id: str, filename: str):
+        self._statuses[upload_id].append(
+            FileUploadProgressUnit(filename, 0, is_done=True)
+        )
+
+    def status(self, upload_id: str) -> deque[FileUploadProgressUnit]:
+        if upload_id not in self._statuses:
+            return deque()
+        return self._statuses[upload_id]
+
+    def is_tracked(self, upload_id: str):
+        return upload_id in self._statuses
+
+
 class GradioMultiPartParser:
     """Vendored from starlette.MultipartParser.
 
@@ -315,6 +353,8 @@ class GradioMultiPartParser:
         *,
         max_files: Union[int, float] = 1000,
         max_fields: Union[int, float] = 1000,
+        upload_id: str | None = None,
+        upload_progress: FileUploadProgress | None = None,
     ) -> None:
         assert (
             multipart is not None
@@ -324,6 +364,8 @@ class GradioMultiPartParser:
         self.max_files = max_files
         self.max_fields = max_fields
         self.items: List[Tuple[str, Union[str, UploadFile]]] = []
+        self.upload_id = upload_id
+        self.upload_progress = upload_progress
         self._current_files = 0
         self._current_fields = 0
         self._current_partial_header_name: bytes = b""
@@ -339,12 +381,20 @@ class GradioMultiPartParser:
 
     def on_part_data(self, data: bytes, start: int, end: int) -> None:
         message_bytes = data[start:end]
+        if self.upload_progress is not None:
+            self.upload_progress.update(
+                self.upload_id, self._current_part.file.filename, message_bytes
+            )
         if self._current_part.file is None:
             self._current_part.data += message_bytes
         else:
             self._file_parts_to_write.append((self._current_part, message_bytes))
 
     def on_part_end(self) -> None:
+        if self.upload_progress is not None:
+            self.upload_progress.set_done(
+                self.upload_id, self._current_part.file.filename
+            )
         if self._current_part.file is None:
             self.items.append(
                 (

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -685,13 +685,12 @@ class App(FastAPI):
         async def get_queue_status():
             return app.get_blocks()._queue.get_estimation()
 
-        @app.get("/upload_progress/{upload_id}")
+        @app.get("/upload_progress")
         def get_upload_progress(upload_id: str, request: fastapi.Request):
             async def sse_stream(request: fastapi.Request):
                 last_heartbeat = time.perf_counter()
                 # if not file_upload_statuses.is_tracked(upload_id):
                 #     raise HTTPException(status_code=404, detail="Upload not found.")
-                print("upload_id", upload_id)
                 while True:
                     if await request.is_disconnected():
                         return

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -56,6 +56,7 @@ from gradio.helpers import CACHED_FOLDER
 from gradio.oauth import attach_oauth
 from gradio.queueing import Estimation, Event
 from gradio.route_utils import (  # noqa: F401
+    FileUploadProgress,
     GradioMultiPartParser,
     GradioUploadFile,
     MultiPartException,
@@ -119,6 +120,9 @@ client = httpx.AsyncClient()
 def move_uploaded_files_to_cache(files: list[str], destinations: list[str]) -> None:
     for file, dest in zip(files, destinations):
         shutil.move(file, dest)
+
+
+file_upload_statuses = FileUploadProgress()
 
 
 class App(FastAPI):
@@ -681,8 +685,52 @@ class App(FastAPI):
         async def get_queue_status():
             return app.get_blocks()._queue.get_estimation()
 
+        @app.get("/upload_progress/{upload_id}")
+        def get_upload_progress(upload_id: str, request: fastapi.Request):
+            async def sse_stream(request: fastapi.Request):
+                last_heartbeat = time.perf_counter()
+                # if not file_upload_statuses.is_tracked(upload_id):
+                #     raise HTTPException(status_code=404, detail="Upload not found.")
+                print("upload_id", upload_id)
+                while True:
+                    if await request.is_disconnected():
+                        return
+
+                    heartbeat_rate = 15
+                    check_rate = 0.05
+                    message = None
+
+                    try:
+                        if update := file_upload_statuses.status(upload_id).popleft():
+                            if update.is_done:  # end of stream marker
+                                message = {"msg": "done"}
+                            else:
+                                message = {
+                                    "msg": "update",
+                                    "file": update.filename,
+                                    "chunk_size": update.chunk_size,
+                                }
+                        else:
+                            await asyncio.sleep(check_rate)
+                            if time.perf_counter() - last_heartbeat > heartbeat_rate:
+                                message = {"msg": "heartbeat"}
+                                last_heartbeat = time.time()
+                        if message:
+                            yield f"data: {json.dumps(message)}\n\n"
+                    except:
+                        continue
+
+            return StreamingResponse(
+                sse_stream(request),
+                media_type="text/event-stream",
+            )
+
         @app.post("/upload", dependencies=[Depends(login_check)])
-        async def upload_file(request: fastapi.Request, bg_tasks: BackgroundTasks):
+        async def upload_file(
+            request: fastapi.Request,
+            bg_tasks: BackgroundTasks,
+            upload_id: Optional[str] = None,
+        ):
             content_type_header = request.headers.get("Content-Type")
             content_type: bytes
             content_type, _ = parse_options_header(content_type_header)
@@ -690,11 +738,15 @@ class App(FastAPI):
                 raise HTTPException(status_code=400, detail="Invalid content type.")
 
             try:
+                if upload_id:
+                    file_upload_statuses.track(upload_id)
                 multipart_parser = GradioMultiPartParser(
                     request.headers,
                     request.stream(),
                     max_files=1000,
                     max_fields=1000,
+                    upload_id=upload_id if upload_id else None,
+                    upload_progress=file_upload_statuses if upload_id else None,
                 )
                 form = await multipart_parser.parse()
             except MultiPartException as exc:

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -78,10 +78,6 @@ def safe_get_lock() -> asyncio.Lock:
         return None  # type: ignore
 
 
-def get_safe_thread_lock() -> threading.Lock:
-    return threading.Lock()
-
-
 class BaseReloader(ABC):
     @property
     @abstractmethod

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -78,6 +78,10 @@ def safe_get_lock() -> asyncio.Lock:
         return None  # type: ignore
 
 
+def get_safe_thread_lock() -> threading.Lock:
+    return threading.Lock()
+
+
 class BaseReloader(ABC):
     @property
     @abstractmethod

--- a/js/app/test/audio_component_events.spec.ts
+++ b/js/app/test/audio_component_events.spec.ts
@@ -7,7 +7,7 @@ test("Audio click-to-upload uploads audio successfuly.", async ({ page }) => {
 	const uploader = await page.locator("input[type=file]");
 	await Promise.all([
 		uploader.setInputFiles(["../../test/test_files/audio_sample.wav"]),
-		page.waitForResponse("**/upload")
+		page.waitForResponse("**/upload?*")
 	]);
 
 	await expect(page.getByLabel("# Change Events")).toHaveValue("1");
@@ -21,7 +21,7 @@ test("Audio click-to-upload uploads audio successfuly.", async ({ page }) => {
 
 	await Promise.all([
 		uploader.setInputFiles(["../../test/test_files/audio_sample.wav"]),
-		page.waitForResponse("**/upload")
+		page.waitForResponse("**/upload?*")
 	]);
 
 	await expect(page.getByLabel("# Change Events")).toHaveValue("3");
@@ -39,7 +39,7 @@ test("Audio drag-and-drop uploads a file to the server correctly.", async ({
 			"audio_sample.wav",
 			"audio/wav"
 		),
-		page.waitForResponse("**/upload")
+		page.waitForResponse("**/upload?*")
 	]);
 	await expect(page.getByLabel("# Change Events")).toHaveValue("1");
 	await expect(page.getByLabel("# Upload Events")).toHaveValue("1");

--- a/js/app/test/video_component_events.spec.ts
+++ b/js/app/test/video_component_events.spec.ts
@@ -9,7 +9,7 @@ test("Video click-to-upload uploads video successfuly. Clear, play, and pause bu
 	const uploader = await page.locator("input[type=file]");
 	await Promise.all([
 		uploader.setInputFiles(["./test/files/file_test.ogg"]),
-		page.waitForResponse("**/upload")
+		page.waitForResponse("**/upload?*?*")
 	]);
 
 	await expect(page.getByLabel("# Change Events")).toHaveValue("1");
@@ -28,7 +28,7 @@ test("Video click-to-upload uploads video successfuly. Clear, play, and pause bu
 
 	await Promise.all([
 		uploader.setInputFiles(["./test/files/file_test.ogg"]),
-		page.waitForResponse("**/upload")
+		page.waitForResponse("**/upload?*")
 	]);
 
 	await expect(page.getByLabel("# Change Events")).toHaveValue("3");
@@ -50,7 +50,7 @@ test("Video drag-and-drop uploads a file to the server correctly.", async ({
 		"file_test.ogg",
 		"video/*"
 	);
-	await page.waitForResponse("**/upload");
+	await page.waitForResponse("**/upload?*");
 	await expect(page.getByLabel("# Change Events")).toHaveValue("1");
 	await expect(page.getByLabel("# Upload Events")).toHaveValue("1");
 });

--- a/js/upload/src/Upload.svelte
+++ b/js/upload/src/Upload.svelte
@@ -3,6 +3,7 @@
 	import type { FileData } from "@gradio/client";
 	import { upload_files, upload, prepare_files } from "@gradio/client";
 	import { _ } from "svelte-i18n";
+	import UploadProgress from "./UploadProgress.svelte";
 
 	export let filetype: string | null = null;
 	export let dragging = false;
@@ -14,6 +15,10 @@
 	export let root: string;
 	export let hidden = false;
 	export let include_sources = false;
+
+	let uploading = false;
+	let upload_id: string;
+	let file_data: FileData[];
 
 	// Needed for wasm support
 	const upload_fn = getContext<typeof upload_files>("upload_files");
@@ -36,7 +41,9 @@
 		file_data: FileData[]
 	): Promise<(FileData | null)[]> {
 		await tick();
-		const _file_data = await upload(file_data, root, upload_fn);
+		upload_id = Math.random().toString(36).substring(2, 15);
+		uploading = true;
+		const _file_data = await upload(file_data, root, upload_id, upload_fn);
 		dispatch("load", file_count === "single" ? _file_data?.[0] : _file_data);
 		return _file_data || [];
 	}
@@ -48,7 +55,7 @@
 			return;
 		}
 		let _files: File[] = files.map((f) => new File([f], f.name));
-		let file_data = await prepare_files(_files);
+		file_data = await prepare_files(_files);
 		return await handle_upload(file_data);
 	}
 
@@ -90,35 +97,46 @@
 	}
 </script>
 
-<button
-	class:hidden
-	class:center
-	class:boundedheight
-	class:flex
-	style:height={include_sources ? "calc(100% - 40px" : "100%"}
-	on:drag|preventDefault|stopPropagation
-	on:dragstart|preventDefault|stopPropagation
-	on:dragend|preventDefault|stopPropagation
-	on:dragover|preventDefault|stopPropagation
-	on:dragenter|preventDefault|stopPropagation
-	on:dragleave|preventDefault|stopPropagation
-	on:drop|preventDefault|stopPropagation
-	on:click={open_file_upload}
-	on:drop={loadFilesFromDrop}
-	on:dragenter={updateDragging}
-	on:dragleave={updateDragging}
->
-	<slot />
-	<input
-		type="file"
-		bind:this={hidden_upload}
-		on:change={load_files_from_upload}
-		accept={filetype}
-		multiple={file_count === "multiple" || undefined}
-		webkitdirectory={file_count === "directory" || undefined}
-		mozdirectory={file_count === "directory" || undefined}
+{#if uploading}
+	<UploadProgress
+		{root}
+		{upload_id}
+		files={file_data}
+		on:done={() => {
+			uploading = false;
+		}}
 	/>
-</button>
+{:else}
+	<button
+		class:hidden
+		class:center
+		class:boundedheight
+		class:flex
+		style:height={include_sources ? "calc(100% - 40px" : "100%"}
+		on:drag|preventDefault|stopPropagation
+		on:dragstart|preventDefault|stopPropagation
+		on:dragend|preventDefault|stopPropagation
+		on:dragover|preventDefault|stopPropagation
+		on:dragenter|preventDefault|stopPropagation
+		on:dragleave|preventDefault|stopPropagation
+		on:drop|preventDefault|stopPropagation
+		on:click={open_file_upload}
+		on:drop={loadFilesFromDrop}
+		on:dragenter={updateDragging}
+		on:dragleave={updateDragging}
+	>
+		<slot />
+		<input
+			type="file"
+			bind:this={hidden_upload}
+			on:change={load_files_from_upload}
+			accept={filetype}
+			multiple={file_count === "multiple" || undefined}
+			webkitdirectory={file_count === "directory" || undefined}
+			mozdirectory={file_count === "directory" || undefined}
+		/>
+	</button>
+{/if}
 
 <style>
 	button {

--- a/js/upload/src/UploadProgress.svelte
+++ b/js/upload/src/UploadProgress.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+	import { FileData } from "@gradio/client";
+	import { onMount, createEventDispatcher } from "svelte";
+
+	type FileDataWithProgress = FileData & { progress: number };
+
+	export let upload_id: string;
+	export let root: string;
+	export let files: FileData[];
+
+	let done_count = 0;
+
+	let event_source: EventSource;
+
+	let files_with_progress: FileDataWithProgress[] = files.map((file) => {
+		return {
+			...file,
+			progress: 0
+		};
+	});
+
+	const dispatch = createEventDispatcher();
+
+	function handleProgress(filename: string, chunk_size: number): void {
+		// Find the corresponding file in the array and update its progress
+		files_with_progress = files_with_progress.map((file) => {
+			if (file.orig_name === filename) {
+				file.progress += chunk_size;
+			}
+			return file;
+		});
+	}
+
+	function getProgress(file: FileDataWithProgress): number {
+		return (file.progress * 100) / (file.size || 0) || 0;
+	}
+
+	onMount(() => {
+		event_source = new EventSource(
+			`${root}/upload_progress?upload_id=${upload_id}`
+		);
+		// Event listener for progress updates
+		event_source.onmessage = async function (event) {
+			const _data = JSON.parse(event.data);
+			if (_data.msg === "done") {
+				done_count += 1;
+				if (done_count === files.length) {
+					dispatch("done");
+				}
+			} else {
+				handleProgress(_data.file, _data.chunk_size);
+			}
+		};
+	});
+</script>
+
+<div class="wrap">
+	{#each files_with_progress as file, index}
+		<div class="file-info">
+			<span>Uploading {file.orig_name}...</span>
+		</div>
+		<div class="progress-bar-wrap">
+			<div class="progress-bar" style="width: {getProgress(file)}%;"></div>
+		</div>
+	{/each}
+</div>
+
+<!-- <div class="progress-level">
+    <div class="progress-level-inner">
+        {#if progress != null}
+            {#each progress as p, i}
+                {#if p.desc != null || (progress_level && progress_level[i] != null)}
+                    {#if i !== 0}
+                        &nbsp;/
+                    {/if}
+                    {#if p.desc != null}
+                        {p.desc}
+                    {/if}
+                    {#if p.desc != null && progress_level && progress_level[i] != null}
+                        -
+                    {/if}
+                    {#if progress_level != null}
+                        {(100 * (progress_level[i] || 0)).toFixed(1)}%
+                    {/if}
+                {/if}
+            {/each}
+        {/if}
+    </div>
+
+    <div class="progress-bar-wrap">
+        <div
+            bind:this={progress_bar}
+            class="progress-bar"
+            style:width="{last_progress_level * 100}%"
+        />
+    </div>
+</div> -->
+
+<style>
+	.wrap {
+		margin-top: var(--size-7);
+		overflow-y: auto;
+	}
+
+	.progress-bar-wrap {
+		border: 1px solid var(--border-color-primary);
+		background: var(--background-fill-primary);
+		height: var(--size-4);
+	}
+	.progress-bar {
+		transform-origin: left;
+		background-color: var(--loader-color);
+		height: var(--size-full);
+	}
+
+	.file-info {
+		height: 100%;
+		justify-content: center;
+		text-align: center;
+		width: 100%;
+		/* position: absolute;
+        top: 0;
+        left: 0; */
+		/* justify-content: center; */
+		/* width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap; */
+	}
+
+	.file-info span {
+		color: var(--body-text-color);
+		font-size: var(--text-med);
+		font-family: var(--font-mono);
+	}
+</style>

--- a/js/upload/src/UploadProgress.svelte
+++ b/js/upload/src/UploadProgress.svelte
@@ -8,8 +8,6 @@
 	export let root: string;
 	export let files: FileData[];
 
-	let done_count = 0;
-
 	let event_source: EventSource;
 
 	let files_with_progress: FileDataWithProgress[] = files.map((file) => {
@@ -43,12 +41,10 @@
 		event_source.onmessage = async function (event) {
 			const _data = JSON.parse(event.data);
 			if (_data.msg === "done") {
-				done_count += 1;
-				if (done_count === files.length) {
-					dispatch("done");
-				}
+				event_source.close();
+				dispatch("done");
 			} else {
-				handleProgress(_data.file, _data.chunk_size);
+				handleProgress(_data.orig_name, _data.chunk_size);
 			}
 		};
 	});

--- a/js/upload/src/UploadProgress.svelte
+++ b/js/upload/src/UploadProgress.svelte
@@ -61,37 +61,6 @@
 	{/each}
 </div>
 
-<!-- <div class="progress-level">
-    <div class="progress-level-inner">
-        {#if progress != null}
-            {#each progress as p, i}
-                {#if p.desc != null || (progress_level && progress_level[i] != null)}
-                    {#if i !== 0}
-                        &nbsp;/
-                    {/if}
-                    {#if p.desc != null}
-                        {p.desc}
-                    {/if}
-                    {#if p.desc != null && progress_level && progress_level[i] != null}
-                        -
-                    {/if}
-                    {#if progress_level != null}
-                        {(100 * (progress_level[i] || 0)).toFixed(1)}%
-                    {/if}
-                {/if}
-            {/each}
-        {/if}
-    </div>
-
-    <div class="progress-bar-wrap">
-        <div
-            bind:this={progress_bar}
-            class="progress-bar"
-            style:width="{last_progress_level * 100}%"
-        />
-    </div>
-</div> -->
-
 <style>
 	.wrap {
 		margin-top: var(--size-7);
@@ -114,18 +83,6 @@
 		justify-content: center;
 		text-align: center;
 		width: 100%;
-		/* position: absolute;
-        top: 0;
-        left: 0; */
-		/* justify-content: center; */
-		/* width: 100%;
-        height: 100%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap; */
 	}
 
 	.file-info span {

--- a/js/upload/src/UploadProgress.svelte
+++ b/js/upload/src/UploadProgress.svelte
@@ -9,6 +9,7 @@
 	export let files: FileData[];
 
 	let event_source: EventSource;
+	let progress = false;
 
 	let files_with_progress: FileDataWithProgress[] = files.map((file) => {
 		return {
@@ -40,6 +41,7 @@
 		// Event listener for progress updates
 		event_source.onmessage = async function (event) {
 			const _data = JSON.parse(event.data);
+			if (!progress) progress = true;
 			if (_data.msg === "done") {
 				event_source.close();
 				dispatch("done");
@@ -50,7 +52,7 @@
 	});
 </script>
 
-<div class="wrap">
+<div class="wrap" class:progress>
 	{#each files_with_progress as file, index}
 		<div class="file-info">
 			<span>Uploading {file.orig_name}...</span>
@@ -65,6 +67,13 @@
 	.wrap {
 		margin-top: var(--size-7);
 		overflow-y: auto;
+		opacity: 0;
+		transition: opacity 0.5s ease-in-out;
+		background: var(--block-background-fill);
+	}
+
+	.wrap.progress {
+		opacity: 1;
 	}
 
 	.progress-bar-wrap {


### PR DESCRIPTION
## Description

Closes #6218

* Adds an optional upload_id query parameter to the `/upload` route. When specified, you can listen to progress updates on the `upload_progress` route. I originally wanted the `/upload` route to return the `upload_id` you can use to listen to updates but we can't send intermediate information from the `/upload` route without closing the request and the `/upload` route needs the request to stay open to stream the files.
* Adds a `UploadProgress.svelte` class in `@gradio/upload` that streams and displays progress updates from the server.
* The `upload_id` parameter is added to the `@gradio/client` but not the python client.

Try it here: https://huggingface.co/spaces/freddyaboulton/file_component

![file_upload_preview](https://github.com/gradio-app/gradio/assets/41651716/943be0a9-3d73-44e0-929d-65aada832aef)



Questions:
* There's a bit of flicker if the uploaded file is really small. Should we only show progress for large files? My thought is no because it depends on the network speed.
* 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
