### PR TITLE
Fix data model for `gr.DataFrame`

### DIFF
--- a/.changeset/all-cougars-matter.md
+++ b/.changeset/all-cougars-matter.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix data model for `gr.DataFrame`

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -17,11 +17,9 @@ from gradio.events import Events
 
 
 class DataframeData(GradioModel):
-    headers: List[str]
+    headers: Optional[List[str]] = None
     data: List[List[Any]]
-    metadata: Optional[
-        Dict[str, List[Any]]
-    ] = None  # Optional[Dict[str, List[Any]]] = None
+    metadata: Optional[Dict[str, List[Any] | None]] = None
 
 
 set_documentation_group("component")

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -214,7 +214,7 @@ class Dataframe(Component):
             return DataframeData(
                 headers=list(df.columns),
                 data=df.to_dict(orient="split")["data"],  # type: ignore
-                metadata=self.__extract_metadata(value),
+                metadata=self.__extract_metadata(value),  # type: ignore
             )
         elif isinstance(value, (str, pd.DataFrame)):
             df = pd.read_csv(value) if isinstance(value, str) else value  # type: ignore

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -19,7 +19,7 @@ from gradio.events import Events
 class DataframeData(GradioModel):
     headers: List[str]
     data: List[List[Any]]
-    metadata: Optional[Dict[str, List[Any] | None]] = None
+    metadata: Optional[Dict[str, Optional[List[Any]]]] = None
 
 
 set_documentation_group("component")

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -17,7 +17,7 @@ from gradio.events import Events
 
 
 class DataframeData(GradioModel):
-    headers: Optional[List[str]] = None
+    headers: List[str]
     data: List[List[Any]]
     metadata: Optional[Dict[str, List[Any] | None]] = None
 

--- a/js/app/test/gallery_component_events.spec.ts
+++ b/js/app/test/gallery_component_events.spec.ts
@@ -18,6 +18,7 @@ test("Gallery preview mode displays all images correctly.", async ({
 test("Gallery select event returns the right value", async ({ page }) => {
 	await page.getByRole("button", { name: "Run" }).click();
 	await page.getByLabel("Thumbnail 2 of 3").click();
+	await page.waitForTimeout(200);
 	expect(await page.getByLabel("Select Data")).toHaveValue(
 		"https://gradio-builds.s3.amazonaws.com/assets/lite-logo.png"
 	);

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -997,6 +997,14 @@ class TestDataframe:
         dataframe_input = gr.Dataframe()
         output = dataframe_input.preprocess(DataframeData(**x_data))
         assert output["Age"][1] == 24
+
+        x_data = {
+            "data": [["Tim", 12, False], ["Jan", 24, True]],
+            "headers": ["Name", "Age", "Member"],
+            "metadata": {"display_value": None, "styling": None},
+        }
+        dataframe_input.preprocess(DataframeData(**x_data))
+
         with pytest.raises(ValueError):
             gr.Dataframe(type="unknown")
 


### PR DESCRIPTION
Closes: #6297

Test with:

```py
import gradio as gr
import pandas as pd


def fn(df: pd.DataFrame) -> str:
    return df


df_orig = pd.DataFrame(data={"a": [1, 2, 3]})

with gr.Blocks() as demo:
    df = gr.Dataframe(value=df_orig, type="pandas")
    df2 = gr.Dataframe(value=df_orig, type="pandas")
    btn = gr.Button()

    btn.click(fn=fn, inputs=df, outputs=df2)

demo.launch()
```

or repro in original issue