### PR TITLE
Temporary fix to be able to load themes from Hub

### DIFF
--- a/.changeset/neat-cups-jump.md
+++ b/.changeset/neat-cups-jump.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Temporary fix to be able to load themes from Hub

--- a/gradio/themes/utils/semver_match.py
+++ b/gradio/themes/utils/semver_match.py
@@ -19,7 +19,7 @@ class ThemeAsset:
 def get_theme_assets(space_info: huggingface_hub.hf_api.SpaceInfo) -> list[ThemeAsset]:
     # Commenting out as it seems that the `huggingface_hub` library is not parsing tags
     # if "gradio-theme" not in getattr(space_info, "tags", []):
-        # raise ValueError(f"{space_info.id} is not a valid gradio-theme space!")
+    # raise ValueError(f"{space_info.id} is not a valid gradio-theme space!")
 
     return [
         ThemeAsset(filename.rfilename)

--- a/gradio/themes/utils/semver_match.py
+++ b/gradio/themes/utils/semver_match.py
@@ -17,8 +17,9 @@ class ThemeAsset:
 
 
 def get_theme_assets(space_info: huggingface_hub.hf_api.SpaceInfo) -> list[ThemeAsset]:
-    if "gradio-theme" not in getattr(space_info, "tags", []):
-        raise ValueError(f"{space_info.id} is not a valid gradio-theme space!")
+    # Commenting out as it seems that the `huggingface_hub` library is not parsing tags
+    # if "gradio-theme" not in getattr(space_info, "tags", []):
+        # raise ValueError(f"{space_info.id} is not a valid gradio-theme space!")
 
     return [
         ThemeAsset(filename.rfilename)

--- a/js/app/test/gallery_component_events.spec.ts
+++ b/js/app/test/gallery_component_events.spec.ts
@@ -18,6 +18,7 @@ test("Gallery preview mode displays all images correctly.", async ({
 test("Gallery select event returns the right value", async ({ page }) => {
 	await page.getByRole("button", { name: "Run" }).click();
 	await page.getByLabel("Thumbnail 2 of 3").click();
+	await page.waitForTimeout(200);
 	expect(await page.getByLabel("Select Data")).toHaveValue(
 		"https://gradio-builds.s3.amazonaws.com/assets/lite-logo.png"
 	);

--- a/test/test_theme_sharing.py
+++ b/test/test_theme_sharing.py
@@ -252,17 +252,22 @@ class TestGetThemeAssets:
         assert gr.Theme._theme_version_exists(space_info, "0.1.1")
         assert not gr.Theme._theme_version_exists(space_info, "2.0.0")
 
-    def test_raises_if_space_not_properly_tagged(self):
-        space_info = huggingface_hub.hf_api.SpaceInfo(
-            id="freddyaboulton/dracula", tags=["gradio"]
-        )
+    @pytest.mark.flaky
+    def test_load_space_from_hub_works(self):
+        theme = gr.Theme.from_hub("gradio/seafoam")
+        assert isinstance(theme, gr.Theme)
 
-        with pytest.raises(
-            ValueError,
-            match="freddyaboulton/dracula is not a valid gradio-theme space!",
-        ):
-            with patch("huggingface_hub.HfApi.space_info", return_value=space_info):
-                get_theme_assets(space_info)
+    # def test_raises_if_space_not_properly_tagged(self):
+    #     space_info = huggingface_hub.hf_api.SpaceInfo(
+    #         id="freddyaboulton/dracula", tags=["gradio"]
+    #     )
+
+    #     with pytest.raises(
+    #         ValueError,
+    #         match="freddyaboulton/dracula is not a valid gradio-theme space!",
+    #     ):
+    #         with patch("huggingface_hub.HfApi.space_info", return_value=space_info):
+    #             get_theme_assets(space_info)
 
 
 class TestBuiltInThemes:


### PR DESCRIPTION
Commented out a check to make sure that the loaded theme has the correct tags, as it seems that the `huggingface_hub` library is not parsing tags from Spaces

Closes: #6298
