### PR TITLE
Fix for stylized DataFrame

### DIFF
--- a/.changeset/floppy-crews-do.md
+++ b/.changeset/floppy-crews-do.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": minor
+"gradio": minor
+---
+
+feat:Fix for stylized DataFrame

--- a/js/app/test/dataframe_colorful.spec.ts
+++ b/js/app/test/dataframe_colorful.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "@gradio/tootils";
+
+test("first couple of cells in table are highlighted correctly", async ({
+	page
+}) => {
+	const first_td = await page.locator("tbody tr.row_odd td").first();
+	await expect(first_td).not.toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+
+	const second_td = await page.locator("tbody tr.row_odd td").nth(1);
+	await expect(second_td).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+});

--- a/js/dataframe/Index.svelte
+++ b/js/dataframe/Index.svelte
@@ -99,7 +99,7 @@
 		{col_count}
 		{value}
 		{headers}
-		on:change={(e) => (value = e.detail)}
+		on:change={interactive ? (e) => (value = e.detail) : () => {}}
 		on:select={(e) => gradio.dispatch("select", e.detail)}
 		{wrap}
 		{datatype}


### PR DESCRIPTION
Fixes a regression: https://github.com/gradio-app/gradio/issues/6315

Sample code:

```py
import pandas as pd 
import gradio as gr

# Creating a sample dataframe
df = pd.DataFrame({
    "A" : [14, 4, 5, 4, 1], 
    "B" : [5, 2, 54, 3, 2], 
    "C" : [20, 20, 7, 3, 8], 
    "D" : [14, 3, 6, 2, 6], 
    "E" : [23, 45, 64, 32, 23]
}) 

# Applying style to highlight the maximum value in each row
styler = df.style.highlight_max(color = 'lightgreen', axis = 0)

# Displaying the styled dataframe in Gradio
with gr.Blocks() as demo:
    gr.DataFrame(styler)
    
demo.launch()
```

Explanation: the introduction of

```js
		on:change={(e) => (value = e.detail)}
```

was causing an infinite loop when working with metadata. This fixes it, but as I'm not sure if this is the best fix, feel free to suggest an alternative. But basically here, we check to see if a Dataframe is interactive before updating the value. I've tested with `matrix_transpose`, which continues to work. 

I also added a functional test since neither the backend nor the frontend tests alone caught this. 