### PR TITLE
Fix `sources` list order in `test_components.py`

### DIFF
--- a/test/test_components.py
+++ b/test/test_components.py
@@ -24,7 +24,7 @@ from gradio_client import utils as client_utils
 from scipy.io import wavfile
 
 try:
-    from typing import cast
+    from typing_extensions import cast
 except ImportError:
     from typing import cast
 


### PR DESCRIPTION
## Description

Fixes a test in `test_components.py` which is failing due to #6314 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
