### PR TITLE
Restore query parameters in request

### DIFF
--- a/.changeset/bitter-knives-yawn.md
+++ b/.changeset/bitter-knives-yawn.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": patch
+"gradio": patch
+---
+
+fix:Restore query parameters in request

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -460,8 +460,7 @@ export function api_factory(
 						});
 
 						post_data(
-							`${http_protocol}//${resolve_root(host, config.path, true)}/run${
-								_endpoint.startsWith("/") ? _endpoint : `/${_endpoint}`
+							`${http_protocol}//${resolve_root(host, config.path, true)}/run${_endpoint.startsWith("/") ? _endpoint : `/${_endpoint}`
 							}${url_params ? "?" + url_params : ""}`,
 							{
 								...payload,
@@ -472,11 +471,11 @@ export function api_factory(
 							.then(([output, status_code]) => {
 								const data = transform_files
 									? transform_output(
-											output.data,
-											api_info,
-											config.root,
-											config.root_url
-									  )
+										output.data,
+										api_info,
+										config.root,
+										config.root_url
+									)
 									: output.data;
 								if (status_code == 200) {
 									fire_event({
@@ -607,11 +606,11 @@ export function api_factory(
 									time: new Date(),
 									data: transform_files
 										? transform_output(
-												data.data,
-												api_info,
-												config.root,
-												config.root_url
-										  )
+											data.data,
+											api_info,
+											config.root,
+											config.root_url
+										)
 										: data.data,
 									endpoint: _endpoint,
 									fn_index
@@ -657,7 +656,7 @@ export function api_factory(
 								host,
 								config.path,
 								true
-							)}/queue/join?${params}${url_params ? "&" + url_params : ""}`
+							)}/queue/join?${url_params ? url_params + "&" : ""}${params}`
 						);
 
 						eventSource = new EventSource(url);
@@ -735,11 +734,11 @@ export function api_factory(
 									time: new Date(),
 									data: transform_files
 										? transform_output(
-												data.data,
-												api_info,
-												config.root,
-												config.root_url
-										  )
+											data.data,
+											api_info,
+											config.root,
+											config.root_url
+										)
 										: data.data,
 									endpoint: _endpoint,
 									fn_index

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -657,8 +657,9 @@ export function api_factory(
 								host,
 								config.path,
 								true
-							)}/queue/join?${params}`
+							)}/queue/join?${params}${url_params ? "&" + url_params : ""}`
 						);
+						console.log(url);
 
 						eventSource = new EventSource(url);
 

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -659,7 +659,6 @@ export function api_factory(
 								true
 							)}/queue/join?${params}${url_params ? "&" + url_params : ""}`
 						);
-						console.log(url);
 
 						eventSource = new EventSource(url);
 

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -460,7 +460,8 @@ export function api_factory(
 						});
 
 						post_data(
-							`${http_protocol}//${resolve_root(host, config.path, true)}/run${_endpoint.startsWith("/") ? _endpoint : `/${_endpoint}`
+							`${http_protocol}//${resolve_root(host, config.path, true)}/run${
+								_endpoint.startsWith("/") ? _endpoint : `/${_endpoint}`
 							}${url_params ? "?" + url_params : ""}`,
 							{
 								...payload,
@@ -471,11 +472,11 @@ export function api_factory(
 							.then(([output, status_code]) => {
 								const data = transform_files
 									? transform_output(
-										output.data,
-										api_info,
-										config.root,
-										config.root_url
-									)
+											output.data,
+											api_info,
+											config.root,
+											config.root_url
+									  )
 									: output.data;
 								if (status_code == 200) {
 									fire_event({
@@ -606,11 +607,11 @@ export function api_factory(
 									time: new Date(),
 									data: transform_files
 										? transform_output(
-											data.data,
-											api_info,
-											config.root,
-											config.root_url
-										)
+												data.data,
+												api_info,
+												config.root,
+												config.root_url
+										  )
 										: data.data,
 									endpoint: _endpoint,
 									fn_index
@@ -734,11 +735,11 @@ export function api_factory(
 									time: new Date(),
 									data: transform_files
 										? transform_output(
-											data.data,
-											api_info,
-											config.root,
-											config.root_url
-										)
+												data.data,
+												api_info,
+												config.root,
+												config.root_url
+										  )
 										: data.data,
 									endpoint: _endpoint,
 									fn_index

--- a/demo/hello_world/run.py
+++ b/demo/hello_world/run.py
@@ -1,23 +1,9 @@
 import gradio as gr
 
-def echo(params):
-    print(params)
-    return params
+def greet(name):
+    return "Hello " + name + "!"
 
-def get_params(request: gr.Request):
-  params = request.query_params
-  ip = request.client.host
-  return {"params": params, 
-          "ip": ip}
-
-  
-with gr.Blocks() as demo:
-  url_params = gr.State()
-  text_in = gr.Textbox()
-  text_out = gr.JSON()
-  btn = gr.Button()
-  btn.click(echo, inputs=[url_params], outputs=[text_out])
-  demo.load(get_params, None, url_params, queue=True)
-  #demo.load(get_params, None, url_params, queue=False)
-
-demo.queue().launch()
+demo = gr.Interface(fn=greet, inputs="text", outputs="text")
+    
+if __name__ == "__main__":
+    demo.launch(show_api=False)   

--- a/demo/hello_world/run.py
+++ b/demo/hello_world/run.py
@@ -1,9 +1,23 @@
 import gradio as gr
 
-def greet(name):
-    return "Hello " + name + "!"
+def echo(params):
+    print(params)
+    return params
 
-demo = gr.Interface(fn=greet, inputs="text", outputs="text")
-    
-if __name__ == "__main__":
-    demo.launch(show_api=False)   
+def get_params(request: gr.Request):
+  params = request.query_params
+  ip = request.client.host
+  return {"params": params, 
+          "ip": ip}
+
+  
+with gr.Blocks() as demo:
+  url_params = gr.State()
+  text_in = gr.Textbox()
+  text_out = gr.JSON()
+  btn = gr.Button()
+  btn.click(echo, inputs=[url_params], outputs=[text_out])
+  demo.load(get_params, None, url_params, queue=True)
+  #demo.load(get_params, None, url_params, queue=False)
+
+demo.queue().launch()


### PR DESCRIPTION
We lost query parameters in the request in upgrading to 4.0, because we were sending the queue information (session_hash, fn_index) via query params - now we send both URL params and queue information via request.url_params. 
This does mean that when a user searches the request for url_params, there will be additional url_parameters they will find now in 4.0. I wanted to strip these but the fastapi.Request object is immutable and would be very messy / hacky to create a new object without these URL parameters. I think this is okay because users are usually looking for a specific key when searching url parameters.

Fixes: #6283 


Try with

```python
import gradio as gr

def echo(params):
    print(params)
    return params

def get_params(request: gr.Request):
  params = request.query_params
  ip = request.client.host
  return {"params": params, 
          "ip": ip}

  
with gr.Blocks() as demo:
  url_params = gr.State()
  text_in = gr.Textbox()
  text_out = gr.JSON()
  btn = gr.Button()
  btn.click(echo, inputs=[url_params], outputs=[text_out])
  demo.load(get_params, None, url_params, queue=True)
  #demo.load(get_params, None, url_params, queue=False)

demo.launch()
```