### PR TITLE
Add AsyncGenerator to the check-list of `dependencies.types.generator`

### DIFF
--- a/.changeset/cute-ghosts-grab.md
+++ b/.changeset/cute-ghosts-grab.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Add AsyncGenerator to the check-list of `dependencies.types.generator`

--- a/.changeset/cute-ghosts-grab.md
+++ b/.changeset/cute-ghosts-grab.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Add AsyncGenerator to the check-list of `dependencies.types.generator`

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -910,7 +910,9 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
             "cancels": cancels or [],
             "types": {
                 "continuous": bool(every),
-                "generator": inspect.isgeneratorfunction(fn) or bool(every),
+                "generator": inspect.isgeneratorfunction(fn)
+                or inspect.isasyncgenfunction(fn)
+                or bool(every),
             },
             "collects_event_data": collects_event_data,
             "trigger_after": trigger_after,


### PR DESCRIPTION
## Description

This is kind of a question, rather than a change request/proposal.

I wonder `inspect.isasyncgenfunction()` should be added here because it is usually used along with `inspect.isgeneratorfunction` in other places to check the function is generator-like,
such as:
https://github.com/gradio-app/gradio/blob/f1409f95ed39c5565bed6a601e41f94e30196a57/gradio/interface.py#L457-L459
https://github.com/gradio-app/gradio/blob/f1409f95ed39c5565bed6a601e41f94e30196a57/gradio/interface.py#L464-L466

If not, plz close the PR.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
