### PR TITLE
Fix audio streaming output issues in 4.0

### DIFF
--- a/.changeset/red-ties-turn.md
+++ b/.changeset/red-ties-turn.md
@@ -1,0 +1,6 @@
+---
+"@gradio/audio": minor
+"gradio": minor
+---
+
+feat:Fix audio streaming output issues in 4.0

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -327,7 +327,6 @@ def resize_and_crop(img, size, crop_type="center"):
 
 def audio_from_file(filename, crop_min=0, crop_max=100):
     try:
-        print(">>>", filename)
         audio = AudioSegment.from_file(filename)
     except FileNotFoundError as e:
         isfile = Path(filename).is_file()

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -327,6 +327,7 @@ def resize_and_crop(img, size, crop_type="center"):
 
 def audio_from_file(filename, crop_min=0, crop_max=100):
     try:
+        print(">>>", filename)
         audio = AudioSegment.from_file(filename)
     except FileNotFoundError as e:
         isfile = Path(filename).is_file()

--- a/js/audio/player/AudioPlayer.svelte
+++ b/js/audio/player/AudioPlayer.svelte
@@ -19,7 +19,7 @@
 		event: "stream" | "change" | "stop_recording"
 	) => Promise<void> = () => Promise.resolve();
 	export let interactive = false;
-	export let waveform_settings = {};
+	export let waveform_settings: Record<string, any> = {};
 	export let mode = "";
 	export let handle_reset_value: () => void = () => {};
 
@@ -44,7 +44,7 @@
 		waveform = WaveSurfer.create({
 			container: container,
 			url: value?.url,
-			...waveform_settings
+			...waveform_settings,
 		});
 	};
 
@@ -123,7 +123,12 @@
 		<Music />
 	</Empty>
 {:else if value.is_stream}
-	<audio class="standard-player" src={value.url} controls />
+	<audio
+		class="standard-player"
+		src={value.url}
+		controls
+		autoplay={waveform_settings.autoplay}
+	/>
 {:else}
 	<div
 		class="component-wrapper"

--- a/js/audio/player/AudioPlayer.svelte
+++ b/js/audio/player/AudioPlayer.svelte
@@ -44,7 +44,7 @@
 		waveform = WaveSurfer.create({
 			container: container,
 			url: value?.url,
-			...waveform_settings,
+			...waveform_settings
 		});
 	};
 


### PR DESCRIPTION
Streaming audio out broke in 4.0, as can be seen in the `stream_audio_out` demo. The waveform generator does not support a streaming audio source, so did a fallback onto a regular audio component. Test this via `stream_audio_out` demo.

There was another issue that whenever the DOM re-rendered for any reason, the waveform would have to regenerate, causing it to fetch the audio source on every DOM re-render. This is because normalize_files caused a new JSON to be passed to the AudioPlayer, so any DOM change caused a re-render. Now only re-renders if the URL changes. Test this via demo below while watching the Network Chrome inspector:

```python
import gradio as gr


def greet(audio):
    for i in range(10):
        import time
        time.sleep(1)
        yield i


with gr.Blocks() as demo:
    name = gr.Audio(label="Name")
    output = gr.Textbox(label="Output Box")
    greet_btn = gr.Button("Greet")
    greet_btn.click(fn=greet, inputs=name, outputs=output, api_name="greet")

if __name__ == "__main__":
    demo.launch()
```

