### PR TITLE
Fix `colorFrom` in theme space readmes

### DIFF
--- a/.changeset/late-donuts-warn.md
+++ b/.changeset/late-donuts-warn.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:Fix `colorFrom` in theme space readmes

--- a/gradio/themes/utils/readme_content.py
+++ b/gradio/themes/utils/readme_content.py
@@ -2,7 +2,7 @@ README_CONTENT = """
 ---
 tags: [gradio-theme]
 title: {theme_name}
-colorFrom: orange
+colorFrom: red
 colorTo: purple
 sdk: gradio
 sdk_version: {gradio_version}


### PR DESCRIPTION
As pointed out by @coyotte508, we use an invalid  `colorFrom` in the theme space readmes, which is preventing theme spaces from returning the tags correctly. 

This changes `orange` to `red`

cc @freddyaboulton @Wauplin