### PR TITLE
Fix component update bug

### DIFF
--- a/.changeset/early-geese-relate.md
+++ b/.changeset/early-geese-relate.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:Fix component update bug

--- a/.changeset/early-geese-relate.md
+++ b/.changeset/early-geese-relate.md
@@ -2,4 +2,4 @@
 "gradio": patch
 ---
 
-feat:Fix component update bug
+fix:Fix component update bug

--- a/gradio/component_meta.py
+++ b/gradio/component_meta.py
@@ -132,6 +132,11 @@ def updateable(fn):
     def wrapper(*args, **kwargs):
         fn_args = inspect.getfullargspec(fn).args
         self = args[0]
+
+        # We need to ensure __init__ is always called at least once
+        # so that the component has all the variables in self defined
+        # test_blocks.py::test_async_iterator_update_with_new_component
+        # checks this
         initialized_before = hasattr(self, "_constructor_args")
         if not initialized_before:
             self._constructor_args = []

--- a/gradio/component_meta.py
+++ b/gradio/component_meta.py
@@ -132,7 +132,8 @@ def updateable(fn):
     def wrapper(*args, **kwargs):
         fn_args = inspect.getfullargspec(fn).args
         self = args[0]
-        if not hasattr(self, "_constructor_args"):
+        initialized_before = hasattr(self, "_constructor_args")
+        if not initialized_before:
             self._constructor_args = []
         for i, arg in enumerate(args):
             if i == 0 or i >= len(fn_args):  #  skip self, *args
@@ -140,7 +141,7 @@ def updateable(fn):
             arg_name = fn_args[i]
             kwargs[arg_name] = arg
         self._constructor_args.append(kwargs)
-        if in_event_listener():
+        if in_event_listener() and initialized_before:
             return None
         else:
             return fn(self, **kwargs)

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1575,3 +1575,19 @@ def test_postprocess_update_dict():
             ("New Country B", "New Country B"),
         ],
     }
+
+
+def test_async_iterator_update_with_new_component(connect):
+    async def get_number_stream():
+        for i in range(10):
+            yield gr.Number(value=i, label="Number (updates every second)")
+
+            await asyncio.sleep(0.1)
+
+    demo = gr.Interface(fn=get_number_stream, inputs=None, outputs=["number"])
+    demo.queue()
+
+    with connect(demo) as client:
+        job = client.submit(api_name="/predict")
+        job.result()
+        assert [r["value"] for r in job.outputs()] == list(range(10))


### PR DESCRIPTION
## Description

Fixes: #6342

The problem was that if the component was initialized for the first time in an event listener, __init__ was not being called. This was a bug that was in version 3 too. 

The reason the bug doesn't "surface" for a normal generator is that "in_event_listener" returns false - probably because it's running in a separate thread (to avoid blocking the event loop) - so the __init__ is always called.

The fix is to call init if it hasn't been called before in an event listener


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
