### PR TITLE
Allows `sources` to be a string for `gr.Image`

### DIFF
--- a/.changeset/eleven-windows-relate.md
+++ b/.changeset/eleven-windows-relate.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Allows `sources` to be a string for `gr.Image`
+fix:Allows `sources` to be a string for `gr.Image`

--- a/.changeset/eleven-windows-relate.md
+++ b/.changeset/eleven-windows-relate.md
@@ -1,5 +1,5 @@
 ---
-"gradio": patch
+"gradio": minor
 ---
 
 fix:Allows `sources` to be a string for `gr.Image`

--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -109,16 +109,20 @@ class Audio(
         """
         valid_sources: list[Literal["upload", "microphone"]] = ["upload", "microphone"]
         if sources is None:
-            sources = ["microphone"] if streaming else valid_sources
+            self.sources = ["microphone"] if streaming else valid_sources
         elif isinstance(sources, str) and sources in valid_sources:
-            sources = [sources]
+            self.sources = [sources]
         elif isinstance(sources, list):
-            pass
+            self.sources = sources
         else:
             raise ValueError(
                 f"`sources` must be a list consisting of elements in {valid_sources}"
             )
-        self.sources = sources
+        for source in self.sources:
+            if source not in valid_sources:
+                raise ValueError(
+                    f"`sources` must a list consisting of elements in {valid_sources}"
+                )
         valid_types = ["numpy", "filepath"]
         if type not in valid_types:
             raise ValueError(

--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -108,7 +108,6 @@ class Audio(
             waveform_options: A dictionary of options for the waveform display. Options include: waveform_color (str), waveform_progress_color (str), show_controls (bool), skip_length (int). Default is None, which uses the default values for these options.
         """
         valid_sources: list[Literal["upload", "microphone"]] = ["upload", "microphone"]
-
         if sources is None:
             sources = ["microphone"] if streaming else valid_sources
         elif isinstance(sources, str) and sources in valid_sources:
@@ -119,7 +118,6 @@ class Audio(
             raise ValueError(
                 f"`sources` must be a list consisting of elements in {valid_sources}"
             )
-
         self.sources = sources
         valid_types = ["numpy", "filepath"]
         if type not in valid_types:

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -116,8 +116,6 @@ class Image(StreamingInput, Component):
                 raise ValueError(
                     f"`sources` must a list consisting of elements in {valid_sources}"
                 )
-        self.sources = sources
-
         self.streaming = streaming
         self.show_download_button = show_download_button
         if streaming and self.sources != ["webcam"]:

--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -126,6 +126,12 @@ class Video(Component):
             raise ValueError(
                 f"`sources` must be a list consisting of elements in {valid_sources}"
             )
+        for source in self.sources:
+            if source not in valid_sources:
+                raise ValueError(
+                    f"`sources` must a list consisting of elements in {valid_sources}"
+                )
+        
         self.sources = sources
         self.height = height
         self.width = width

--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -111,11 +111,7 @@ class Video(Component):
             min_length: The minimum length of video (in seconds) that the user can pass into the prediction function. If None, there is no minimum length.
             max_length: The maximum length of video (in seconds) that the user can pass into the prediction function. If None, there is no maximum length.
         """
-        self.format = format
-        self.autoplay = autoplay
-
         valid_sources: list[Literal["upload", "webcam"]] = ["webcam", "upload"]
-
         if sources is None:
             sources = valid_sources
         elif isinstance(sources, str) and sources in valid_sources:
@@ -131,8 +127,9 @@ class Video(Component):
                 raise ValueError(
                     f"`sources` must a list consisting of elements in {valid_sources}"
                 )
-        
         self.sources = sources
+        self.format = format
+        self.autoplay = autoplay
         self.height = height
         self.width = width
         self.mirror_webcam = mirror_webcam

--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -113,11 +113,11 @@ class Video(Component):
         """
         valid_sources: list[Literal["upload", "webcam"]] = ["webcam", "upload"]
         if sources is None:
-            sources = valid_sources
+            self.sources = valid_sources
         elif isinstance(sources, str) and sources in valid_sources:
-            sources = [sources]
+            self.sources = [sources]
         elif isinstance(sources, list):
-            pass
+            self.sources = sources
         else:
             raise ValueError(
                 f"`sources` must be a list consisting of elements in {valid_sources}"
@@ -127,14 +127,13 @@ class Video(Component):
                 raise ValueError(
                     f"`sources` must a list consisting of elements in {valid_sources}"
                 )
-        self.sources = sources
         self.format = format
         self.autoplay = autoplay
         self.height = height
         self.width = width
         self.mirror_webcam = mirror_webcam
         self.include_audio = (
-            include_audio if include_audio is not None else "upload" in sources
+            include_audio if include_audio is not None else "upload" in self.sources
         )
         self.show_share_button = (
             (utils.get_space() is not None)

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -572,7 +572,7 @@ class TestImage:
         image_input = gr.Image(type="pil", label="Upload Your Image")
         assert image_input.get_config() == {
             "image_mode": "RGB",
-            "sources": ['upload', 'webcam', 'clipboard'],
+            "sources": ["upload", "webcam", "clipboard"],
             "name": "image",
             "show_share_button": False,
             "show_download_button": True,

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -572,7 +572,7 @@ class TestImage:
         image_input = gr.Image(type="pil", label="Upload Your Image")
         assert image_input.get_config() == {
             "image_mode": "RGB",
-            "sources": None,
+            "sources": ['upload', 'webcam', 'clipboard'],
             "name": "image",
             "show_share_button": False,
             "show_download_button": True,
@@ -604,6 +604,8 @@ class TestImage:
         with pytest.raises(ValueError):
             gr.Image(type="unknown")
 
+        string_source = gr.Image(sources="upload")
+        assert string_source.sources == ["upload"]
         # Output functionalities
         image_output = gr.Image(type="pil")
         processed_image = image_output.postprocess(


### PR DESCRIPTION
A typo was causing the frontend to crash if `sources` was specified as a string

Closes: #6371 
Closes: #6337 