### PR TITLE
Async functions and async generator functions with the `every` option to work

### DIFF
--- a/.changeset/cold-gifts-tickle.md
+++ b/.changeset/cold-gifts-tickle.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Async functions and async generator functions with the `every` option to work

--- a/.changeset/cold-gifts-tickle.md
+++ b/.changeset/cold-gifts-tickle.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Async functions and async generator functions with the `every` option to work

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 from io import BytesIO
 from numbers import Number
 from pathlib import Path
-from types import GeneratorType
+from types import AsyncGeneratorType, GeneratorType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -604,6 +604,11 @@ def get_continuous_fn(fn: Callable, every: float) -> Callable:
             if isinstance(output, GeneratorType):
                 for item in output:
                     yield item
+            elif isinstance(output, AsyncGeneratorType):
+                async for item in output:
+                    yield item
+            elif inspect.isawaitable(output):
+                yield await output
             else:
                 yield output
             await asyncio.sleep(every)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -348,6 +348,39 @@ class TestGetContinuousFn:
         assert [1, 1] == await agener_list.__anext__()
         assert [1, 1, 1] == await agener_list.__anext__()
 
+    @pytest.mark.asyncio
+    async def test_get_continuous_fn_with_async_function(self):
+        async def async_int_return(x):  # for origin condition
+            return x + 1
+
+        agen_int_return = get_continuous_fn(fn=async_int_return, every=0.01)
+        agener_int_return = agen_int_return(1)
+        assert await agener_int_return.__anext__() == 2
+        assert await agener_int_return.__anext__() == 2
+
+    @pytest.mark.asyncio
+    async def test_get_continuous_fn_with_async_generator(self):
+        async def async_int_yield(x):  # new condition
+            for _i in range(2):
+                yield x
+                x += 1
+
+        async def async_list_yield(x):  # new condition
+            for _i in range(2):
+                yield x
+                x += [1]
+
+        agen_int_yield = get_continuous_fn(fn=async_int_yield, every=0.01)
+        agen_list_yield = get_continuous_fn(fn=async_list_yield, every=0.01)
+        agener_int = agen_int_yield(1)  # Primitive
+        agener_list = agen_list_yield([1])  # Reference
+        assert await agener_int.__anext__() == 1
+        assert await agener_int.__anext__() == 2
+        assert await agener_int.__anext__() == 1
+        assert [1] == await agener_list.__anext__()
+        assert [1, 1] == await agener_list.__anext__()
+        assert [1, 1, 1] == await agener_list.__anext__()
+
 
 def test_tex2svg_preserves_matplotlib_backend():
     import matplotlib


### PR DESCRIPTION
Currently looks like the [`every`](https://www.gradio.app/guides/blocks-and-event-listeners#running-events-continuously) option expects `fn` to be only a normal function or a generator function.
However, `fn` can be an async function (coroutine function) or an async generator function in normal use, so such types should also be able to be passed as `fn` with the `every` option.

The following code should work.
```python
import gradio as gr


async def get_data():
    res = await async_data_fetcher()
    return res


with gr.Blocks() as demo:
    textbox = gr.Textbox()

    demo.load(get_data, None, textbox, every=1)

if __name__ == "__main__":
    demo.queue().launch()
```
However, currently the returned coroutine is not awaited and the result would be like this:
![CleanShot 2023-11-13 at 18 40 29](https://github.com/gradio-app/gradio/assets/3135397/b8adb845-df96-4fcf-b6a8-5a425b96a697)

This PR modifies `utils.get_continuous_fn()` to deal with async functions and async generator functions so that these types can be used with the `every` option.