### PR TITLE
Remove  websockets dependency

### DIFF
--- a/.changeset/deep-cycles-switch.md
+++ b/.changeset/deep-cycles-switch.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:Remove  websockets dependency

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,5 @@ requests~=2.0
 semantic_version~=2.0
 typing_extensions~=4.0
 uvicorn>=0.14.0
-websockets>=10.0,<12.0
 typer[all]>=0.9,<1.0
 tomlkit==0.12.0


### PR DESCRIPTION
## Description

It's not used anywhere.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
