### PR TITLE
Do not show warnings when renaming api_names

### DIFF
--- a/.changeset/twelve-monkeys-move.md
+++ b/.changeset/twelve-monkeys-move.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Do not show warnings when renaming api_names

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -925,7 +925,6 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
                 api_name, [dep["api_name"] for dep in self.dependencies]
             )
             if api_name != api_name_:
-                warnings.warn(f"api_name {api_name} already exists, using {api_name_}")
                 api_name = api_name_
 
         if collects_event_data is None:
@@ -984,9 +983,6 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
                         [dep["api_name"] for dep in Context.root_block.dependencies],
                     )
                     if api_name != api_name_:
-                        warnings.warn(
-                            f"api_name {api_name} already exists, using {api_name_}"
-                        )
                         dependency["api_name"] = api_name_
                 dependency["cancels"] = [
                     c + dependency_offset for c in dependency["cancels"]


### PR DESCRIPTION
In Gradio 4.0, all API endpoints are named by default, which means that warnings about duplicated api names pop up too easily and pollute the stdout. This PR removes those warnings, which are not too necessary. 