### PR TITLE
Allow google analytics to work on Spaces (and other iframe situations)

### DIFF
--- a/.changeset/slimy-oranges-dress.md
+++ b/.changeset/slimy-oranges-dress.md
@@ -1,0 +1,7 @@
+---
+"@gradio/app": minor
+"gradio": minor
+"website": minor
+---
+
+feat:Allow google analytics to work on Spaces (and other iframe situations)

--- a/js/_website/src/routes/+layout.svelte
+++ b/js/_website/src/routes/+layout.svelte
@@ -69,9 +69,9 @@
 			dataLayer.push(arguments);
 		}
 		gtag("js", new Date());
-		gtag('config', 'UA-156449732-1', {
-        	'cookie_flags': 'samesite=none;secure'
-    	});
+		gtag("config", "UA-156449732-1", {
+			cookie_flags: "samesite=none;secure"
+		});
 	</script>
 
 	<script

--- a/js/_website/src/routes/+layout.svelte
+++ b/js/_website/src/routes/+layout.svelte
@@ -69,7 +69,9 @@
 			dataLayer.push(arguments);
 		}
 		gtag("js", new Date());
-		gtag("config", "UA-156449732-1");
+		gtag('config', 'UA-156449732-1', {
+        	'cookie_flags': 'samesite=none;secure'
+    	});
 	</script>
 
 	<script

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -687,7 +687,7 @@
 			}
 			gtag("js", new Date());
 			gtag("config", "UA-156449732-1", {
-				'cookie_flags': 'samesite=none;secure'
+				cookie_flags: "samesite=none;secure"
 			});
 		</script>
 	{/if}

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -686,7 +686,9 @@
 				dataLayer.push(arguments);
 			}
 			gtag("js", new Date());
-			gtag("config", "UA-156449732-1");
+			gtag("config", "UA-156449732-1", {
+				'cookie_flags': 'samesite=none;secure'
+			});
 		</script>
 	{/if}
 </svelte:head>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
Following https://stackoverflow.com/questions/74494818/google-analytics-not-working-for-web-site-embeded-in-iframe (thanks for sharing @aliabd), modified our google analytics tag to work on Spaces. 

Not sure if there's an easy way to test that this is working, but will take a look at our GA to see if anything shows up due to the deployed Space PR.