### PR TITLE
Preserve original image extension in backend processing

### DIFF
--- a/.changeset/rotten-results-judge.md
+++ b/.changeset/rotten-results-judge.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Preserve original image extension in backend processing

--- a/.changeset/rotten-results-judge.md
+++ b/.changeset/rotten-results-judge.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Preserve original image extension in backend processing

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -150,8 +150,12 @@ class Image(StreamingInput, Component):
         if payload.orig_name:
             p = Path(payload.orig_name)
             name = p.stem
+            suffix = p.suffix.replace(".", "")
+            if suffix in ["jpg", "jpeg"]:
+                suffix = "jpeg"
         else:
             name = "image"
+            suffix = "png"
         im = _Image.open(payload.path)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -161,6 +165,7 @@ class Image(StreamingInput, Component):
             cast(Literal["numpy", "pil", "filepath"], self.type),
             self.GRADIO_CACHE,
             name=name,
+            format=suffix,
         )
 
     def postprocess(

--- a/gradio/image_utils.py
+++ b/gradio/image_utils.py
@@ -16,6 +16,7 @@ def format_image(
     type: Literal["numpy", "pil", "filepath"],
     cache_dir: str,
     name: str = "image",
+    format: str = "png",
 ) -> np.ndarray | _Image.Image | str | None:
     """Helper method to format an image based on self.type"""
     if im is None:
@@ -27,7 +28,7 @@ def format_image(
         return np.array(im)
     elif type == "filepath":
         path = processing_utils.save_pil_to_cache(
-            im, cache_dir=cache_dir, name=name, format=fmt or "png"  # type: ignore
+            im, cache_dir=cache_dir, name=name, format=fmt or format  # type: ignore
         )
         return path
     else:
@@ -39,10 +40,12 @@ def format_image(
 
 
 def save_image(y: np.ndarray | _Image.Image | str | Path, cache_dir: str):
+    # numpy and PIL get saved to png as default format
     if isinstance(y, np.ndarray):
         path = processing_utils.save_img_array_to_cache(y, cache_dir=cache_dir)
     elif isinstance(y, _Image.Image):
         path = processing_utils.save_pil_to_cache(y, cache_dir=cache_dir)
+    # We preserve the format if the developer passes a filepath
     elif isinstance(y, Path):
         path = str(y)
     elif isinstance(y, str):

--- a/gradio/image_utils.py
+++ b/gradio/image_utils.py
@@ -32,7 +32,7 @@ def format_image(
                 im, cache_dir=cache_dir, name=name, format=fmt or format  # type: ignore
             )
         # Catch error if format is not supported by PIL
-        except Exception:
+        except KeyError:
             path = processing_utils.save_pil_to_cache(
                 im, cache_dir=cache_dir, name=name, format="png"  # type: ignore
             )

--- a/gradio/image_utils.py
+++ b/gradio/image_utils.py
@@ -57,7 +57,7 @@ def save_image(y: np.ndarray | _Image.Image | str | Path, cache_dir: str):
                 y, cache_dir=cache_dir, format=fmt  # type: ignore
             )
         # Catch error if format is not supported by PIL
-        except Exception:
+        except KeyError:
             path = processing_utils.save_pil_to_cache(
                 y, cache_dir=cache_dir, format="png"
             )

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -144,7 +144,7 @@ def save_pil_to_cache(
     img: Image.Image,
     cache_dir: str,
     name: str = "image",
-    format: Literal["png", "jpg"] = "png",
+    format: Literal["png", "jpeg"] = "png",
 ) -> str:
     bytes_data = encode_pil_to_bytes(img, format)
     temp_dir = Path(cache_dir) / hash_bytes(bytes_data)
@@ -155,7 +155,7 @@ def save_pil_to_cache(
 
 
 def save_img_array_to_cache(
-    arr: np.ndarray, cache_dir: str, format: Literal["png", "jpg"] = "png"
+    arr: np.ndarray, cache_dir: str, format: Literal["png", "jpeg"] = "png"
 ) -> str:
     pil_image = Image.fromarray(_convert(arr, np.uint8, force_copy=False))
     return save_pil_to_cache(pil_image, cache_dir, format=format)

--- a/js/app/test/image_component_events.spec.ts
+++ b/js/app/test/image_component_events.spec.ts
@@ -21,7 +21,7 @@ test("Image click-to-upload uploads image successfuly. Clear button dispatches e
 	await page.getByLabel("Download").click();
 	const download = await downloadPromise;
 	// Automatically convert to png in the backend since PIL is very picky
-	await expect(download.suggestedFilename()).toBe("cheetah1.png");
+	await expect(download.suggestedFilename()).toBe("cheetah1.jpeg");
 
 	await page.getByLabel("Remove Image").click();
 	await expect(page.getByLabel("# Clear Events")).toHaveValue("1");


### PR DESCRIPTION
## Description

Jpegs were being converted to png always.

e2e test reflects this change.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
