### PR TITLE
Catch ValueError, KeyError when saving PIL Image

### DIFF
--- a/.changeset/nice-dolls-rescue.md
+++ b/.changeset/nice-dolls-rescue.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Catch ValueError, KeyError when saving PIL Image

--- a/gradio/image_utils.py
+++ b/gradio/image_utils.py
@@ -32,7 +32,7 @@ def format_image(
                 im, cache_dir=cache_dir, name=name, format=fmt or format  # type: ignore
             )
         # Catch error if format is not supported by PIL
-        except KeyError:
+        except (KeyError, ValueError):
             path = processing_utils.save_pil_to_cache(
                 im, cache_dir=cache_dir, name=name, format="png"  # type: ignore
             )
@@ -57,7 +57,7 @@ def save_image(y: np.ndarray | _Image.Image | str | Path, cache_dir: str):
                 y, cache_dir=cache_dir, format=fmt  # type: ignore
             )
         # Catch error if format is not supported by PIL
-        except KeyError:
+        except (KeyError, ValueError):
             path = processing_utils.save_pil_to_cache(
                 y, cache_dir=cache_dir, format="png"
             )


### PR DESCRIPTION
## Description

Was breaking the image_mod_default_image demo

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
