### PR TITLE
Fix SourceFileReloader to watch the module with a qualified name to avoid importing a module with the same name from a different path

### DIFF
--- a/.changeset/bumpy-rockets-rush.md
+++ b/.changeset/bumpy-rockets-rush.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix SourceFileReloader to watch the module with a qualified name to avoid importing a module with the same name from a different path

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -35,7 +35,7 @@ should_watch = bool(os.getenv("GRADIO_WATCH_DIRS", False))
 GRADIO_WATCH_DIRS = (
     os.getenv("GRADIO_WATCH_DIRS", "").split(",") if should_watch else []
 )
-GRADIO_WATCH_FILE = os.getenv("GRADIO_WATCH_FILE", "app")
+GRADIO_WATCH_MODULE_NAME = os.getenv("GRADIO_WATCH_MODULE_NAME", "app")
 GRADIO_WATCH_DEMO_NAME = os.getenv("GRADIO_WATCH_DEMO_NAME", "demo")
 
 
@@ -192,7 +192,7 @@ def start_server(
                 reloader = SourceFileReloader(
                     app=app,
                     watch_dirs=GRADIO_WATCH_DIRS,
-                    watch_file=GRADIO_WATCH_FILE,
+                    watch_module_name=GRADIO_WATCH_MODULE_NAME,
                     demo_name=GRADIO_WATCH_DEMO_NAME,
                     stop_event=threading.Event(),
                     change_event=change_event,

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -107,7 +107,7 @@ class SourceFileReloader(BaseReloader):
         self,
         app: App,
         watch_dirs: list[str],
-        watch_file: str,
+        watch_module_name: str,
         stop_event: threading.Event,
         change_event: threading.Event,
         demo_name: str = "demo",
@@ -115,7 +115,7 @@ class SourceFileReloader(BaseReloader):
         super().__init__()
         self.app = app
         self.watch_dirs = watch_dirs
-        self.watch_file = watch_file
+        self.watch_module_name = watch_module_name
         self.stop_event = stop_event
         self.change_event = change_event
         self.demo_name = demo_name
@@ -200,11 +200,11 @@ def watchfn(reloader: SourceFileReloader):
                 if sourcefile and is_in_or_equal(sourcefile, dir_):
                     del sys.modules[k]
             try:
-                module = importlib.import_module(reloader.watch_file)
+                module = importlib.import_module(reloader.watch_module_name)
                 module = importlib.reload(module)
             except Exception as e:
                 print(
-                    f"Reloading {reloader.watch_file} failed with the following exception: "
+                    f"Reloading {reloader.watch_module_name} failed with the following exception: "
                 )
                 traceback.print_exception(None, value=e, tb=None)
                 mtimes = {}

--- a/test/test_reload.py
+++ b/test/test_reload.py
@@ -19,7 +19,7 @@ def build_demo():
 
 @dataclasses.dataclass
 class Config:
-    filename: str
+    module_name: str
     path: Path
     watch_dirs: List[str]
     demo_name: str
@@ -44,11 +44,11 @@ class TestReload:
         reloader.close()
 
     def test_config_default_app(self, config):
-        assert config.filename == "run"
+        assert config.module_name == "demo.calculator.run"
 
     @pytest.mark.parametrize("argv", [["demo/calculator/run.py", "--demo-name test"]])
     def test_config_custom_app(self, config):
-        assert config.filename == "run"
+        assert config.module_name == "demo.calculator.run"
         assert config.demo_name == "test"
 
     def test_config_watch_gradio(self, config):


### PR DESCRIPTION
## Description

Current reloader manages the target module only with a name e.g. `"app"` even when its source file is located in a nested path like "./sub/path/app.py". So it wrongly imports a module with the same name from a different path which is registered in `sys.path` with a higher priority like ".".
This PR fixes it by modifying the reloader to manage the target module with a qualified name like `"sub.path.app"` to avoid such unexpected imports.

Closes:  #6488