### PR TITLE
Ensure image editor crop and draw cursor works as expected when the scroll position changes

### DIFF
--- a/.changeset/whole-buckets-add.md
+++ b/.changeset/whole-buckets-add.md
@@ -1,0 +1,6 @@
+---
+"@gradio/imageeditor": patch
+"gradio": patch
+---
+
+fix:Ensure image editor crop and draw cursor works as expected when the scroll position changes

--- a/gradio/components/image_editor.py
+++ b/gradio/components/image_editor.py
@@ -68,8 +68,8 @@ class Brush(Eraser):
 class ImageEditor(Component):
     """
     Creates an image component that can be used to upload and edit images (as an input) or display images (as an output).
-    Preprocessing: passes the uploaded image as a ductionary of {numpy.array}, {PIL.Image} or {str} filepath depending on `type`.
-    Postprocessing: expects a ductinoary of {numpy.array}, {PIL.Image} or {str} or {pathlib.Path} filepath to an image and displays the image.
+    Preprocessing: passes the uploaded image as a dictionary of {numpy.array}, {PIL.Image} or {str} filepath depending on `type`.
+    Postprocessing: expects a dictionary of {numpy.array}, {PIL.Image} or {str} or {pathlib.Path} filepath to an image and displays the image.
     Examples-format: a {str} local filepath or URL to an image.
     Demos: image_mod, image_mod_default_image
     Guides: image-classification-in-pytorch, image-classification-in-tensorflow, image-classification-with-vision-transformers, building-a-pictionary_app, create-your-own-friends-with-a-gan

--- a/js/imageeditor/shared/ImageEditor.svelte
+++ b/js/imageeditor/shared/ImageEditor.svelte
@@ -308,6 +308,8 @@
 	}
 </script>
 
+<svelte:window on:scroll={() => get_dimensions(canvas_wrap, pixi_target)} />
+
 <div data-testid="image" class="image-container">
 	<Controls
 		can_undo={$can_undo}


### PR DESCRIPTION
## Description
 _I am not here. I did not make this PR_

There was a bug (pretty bad one imo), where the crop and draw/erase cursor would get funky if the user scrolled the page after uploading an image. This is because they rely on DOM measurements but those measurements are not updated on scroll.  This PR fixes that.

Also corrected the typos in the docstrings.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
