### PR TITLE
Allow reselecting the original option in `gr.Dropdown` after value has changed programmatically

### DIFF
--- a/.changeset/nine-bats-sin.md
+++ b/.changeset/nine-bats-sin.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dropdown": minor
+"gradio": minor
+---
+
+feat:Allow reselecting the original option in `gr.Dropdown` after value has changed programmatically

--- a/js/dropdown/dropdown.test.ts
+++ b/js/dropdown/dropdown.test.ts
@@ -364,5 +364,10 @@ describe("Dropdown", () => {
 		expect(item.value).toBe("");
 		options = getAllByTestId("dropdown-option");
 		expect(options[0]).not.toHaveClass("selected");
+
+		await component.$set({ value: "zebra" });
+		expect(item.value).toBe("zebra");
+		options = getAllByTestId("dropdown-option");
+		expect(options[0]).toHaveClass("selected");
 	});
 });

--- a/js/dropdown/shared/Dropdown.svelte
+++ b/js/dropdown/shared/Dropdown.svelte
@@ -116,6 +116,7 @@
 			input_text = "";
 			selected_index = null;
 		}
+		old_selected_index = selected_index;
 	}
 
 	function handle_option_selected(e: any): void {


### PR DESCRIPTION
Fixes the issue identified by [sbarman-mi9](https://github.com/sbarman-mi9) in https://github.com/gradio-app/gradio/pull/6425#issuecomment-1817426966

Test with:

```py
import gradio as gr

def do_something():
    return gr.update(value=None)

with gr.Blocks() as demo:
    drop_dwn = gr.Dropdown(["a", "b", "c", "d", "e"], 
                           value='b', 
                           label="Select", 
                           elem_id="drp_dwn",
                           interactive=True
                           )
    reset_btn = gr.Button("Reset")

    reset_btn.click(do_something, None, [drop_dwn])

demo.queue(default_concurrency_limit=13).launch()
```