### PR TITLE
Allows setting parameters of `gr.ChatInterface`'s `Accordion`

### DIFF
--- a/.changeset/warm-otters-rest.md
+++ b/.changeset/warm-otters-rest.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Allows setting parameters of `gr.ChatInterface`'s `Accordion`

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -259,7 +259,7 @@ class ChatInterface(Blocks):
                 not inp.is_rendered for inp in self.additional_inputs
             )
             if self.additional_inputs and any_unrendered_inputs:
-                with Accordion(**self.additional_inputs_accordion_params):
+                with Accordion(**self.additional_inputs_accordion_params):  # type: ignore
                     for input_component in self.additional_inputs:
                         if not input_component.is_rendered:
                             input_component.render()

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -60,7 +60,8 @@ class ChatInterface(Blocks):
         chatbot: Chatbot | None = None,
         textbox: Textbox | None = None,
         additional_inputs: str | Component | list[str | Component] | None = None,
-        additional_inputs_accordion_name: str = "Additional Inputs",
+        additional_inputs_accordion_name: str | None = None,
+        additional_inputs_accordion: str | Accordion | None = None,
         examples: list[str] | None = None,
         cache_examples: bool | None = None,
         title: str | None = None,
@@ -81,7 +82,8 @@ class ChatInterface(Blocks):
             chatbot: an instance of the gr.Chatbot component to use for the chat interface, if you would like to customize the chatbot properties. If not provided, a default gr.Chatbot component will be created.
             textbox: an instance of the gr.Textbox component to use for the chat interface, if you would like to customize the textbox properties. If not provided, a default gr.Textbox component will be created.
             additional_inputs: an instance or list of instances of gradio components (or their string shortcuts) to use as additional inputs to the chatbot. If components are not already rendered in a surrounding Blocks, then the components will be displayed under the chatbot, in an accordion.
-            additional_inputs_accordion_name: the label of the accordion to use for additional inputs, only used if additional_inputs is provided.
+            additional_inputs_accordion_name: Deprecated. Will be removed in a future version of Gradio. Use the `additional_inputs_accordion` parameter instead.
+            additional_inputs_accordion: If a string is provided, this is the label of the `gr.Accordion` to use to contain additional inputs. A `gr.Accordion` object can be provided as well to configure other properties of the container holding the additional inputs. Defaults to a `gr.Accordion(label="Additional Inputs", open=False)`. This parameter is only used if `additional_inputs` is provided.
             examples: sample inputs for the function; if provided, appear below the chatbot and can be clicked to populate the chatbot input.
             cache_examples: If True, caches examples in the server for fast runtime in examples. The default option in HuggingFace Spaces is True. The default option elsewhere is False.
             title: a title for the interface; if provided, appears above chatbot in large font. Also used as the tab title when opened in a browser window.
@@ -125,7 +127,32 @@ class ChatInterface(Blocks):
             ]
         else:
             self.additional_inputs = []
-        self.additional_inputs_accordion_name = additional_inputs_accordion_name
+        if additional_inputs_accordion_name is not None:
+            print(
+                "The `additional_inputs_accordion_name` parameter is deprecated and will be removed in a future version of Gradio. Use the `additional_inputs_accordion` parameter instead."
+            )
+            self.additional_inputs_accordion_params = {
+                "label": additional_inputs_accordion_name
+            }
+        if additional_inputs_accordion is None:
+            self.additional_inputs_accordion_params = {
+                "label": "Additional Inputs",
+                "open": False,
+            }
+        elif isinstance(additional_inputs_accordion, str):
+            self.additional_inputs_accordion_params = {
+                "label": additional_inputs_accordion
+            }
+        elif isinstance(additional_inputs_accordion, Accordion):
+            self.additional_inputs_accordion_params = (
+                additional_inputs_accordion.recover_kwargs(
+                    additional_inputs_accordion.get_config()
+                )
+            )
+        else:
+            raise ValueError(
+                f"The `additional_inputs_accordion` parameter must be a string or gr.Accordion, not {type(additional_inputs_accordion)}"
+            )
 
         with self:
             if title:
@@ -232,7 +259,7 @@ class ChatInterface(Blocks):
                 not inp.is_rendered for inp in self.additional_inputs
             )
             if self.additional_inputs and any_unrendered_inputs:
-                with Accordion(self.additional_inputs_accordion_name, open=False):
+                with Accordion(**self.additional_inputs_accordion_params):
                     for input_component in self.additional_inputs:
                         if not input_component.is_rendered:
                             input_component.render()

--- a/test/test_chat_interface.py
+++ b/test/test_chat_interface.py
@@ -112,6 +112,33 @@ class TestInit:
         assert prediction_hello[0].root[0] == ("hello", "hello")
         assert prediction_hi[0].root[0] == ("hi", "hi")
 
+    def test_default_accordion_params(self):
+        chatbot = gr.ChatInterface(
+            echo_system_prompt_plus_message,
+            additional_inputs=["textbox", "slider"],
+        )
+        accordion = [
+            comp
+            for comp in chatbot.blocks.values()
+            if comp.get_config().get("name") == "accordion"
+        ][0]
+        assert accordion.get_config().get("open") is False
+        assert accordion.get_config().get("label") == "Additional Inputs"
+
+    def test_setting_accordion_params(self, monkeypatch):
+        chatbot = gr.ChatInterface(
+            echo_system_prompt_plus_message,
+            additional_inputs=["textbox", "slider"],
+            additional_inputs_accordion=gr.Accordion(open=True, label="MOAR"),
+        )
+        accordion = [
+            comp
+            for comp in chatbot.blocks.values()
+            if comp.get_config().get("name") == "accordion"
+        ][0]
+        assert accordion.get_config().get("open") is True
+        assert accordion.get_config().get("label") == "MOAR"
+
     def test_example_caching_with_additional_inputs(self, monkeypatch):
         monkeypatch.setattr(helpers, "CACHED_FOLDER", tempfile.mkdtemp())
         chatbot = gr.ChatInterface(


### PR DESCRIPTION
Deprecates the overly restrictive `additional_inputs_accordion_name` argument and instead replaces it with a `additional_inputs_accordion` argument which can take either a string or a whole `gr.Accordion` object. 

This is more inline with the other arguments in `gr.ChatInterface`, such as `submit_btn`

Test with:

```py
import gradio as gr

def echo_system_prompt_plus_message(message, history, system_prompt, tokens):
    response = f"{system_prompt} {message}"
    for i in range(min(len(response), int(tokens))):
        yield response[: i + 1]

chatbot = gr.ChatInterface(
    echo_system_prompt_plus_message,
    additional_inputs=["textbox", "slider"],
    additional_inputs_accordion=gr.Accordion(open=True, label="MOAR"),
)
```

Closes: https://github.com/gradio-app/gradio/issues/6493