### PR TITLE
File table style with accessible file name texts

### DIFF
--- a/.changeset/stupid-knives-fold.md
+++ b/.changeset/stupid-knives-fold.md
@@ -1,0 +1,6 @@
+---
+"@gradio/file": minor
+"gradio": minor
+---
+
+feat:File table style with accessible file name texts

--- a/js/file/shared/FilePreview.svelte
+++ b/js/file/shared/FilePreview.svelte
@@ -16,9 +16,8 @@
 		const last_dot = filename.lastIndexOf(".");
 		if (last_dot === -1) {
 			return [filename, ""];
-		} else {
-			return [filename.slice(0, last_dot), filename.slice(last_dot)];
 		}
+		return [filename.slice(0, last_dot), filename.slice(last_dot)];
 	}
 
 	$: normalized_files = (Array.isArray(value) ? value : [value]).map((file) => {

--- a/js/file/shared/FilePreview.svelte
+++ b/js/file/shared/FilePreview.svelte
@@ -92,7 +92,6 @@
 	}
 
 	.filename {
-		width: auto;
 		flex-grow: 1;
 		display: flex;
 		overflow: hidden;

--- a/js/file/shared/FilePreview.svelte
+++ b/js/file/shared/FilePreview.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { FileData } from "@gradio/client";
-	import { display_file_name, display_file_size } from "./utils";
+	import { prettyBytes } from "./utils";
 	import { createEventDispatcher } from "svelte";
 	import type { I18nFormatter, SelectData } from "@gradio/utils";
 
@@ -11,6 +11,24 @@
 	export let selectable = false;
 	export let height: number | undefined = undefined;
 	export let i18n: I18nFormatter;
+
+	function split_filename(filename: string): [string, string] {
+		const last_dot = filename.lastIndexOf(".");
+		if (last_dot === -1) {
+			return [filename, ""];
+		} else {
+			return [filename.slice(0, last_dot), filename.slice(last_dot)];
+		}
+	}
+
+	$: normalized_files = (Array.isArray(value) ? value : [value]).map((file) => {
+		const [filename_stem, filename_ext] = split_filename(file.orig_name ?? "");
+		return {
+			...file,
+			filename_stem,
+			filename_ext
+		};
+	});
 </script>
 
 <div
@@ -19,7 +37,7 @@
 >
 	<table class="file-preview">
 		<tbody>
-			{#each Array.isArray(value) ? value : [value] as file, i}
+			{#each normalized_files as file, i}
 				<tr
 					class="file"
 					class:selectable
@@ -29,8 +47,9 @@
 							index: i
 						})}
 				>
-					<td>
-						{display_file_name(file)}
+					<td class="filename" aria-label={file.orig_name}>
+						<span class="stem">{file.filename_stem}</span>
+						<span class="ext">{file.filename_ext}</span>
 					</td>
 
 					<td class="download">
@@ -40,7 +59,9 @@
 								target="_blank"
 								download={window.__is_colab__ ? null : file.orig_name}
 							>
-								{@html display_file_size(file)}&nbsp;&#8675;
+								{@html file.size != null
+									? prettyBytes(file.size)
+									: "(size unknown)"}&nbsp;&#8675;
 							</a>
 						{:else}
 							{i18n("file.uploading")}
@@ -53,26 +74,17 @@
 </div>
 
 <style>
-	td {
-		width: 45%;
-	}
-
-	td:last-child {
-		width: 10%;
-		text-align: right;
-	}
-	.file-preview-holder {
-		overflow-x: auto;
-		overflow-y: auto;
-	}
 	.file-preview {
+		table-layout: fixed;
 		width: var(--size-full);
 		max-height: var(--size-60);
 		overflow-y: auto;
 		margin-top: var(--size-1);
 		color: var(--body-text-color);
 	}
+
 	.file {
+		display: flex;
 		width: var(--size-full);
 	}
 
@@ -80,6 +92,27 @@
 		padding: var(--size-1) var(--size-2-5);
 	}
 
+	.filename {
+		width: auto;
+		flex-grow: 1;
+		display: flex;
+		overflow: hidden;
+	}
+	.filename .stem {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.filename .ext {
+		white-space: nowrap;
+	}
+
+	.download {
+		min-width: 8rem;
+		width: 10%;
+		white-space: nowrap;
+		text-align: right;
+	}
 	.download:hover {
 		text-decoration: underline;
 	}

--- a/js/file/shared/utils.ts
+++ b/js/file/shared/utils.ts
@@ -10,31 +10,3 @@ export const prettyBytes = (bytes: number): string => {
 	let unit = units[i];
 	return bytes.toFixed(1) + "&nbsp;" + unit;
 };
-
-export const display_file_name = (value: FileData): string => {
-	const orig_name: string = value.orig_name ?? "";
-	const max_length = 30;
-
-	if (orig_name.length > max_length) {
-		const truncated_name = orig_name.substring(0, max_length);
-		const file_extension_index = orig_name.lastIndexOf(".");
-		if (file_extension_index !== -1) {
-			const file_extension = orig_name.slice(file_extension_index);
-			return `${truncated_name}..${file_extension}`;
-		}
-		return truncated_name;
-	}
-	return orig_name;
-};
-
-export const display_file_size = (value: FileData | FileData[]): string => {
-	var total_size = 0;
-	if (Array.isArray(value)) {
-		for (var file of value) {
-			if (file.size !== undefined) total_size += file.size;
-		}
-	} else {
-		total_size = value.size || 0;
-	}
-	return prettyBytes(total_size);
-};


### PR DESCRIPTION
## Description

From the a11y perspective, file names shouldn't be truncated at HTML/JS level. Instead, such text truncation only for visual appearance should be controlled by CSS.

Full width:
![CleanShot 2023-11-21 at 18 33 59@2x](https://github.com/gradio-app/gradio/assets/3135397/1e91b004-4f83-4210-bfa1-c1b0395b626f)

Narrow screen:
![CleanShot 2023-11-21 at 18 35 14@2x](https://github.com/gradio-app/gradio/assets/3135397/f82d17c2-8e6d-4cce-8ba3-9f753b39fb28)

ARIA properties:
![CleanShot 2023-11-21 at 18 35 54@2x](https://github.com/gradio-app/gradio/assets/3135397/9a9277b6-b673-4880-a897-a4adad70ed7c)
For a11y purpose, setting `aria-label` might be enough though, the overridden "Contents" still keeps original file name readable.
