### PR TITLE
Fix gradio_client duplicating upgraded Spaces

### DIFF
--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -253,7 +253,7 @@ class Client:
         )
         hardware = hardware or original_info.hardware
         if current_hardware != hardware:
-            huggingface_hub.request_space_hardware(space_id, hardware)  # type: ignore
+            huggingface_hub.request_space_hardware(space_id, hardware, token=hf_token)  # type: ignore
             print(
                 f"-------\nNOTE: this Space uses upgraded hardware: {hardware}... see billing info at https://huggingface.co/settings/billing\n-------"
             )


### PR DESCRIPTION
## Description

[internal convo](https://huggingface.slack.com/archives/C02QZLG8GMN/p1700475888741849). When passing the token explicitly, e.g.

```python
from gradio_client import Client
client = Client.duplicate("abidlabs/whisper", hf_token="token")
```
the repo is duplicated with a CPU but then the client fails with a 

```
Repository Not Found for url: https://huggingface.co/api/spaces/osanseviero/whisper/hardware.
Please make sure you specified the correct `repo_id` and `repo_type`.
If you are trying to access a private or gated repo, make sure you are authenticated.
Invalid username or password.
``` 

error. This is due to the token not being passed when requesting a hardware.
  
