### PR TITLE
Fix Theme Dropdown in deployed theme space

### DIFF
--- a/.changeset/easy-turtles-tie.md
+++ b/.changeset/easy-turtles-tie.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix Theme Dropdown in deployed theme space

--- a/gradio/themes/app.py
+++ b/gradio/themes/app.py
@@ -6,7 +6,7 @@ from gradio.themes.utils.theme_dropdown import create_theme_dropdown
 dropdown, js = create_theme_dropdown()
 
 with gr.Blocks(theme=gr.themes.Default()) as demo:
-    with gr.Row().style(equal_height=True):
+    with gr.Row(equal_height=True):
         with gr.Column(scale=10):
             gr.Markdown(
                 """
@@ -17,9 +17,9 @@ with gr.Blocks(theme=gr.themes.Default()) as demo:
                 """
             )
         with gr.Column(scale=3):
-            with gr.Box():
+            with gr.Group():
                 dropdown.render()
-                toggle_dark = gr.Button(value="Toggle Dark").style(full_width=True)
+                toggle_dark = gr.Button(value="Toggle Dark")
 
     dropdown.change(None, dropdown, None, js=js)
     toggle_dark.click(
@@ -65,11 +65,12 @@ with gr.Blocks(theme=gr.themes.Default()) as demo:
             img = gr.Image(
                 "https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg",
                 label="Image",
-            ).style(height=320)
+                height=320,
+            )
             with gr.Row():
-                go_btn = gr.Button("Go", label="Primary Button", variant="primary")
+                go_btn = gr.Button("Go", variant="primary")
                 clear_btn = gr.Button(
-                    "Clear", label="Secondary Button", variant="secondary"
+                    "Clear", variant="secondary"
                 )
 
                 def go(*args):
@@ -85,11 +86,9 @@ with gr.Blocks(theme=gr.themes.Default()) as demo:
                 clear_btn.click(clear, None, img)
 
             with gr.Row():
-                btn1 = gr.Button("Button 1").style(size="sm")
-                btn2 = gr.UploadButton().style(size="sm")
-                stop_btn = gr.Button("Stop", label="Stop Button", variant="stop").style(
-                    size="sm"
-                )
+                btn1 = gr.Button("Button 1", size="sm")
+                btn2 = gr.UploadButton(size="sm")
+                stop_btn = gr.Button("Stop", size="sm", variant="stop")
 
     with gr.Row():
         gr.Dataframe(value=[[1, 2, 3], [4, 5, 6], [7, 8, 9]], label="Dataframe")
@@ -115,8 +114,8 @@ with gr.Blocks(theme=gr.themes.Default()) as demo:
                     "https://gradio-static-files.s3.us-west-2.amazonaws.com/tower.jpg",
                     "tower",
                 ),
-            ]
-        ).style(height="200px", grid=2)
+            ],
+        height=200)
 
     with gr.Row():
         with gr.Column(scale=2):

--- a/gradio/themes/app.py
+++ b/gradio/themes/app.py
@@ -69,9 +69,7 @@ with gr.Blocks(theme=gr.themes.Default()) as demo:
             )
             with gr.Row():
                 go_btn = gr.Button("Go", variant="primary")
-                clear_btn = gr.Button(
-                    "Clear", variant="secondary"
-                )
+                clear_btn = gr.Button("Clear", variant="secondary")
 
                 def go(*args):
                     time.sleep(3)
@@ -115,7 +113,8 @@ with gr.Blocks(theme=gr.themes.Default()) as demo:
                     "tower",
                 ),
             ],
-        height=200)
+            height=200,
+        )
 
     with gr.Row():
         with gr.Column(scale=2):

--- a/gradio/themes/utils/theme_dropdown.py
+++ b/gradio/themes/utils/theme_dropdown.py
@@ -37,7 +37,7 @@ def create_theme_dropdown():
         value=latest_to_oldest[0],
         render=False,
         label="Select Version",
-        container=False
+        container=False,
     )
 
     return (

--- a/gradio/themes/utils/theme_dropdown.py
+++ b/gradio/themes/utils/theme_dropdown.py
@@ -37,7 +37,8 @@ def create_theme_dropdown():
         value=latest_to_oldest[0],
         render=False,
         label="Select Version",
-    ).style(container=False)
+        container=False
+    )
 
     return (
         component,


### PR DESCRIPTION
## Description

Closes: #6527

<img width="717" alt="Screenshot 2023-11-21 at 12 44 54 PM" src="https://github.com/gradio-app/gradio/assets/41651716/663cbc13-7681-4d84-b5e6-50331b245457">

https://huggingface.co/spaces/freddyaboulton/testSoft

You need to install the package from this PR for the deployed space to work though.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
