### PR TITLE
Fix encoding issue #6364 of reload mode

### DIFF
--- a/.changeset/heavy-planes-dig.md
+++ b/.changeset/heavy-planes-dig.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix encoding issue #6364 of reload mode

--- a/gradio/cli/commands/reload.py
+++ b/gradio/cli/commands/reload.py
@@ -29,9 +29,10 @@ def _setup_config(
     demo_path: Path,
     demo_name: str = "demo",
     additional_watch_dirs: list[str] | None = None,
+    encoding: str = "utf-8",
 ):
     original_path = Path(demo_path)
-    app_text = original_path.read_text()
+    app_text = original_path.read_text(encoding=encoding)
 
     patterns = [
         f"with gr\\.Blocks\\(\\) as {demo_name}",
@@ -96,11 +97,11 @@ def _setup_config(
 
 
 def main(
-    demo_path: Path, demo_name: str = "demo", watch_dirs: Optional[List[str]] = None
+    demo_path: Path, demo_name: str = "demo", watch_dirs: Optional[List[str]] = None, encoding: str = "utf-8"
 ):
     # default execution pattern to start the server and watch changes
     module_name, path, watch_dirs, demo_name = _setup_config(
-        demo_path, demo_name, watch_dirs
+        demo_path, demo_name, watch_dirs, encoding
     )
     # extra_args = args[1:] if len(args) == 1 or args[1].startswith("--") else args[2:]
     popen = subprocess.Popen(

--- a/gradio/cli/commands/reload.py
+++ b/gradio/cli/commands/reload.py
@@ -97,7 +97,10 @@ def _setup_config(
 
 
 def main(
-    demo_path: Path, demo_name: str = "demo", watch_dirs: Optional[List[str]] = None, encoding: str = "utf-8"
+    demo_path: Path,
+    demo_name: str = "demo",
+    watch_dirs: Optional[List[str]] = None,
+    encoding: str = "utf-8",
 ):
     # default execution pattern to start the server and watch changes
     module_name, path, watch_dirs, demo_name = _setup_config(

--- a/guides/09_other-tutorials/developing-faster-with-reload-mode.md
+++ b/guides/09_other-tutorials/developing-faster-with-reload-mode.md
@@ -70,6 +70,12 @@ if __name__ == "__main__":
 
 Then you would launch it in reload mode like this: `gradio run.py my_demo`.
 
+By default, the Gradio use UTF-8 encoding for scripts. **For reload mode**, If you are using encoding formats other than UTF-8 (such as cp1252 or cp936, etc.), make sure you've done like this:
+
+1. Configure encoding declaration of python script, for example: `# -*- coding: cp1252 -*-`
+2. Confirm that your code editor has identified that encoding format. 
+3. Run like this: `gradio run.py --encoding cp1252`
+
 🔥 If your application accepts command line arguments, you can pass them in as well. Here's an example:
 
 ```python

--- a/guides/09_other-tutorials/developing-faster-with-reload-mode.md
+++ b/guides/09_other-tutorials/developing-faster-with-reload-mode.md
@@ -70,7 +70,7 @@ if __name__ == "__main__":
 
 Then you would launch it in reload mode like this: `gradio run.py my_demo`.
 
-By default, the Gradio use UTF-8 encoding for scripts. **For reload mode**, If you are using encoding formats other than UTF-8 (such as cp1252 or cp936, etc.), make sure you've done like this:
+By default, the Gradio use UTF-8 encoding for scripts. **For reload mode**, If you are using encoding formats other than UTF-8 (such as cp1252), make sure you've done like this:
 
 1. Configure encoding declaration of python script, for example: `# -*- coding: cp1252 -*-`
 2. Confirm that your code editor has identified that encoding format. 

--- a/guides/cn/07_other-tutorials/developing-faster-with-reload-mode.md
+++ b/guides/cn/07_other-tutorials/developing-faster-with-reload-mode.md
@@ -72,6 +72,12 @@ if __name__ == "__main__":
 
 那么您可以这样启动它：`gradio run.py my_demo.app`。
 
+Gradio默认使用UTF-8编码格式。对于**重新加载模式**，如果你的脚本使用的是除UTF-8以外的编码（如GBK）：
+
+1. 在Python脚本的编码声明处指定你想要的编码格式，如：`# -*- coding: gbk -*-`
+2. 确保你的代码编辑器识别到该格式。 
+3. 执行：`gradio run.py --encoding gbk`
+
 🔥 如果您的应用程序接受命令行参数，您也可以传递它们。下面是一个例子：
 
 ```python


### PR DESCRIPTION
## Description

This fix is target on Windows platform.

In reload mode, the dev-created Python script shall be crunched via cmd, however the script's encoding format is not informed for it. This PR fix the problem.

Meanwhile, if I'd like to use GBK encoding (or anything but UTF-8) for my script, such error occurs:

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0xac in position 2517: illegal mutibyte sequence
```

Therefore I added a `encoding` parameter into cli, allowing devs free to specify any encoding format they want.

Doc changes are included in the PR.

Closes: [#6364]
  
