### PR TITLE
Set gradio api server from env

### DIFF
--- a/.changeset/odd-garlics-teach.md
+++ b/.changeset/odd-garlics-teach.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Set gradio api server from env

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:  # Only import for type checking (to avoid circular imports).
 INITIAL_PORT_VALUE = int(os.getenv("GRADIO_SERVER_PORT", "7860"))
 TRY_NUM_PORTS = int(os.getenv("GRADIO_NUM_PORTS", "100"))
 LOCALHOST_NAME = os.getenv("GRADIO_SERVER_NAME", "127.0.0.1")
-GRADIO_API_SERVER = "https://api.gradio.app/v2/tunnel-request"
+GRADIO_API_SERVER = os.getenv("GRADIO_API_SERVER", "https://api.gradio.app/v2/tunnel-request")
 
 should_watch = bool(os.getenv("GRADIO_WATCH_DIRS", False))
 GRADIO_WATCH_DIRS = (

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -29,9 +29,8 @@ if TYPE_CHECKING:  # Only import for type checking (to avoid circular imports).
 INITIAL_PORT_VALUE = int(os.getenv("GRADIO_SERVER_PORT", "7860"))
 TRY_NUM_PORTS = int(os.getenv("GRADIO_NUM_PORTS", "100"))
 LOCALHOST_NAME = os.getenv("GRADIO_SERVER_NAME", "127.0.0.1")
-GRADIO_API_SERVER = os.getenv(
-    "GRADIO_API_SERVER", "https://api.gradio.app/v2/tunnel-request"
-)
+GRADIO_API_SERVER = "https://api.gradio.app/v2/tunnel-request"
+GRADIO_SHARE_SERVER_ADDRESS = os.getenv("GRADIO_SHARE_SERVER_ADDRESS")
 
 should_watch = bool(os.getenv("GRADIO_WATCH_DIRS", False))
 GRADIO_WATCH_DIRS = (
@@ -220,6 +219,11 @@ def start_server(
 def setup_tunnel(
     local_host: str, local_port: int, share_token: str, share_server_address: str | None
 ) -> str:
+    share_server_address = (
+        GRADIO_SHARE_SERVER_ADDRESS
+        if share_server_address is None
+        else share_server_address
+    )
     if share_server_address is None:
         response = requests.get(GRADIO_API_SERVER)
         if not (response and response.status_code == 200):

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -29,7 +29,9 @@ if TYPE_CHECKING:  # Only import for type checking (to avoid circular imports).
 INITIAL_PORT_VALUE = int(os.getenv("GRADIO_SERVER_PORT", "7860"))
 TRY_NUM_PORTS = int(os.getenv("GRADIO_NUM_PORTS", "100"))
 LOCALHOST_NAME = os.getenv("GRADIO_SERVER_NAME", "127.0.0.1")
-GRADIO_API_SERVER = os.getenv("GRADIO_API_SERVER", "https://api.gradio.app/v2/tunnel-request")
+GRADIO_API_SERVER = os.getenv(
+    "GRADIO_API_SERVER", "https://api.gradio.app/v2/tunnel-request"
+)
 
 should_watch = bool(os.getenv("GRADIO_WATCH_DIRS", False))
 GRADIO_WATCH_DIRS = (


### PR DESCRIPTION
## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Set share link server from env `GRADIO_API_SERVER` so that I can make the gradio automatically use another gradio share server without changing the source code.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

This fix is very small, so I do not create an issue for it.

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
