### PR TITLE
use gr.Error for audio length errors

### DIFF
--- a/.changeset/eager-snakes-boil.md
+++ b/.changeset/eager-snakes-boil.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:use gr.Error for audio length errors

--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -15,6 +15,7 @@ from gradio import processing_utils, utils
 from gradio.components.base import Component, StreamingInput, StreamingOutput
 from gradio.data_classes import FileData
 from gradio.events import Events
+from gradio.exceptions import Error
 
 set_documentation_group("component")
 
@@ -190,11 +191,11 @@ class Audio(
 
         duration = len(data) / sample_rate
         if self.min_length is not None and duration < self.min_length:
-            raise ValueError(
+            raise Error(
                 f"Audio is too short, and must be at least {self.min_length} seconds"
             )
         if self.max_length is not None and duration > self.max_length:
-            raise ValueError(
+            raise Error(
                 f"Audio is too long, and must be at most {self.max_length} seconds"
             )
 


### PR DESCRIPTION
Quick fix, closes: https://github.com/gradio-app/gradio/issues/6335