### PR TITLE
Rotate Images to Upright Position in preprocess

### DIFF
--- a/.changeset/evil-readers-reply.md
+++ b/.changeset/evil-readers-reply.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Rotate Images to Upright Position in preprocess

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -8,8 +8,8 @@ from typing import Any, Literal, cast
 
 import numpy as np
 from gradio_client.documentation import document, set_documentation_group
-from PIL import Image as _Image
-from PIL import ImageOps  # using _ to minimize namespace pollution
+from PIL import Image as _Image  # using _ to minimize namespace pollution
+from PIL import ImageOps
 
 import gradio.image_utils as image_utils
 from gradio import utils

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -8,7 +8,8 @@ from typing import Any, Literal, cast
 
 import numpy as np
 from gradio_client.documentation import document, set_documentation_group
-from PIL import Image as _Image  # using _ to minimize namespace pollution
+from PIL import Image as _Image
+from PIL import ImageOps  # using _ to minimize namespace pollution
 
 import gradio.image_utils as image_utils
 from gradio import utils
@@ -162,6 +163,10 @@ class Image(StreamingInput, Component):
             return str(file_path)
 
         im = _Image.open(file_path)
+        exif = im.getexif()
+        # 274 is the code for image rotation and 1 means "correct orientation"
+        if exif.get(274, 1) != 1 and hasattr(ImageOps, "exif_transpose"):
+            im = ImageOps.exif_transpose(im)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             im = im.convert(self.image_mode)

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -169,7 +169,7 @@ class Image(StreamingInput, Component):
             try:
                 im = ImageOps.exif_transpose(im)
             except Exception:
-                print(f"Failed to transpose image {file_path} based on EXIF data.")
+                warnings.warn(f"Failed to transpose image {file_path} based on EXIF data.")
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             im = im.convert(self.image_mode)

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -169,7 +169,9 @@ class Image(StreamingInput, Component):
             try:
                 im = ImageOps.exif_transpose(im)
             except Exception:
-                warnings.warn(f"Failed to transpose image {file_path} based on EXIF data.")
+                warnings.warn(
+                    f"Failed to transpose image {file_path} based on EXIF data."
+                )
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             im = im.convert(self.image_mode)

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -166,7 +166,10 @@ class Image(StreamingInput, Component):
         exif = im.getexif()
         # 274 is the code for image rotation and 1 means "correct orientation"
         if exif.get(274, 1) != 1 and hasattr(ImageOps, "exif_transpose"):
-            im = ImageOps.exif_transpose(im)
+            try:
+                im = ImageOps.exif_transpose(im)
+            except Exception:
+                print(f"Failed to transpose image {file_path} based on EXIF data.")
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             im = im.convert(self.image_mode)

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -58,21 +58,6 @@ def extract_base64_data(x: str) -> str:
 #########################
 
 
-def decode_base64_to_image(encoding: str) -> Image.Image:
-    image_encoded = extract_base64_data(encoding)
-    img = Image.open(BytesIO(base64.b64decode(image_encoded)))
-    try:
-        if hasattr(ImageOps, "exif_transpose"):
-            img = ImageOps.exif_transpose(img)
-    except Exception:
-        log.warning(
-            "Failed to transpose image %s based on EXIF data.",
-            img,
-            exc_info=True,
-        )
-    return img
-
-
 def encode_plot_to_base64(plt):
     with BytesIO() as output_bytes:
         plt.savefig(output_bytes, format="png")

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -640,6 +640,17 @@ class TestImage:
         component = gr.Image(None)
         assert component.get_config().get("value") is None
 
+    def test_images_upright_after_preprocess(self):
+        """
+        postprocess
+        """
+        component = gr.Image(type="pil")
+        file_path = "test/test_files/rotated_image.jpeg"
+        im = PIL.Image.open(file_path)
+        assert im.getexif().get(274) != 1
+        image = component.preprocess(FileData(path=file_path))
+        assert image == PIL.ImageOps.exif_transpose(im)
+
 
 class TestPlot:
     @pytest.mark.asyncio

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -641,9 +641,6 @@ class TestImage:
         assert component.get_config().get("value") is None
 
     def test_images_upright_after_preprocess(self):
-        """
-        postprocess
-        """
         component = gr.Image(type="pil")
         file_path = "test/test_files/rotated_image.jpeg"
         im = PIL.Image.open(file_path)

--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -1,6 +1,3 @@
-import base64
-import io
-import logging
 import os
 import shutil
 import tempfile
@@ -106,19 +103,6 @@ class TestTempFileManagement:
 
 
 class TestImagePreprocessing:
-    def test_decode_base64_to_image(self):
-        output_image = processing_utils.decode_base64_to_image(
-            deepcopy(media_data.BASE64_IMAGE)
-        )
-        assert isinstance(output_image, Image.Image)
-
-        b64_img_without_header = deepcopy(media_data.BASE64_IMAGE).split(",")[1]
-        output_image_without_header = processing_utils.decode_base64_to_image(
-            b64_img_without_header
-        )
-
-        assert output_image == output_image_without_header
-
     def test_encode_plot_to_base64(self):
         with utils.MatplotlibBackendMananger():
             import matplotlib.pyplot as plt
@@ -196,24 +180,6 @@ class TestImagePreprocessing:
             img_cp2, cache_dir=gradio_temp_dir
         )
         assert len({img_path, img_metadata_path, img_cp1_path, img_cp2_path}) == 4
-
-    def test_encode_pil_to_base64_keeps_pnginfo(self):
-        input_img = Image.open("gradio/test_data/test_image.png")
-        input_img = input_img.convert("RGB")
-        input_img.info = {"key1": "value1", "key2": "value2"}
-
-        encoded_image = processing_utils.encode_pil_to_base64(input_img)
-        decoded_image = processing_utils.decode_base64_to_image(encoded_image)
-
-        assert decoded_image.info == input_img.info
-
-    @patch("PIL.Image.Image.getexif", return_value={274: 3})
-    @patch("PIL.ImageOps.exif_transpose")
-    def test_base64_to_image_does_rotation(self, mock_rotate, mock_exif):
-        input_img = Image.open("gradio/test_data/test_image.png")
-        base64 = processing_utils.encode_pil_to_base64(input_img)
-        processing_utils.decode_base64_to_image(base64)
-        mock_rotate.assert_called_once()
 
     def test_resize_and_crop(self):
         img = Image.open("gradio/test_data/test_image.png")
@@ -361,20 +327,3 @@ class TestVideoProcessing:
             )
             # If the conversion succeeded it'd be .mp4
             assert Path(playable_vid).suffix == ".avi"
-
-
-def test_decode_base64_to_image_does_not_crash_when_image_has_bogus_exif_data(caplog):
-    from PIL.PngImagePlugin import PngInfo
-
-    caplog.set_level(logging.WARNING)
-    i = Image.new("RGB", (32, 32), "orange")
-    bio = io.BytesIO()
-    # since `exif` is the `.info` key for EXIF data parsed from a JPEG,
-    # adding an iTXt chunk with the same name should trigger the warning
-    pi = PngInfo()
-    pi.add_text("exif", "bogus")
-    i.save(bio, format="png", pnginfo=pi)
-    bio.seek(0)
-    encoded = base64.b64encode(bio.getvalue()).decode()
-    assert processing_utils.decode_base64_to_image(encoded).size == (32, 32)
-    assert "Failed to transpose image" in caplog.text


### PR DESCRIPTION
## Description

Closes: #6617

Added a unit test. Test visually by running `image_mod_default_image` with the `rotated_image.jpeg` saved in `test/test_files`.

The correct output is a 45 degree rotation from the upright position.

### This branch
<img width="1320" alt="image" src="https://github.com/gradio-app/gradio/assets/41651716/ba0246a3-a429-4872-ae26-f6a78ef18e49">

### Main
<img width="1556" alt="image" src="https://github.com/gradio-app/gradio/assets/41651716/7205f896-4edd-4c8d-b580-0ce2a4422357">


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
