### PR TITLE
Tweak to our bug issue template

### DIFF
--- a/.changeset/tall-regions-wash.md
+++ b/.changeset/tall-regions-wash.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Tweak to our bug issue template

--- a/.github/ISSUE_TEMPLATE/bug_report_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.yml
@@ -27,6 +27,11 @@ body:
       label: Reproduction
       description: Please provide a minimal example, with code, that can be run to reproduce the issue. Do NOT provide screenshots of code, or link to external repos or applications. Use ``` to format code blocks.
       placeholder: Reproduction
+      value: |
+        ```python
+        import gradio as gr
+        
+        ```
     validations:
       required: true
   - type: textarea

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -220,7 +220,7 @@ def setup_tunnel(
 ) -> str:
     if share_server_address is None:
         try:
-            response = httpx.get(GRADIO_API_SERVER)
+            response = httpx.get(GRADIO_API_SERVER, timeout=30)
             payload = response.json()[0]
             remote_host, remote_port = payload["host"], int(payload["port"])
         except Exception as e:

--- a/gradio/tunneling.py
+++ b/gradio/tunneling.py
@@ -46,7 +46,7 @@ class Tunnel:
     @staticmethod
     def download_binary():
         if not Path(BINARY_PATH).exists():
-            resp = httpx.get(BINARY_URL)
+            resp = httpx.get(BINARY_URL, timeout=30)
 
             if resp.status_code == 403:
                 raise OSError(


### PR DESCRIPTION
Small tweak to our bug issue template which adds the code syntax to the "Reproduction" section. I've noticed a lot of people dump code without the formatting, which makes it hard to parse. Hopefully, this will help!

<img width="951" alt="image" src="https://github.com/gradio-app/gradio/assets/1778297/6fe12343-729c-43b4-a27e-a42950a9a085">

Here's how it looks: https://github.com/abidlabs/gradio/issues/new?assignees=&labels=bug&projects=&template=bug_report_template.yml