### PR TITLE
Remove Discourse Forum Link from Website

### DIFF
--- a/.changeset/dark-wolves-sit.md
+++ b/.changeset/dark-wolves-sit.md
@@ -1,0 +1,5 @@
+---
+"website": minor
+---
+
+feat:Remove Discourse Forum Link from Website

--- a/js/_website/src/lib/components/Header.svelte
+++ b/js/_website/src/lib/components/Header.svelte
@@ -99,11 +99,6 @@
 						>
 						<a
 							class="thin-link inline-block px-4 py-2 hover:bg-gray-100"
-							href="https://discuss.huggingface.co/c/gradio/26"
-							target="_blank">Discuss</a
-						>
-						<a
-							class="thin-link inline-block px-4 py-2 hover:bg-gray-100"
 							target="_blank"
 							href="https://discord.gg/feTf9x3ZSB">Discord</a
 						>


### PR DESCRIPTION
Removes link to forum from the website header, since we're [shutting it down](https://discuss.huggingface.co/t/announcement-we-will-be-closing-this-gradio-section-of-the-forums/64720).