### PR TITLE
URL + onMessage: Issues with javascript `@gradio/client` package

### DIFF
--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -667,7 +667,7 @@ export function api_factory(
 							)}/queue/join?${url_params ? url_params + "&" : ""}${params}`
 						);
 
-						eventSource = new EventSource(url);
+						eventSource = new EventSource(url.toString());
 
 						eventSource.onmessage = async function (event) {
 							const _data = JSON.parse(event.data);
@@ -1025,7 +1025,7 @@ function transform_output(
 					? [normalise_file(img[0], root_url, remote_url), img[1]]
 					: [normalise_file(img, root_url, remote_url), null];
 			});
-		} else if (typeof d === "object" && d.path) {
+		} else if (typeof d === "object" & d !== null && d.path) {
 			return normalise_file(d, root_url, remote_url);
 		}
 		return d;


### PR DESCRIPTION
1. This `url` is an instance of URL, so it needs `.toString()` for initializing EventSource.
2. Processing a response often comes with a null portion to indicate the end of the data being streamed, so we need to explicitly avoid checking for `null.path`

ℹ️ I will come back to this and open the appropriate issues against the repository. ℹ️ 

## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
