### PR TITLE
Hotfix: update `huggingface_hub` dependency version

### DIFF
--- a/.changeset/tough-beers-unite.md
+++ b/.changeset/tough-beers-unite.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:Hotfix: update `huggingface_hub` dependency version

--- a/.changeset/tough-beers-unite.md
+++ b/.changeset/tough-beers-unite.md
@@ -1,5 +1,6 @@
 ---
 "gradio": patch
+"gradio_client": patch
 ---
 
 feat:Hotfix: update `huggingface_hub` dependency version

--- a/client/python/requirements.txt
+++ b/client/python/requirements.txt
@@ -1,6 +1,6 @@
 fsspec
 httpx
-huggingface_hub>=0.13.0
+huggingface_hub>=0.19.3
 packaging
 typing_extensions~=4.0
 websockets>=10.0,<12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ fastapi
 ffmpy
 gradio_client==0.7.1
 httpx
-huggingface_hub>=0.14.0
+huggingface_hub>=0.19.3
 importlib_resources>=1.3,<7.0
 Jinja2<4.0
 markupsafe~=2.0

--- a/test/test_theme_sharing.py
+++ b/test/test_theme_sharing.py
@@ -240,6 +240,8 @@ class TestGetThemeAssets:
                 },
             ],
             tags=["gradio-theme", "gradio"],
+            private=False,
+            likes=0,
         )
 
         assert get_theme_assets(space_info) == [
@@ -256,18 +258,6 @@ class TestGetThemeAssets:
     def test_load_space_from_hub_works(self):
         theme = gr.Theme.from_hub("gradio/seafoam")
         assert isinstance(theme, gr.Theme)
-
-    # def test_raises_if_space_not_properly_tagged(self):
-    #     space_info = huggingface_hub.hf_api.SpaceInfo(
-    #         id="freddyaboulton/dracula", tags=["gradio"]
-    #     )
-
-    #     with pytest.raises(
-    #         ValueError,
-    #         match="freddyaboulton/dracula is not a valid gradio-theme space!",
-    #     ):
-    #         with patch("huggingface_hub.HfApi.space_info", return_value=space_info):
-    #             get_theme_assets(space_info)
 
 
 class TestBuiltInThemes:
@@ -289,7 +279,7 @@ class TestThemeUploadDownload:
     @patch("gradio.themes.base.get_theme_assets", return_value=assets)
     def test_get_next_version(self, mock):
         next_version = gr.themes.Base._get_next_version(
-            SpaceInfo(id="gradio/dracula_test")
+            SpaceInfo(id="gradio/dracula_test", private=False, likes=0, tags=[])
         )
         assert next_version == "3.20.2"
 


### PR DESCRIPTION
As part of #6616, some of the backend tests now need a valid hf token to run. These can be specified via the HF_TOKEN environment variable, or by logging in via the hf-cli. In the GitHub CI runners, we use the HF_TOKEN variable, so we use the former approach. However, this requires `huggingface_hub>=0.19.3` since in previous versions, the `huggingface_hub` library looked for a different environment variable called `HUGGING_FACE_HUB_TOKEN`