### PR TITLE
Remove the styles from the Image/Video primitive components and Fix the container styles

### DIFF
--- a/.changeset/legal-geese-agree.md
+++ b/.changeset/legal-geese-agree.md
@@ -1,0 +1,7 @@
+---
+"@gradio/image": minor
+"@gradio/video": minor
+"gradio": minor
+---
+
+feat:Remove the styles from the Image/Video primitive components and Fix the container styles

--- a/js/image/Example.svelte
+++ b/js/image/Example.svelte
@@ -18,8 +18,8 @@
 
 <style>
 	.container :global(img) {
-		max-width: 100%;
-		max-height: 100%;
+		width: 100%;
+		height: 100%;
 	}
 
 	.container.selected {

--- a/js/image/Example.svelte
+++ b/js/image/Example.svelte
@@ -37,7 +37,6 @@
 	}
 
 	.container.gallery {
-		border: 2px solid var(--border-color-primary);
 		height: var(--size-20);
 		max-height: var(--size-20);
 		object-fit: cover;

--- a/js/image/Example.svelte
+++ b/js/image/Example.svelte
@@ -17,6 +17,11 @@
 </div>
 
 <style>
+	.container :global(img) {
+		max-width: 100%;
+		max-height: 100%;
+	}
+
 	.container.selected {
 		border-color: var(--border-color-accent);
 	}
@@ -25,6 +30,7 @@
 		margin: 0 auto;
 		border: 2px solid var(--border-color-primary);
 		border-radius: var(--radius-lg);
+		overflow: hidden;
 		width: var(--size-20);
 		height: var(--size-20);
 		object-fit: cover;

--- a/js/image/shared/Image.svelte
+++ b/js/image/shared/Image.svelte
@@ -13,11 +13,3 @@
 {:catch error}
 	<p style="color: red;">{error.message}</p>
 {/await}
-
-<style>
-	img {
-		width: 100%;
-		height: 100%;
-		border-radius: var(--radius-lg);
-	}
-</style>

--- a/js/video/Example.svelte
+++ b/js/video/Example.svelte
@@ -46,6 +46,12 @@
 		border: 2px solid var(--border-color-primary);
 		border-radius: var(--radius-lg);
 		max-width: none;
+		overflow: hidden;
+	}
+	.container :global(video) {
+		width: var(--size-full);
+		height: var(--size-full);
+		object-fit: cover;
 	}
 
 	.container:hover,

--- a/js/video/Example.svelte
+++ b/js/video/Example.svelte
@@ -43,10 +43,7 @@
 <style>
 	.container {
 		flex: none;
-		border: 2px solid var(--border-color-primary);
-		border-radius: var(--radius-lg);
 		max-width: none;
-		overflow: hidden;
 	}
 	.container :global(video) {
 		width: var(--size-full);
@@ -60,6 +57,9 @@
 	}
 	.container.table {
 		margin: 0 auto;
+		border: 2px solid var(--border-color-primary);
+		border-radius: var(--radius-lg);
+		overflow: hidden;
 		width: var(--size-20);
 		height: var(--size-20);
 		object-fit: cover;

--- a/js/video/shared/Player.svelte
+++ b/js/video/shared/Player.svelte
@@ -254,4 +254,8 @@
 		width: var(--size-full);
 		border-radius: var(--radius-xl);
 	}
+	.wrap :global(video) {
+		height: var(--size-full);
+		width: var(--size-full);
+	}
 </style>

--- a/js/video/shared/Video.svelte
+++ b/js/video/shared/Video.svelte
@@ -121,13 +121,4 @@
 			background: #fff;
 		}
 	}
-
-	video {
-		position: inherit;
-		background-color: black;
-		width: var(--size-full);
-		height: var(--size-full);
-		object-fit: contain;
-		border-radius: var(--radius-xl);
-	}
 </style>


### PR DESCRIPTION
This PR contains these:

### Remove the styles from the reusable media primitive components
* Remove the styles from `js/image/shared/Image.svelte` and `js/video/shared/Video.svelte`, which are reusable components and shouldn't have their own styles.
* Instead, apply the styles to them by adding the `<container-selector> :global(img or video)` style to the user components.

### Fix the gap between the borders and the inner contents
* See https://github.com/gradio-app/gradio/pull/6726#issuecomment-1848788599

### Fix style inconsistency
* Also fixed two inconsistent styles. Plz see the following comments (https://github.com/gradio-app/gradio/pull/6726#discussion_r1421611426 and https://github.com/gradio-app/gradio/pull/6726#issuecomment-1848790865). Plz let me know what you think.