### PR TITLE
reload on css changes + fix css specificity

### DIFF
--- a/.changeset/fresh-dryers-send.md
+++ b/.changeset/fresh-dryers-send.md
@@ -1,5 +1,6 @@
 ---
 "@gradio/app": minor
+"@gradio/preview": minor
 "gradio": minor
 ---
 

--- a/.changeset/fresh-dryers-send.md
+++ b/.changeset/fresh-dryers-send.md
@@ -1,0 +1,6 @@
+---
+"@gradio/app": minor
+"gradio": minor
+---
+
+feat:reload on css changes + fix css specificity

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -170,6 +170,8 @@ def watchfn(reloader: SourceFileReloader):
         for reload_dir in reload_dirs:
             for path in list(reload_dir.rglob("*.py")):
                 yield path.resolve()
+            for path in list(reload_dir.rglob("*.css")):
+                yield path.resolve()
 
     module = None
     reload_dirs = [Path(dir_) for dir_ in reloader.watch_dirs]

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -1,6 +1,6 @@
 <script context="module" lang="ts">
 	import { writable } from "svelte/store";
-	import { mount_css as default_mount_css } from "./css";
+	import { mount_css as default_mount_css, prefix_css } from "./css";
 
 	import type { ComponentMeta, Dependency, LayoutNode } from "./types";
 
@@ -119,14 +119,14 @@
 		app_id = config.app_id;
 	}
 
-	async function mount_custom_css(
-		target: HTMLElement,
-		css_string: string | null
-	): Promise<void> {
+	let css_text_stylesheet: HTMLStyleElement | null = null;
+	async function mount_custom_css(css_string: string | null): Promise<void> {
 		if (css_string) {
-			let style = document.createElement("style");
-			style.innerHTML = css_string;
-			target.appendChild(style);
+			css_text_stylesheet = prefix_css(
+				css_string,
+				version,
+				css_text_stylesheet || undefined
+			);
 		}
 		await mount_css(config.root + "/theme.css", document.head);
 		if (!config.stylesheets) return;
@@ -135,10 +135,15 @@
 			config.stylesheets.map((stylesheet) => {
 				let absolute_link =
 					stylesheet.startsWith("http:") || stylesheet.startsWith("https:");
-				return mount_css(
-					absolute_link ? stylesheet : config.root + "/" + stylesheet,
-					document.head
-				);
+				if (absolute_link) {
+					return mount_css(stylesheet, document.head);
+				}
+
+				return fetch(config.root + "/" + stylesheet)
+					.then((response) => response.text())
+					.then((css_string) => {
+						prefix_css(css_string, version);
+					});
 			})
 		);
 	}
@@ -243,7 +248,7 @@
 			detail: "RUNNING"
 		};
 
-		await mount_custom_css(wrapper, config.css);
+		await mount_custom_css(config.css);
 		await add_custom_html_head(config.head);
 		css_ready = true;
 		window.__is_colab__ = config.is_colab;
@@ -259,22 +264,12 @@
 							status_callback: handle_status,
 							normalise_files: false
 						});
+
 						config = app.config;
 						window.__gradio_space__ = config.space_id;
+						await mount_custom_css(config.css);
 					}
 				};
-
-				// websocket = new WebSocket(url);
-				// websocket.onmessage = async function (event) {
-				// 	if (event.data === "CHANGE") {
-				// 		app = await client(api_url, {
-				// 			status_callback: handle_status,
-				// 			normalise_files: false
-				// 		});
-				// 		config = app.config;
-				// 		window.__gradio_space__ = config.space_id;
-				// 	}
-				// };
 			}, 200);
 		}
 	});

--- a/js/app/src/css.ts
+++ b/js/app/src/css.ts
@@ -18,3 +18,39 @@ export function mount_css(url: string, target: HTMLElement): Promise<void> {
 		target.appendChild(link);
 	});
 }
+
+export function prefix_css(
+	string: string,
+	version: string,
+	style_element = document.createElement("style")
+): HTMLStyleElement {
+	//  create style element
+	style_element.remove();
+
+	const stylesheet = new CSSStyleSheet();
+	stylesheet.replaceSync(string);
+
+	const rules = stylesheet.cssRules;
+
+	let css_string = "";
+
+	for (let i = 0; i < rules.length; i++) {
+		const rule = rules[i];
+
+		if (rule instanceof CSSStyleRule) {
+			const selector = rule.selectorText;
+			if (selector) {
+				const new_selector = selector
+					.split(",")
+					.map((s) => `.gradio-container-${version} .contain ${s.trim()}`)
+					.join(",");
+
+				css_string += rule.cssText.replace(selector, new_selector);
+			}
+		}
+	}
+	style_element.textContent = css_string;
+
+	document.head.appendChild(style_element);
+	return style_element;
+}

--- a/js/app/src/css.ts
+++ b/js/app/src/css.ts
@@ -24,7 +24,6 @@ export function prefix_css(
 	version: string,
 	style_element = document.createElement("style")
 ): HTMLStyleElement {
-	//  create style element
 	style_element.remove();
 
 	const stylesheet = new CSSStyleSheet();
@@ -45,6 +44,7 @@ export function prefix_css(
 					.map((s) => `.gradio-container-${version} .contain ${s.trim()}`)
 					.join(",");
 
+				css_string += rule.cssText;
 				css_string += rule.cssText.replace(selector, new_selector);
 			}
 		}

--- a/js/app/src/css.ts
+++ b/js/app/src/css.ts
@@ -41,7 +41,10 @@ export function prefix_css(
 			if (selector) {
 				const new_selector = selector
 					.split(",")
-					.map((s) => `.gradio-container-${version} .contain ${s.trim()}`)
+					.map(
+						(s) =>
+							`gradio-app .gradio-container.gradio-container-${version} .contain ${s.trim()}`
+					)
 					.join(",");
 
 				css_string += rule.cssText;

--- a/js/preview/package.json
+++ b/js/preview/package.json
@@ -21,7 +21,7 @@
 	"dependencies": {
 		"@originjs/vite-plugin-commonjs": "^1.0.3",
 		"@rollup/plugin-sucrase": "^5.0.1",
-		"@sveltejs/vite-plugin-svelte": "^3.0.0",
+		"@sveltejs/vite-plugin-svelte": "^2.5.2",
 		"@types/which": "^3.0.0",
 		"coffeescript": "^2.7.0",
 		"css-tree": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"@manypkg/get-packages": "^2.2.0",
 		"@playwright/experimental-ct-svelte": "^1.39.0",
 		"@playwright/test": "^1.39.0",
-		"@sveltejs/vite-plugin-svelte": "^3.0.0",
+		"@sveltejs/vite-plugin-svelte": "^2.5.2",
 		"@tailwindcss/forms": "^0.5.0",
 		"@testing-library/dom": "^9.0.0",
 		"@testing-library/jest-dom": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.39.0
         version: 1.39.0
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^3.0.0
-        version: 3.0.0(svelte@4.2.2)(vite@4.3.9)
+        specifier: ^2.5.2
+        version: 2.5.2(svelte@4.2.2)(vite@4.3.9)
       '@tailwindcss/forms':
         specifier: ^0.5.0
         version: 0.5.0(tailwindcss@3.1.6)
@@ -185,7 +185,7 @@ importers:
         version: 1.3.7(less@4.2.0)(postcss@8.4.27)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.2)(webpack@5.89.0)
       '@storybook/addon-svelte-csf':
         specifier: ^4.0.9
-        version: 4.0.9(@storybook/svelte@7.5.1)(@storybook/theming@7.5.1)(@sveltejs/vite-plugin-svelte@3.0.0)(svelte@4.2.2)(vite@4.3.9)
+        version: 4.0.9(@storybook/svelte@7.5.1)(@storybook/theming@7.5.1)(@sveltejs/vite-plugin-svelte@2.5.2)(svelte@4.2.2)(vite@4.3.9)
       '@storybook/blocks':
         specifier: ^7.5.1
         version: 7.5.1(react-dom@18.2.0)(react@18.2.0)
@@ -1195,8 +1195,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(rollup@3.28.0)
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^3.0.0
-        version: 3.0.1(svelte@4.2.3)(vite@5.0.6)
+        specifier: ^2.5.2
+        version: 2.5.2(svelte@4.2.3)(vite@4.5.0)
       '@types/which':
         specifier: ^3.0.0
         version: 3.0.0
@@ -1492,7 +1492,6 @@ packages:
 
   /@adobe/css-tools@4.3.1:
     resolution: {integrity: sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==}
-    dev: false
 
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
@@ -4859,7 +4858,7 @@ packages:
     dependencies:
       playwright: 1.39.0
       playwright-core: 1.39.0
-      vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)
+      vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -5523,110 +5522,6 @@ packages:
       picomatch: 2.3.1
       rollup: 3.28.0
 
-  /@rollup/rollup-android-arm-eabi@4.7.0:
-    resolution: {integrity: sha512-rGku10pL1StFlFvXX5pEv88KdGW6DHUghsxyP/aRYb9eH+74jTGJ3U0S/rtlsQ4yYq1Hcc7AMkoJOb1xu29Fxw==}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-android-arm64@4.7.0:
-    resolution: {integrity: sha512-/EBw0cuJ/KVHiU2qyVYUhogXz7W2vXxBzeE9xtVIMC+RyitlY2vvaoysMUqASpkUtoNIHlnKTu/l7mXOPgnKOA==}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-darwin-arm64@4.7.0:
-    resolution: {integrity: sha512-4VXG1bgvClJdbEYYjQ85RkOtwN8sqI3uCxH0HC5w9fKdqzRzgG39K7GAehATGS8jghA7zNoS5CjSKkDEqWmNZg==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-darwin-x64@4.7.0:
-    resolution: {integrity: sha512-/ImhO+T/RWJ96hUbxiCn2yWI0/MeQZV/aeukQQfhxiSXuZJfyqtdHPUPrc84jxCfXTxbJLmg4q+GBETeb61aNw==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-arm-gnueabihf@4.7.0:
-    resolution: {integrity: sha512-zhye8POvTyUXlKbfPBVqoHy3t43gIgffY+7qBFqFxNqVtltQLtWeHNAbrMnXiLIfYmxcoL/feuLDote2tx+Qbg==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-arm64-gnu@4.7.0:
-    resolution: {integrity: sha512-RAdr3OJnUum6Vs83cQmKjxdTg31zJnLLTkjhcFt0auxM6jw00GD6IPFF42uasYPr/wGC6TRm7FsQiJyk0qIEfg==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-arm64-musl@4.7.0:
-    resolution: {integrity: sha512-nhWwYsiJwZGq7SyR3afS3EekEOsEAlrNMpPC4ZDKn5ooYSEjDLe9W/xGvoIV8/F/+HNIY6jY8lIdXjjxfxopXw==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-riscv64-gnu@4.7.0:
-    resolution: {integrity: sha512-rlfy5RnQG1aop1BL/gjdH42M2geMUyVQqd52GJVirqYc787A/XVvl3kQ5NG/43KXgOgE9HXgCaEH05kzQ+hLoA==}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-x64-gnu@4.7.0:
-    resolution: {integrity: sha512-cCkoGlGWfBobdDtiiypxf79q6k3/iRVGu1HVLbD92gWV5WZbmuWJCgRM4x2N6i7ljGn1cGytPn9ZAfS8UwF6vg==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-linux-x64-musl@4.7.0:
-    resolution: {integrity: sha512-R2oBf2p/Arc1m+tWmiWbpHBjEcJnHVnv6bsypu4tcKdrYTpDfl1UT9qTyfkIL1iiii5D4WHxUHCg5X0pzqmxFg==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-win32-arm64-msvc@4.7.0:
-    resolution: {integrity: sha512-CPtgaQL1aaPc80m8SCVEoxFGHxKYIt3zQYC3AccL/SqqiWXblo3pgToHuBwR8eCP2Toa+X1WmTR/QKFMykws7g==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-win32-ia32-msvc@4.7.0:
-    resolution: {integrity: sha512-pmioUlttNh9GXF5x2CzNa7Z8kmRTyhEzzAC+2WOOapjewMbl+3tGuAnxbwc5JyG8Jsz2+hf/QD/n5VjimOZ63g==}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@rollup/rollup-win32-x64-msvc@4.7.0:
-    resolution: {integrity: sha512-SeZzC2QhhdBQUm3U0c8+c/P6UlRyBcLL2Xp5KX7z46WXZxzR8RJSIWL9wSUeBTgxog5LTPJuPj0WOT9lvrtP7Q==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
@@ -6007,7 +5902,7 @@ packages:
       - typescript
     dev: true
 
-  /@storybook/addon-svelte-csf@4.0.9(@storybook/svelte@7.5.1)(@storybook/theming@7.5.1)(@sveltejs/vite-plugin-svelte@3.0.0)(svelte@4.2.2)(vite@4.3.9):
+  /@storybook/addon-svelte-csf@4.0.9(@storybook/svelte@7.5.1)(@storybook/theming@7.5.1)(@sveltejs/vite-plugin-svelte@2.5.2)(svelte@4.2.2)(vite@4.3.9):
     resolution: {integrity: sha512-840GekS9Cpq6QIx+8I1djkBDOxCODlUKoITU6aIbEssrt5a4sQQlW6BVoJ/abVas/qs253XSBHOj0cpQ7Aii0w==}
     peerDependencies:
       '@storybook/svelte': ^7.0.0
@@ -6027,7 +5922,7 @@ packages:
       '@babel/runtime': 7.23.2
       '@storybook/svelte': 7.5.1(svelte@4.2.2)
       '@storybook/theming': 7.5.1(react-dom@18.2.0)(react@18.2.0)
-      '@sveltejs/vite-plugin-svelte': 3.0.0(svelte@4.2.2)(vite@4.3.9)
+      '@sveltejs/vite-plugin-svelte': 2.5.2(svelte@4.2.2)(vite@4.3.9)
       dedent: 1.5.1
       fs-extra: 11.1.1
       magic-string: 0.30.5
@@ -6887,7 +6782,7 @@ packages:
       svelte: 4.2.3
       tiny-glob: 0.2.9
       undici: 5.26.5
-      vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)
+      vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6915,7 +6810,7 @@ packages:
       svelte: 4.2.3
       tiny-glob: 0.2.9
       undici: 5.26.5
-      vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)
+      vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6945,40 +6840,9 @@ packages:
       '@sveltejs/vite-plugin-svelte': 2.5.2(svelte@4.2.3)(vite@4.5.0)
       debug: 4.3.4
       svelte: 4.2.3
-      vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)
+      vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1)
     transitivePeerDependencies:
       - supports-color
-
-  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.0)(svelte@4.2.2)(vite@4.3.9):
-    resolution: {integrity: sha512-gjr9ZFg1BSlIpfZ4PRewigrvYmHWbDrq2uvvPB1AmTWKuM+dI1JXQSUu2pIrYLb/QncyiIGkFDFKTwJ0XqQZZg==}
-    engines: {node: ^18.0.0 || >=20}
-    peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^3.0.0
-      svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.0
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.0(svelte@4.2.2)(vite@4.3.9)
-      debug: 4.3.4
-      svelte: 4.2.2
-      vite: 4.3.9(@types/node@20.3.2)(less@4.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.3)(vite@5.0.6):
-    resolution: {integrity: sha512-gjr9ZFg1BSlIpfZ4PRewigrvYmHWbDrq2uvvPB1AmTWKuM+dI1JXQSUu2pIrYLb/QncyiIGkFDFKTwJ0XqQZZg==}
-    engines: {node: ^18.0.0 || >=20}
-    peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^3.0.0
-      svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.0
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.2.3)(vite@5.0.6)
-      debug: 4.3.4
-      svelte: 4.2.3
-      vite: 5.0.6(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@sveltejs/vite-plugin-svelte@2.5.2(svelte@4.2.2)(vite@4.3.9):
     resolution: {integrity: sha512-Dfy0Rbl+IctOVfJvWGxrX/3m6vxPLH8o0x+8FA5QEyMUQMo4kGOVIojjryU7YomBAexOTAuYf1RT7809yDziaA==}
@@ -7013,49 +6877,10 @@ packages:
       magic-string: 0.30.5
       svelte: 4.2.3
       svelte-hmr: 0.15.3(svelte@4.2.3)
-      vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)
+      vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1)
       vitefu: 0.2.5(vite@4.5.0)
     transitivePeerDependencies:
       - supports-color
-
-  /@sveltejs/vite-plugin-svelte@3.0.0(svelte@4.2.2)(vite@4.3.9):
-    resolution: {integrity: sha512-Th0nupxk8hl5Rcg9jm+1xWylwco4bSUAvutWxM4W4bjOAollpXLmrYqSSnYo9pPbZOO6ZGRm6sSqYa/v1d/Saw==}
-    engines: {node: ^18.0.0 || >=20}
-    peerDependencies:
-      svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.0
-    dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.0)(svelte@4.2.2)(vite@4.3.9)
-      debug: 4.3.4
-      deepmerge: 4.3.1
-      kleur: 4.1.5
-      magic-string: 0.30.5
-      svelte: 4.2.2
-      svelte-hmr: 0.15.3(svelte@4.2.2)
-      vite: 4.3.9(@types/node@20.3.2)(less@4.2.0)
-      vitefu: 0.2.5(vite@4.3.9)
-    transitivePeerDependencies:
-      - supports-color
-
-  /@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.2.3)(vite@5.0.6):
-    resolution: {integrity: sha512-CGURX6Ps+TkOovK6xV+Y2rn8JKa8ZPUHPZ/NKgCxAmgBrXReavzFl8aOSCj3kQ1xqT7yGJj53hjcV/gqwDAaWA==}
-    engines: {node: ^18.0.0 || >=20}
-    peerDependencies:
-      svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.0
-    dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.3)(vite@5.0.6)
-      debug: 4.3.4
-      deepmerge: 4.3.1
-      kleur: 4.1.5
-      magic-string: 0.30.5
-      svelte: 4.2.3
-      svelte-hmr: 0.15.3(svelte@4.2.3)
-      vite: 5.0.6(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1)
-      vitefu: 0.2.5(vite@5.0.6)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@tailwindcss/forms@0.5.0(tailwindcss@3.1.6):
     resolution: {integrity: sha512-KzWugryEBFkmoaYcBE18rs6gthWCFHHO7cAZm2/hv3hwD67AzwP7udSCa22E7R1+CEJL/FfhYsJWrc0b1aeSzw==}
@@ -9388,7 +9213,6 @@ packages:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
     hasBin: true
-    dev: false
 
   /detect-libc@2.0.2:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
@@ -11166,7 +10990,6 @@ packages:
 
   /immutable@4.3.4:
     resolution: {integrity: sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==}
-    dev: false
 
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -11951,7 +11774,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /lightningcss-darwin-x64@1.21.7:
@@ -11960,7 +11782,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /lightningcss-freebsd-x64@1.21.7:
@@ -11969,7 +11790,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /lightningcss-linux-arm-gnueabihf@1.21.7:
@@ -11978,7 +11798,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /lightningcss-linux-arm64-gnu@1.21.7:
@@ -11987,7 +11806,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /lightningcss-linux-arm64-musl@1.21.7:
@@ -11996,7 +11814,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /lightningcss-linux-x64-gnu@1.21.7:
@@ -12005,7 +11822,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /lightningcss-linux-x64-musl@1.21.7:
@@ -12014,7 +11830,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /lightningcss-win32-x64-msvc@1.21.7:
@@ -12023,7 +11838,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /lightningcss@1.21.7:
@@ -12041,7 +11855,6 @@ packages:
       lightningcss-linux-x64-gnu: 1.21.7
       lightningcss-linux-x64-musl: 1.21.7
       lightningcss-win32-x64-msvc: 1.21.7
-    dev: false
 
   /lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
@@ -13383,7 +13196,6 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: false
 
   /preferred-pm@3.1.2:
     resolution: {integrity: sha512-nk7dKrcW8hfCZ4H6klWcdRknBOXWzNQByJ0oJyX97BOupsYD+FzLS4hflgEu/uPUEHZCuRfMxzCBsuWd7OzT8Q==}
@@ -14137,27 +13949,6 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
-  /rollup@4.7.0:
-    resolution: {integrity: sha512-7Kw0dUP4BWH78zaZCqF1rPyQ8D5DSU6URG45v1dqS/faNsx9WXyess00uTOZxKr7oR/4TOjO1CPudT8L1UsEgw==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.7.0
-      '@rollup/rollup-android-arm64': 4.7.0
-      '@rollup/rollup-darwin-arm64': 4.7.0
-      '@rollup/rollup-darwin-x64': 4.7.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.7.0
-      '@rollup/rollup-linux-arm64-gnu': 4.7.0
-      '@rollup/rollup-linux-arm64-musl': 4.7.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.7.0
-      '@rollup/rollup-linux-x64-gnu': 4.7.0
-      '@rollup/rollup-linux-x64-musl': 4.7.0
-      '@rollup/rollup-win32-arm64-msvc': 4.7.0
-      '@rollup/rollup-win32-ia32-msvc': 4.7.0
-      '@rollup/rollup-win32-x64-msvc': 4.7.0
-      fsevents: 2.3.3
-    dev: false
-
   /rrweb-cssom@0.6.0:
     resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
     dev: false
@@ -14259,7 +14050,6 @@ packages:
       chokidar: 3.5.3
       immutable: 4.3.4
       source-map-js: 1.0.2
-    dev: false
 
   /sax@1.3.0:
     resolution: {integrity: sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==}
@@ -14513,7 +14303,6 @@ packages:
   /source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
-    dev: false
 
   /space-separated-tokens@1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
@@ -14729,7 +14518,6 @@ packages:
       source-map: 0.7.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /subscribable-things@2.1.26:
     resolution: {integrity: sha512-Fz+/UKellsC2SSGxsmWfxP9cJpcEP1Xb+5rNm/QIz9onpZlFqsDELWapEKaGSJFzlzW4WkGlyNR6t/pCrzuvXw==}
@@ -14760,7 +14548,6 @@ packages:
       postcss: ^8.3.3
     dependencies:
       postcss: 8.4.32
-    dev: false
 
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -16310,7 +16097,7 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
-  /vite@4.5.0(@types/node@20.3.2)(less@4.2.0):
+  /vite@4.5.0(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1):
     resolution: {integrity: sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -16341,8 +16128,12 @@ packages:
       '@types/node': 20.3.2
       esbuild: 0.18.20
       less: 4.2.0
+      lightningcss: 1.21.7
       postcss: 8.4.31
       rollup: 3.29.4
+      sass: 1.66.1
+      stylus: 0.62.0
+      sugarss: 4.0.1(postcss@8.4.32)
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -16383,47 +16174,6 @@ packages:
       fsevents: 2.3.3
     dev: false
 
-  /vite@5.0.6(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1):
-    resolution: {integrity: sha512-MD3joyAEBtV7QZPl2JVVUai6zHms3YOmLR+BpMzLlX2Yzjfcc4gTgNi09d/Rua3F4EtC8zdwPU8eQYyib4vVMQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.3.2
-      esbuild: 0.19.5
-      less: 4.2.0
-      lightningcss: 1.21.7
-      postcss: 8.4.32
-      rollup: 4.7.0
-      sass: 1.66.1
-      stylus: 0.62.0
-      sugarss: 4.0.1(postcss@8.4.32)
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: false
-
   /vitefu@0.2.5(vite@4.3.9):
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
     peerDependencies:
@@ -16442,18 +16192,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)
-
-  /vitefu@0.2.5(vite@5.0.6):
-    resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
-    peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
-    peerDependenciesMeta:
-      vite:
-        optional: true
-    dependencies:
-      vite: 5.0.6(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1)
-    dev: false
+      vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1)
 
   /vitest@0.34.6(jsdom@23.0.0)(less@4.2.0)(playwright@1.39.0):
     resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}


### PR DESCRIPTION
## Description

This has been driving me up the wall all weekend, so here is a fix.

- Ensure the app reloads + css is correctly applied when CSS files in a watch dir are edited. cc @freddyaboulton 
- Ensure CSS is correctly applied when CSS (as a string) changed.
- Make working with custom CSS much simpler (genuine fix for #3851) cc @aliabid94 @abidlabs 

This should work fine now with no need for `!important` modifiers or other CSS hacks:

```python
import gradio as gr

css = """
#custom-md h1 {
  color: hotpink;
}

.custom-md h2 {
  color: orange;
}
"""

with gr.Blocks(css=css) as demo:
  gr.Markdown("# Heading one", elem_id="custom-md")
  gr.Markdown("## Heading two", elem_classes=["custom-md"])

demo.launch()
```

We do this by modifying the selectors passed by a user, prepending them with a series of addition selectors to increase their specificity enough that they override the svelte hashed classes. It's hacky but should be relatively robust.

Closes #6735. Closes #6736.


