### PR TITLE
Mount on a FastAPI app with lifespan manager

### DIFF
--- a/.changeset/wild-planets-sin.md
+++ b/.changeset/wild-planets-sin.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Mount on a FastAPI app with lifespan manager

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -4,6 +4,7 @@ module use the Optional/Union notation so that they work correctly with pydantic
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import sys
 
 if sys.version_info >= (3, 9):
@@ -892,9 +893,17 @@ def mount_gradio_app(
     blocks.validate_queue_settings()
     gradio_app = App.create_app(blocks, app_kwargs=app_kwargs)
 
-    @app.on_event("startup")
-    async def start_queue():
-        gradio_app.get_blocks().startup_events()
+    old_lifespan = app.router.lifespan_context
+
+    @contextlib.asynccontextmanager
+    async def new_lifespan(app: FastAPI):
+        async with old_lifespan(
+            app
+        ):  # Instert the startup events inside the FastAPI context manager
+            gradio_app.get_blocks().startup_events()
+            yield
+
+    app.router.lifespan_context = new_lifespan
 
     app.mount(path, gradio_app)
     return app


### PR DESCRIPTION
## Description

### Original Issue

When mounted on a FastAPI implementing a lifespan context manager the requests remain in the queue.

### Proposed Fix

Stack a new context manager on top of the original one.

### Code modified

`gradio>routes.py>mount_gradio_app`

\>>>
```python
...
@app.on_event("startup")
async def start_queue():
    gradio_app.get_blocks().startup_events()
...
```
<<<
```python
...
old_lifespan = app.router.lifespan_context

@contextlib.asynccontextmanager
async def new_lifespan(app: FastAPI):
    async with old_lifespan(
        app
    ):  # Instert the startup events inside the FastAPI context manager
        gradio_app.get_blocks().startup_events()
        yield

app.router.lifespan_context = new_lifespan
...
```

Closes: #6718 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
