### PR TITLE
Fix backend tests on Windows

### DIFF
--- a/.changeset/vast-kings-deny.md
+++ b/.changeset/vast-kings-deny.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix backend tests on Windows

--- a/.changeset/vast-kings-deny.md
+++ b/.changeset/vast-kings-deny.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Fix backend tests on Windows

--- a/gradio/components/file_explorer.py
+++ b/gradio/components/file_explorer.py
@@ -170,7 +170,7 @@ class FileExplorer(Component):
         def make_tree(files):
             tree = []
             for file in files:
-                parts = file.split("/")
+                parts = file.split(os.path.sep)
                 make_node(parts, tree)
             return tree
 

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -2144,10 +2144,11 @@ class TestGallery:
                 Path("test/test_files/qux.png"),
             ]
         ).model_dump()
+        assert True
         assert postprocessed_gallery == [
             {
                 "image": {
-                    "path": str(Path("test/test_files/foo.png")),
+                    "path": os.path.join("test", "test_files", "foo.png"),
                     "orig_name": "foo.png",
                     "mime_type": None,
                     "size": None,

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -2145,11 +2145,11 @@ class TestGallery:
             ]
         ).model_dump()
 
-        # Using os.path.join() below to make sure the test works on Windows
+        # Using str(Path(...)) to ensure that the test passes on all platforms
         assert postprocessed_gallery == [
             {
                 "image": {
-                    "path": os.path.join("test", "test_files", "foo.png"),
+                    "path": str(Path("test") / "test_files" / "foo.png"),
                     "orig_name": "foo.png",
                     "mime_type": None,
                     "size": None,
@@ -2159,7 +2159,7 @@ class TestGallery:
             },
             {
                 "image": {
-                    "path": os.path.join("test", "test_files", "bar.png"),
+                    "path": str(Path("test") / "test_files" / "bar.png"),
                     "orig_name": "bar.png",
                     "mime_type": None,
                     "size": None,
@@ -2169,7 +2169,7 @@ class TestGallery:
             },
             {
                 "image": {
-                    "path": os.path.join("test", "test_files", "baz.png"),
+                    "path": str(Path("test") / "test_files" / "baz.png"),
                     "orig_name": "baz.png",
                     "mime_type": None,
                     "size": None,
@@ -2179,7 +2179,7 @@ class TestGallery:
             },
             {
                 "image": {
-                    "path": os.path.join("test", "test_files", "qux.png"),
+                    "path": str(Path("test") / "test_files" / "qux.png"),
                     "orig_name": "qux.png",
                     "mime_type": None,
                     "size": None,

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -2147,7 +2147,7 @@ class TestGallery:
         assert postprocessed_gallery == [
             {
                 "image": {
-                    "path": "test/test_files/foo.png",
+                    "path": str(Path("test/test_files/foo.png")),
                     "orig_name": "foo.png",
                     "mime_type": None,
                     "size": None,
@@ -2157,7 +2157,7 @@ class TestGallery:
             },
             {
                 "image": {
-                    "path": "test/test_files/bar.png",
+                    "path": str(Path("test/test_files/bar.png")),
                     "orig_name": "bar.png",
                     "mime_type": None,
                     "size": None,
@@ -2167,7 +2167,7 @@ class TestGallery:
             },
             {
                 "image": {
-                    "path": "test/test_files/baz.png",
+                    "path": str(Path("test/test_files/baz.png")),
                     "orig_name": "baz.png",
                     "mime_type": None,
                     "size": None,
@@ -2177,7 +2177,7 @@ class TestGallery:
             },
             {
                 "image": {
-                    "path": "test/test_files/qux.png",
+                    "path": str(Path("test/test_files/qux.png")),
                     "orig_name": "qux.png",
                     "mime_type": None,
                     "size": None,

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -2138,13 +2138,14 @@ class TestGallery:
 
         postprocessed_gallery = gallery.postprocess(
             [
-                ("test/test_files/foo.png", "foo_caption"),
+                (str(Path("test/test_files/foo.png")), "foo_caption"),
                 (Path("test/test_files/bar.png"), "bar_caption"),
-                "test/test_files/baz.png",
+                str(Path("test/test_files/baz.png")),
                 Path("test/test_files/qux.png"),
             ]
         ).model_dump()
-        assert True
+
+        # Using os.path.join() below to make sure the test works on Windows
         assert postprocessed_gallery == [
             {
                 "image": {
@@ -2158,7 +2159,7 @@ class TestGallery:
             },
             {
                 "image": {
-                    "path": str(Path("test/test_files/bar.png")),
+                    "path": os.path.join("test", "test_files", "bar.png"),
                     "orig_name": "bar.png",
                     "mime_type": None,
                     "size": None,
@@ -2168,7 +2169,7 @@ class TestGallery:
             },
             {
                 "image": {
-                    "path": str(Path("test/test_files/baz.png")),
+                    "path": os.path.join("test", "test_files", "baz.png"),
                     "orig_name": "baz.png",
                     "mime_type": None,
                     "size": None,
@@ -2178,7 +2179,7 @@ class TestGallery:
             },
             {
                 "image": {
-                    "path": str(Path("test/test_files/qux.png")),
+                    "path": os.path.join("test", "test_files", "qux.png"),
                     "orig_name": "qux.png",
                     "mime_type": None,
                     "size": None,


### PR DESCRIPTION
2 non-flaky tests were failing on Windows. Turns out one was a problem with the test, while the other was actually an issue in the code. Both should be fixed now.