### PR TITLE
Added catch/fix for no event loop in main thread.

### DIFF
--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -77,8 +77,13 @@ def safe_get_lock() -> asyncio.Lock:
     try:
         asyncio.get_event_loop()
         return asyncio.Lock()
-    except RuntimeError:
-        return None  # type: ignore
+    except RuntimeError as e:
+        if str(e) == "There is no current event loop in thread 'MainThread'.":
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            return asyncio.Lock()
+        else:
+            raise e
 
 
 class BaseReloader(ABC):


### PR DESCRIPTION
## Description

Addresses Runtime exception regarding a lack of a main thread event loop, ultimately resulting in:
"TypeError: 'NoneType' object does not support the asynchronous context manager protocol"

Code I was running:
https://github.com/Bikatr7/Kudasai/commit/e6ed5561f5129cd0d84d24cdb581b3c6e6af61c0

## Closes:

N/A

Didn't create an issue, as I wasn't able to minimize my code enough to a point that could replicate the error. My thought that this was a small specific fix for a small error, so it should be fine. If not, feel free to decline, and I'll work around it and not use queues.

  
