### PR TITLE
Improve how server/js client handle unexpected errors

### DIFF
--- a/.changeset/dirty-experts-cry.md
+++ b/.changeset/dirty-experts-cry.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": minor
+"gradio": minor
+---
+
+feat:Improve how server/js client handle unexpected errors

--- a/.changeset/dirty-experts-cry.md
+++ b/.changeset/dirty-experts-cry.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/client": minor
-"gradio": minor
+"@gradio/client": patch
+"gradio": patch
 ---
 
 feat:Improve how server/js client handle unexpected errors

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -1051,7 +1051,7 @@ export function api_factory(
 				event_stream = new EventSource(url);
 				event_stream.onmessage = async function (event) {
 					let _data = JSON.parse(event.data);
-					if (_data.session_hash) {
+					if (!("event_id" in _data)) {
 						await Promise.all(
 							Object.keys(event_callbacks).map((event_id) =>
 								event_callbacks[event_id](_data)

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -931,7 +931,6 @@ export function api_factory(
 											time: new Date()
 										});
 										close_stream();
-										console.trace()
 									}
 								};
 								event_ids.push(event_id);

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -289,7 +289,6 @@ export function api_factory(
 			let stream_open = false;
 			let event_stream: EventSource | null = null;
 			const event_callbacks: Record<string, () => Promise<void>> = {};
-			const event_ids = [];
 			let config: Config;
 			let api_map: Record<string, number> = {};
 
@@ -933,7 +932,6 @@ export function api_factory(
 										close_stream();
 									}
 								};
-								event_ids.push(event_id);
 								event_callbacks[event_id] = callback;
 								if (!stream_open) {
 									open_stream();
@@ -1055,7 +1053,9 @@ export function api_factory(
 					let _data = JSON.parse(event.data);
 					if (_data.session_hash) {
 						await Promise.all(
-							event_ids.map((event_id) => event_callbacks[event_id](_data))
+							Object.keys(event_callbacks).map((event_id) =>
+								event_callbacks[event_id](_data)
+							)
 						);
 						return;
 					}

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -837,14 +837,6 @@ export function api_factory(
 											return;
 										}
 
-										// TODO: Find out how to print this information
-										// only during testing
-										// console.info("data", type, status, data);
-
-										if (type == "heartbeat") {
-											return;
-										}
-
 										if (type === "update" && status && !complete) {
 											// call 'status' listeners
 											fire_event({
@@ -857,7 +849,7 @@ export function api_factory(
 										} else if (type === "complete") {
 											complete = status;
 										} else if (type == "unexpected_error") {
-											console.error("Unexpected error", status.message);
+											console.error("Unexpected error", status?.message);
 											fire_event({
 												type: "status",
 												stage: "error",
@@ -875,6 +867,7 @@ export function api_factory(
 												endpoint: _endpoint,
 												fn_index
 											});
+											return;
 										} else if (type === "generating") {
 											fire_event({
 												type: "status",
@@ -938,6 +931,7 @@ export function api_factory(
 											time: new Date()
 										});
 										close_stream();
+										console.trace()
 									}
 								};
 								event_ids.push(event_id);

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -830,6 +830,10 @@ export function api_factory(
 									);
 									console.log("data", type, status, data);
 
+									if (type == "heartbeat") {
+										return;
+									}
+
 									if (type === "update" && status && !complete) {
 										// call 'status' listeners
 										fire_event({
@@ -1620,6 +1624,10 @@ function handle_message(
 					code: data.code,
 					success: data.success
 				}
+			};
+		case "heartbeat":
+			return {
+				type: "heartbeat"
 			};
 		case "unexpected_error":
 			return {

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -822,13 +822,15 @@ export function api_factory(
 								});
 							} else {
 								event_id = response.event_id as string;
-								console.log("event_id", event_id, "HERE");
 								let callback = async function (_data: object): void {
 									const { type, status, data } = handle_message(
 										_data,
 										last_status[fn_index]
 									);
-									console.log("data", type, status, data);
+
+									// TODO: Find out how to print this information
+									// only during testing
+									// console.info("data", type, status, data);
 
 									if (type == "heartbeat") {
 										return;
@@ -846,10 +848,11 @@ export function api_factory(
 									} else if (type === "complete") {
 										complete = status;
 									} else if (type == "unexpected_error") {
+										console.error("Unexpected error", status.message);
 										fire_event({
 											type: "status",
 											stage: "error",
-											message: data.message,
+											message: "An Unexpected Error Occurred!",
 											queue: true,
 											endpoint: _endpoint,
 											fn_index,
@@ -914,9 +917,7 @@ export function api_factory(
 								};
 								event_ids.push(event_id);
 								event_callbacks[event_id] = callback;
-								console.log("HERE");
 								if (!stream_open) {
-									console.log("OPENING");
 									open_stream();
 								}
 							}
@@ -1615,7 +1616,7 @@ function handle_message(
 			};
 		case "unexpected_error":
 			return {
-				type: "update",
+				type: "unexpected_error",
 				status: {
 					queue,
 					message: data.message,

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -1035,22 +1035,6 @@ export function api_factory(
 				event_stream.onmessage = async function (event) {
 					let _data = JSON.parse(event.data);
 					if (_data.session_hash) {
-						// const status = {
-						// 		type: "update",
-						// 		status: {
-						// 			queue: true,
-						// 			message: _data.message,
-						// 			stage: "error",
-						// 			success: false
-						// 		}
-						// 	}
-						// fire_event({
-						// 	type: "status",
-						// 	...status,
-						// 	endpoint: _endpoint,
-						// 	fn_index,
-						// 	time: new Date()
-						// });
 						await Promise.all(
 							event_ids.map((event_id) => event_callbacks[event_id](_data))
 						);

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -828,8 +828,7 @@ export function api_factory(
 											_data,
 											last_status[fn_index]
 										);
-										throw new Error("Bad!");
-
+\
 										// TODO: Find out how to print this information
 										// only during testing
 										// console.info("data", type, status, data);

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -828,7 +828,7 @@ export function api_factory(
 											_data,
 											last_status[fn_index]
 										);
-\
+
 										// TODO: Find out how to print this information
 										// only during testing
 										// console.info("data", type, status, data);

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -650,7 +650,7 @@ class App(FastAPI):
                                     )
                                 ):
                                     return
-                except Exception as e:
+                except BaseException as e:
                     message = {
                         "msg": "unexpected_error",
                         "success": False,

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -616,7 +616,10 @@ class App(FastAPI):
                             await asyncio.sleep(check_rate)
                             if time.perf_counter() - last_heartbeat > heartbeat_rate:
                                 # Fix this
-                                message = {"msg": ServerMessage.heartbeat}
+                                message = {
+                                    "msg": ServerMessage.heartbeat,
+                                    "session_hash": session_hash,
+                                }
                                 # Need to reset last_heartbeat with perf_counter
                                 # otherwise only a single hearbeat msg will be sent
                                 # and then the stream will retry leading to infinite queue 😬
@@ -627,7 +630,7 @@ class App(FastAPI):
                                 "msg": "unexpected_error",
                                 "message": "Server stopped unexpectedly.",
                                 "success": False,
-                                "event_id": session_hash,
+                                "session_hash": session_hash,
                             }
                         if message:
                             yield f"data: {json.dumps(message)}\n\n"
@@ -649,11 +652,11 @@ class App(FastAPI):
                                     return
                 except Exception as e:
                     message = {
-                                "msg": "unexpected_error",
-                                "success": False,
-                                "message": str(e),
-                                "session_hash": session_hash,
-                            }
+                        "msg": "unexpected_error",
+                        "success": False,
+                        "message": str(e),
+                        "session_hash": session_hash,
+                    }
                     yield f"data: {json.dumps(message)}\n\n"
                     if isinstance(e, asyncio.CancelledError):
                         del blocks._queue.pending_messages_per_session[session_hash]

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -618,7 +618,6 @@ class App(FastAPI):
                                 # Fix this
                                 message = {
                                     "msg": ServerMessage.heartbeat,
-                                    "session_hash": session_hash,
                                 }
                                 # Need to reset last_heartbeat with perf_counter
                                 # otherwise only a single hearbeat msg will be sent
@@ -630,7 +629,6 @@ class App(FastAPI):
                                 "msg": "unexpected_error",
                                 "message": "Server stopped unexpectedly.",
                                 "success": False,
-                                "session_hash": session_hash,
                             }
                         if message:
                             yield f"data: {json.dumps(message)}\n\n"
@@ -655,7 +653,6 @@ class App(FastAPI):
                         "msg": "unexpected_error",
                         "success": False,
                         "message": str(e),
-                        "session_hash": session_hash,
                     }
                     yield f"data: {json.dumps(message)}\n\n"
                     if isinstance(e, asyncio.CancelledError):


### PR DESCRIPTION
## Description

Noticed two things when I was debugging flaky tests:
- If there's an exception in the `queue/data/` route the client will hang forever. the server now catches general exceptions
- If the message didn't have an `event_id`, the client would error out, e.g. heartbeat, server_stopped. This wouldn't cause any noticeable errors to users (except console exceptions) but wanted to fix.My guess is that the playwright tests are mysteriously erroring server side so printing the exception message in the UI can help us debug.
- `gr.Info` and `gr.Warning` would also raise exceptions in the client. Would not be obvious to users but not desirable anyways.
- Think I found the issue for the weird HTTPExceptions in logs

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
