### PR TITLE
Adds docstrings for `gr.WaveformOptions`, `gr.Brush`, and `gr.Eraser`, fixes examples for `ImageEditor`, and allows individual images to be used as the initial `value` for `ImageEditor`

### DIFF
--- a/demo/image_editor/run.py
+++ b/demo/image_editor/run.py
@@ -11,6 +11,7 @@ with gr.Blocks() as demo:
     im = gr.ImageEditor(
         type="pil",
         crop_size="1:1",
+        eraser=gr.Eraser()
     )
 
     with gr.Group():

--- a/demo/image_editor/run.py
+++ b/demo/image_editor/run.py
@@ -11,7 +11,6 @@ with gr.Blocks() as demo:
     im = gr.ImageEditor(
         type="pil",
         crop_size="1:1",
-        eraser=gr.Eraser()
     )
 
     with gr.Group():

--- a/gradio/__init__.py
+++ b/gradio/__init__.py
@@ -57,7 +57,8 @@ from gradio.components import (
     Video,
     component,
 )
-from gradio.components.audio import WaveformOptions  # type: ignore
+from gradio.components.audio import WaveformOptions
+from gradio.components.image_editor import Brush, Eraser
 from gradio.data_classes import FileData
 from gradio.events import EventData, LikeData, SelectData, on
 from gradio.exceptions import Error

--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -22,11 +22,20 @@ set_documentation_group("component")
 
 @dataclasses.dataclass
 class WaveformOptions:
-    waveform_color: str | None = None
-    waveform_progress_color: str | None = None
-    show_controls: bool = False
-    skip_length: str | None = None
+    """
+    A dataclass for specifying options for the waveform display in the gr.Audio component.
+    Parameters:
+        waveform_color: The color (as a hex string or valid CSS color) of the full waveform representing the amplitude of the audio. Defaults to a light gray color.
+        waveform_progress_color: The color (as a hex string or valid CSS color) that the waveform fills up to as the audio plays. Defaults to an orange color.
+        show_recording_waveform: Whether to show the waveform when recording audio. Defaults to True.
+        show_controls: Whether to show the standard HTML audio player below the waveform when recording audio or playing recorded audio. Defaults to False.
+        skip_length: The percentage (between 0 and 100) of the audio to skip when clicking on the skip forward / skip backward buttons. Defaults to 5.
+    """
+    waveform_color: str = "#9ca3af"
+    waveform_progress_color: str = "#f97316"
     show_recording_waveform: bool = True
+    show_controls: bool = False
+    skip_length: int | float = 5
 
 
 @document()

--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -31,6 +31,7 @@ class WaveformOptions:
         show_controls: Whether to show the standard HTML audio player below the waveform when recording audio or playing recorded audio. Defaults to False.
         skip_length: The percentage (between 0 and 100) of the audio to skip when clicking on the skip forward / skip backward buttons. Defaults to 5.
     """
+
     waveform_color: str = "#9ca3af"
     waveform_progress_color: str = "#f97316"
     show_recording_waveform: bool = True

--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -23,10 +23,10 @@ set_documentation_group("component")
 @dataclasses.dataclass
 class WaveformOptions:
     """
-    A dataclass for specifying options for the waveform display in the gr.Audio component.
+    A dataclass for specifying options for the waveform display in the Audio component. An instance of this class can be passed into the `waveform_options` parameter of `gr.Audio`.
     Parameters:
         waveform_color: The color (as a hex string or valid CSS color) of the full waveform representing the amplitude of the audio. Defaults to a light gray color.
-        waveform_progress_color: The color (as a hex string or valid CSS color) that the waveform fills up to as the audio plays. Defaults to an orange color.
+        waveform_progress_color: The color (as a hex string or valid CSS color) that the waveform fills with to as the audio plays. Defaults to an orange color.
         show_recording_waveform: Whether to show the waveform when recording audio. Defaults to True.
         show_controls: Whether to show the standard HTML audio player below the waveform when recording audio or playing recorded audio. Defaults to False.
         skip_length: The percentage (between 0 and 100) of the audio to skip when clicking on the skip forward / skip backward buttons. Defaults to 5.

--- a/gradio/components/image_editor.py
+++ b/gradio/components/image_editor.py
@@ -37,15 +37,23 @@ class EditorData(GradioModel):
 @dataclasses.dataclass
 class Eraser:
     """
-    A dataclass for specifying options for the eraser tool in the ImageEditor component. An instance of this class can be passed to the `eraser` parameter of the ImageEditor component.
+    A dataclass for specifying options for the eraser tool in the ImageEditor component. An instance of this class can be passed to the `eraser` parameter of `gr.ImageEditor`.
     Parameters:
-        default_size: The default size of the eraser tool. If "auto" (default), the size will be automatically determined based on the size of the image.
+        default_size: The default radius, in pixels, of the eraser tool. Defaults to "auto" in which case the radius is automatically determined based on the size of the image (generally 1/50th of smaller dimension).
     """
     default_size: int | Literal["auto"] = "auto"
 
 
 @dataclasses.dataclass
 class Brush(Eraser):
+    """
+    A dataclass for specifying options for the brush tool in the ImageEditor component. An instance of this class can be passed to the `brush` parameter of `gr.ImageEditor`.
+    Parameters:
+        default_size: The default radius, in pixels, of the brush tool. Defaults to "auto" in which case the radius is automatically determined based on the size of the image (generally 1/50th of smaller dimension).
+        colors: A list of colors to make available to the user when using the brush. Defaults to a list of 5 colors.
+        default_color: The default color of the brush. Defaults to the first color in the `colors` list.
+        color_mode: If set to "fixed", user can only select from among the colors in `colors`. If "defaults", the colors in `colors` are provided as a default palette, but the user can also select any color using a color picker.
+    """
     colors: Union[
         list[str],
         str,

--- a/gradio/components/image_editor.py
+++ b/gradio/components/image_editor.py
@@ -325,7 +325,11 @@ class ImageEditor(Component):
         if input_data is None:
             return None
         elif isinstance(input_data, str):
-            input_data = {"background": input_data, "layers": [], "composite": None}
+            input_data = {
+                "background": input_data,
+                "layers": [],
+                "composite": input_data,
+            }
 
         input_data["background"] = resolve_path(input_data["background"])
         input_data["layers"] = (

--- a/gradio/components/image_editor.py
+++ b/gradio/components/image_editor.py
@@ -36,6 +36,11 @@ class EditorData(GradioModel):
 
 @dataclasses.dataclass
 class Eraser:
+    """
+    A dataclass for specifying options for the eraser tool in the ImageEditor component. An instance of this class can be passed to the `eraser` parameter of the ImageEditor component.
+    Parameters:
+        default_size: The default size of the eraser tool. If "auto" (default), the size will be automatically determined based on the size of the image.
+    """
     default_size: int | Literal["auto"] = "auto"
 
 
@@ -142,6 +147,7 @@ class ImageEditor(Component):
             show_share_button: If True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
             crop_size: The size of the crop box in pixels. If a tuple, the first value is the width and the second value is the height. If a string, the value must be a ratio in the form `width:height` (e.g. "16:9").
             transforms: The transforms tools to make available to users. "crop" allows the user to crop the image.
+            eraser: 
         """
         self._selectable = _selectable
         self.mirror_webcam = mirror_webcam

--- a/gradio/components/image_editor.py
+++ b/gradio/components/image_editor.py
@@ -24,15 +24,18 @@ _Image.init()  # fixes https://github.com/gradio-app/gradio/issues/2843
 
 ImageType = Union[np.ndarray, _Image.Image, str]
 
+
 class EditorValue(TypedDict):
     background: Optional[ImageType]
     layers: list[ImageType]
     composite: Optional[ImageType]
 
+
 class EditorExampleValue(TypedDict):
     background: Optional[str]
     layers: Optional[list[str | None]]
     composite: Optional[str]
+
 
 class EditorData(GradioModel):
     background: Optional[FileData] = None
@@ -272,8 +275,10 @@ class ImageEditor(Component):
         elif isinstance(value, (np.ndarray, _Image.Image, str)):
             value = {"background": value, "layers": [], "composite": value}
         else:
-            raise ValueError("The value to `gr.ImageEditor` must be a dictionary of images or a single image.")
-        
+            raise ValueError(
+                "The value to `gr.ImageEditor` must be a dictionary of images or a single image."
+            )
+
         layers = (
             [
                 FileData(
@@ -305,7 +310,9 @@ class ImageEditor(Component):
             else None,
         )
 
-    def as_example(self, input_data: EditorExampleValue | str | None) -> EditorExampleValue | None:
+    def as_example(
+        self, input_data: EditorExampleValue | str | None
+    ) -> EditorExampleValue | None:
         def resolve_path(file_or_url: str | None) -> str | None:
             if file_or_url is None:
                 return None
@@ -321,14 +328,18 @@ class ImageEditor(Component):
             input_data = {"background": input_data, "layers": [], "composite": None}
 
         input_data["background"] = resolve_path(input_data["background"])
-        input_data["layers"] = [resolve_path(f) for f in input_data["layers"]] if input_data["layers"] else []
+        input_data["layers"] = (
+            [resolve_path(f) for f in input_data["layers"]]
+            if input_data["layers"]
+            else []
+        )
         input_data["composite"] = resolve_path(input_data["composite"])
-        
+
         return input_data
 
     def example_inputs(self) -> Any:
         return {
             "background": "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png",
             "layers": [],
-            "composite": None
+            "composite": None,
         }

--- a/gradio/components/image_editor.py
+++ b/gradio/components/image_editor.py
@@ -41,6 +41,7 @@ class Eraser:
     Parameters:
         default_size: The default radius, in pixels, of the eraser tool. Defaults to "auto" in which case the radius is automatically determined based on the size of the image (generally 1/50th of smaller dimension).
     """
+
     default_size: int | Literal["auto"] = "auto"
 
 
@@ -54,6 +55,7 @@ class Brush(Eraser):
         default_color: The default color of the brush. Defaults to the first color in the `colors` list.
         color_mode: If set to "fixed", user can only select from among the colors in `colors`. If "defaults", the colors in `colors` are provided as a default palette, but the user can also select any color using a color picker.
     """
+
     colors: Union[
         list[str],
         str,

--- a/gradio/components/image_editor.py
+++ b/gradio/components/image_editor.py
@@ -128,8 +128,8 @@ class ImageEditor(Component):
         _selectable: bool = False,
         crop_size: tuple[int | float, int | float] | str | None = None,
         transforms: Iterable[Literal["crop"]] = ("crop",),
-        eraser: Eraser | None | bool = None,
-        brush: Brush | None | bool = None,
+        eraser: Eraser | None | Literal[False] = None,
+        brush: Brush | None | Literal[False] = None,
     ):
         """
         Parameters:
@@ -155,7 +155,8 @@ class ImageEditor(Component):
             show_share_button: If True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
             crop_size: The size of the crop box in pixels. If a tuple, the first value is the width and the second value is the height. If a string, the value must be a ratio in the form `width:height` (e.g. "16:9").
             transforms: The transforms tools to make available to users. "crop" allows the user to crop the image.
-            eraser: 
+            eraser: The options for the eraser tool in the image editor. Should be an instance of the `gr.Eraser` class, or None to use the default settings. Can also be False to hide the eraser tool.
+            brush: The options for the brush tool in the image editor. Should be an instance of the `gr.Brush` class, or None to use the default settings. Can also be False to hide the brush tool, which will also hide the eraser tool.
         """
         self._selectable = _selectable
         self.mirror_webcam = mirror_webcam
@@ -188,8 +189,8 @@ class ImageEditor(Component):
 
         self.crop_size = crop_size
         self.transforms = transforms
-        self.eraser = eraser if eraser is not None and eraser is not True else Eraser()
-        self.brush = brush if brush is not None and brush is not True else Brush()
+        self.eraser = Eraser() if eraser is None else eraser
+        self.brush = Brush() if brush is None else brush
 
         super().__init__(
             label=label,

--- a/js/audio/player/AudioPlayer.svelte
+++ b/js/audio/player/AudioPlayer.svelte
@@ -3,7 +3,7 @@
 	import { Music } from "@gradio/icons";
 	import type { I18nFormatter } from "@gradio/utils";
 	import WaveSurfer from "wavesurfer.js";
-	import { skipAudio, process_audio } from "../shared/utils";
+	import { skip_audio, process_audio } from "../shared/utils";
 	import WaveformControls from "../shared/WaveformControls.svelte";
 	import { Empty } from "@gradio/atoms";
 	import { resolve_wasm_src } from "@gradio/wasm/svelte";
@@ -33,7 +33,7 @@
 
 	let timeRef: HTMLTimeElement;
 	let durationRef: HTMLTimeElement;
-	let audioDuration: number;
+	let audio_duration: number;
 
 	let trimDuration = 0;
 
@@ -74,7 +74,7 @@
 	}
 
 	$: waveform?.on("decode", (duration: any) => {
-		audioDuration = duration;
+		audio_duration = duration;
 		durationRef && (durationRef.textContent = formatTime(duration));
 	});
 
@@ -135,9 +135,9 @@
 		window.addEventListener("keydown", (e) => {
 			if (!waveform || show_volume_slider) return;
 			if (e.key === "ArrowRight" && mode !== "edit") {
-				skipAudio(waveform, 0.1);
+				skip_audio(waveform, 0.1);
 			} else if (e.key === "ArrowLeft" && mode !== "edit") {
-				skipAudio(waveform, -0.1);
+				skip_audio(waveform, -0.1);
 			}
 		});
 	});
@@ -178,7 +178,7 @@
 				{container}
 				{waveform}
 				{playing}
-				{audioDuration}
+				{audio_duration}
 				{i18n}
 				{interactive}
 				{handle_trim_audio}

--- a/js/audio/recorder/AudioRecorder.svelte
+++ b/js/audio/recorder/AudioRecorder.svelte
@@ -3,7 +3,7 @@
 	import type { I18nFormatter } from "@gradio/utils";
 	import { createEventDispatcher } from "svelte";
 	import WaveSurfer from "wavesurfer.js";
-	import { skipAudio, process_audio } from "../shared/utils";
+	import { skip_audio, process_audio } from "../shared/utils";
 	import WSRecord from "wavesurfer.js/dist/plugins/record.js";
 	import WaveformControls from "../shared/WaveformControls.svelte";
 	import WaveformRecordControls from "../shared/WaveformRecordControls.svelte";
@@ -35,7 +35,7 @@
 	// timestamps
 	let timeRef: HTMLTimeElement;
 	let durationRef: HTMLTimeElement;
-	let audioDuration: number;
+	let audio_duration: number;
 	let seconds = 0;
 	let interval: NodeJS.Timeout;
 	let timing = false;
@@ -102,7 +102,7 @@
 	});
 
 	$: recordingWaveform?.on("decode", (duration: any) => {
-		audioDuration = duration;
+		audio_duration = duration;
 		durationRef && (durationRef.textContent = format_time(duration));
 	});
 
@@ -187,9 +187,9 @@
 
 		window.addEventListener("keydown", (e) => {
 			if (e.key === "ArrowRight") {
-				skipAudio(recordingWaveform, 0.1);
+				skip_audio(recordingWaveform, 0.1);
 			} else if (e.key === "ArrowLeft") {
-				skipAudio(recordingWaveform, -0.1);
+				skip_audio(recordingWaveform, -0.1);
 			}
 		});
 	});
@@ -234,7 +234,7 @@
 			bind:waveform={recordingWaveform}
 			container={recordingContainer}
 			{playing}
-			{audioDuration}
+			{audio_duration}
 			{i18n}
 			interactive={true}
 			{handle_trim_audio}

--- a/js/audio/shared/WaveformControls.svelte
+++ b/js/audio/shared/WaveformControls.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Play, Pause, Forward, Backward, Undo, Trim } from "@gradio/icons";
-	import { getSkipRewindAmount } from "../shared/utils";
+	import { get_skip_rewind_amount } from "../shared/utils";
 	import type { I18nFormatter } from "@gradio/utils";
 	import WaveSurfer from "wavesurfer.js";
 	import RegionsPlugin, {
@@ -11,7 +11,7 @@
 	import VolumeControl from "./VolumeControl.svelte";
 
 	export let waveform: WaveSurfer;
-	export let audioDuration: number;
+	export let audio_duration: number;
 	export let i18n: I18nFormatter;
 	export let playing: boolean;
 	export let showRedo = false;
@@ -57,8 +57,8 @@
 
 	const addTrimRegion = (): void => {
 		activeRegion = trimRegion.addRegion({
-			start: audioDuration / 4,
-			end: audioDuration / 2,
+			start: audio_duration / 4,
+			end: audio_duration / 2,
 			...trim_region_settings
 		});
 
@@ -200,13 +200,13 @@
 	<div class="play-pause-wrapper">
 		<button
 			class="rewind icon"
-			aria-label={`Skip backwards by ${getSkipRewindAmount(
-				audioDuration,
+			aria-label={`Skip backwards by ${get_skip_rewind_amount(
+				audio_duration,
 				waveform_options.skip_length
 			)} seconds`}
 			on:click={() =>
 				waveform.skip(
-					getSkipRewindAmount(audioDuration, waveform_options.skip_length) * -1
+					get_skip_rewind_amount(audio_duration, waveform_options.skip_length) * -1
 				)}
 		>
 			<Backward />
@@ -224,13 +224,13 @@
 		</button>
 		<button
 			class="skip icon"
-			aria-label="Skip forward by {getSkipRewindAmount(
-				audioDuration,
+			aria-label="Skip forward by {get_skip_rewind_amount(
+				audio_duration,
 				waveform_options.skip_length
 			)} seconds"
 			on:click={() =>
 				waveform.skip(
-					getSkipRewindAmount(audioDuration, waveform_options.skip_length)
+					get_skip_rewind_amount(audio_duration, waveform_options.skip_length)
 				)}
 		>
 			<Forward />

--- a/js/audio/shared/WaveformControls.svelte
+++ b/js/audio/shared/WaveformControls.svelte
@@ -206,7 +206,8 @@
 			)} seconds`}
 			on:click={() =>
 				waveform.skip(
-					get_skip_rewind_amount(audio_duration, waveform_options.skip_length) * -1
+					get_skip_rewind_amount(audio_duration, waveform_options.skip_length) *
+						-1
 				)}
 		>
 			<Backward />

--- a/js/audio/shared/utils.ts
+++ b/js/audio/shared/utils.ts
@@ -61,17 +61,17 @@ export function loaded(
 	}
 }
 
-export const skipAudio = (waveform: WaveSurfer, amount: number): void => {
+export const skip_audio = (waveform: WaveSurfer, amount: number): void => {
 	if (!waveform) return;
 	waveform.skip(amount);
 };
 
-export const getSkipRewindAmount = (
-	audioDuration: number,
+export const get_skip_rewind_amount = (
+	audio_duration: number,
 	skip_length?: number | null
 ): number => {
 	if (!skip_length) {
 		skip_length = 5;
 	}
-	return (audioDuration / 100) * skip_length || 5;
+	return (audio_duration / 100) * skip_length || 5;
 };

--- a/js/imageeditor/Example.svelte
+++ b/js/imageeditor/Example.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	import { BaseImage as Image } from "@gradio/image";
-	import type {
-		EditorData,
-	} from "./shared/InteractiveImageEditor.svelte";
+	import type { EditorData } from "./shared/InteractiveImageEditor.svelte";
 
 	export let value: EditorData;
 	export let samples_dir: string;
@@ -24,7 +22,7 @@
 		width: 100%;
 		height: 100%;
 	}
-	
+
 	.container.selected {
 		border-color: var(--border-color-accent);
 	}

--- a/js/imageeditor/Example.svelte
+++ b/js/imageeditor/Example.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import { BaseImage as Image } from "@gradio/image";
+	import type {
+		EditorData,
+	} from "./shared/InteractiveImageEditor.svelte";
 
-	export let value: string;
+	export let value: EditorData;
 	export let samples_dir: string;
 	export let type: "gallery" | "table";
 	export let selected = false;
@@ -13,10 +16,15 @@
 	class:gallery={type === "gallery"}
 	class:selected
 >
-	<Image src={samples_dir + value} alt="" />
+	<Image src={samples_dir + (value.composite || value.background)} alt="" />
 </div>
 
 <style>
+	.container :global(img) {
+		width: 100%;
+		height: 100%;
+	}
+	
 	.container.selected {
 		border-color: var(--border-color-accent);
 	}

--- a/js/imageeditor/ImageEditor.stories.svelte
+++ b/js/imageeditor/ImageEditor.stories.svelte
@@ -25,17 +25,12 @@
 		interactive: "true",
 		brush: {
 			default_size: "auto",
-			sizes: "auto",
-			size_mode: "fixed",
-			antialias: true,
 			colors: ["#ff0000", "#00ff00", "#0000ff"],
-			default_color: "#ff0000"
+			default_color: "#ff0000",
+			color_mode: "defaults"
 		},
 		eraser: {
-			default_size: "auto",
-			sizes: "auto",
-			size_mode: "fixed",
-			antialias: true
+			default_size: "auto"
 		}
 	}}
 />
@@ -53,17 +48,12 @@
 		interactive: "true",
 		brush: {
 			default_size: "auto",
-			sizes: "auto",
-			size_mode: "fixed",
-			antialias: true,
 			colors: ["#ff0000", "#00ff00", "#0000ff"],
-			default_color: "#ff0000"
+			default_color: "#ff0000",
+			color_mode: "defaults"
 		},
 		eraser: {
-			default_size: "auto",
-			sizes: "auto",
-			size_mode: "fixed",
-			antialias: true
+			default_size: "auto"
 		}
 	}}
 	play={async ({ canvasElement }) => {

--- a/js/imageeditor/shared/tools/Brush.svelte
+++ b/js/imageeditor/shared/tools/Brush.svelte
@@ -6,18 +6,6 @@
 		 * The default size of the eraser.
 		 */
 		default_size: number | "auto";
-		/**
-		 * The sizes to show in the size swatch
-		 */
-		sizes: number[] | "auto";
-		/**
-		 * Whether to show _only_ the sizes specified in `sizes`, or to show the sizes specified in `sizes` along with the size slider.
-		 */
-		size_mode: "fixed" | "defaults";
-		/**
-		 * Whether to use antialiasing when drawing the eraser.
-		 */
-		antialias: boolean;
 	}
 
 	export interface Brush extends Eraser {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -262,16 +262,16 @@ importers:
         version: 2.0.0(@sveltejs/kit@1.26.0)
       '@sveltejs/kit':
         specifier: ^1.5.0
-        version: 1.26.0(svelte@4.2.3)(vite@4.5.0)
+        version: 1.26.0(svelte@4.2.2)(vite@4.5.0)
       prettier:
         specifier: ^3.0.0
         version: 3.0.0
       prettier-plugin-svelte:
         specifier: ^3.0.0
-        version: 3.0.0(prettier@3.0.0)(svelte@4.2.3)
+        version: 3.0.0(prettier@3.0.0)(svelte@4.2.2)
       svelte-check:
         specifier: ^3.0.1
-        version: 3.4.4(@babel/core@7.23.3)(less@4.2.0)(postcss@8.4.27)(svelte@4.2.3)
+        version: 3.4.4(@babel/core@7.23.3)(less@4.2.0)(postcss@8.4.27)(svelte@4.2.2)
       typescript:
         specifier: ^5.0.0
         version: 5.0.2
@@ -292,7 +292,7 @@ importers:
         version: 3.0.0
       mdsvex:
         specifier: ^0.11.0
-        version: 0.11.0(svelte@4.2.3)
+        version: 0.11.0(svelte@4.2.2)
       postcss:
         specifier: '>=8.3.3 <9.0.0'
         version: 8.4.27
@@ -305,7 +305,7 @@ importers:
         version: 2.0.2(@sveltejs/kit@1.27.6)
       '@sveltejs/kit':
         specifier: ^1.27.6
-        version: 1.27.6(svelte@4.2.3)(vite@4.5.0)
+        version: 1.27.6(svelte@4.2.2)(vite@4.5.0)
       '@tailwindcss/forms':
         specifier: ^0.5.0
         version: 0.5.0(tailwindcss@3.1.6)
@@ -6731,7 +6731,7 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
     dependencies:
-      '@sveltejs/kit': 1.26.0(svelte@4.2.3)(vite@4.5.0)
+      '@sveltejs/kit': 1.26.0(svelte@4.2.2)(vite@4.5.0)
       import-meta-resolve: 2.2.2
     dev: true
 
@@ -6740,7 +6740,7 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
     dependencies:
-      '@sveltejs/kit': 1.27.6(svelte@4.2.3)(vite@4.5.0)
+      '@sveltejs/kit': 1.27.6(svelte@4.2.2)(vite@4.5.0)
       import-meta-resolve: 2.2.2
     dev: true
 
@@ -6749,7 +6749,7 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^1.5.0
     dependencies:
-      '@sveltejs/kit': 1.27.6(svelte@4.2.3)(vite@4.5.0)
+      '@sveltejs/kit': 1.27.6(svelte@4.2.2)(vite@4.5.0)
     dev: true
 
   /@sveltejs/adapter-vercel@3.0.3(@sveltejs/kit@1.27.6):
@@ -6757,7 +6757,7 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^1.5.0
     dependencies:
-      '@sveltejs/kit': 1.27.6(svelte@4.2.3)(vite@4.5.0)
+      '@sveltejs/kit': 1.27.6(svelte@4.2.2)(vite@4.5.0)
       '@vercel/nft': 0.23.1
       esbuild: 0.18.20
     transitivePeerDependencies:
@@ -6765,7 +6765,7 @@ packages:
       - supports-color
     dev: false
 
-  /@sveltejs/kit@1.26.0(svelte@4.2.3)(vite@4.5.0):
+  /@sveltejs/kit@1.26.0(svelte@4.2.2)(vite@4.5.0):
     resolution: {integrity: sha512-CV/AlTziC05yrz7UjVqEd0pH6+2dnrbmcnHGr2d3jXtmOgzNnlDkXtX8g3BfJ6nntsPD+0jtS2PzhvRHblRz4A==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
@@ -6774,7 +6774,7 @@ packages:
       svelte: ^3.54.0 || ^4.0.0-next.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.5.2(svelte@4.2.3)(vite@4.5.0)
+      '@sveltejs/vite-plugin-svelte': 2.5.2(svelte@4.2.2)(vite@4.5.0)
       '@types/cookie': 0.5.4
       cookie: 0.5.0
       devalue: 4.3.2
@@ -6785,7 +6785,7 @@ packages:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 2.0.3
-      svelte: 4.2.3
+      svelte: 4.2.2
       tiny-glob: 0.2.9
       undici: 5.26.5
       vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1)
@@ -6793,7 +6793,7 @@ packages:
       - supports-color
     dev: true
 
-  /@sveltejs/kit@1.27.6(svelte@4.2.3)(vite@4.5.0):
+  /@sveltejs/kit@1.27.6(svelte@4.2.2)(vite@4.5.0):
     resolution: {integrity: sha512-GsjTkMbKzXdbeRg0tk8S7HNShQ4879ftRr0ZHaZfjbig1xQwG57Bvcm9U9/mpLJtCapLbLWUnygKrgcLISLC8A==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
@@ -6802,7 +6802,7 @@ packages:
       svelte: ^3.54.0 || ^4.0.0-next.0 || ^5.0.0-next.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.5.2(svelte@4.2.3)(vite@4.5.0)
+      '@sveltejs/vite-plugin-svelte': 2.5.2(svelte@4.2.2)(vite@4.5.0)
       '@types/cookie': 0.5.4
       cookie: 0.5.0
       devalue: 4.3.2
@@ -6813,7 +6813,7 @@ packages:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 2.0.3
-      svelte: 4.2.3
+      svelte: 4.2.2
       tiny-glob: 0.2.9
       undici: 5.26.5
       vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1)
@@ -6835,6 +6835,21 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.5.2)(svelte@4.2.2)(vite@4.5.0):
+    resolution: {integrity: sha512-zjiuZ3yydBtwpF3bj0kQNV0YXe+iKE545QGZVTaylW3eAzFr+pJ/cwK8lZEaRp4JtaJXhD5DyWAV4AxLh6DgaQ==}
+    engines: {node: ^14.18.0 || >= 16}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^2.2.0
+      svelte: ^3.54.0 || ^4.0.0
+      vite: ^4.0.0
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 2.5.2(svelte@4.2.2)(vite@4.5.0)
+      debug: 4.3.4
+      svelte: 4.2.2
+      vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1)
+    transitivePeerDependencies:
+      - supports-color
+
   /@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.5.2)(svelte@4.2.3)(vite@4.5.0):
     resolution: {integrity: sha512-zjiuZ3yydBtwpF3bj0kQNV0YXe+iKE545QGZVTaylW3eAzFr+pJ/cwK8lZEaRp4JtaJXhD5DyWAV4AxLh6DgaQ==}
     engines: {node: ^14.18.0 || >= 16}
@@ -6849,6 +6864,7 @@ packages:
       vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1)
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@sveltejs/vite-plugin-svelte@2.5.2(svelte@4.2.2)(vite@4.3.9):
     resolution: {integrity: sha512-Dfy0Rbl+IctOVfJvWGxrX/3m6vxPLH8o0x+8FA5QEyMUQMo4kGOVIojjryU7YomBAexOTAuYf1RT7809yDziaA==}
@@ -6866,6 +6882,25 @@ packages:
       svelte-hmr: 0.15.3(svelte@4.2.2)
       vite: 4.3.9(@types/node@20.3.2)(less@4.2.0)
       vitefu: 0.2.5(vite@4.3.9)
+    transitivePeerDependencies:
+      - supports-color
+
+  /@sveltejs/vite-plugin-svelte@2.5.2(svelte@4.2.2)(vite@4.5.0):
+    resolution: {integrity: sha512-Dfy0Rbl+IctOVfJvWGxrX/3m6vxPLH8o0x+8FA5QEyMUQMo4kGOVIojjryU7YomBAexOTAuYf1RT7809yDziaA==}
+    engines: {node: ^14.18.0 || >= 16}
+    peerDependencies:
+      svelte: ^3.54.0 || ^4.0.0 || ^5.0.0-next.0
+      vite: ^4.0.0
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.5.2)(svelte@4.2.2)(vite@4.5.0)
+      debug: 4.3.4
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.5
+      svelte: 4.2.2
+      svelte-hmr: 0.15.3(svelte@4.2.2)
+      vite: 4.5.0(@types/node@20.3.2)(less@4.2.0)(lightningcss@1.21.7)(sass@1.66.1)(stylus@0.62.0)(sugarss@4.0.1)
+      vitefu: 0.2.5(vite@4.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6887,6 +6922,7 @@ packages:
       vitefu: 0.2.5(vite@4.5.0)
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@tailwindcss/forms@0.5.0(tailwindcss@3.1.6):
     resolution: {integrity: sha512-KzWugryEBFkmoaYcBE18rs6gthWCFHHO7cAZm2/hv3hwD67AzwP7udSCa22E7R1+CEJL/FfhYsJWrc0b1aeSzw==}
@@ -12105,7 +12141,7 @@ packages:
   /mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
-  /mdsvex@0.11.0(svelte@4.2.3):
+  /mdsvex@0.11.0(svelte@4.2.2):
     resolution: {integrity: sha512-gJF1s0N2nCmdxcKn8HDn0LKrN8poStqAicp6bBcsKFd/zkUBGLP5e7vnxu+g0pjBbDFOscUyI1mtHz+YK2TCDw==}
     peerDependencies:
       svelte: '>=3 <5'
@@ -12113,7 +12149,7 @@ packages:
       '@types/unist': 2.0.10
       prism-svelte: 0.4.7
       prismjs: 1.29.0
-      svelte: 4.2.3
+      svelte: 4.2.2
       vfile-message: 2.0.4
     dev: false
 
@@ -13239,17 +13275,6 @@ packages:
     dependencies:
       prettier: 3.0.0
       svelte: 4.2.2
-    dev: false
-
-  /prettier-plugin-svelte@3.0.0(prettier@3.0.0)(svelte@4.2.3):
-    resolution: {integrity: sha512-l3RQcPty2UBCoRh3yb9c5XCAmxkrc4BptAnbd5acO1gmSJtChOWkiEjnOvh7hvmtT4V80S8gXCOKAq8RNeIzSw==}
-    peerDependencies:
-      prettier: ^3.0.0
-      svelte: ^3.2.0 || ^4.0.0-next.0
-    dependencies:
-      prettier: 3.0.0
-      svelte: 4.2.3
-    dev: true
 
   /prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -14603,34 +14628,6 @@ packages:
       - sass
       - stylus
       - sugarss
-    dev: false
-
-  /svelte-check@3.4.4(@babel/core@7.23.3)(less@4.2.0)(postcss@8.4.27)(svelte@4.2.3):
-    resolution: {integrity: sha512-Uys9+R65cj8TmP8f5UpS7B2xKpNLYNxEWJsA5ZoKcWq/uwvABFF7xS6iPQGLoa7hxz0DS6xU60YFpmq06E4JxA==}
-    hasBin: true
-    peerDependencies:
-      svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.20
-      chokidar: 3.5.3
-      fast-glob: 3.3.2
-      import-fresh: 3.3.0
-      picocolors: 1.0.0
-      sade: 1.8.1
-      svelte: 4.2.3
-      svelte-preprocess: 5.0.4(@babel/core@7.23.3)(less@4.2.0)(postcss@8.4.27)(svelte@4.2.3)(typescript@5.2.2)
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - coffeescript
-      - less
-      - postcss
-      - postcss-load-config
-      - pug
-      - sass
-      - stylus
-      - sugarss
-    dev: true
 
   /svelte-eslint-parser@0.32.2(svelte@4.2.2):
     resolution: {integrity: sha512-Ok9D3A4b23iLQsONrjqtXtYDu5ZZ/826Blaw2LeFZVTg1pwofKDG4mz3/GYTax8fQ0plRGHI6j+d9VQYy5Lo/A==}
@@ -14795,57 +14792,6 @@ packages:
       strip-indent: 3.0.0
       svelte: 4.2.2
       typescript: 5.2.2
-    dev: false
-
-  /svelte-preprocess@5.0.4(@babel/core@7.23.3)(less@4.2.0)(postcss@8.4.27)(svelte@4.2.3)(typescript@5.2.2):
-    resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
-    engines: {node: '>= 14.10.0'}
-    requiresBuild: true
-    peerDependencies:
-      '@babel/core': ^7.10.2
-      coffeescript: ^2.5.1
-      less: ^3.11.3 || ^4.0.0
-      postcss: ^7 || ^8
-      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
-      pug: ^3.0.0
-      sass: ^1.26.8
-      stylus: ^0.55.0
-      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0
-      typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      coffeescript:
-        optional: true
-      less:
-        optional: true
-      postcss:
-        optional: true
-      postcss-load-config:
-        optional: true
-      pug:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.23.3
-      '@types/pug': 2.0.9
-      detect-indent: 6.1.0
-      less: 4.2.0
-      magic-string: 0.27.0
-      postcss: 8.4.27
-      sorcery: 0.11.0
-      strip-indent: 3.0.0
-      svelte: 4.2.3
-      typescript: 5.2.2
-    dev: true
 
   /svelte-range-slider-pips@2.0.1:
     resolution: {integrity: sha512-sCHvcTgi0ZYE4c/mwSsdALRsfuqEmpwTsSUdL+PUrumZ8u2gv1GKwZ3GohcAcTB6gfmqRBkyn6ujRXrOIga1gw==}

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -32,6 +32,7 @@ import gradio as gr
 from gradio import processing_utils, utils
 from gradio.components.dataframe import DataframeData
 from gradio.components.file_explorer import FileExplorerData
+from gradio.components.image_editor import EditorData
 from gradio.components.video import VideoData
 from gradio.data_classes import FileData
 
@@ -552,6 +553,70 @@ class TestDropdown:
         iface = gr.Interface(lambda x: "|".join(x), dropdown_input, "textbox")
         assert iface(["a", "c"]) == "a|c"
         assert iface([]) == ""
+
+
+class TestImageEditor:
+    def test_component_functions(self):
+        test_image_path = "test/test_files/bus.png"
+        image_data = FileData(path=test_image_path)
+        image_editor_data = EditorData(
+            background=image_data, layers=[image_data, image_data], composite=image_data
+        )
+        payload = {
+            "background": test_image_path,
+            "layers": [test_image_path, test_image_path],
+            "composite": test_image_path,
+        }
+
+        image_editor_component = gr.ImageEditor()
+
+        assert isinstance(image_editor_component.preprocess(image_editor_data), dict)
+        assert image_editor_component.postprocess(payload) == image_editor_data
+
+        # Test that ImageEditor can accept just a filepath as well
+        simpler_data = EditorData(
+            background=image_data, layers=[], composite=image_data
+        )
+        assert image_editor_component.postprocess(test_image_path) == simpler_data
+
+        assert image_editor_component.get_config() == {
+            "value": None,
+            "height": None,
+            "width": None,
+            "image_mode": "RGBA",
+            "sources": ("upload", "webcam", "clipboard"),
+            "type": "numpy",
+            "label": None,
+            "show_label": True,
+            "show_download_button": True,
+            "container": True,
+            "scale": None,
+            "min_width": 160,
+            "interactive": None,
+            "visible": True,
+            "elem_id": None,
+            "elem_classes": [],
+            "mirror_webcam": True,
+            "show_share_button": False,
+            "_selectable": False,
+            "crop_size": None,
+            "transforms": ("crop",),
+            "eraser": {"default_size": "auto"},
+            "brush": {
+                "default_size": "auto",
+                "colors": [
+                    "rgb(204, 50, 50)",
+                    "rgb(173, 204, 50)",
+                    "rgb(50, 204, 112)",
+                    "rgb(50, 112, 204)",
+                    "rgb(173, 50, 204)",
+                ],
+                "default_color": "auto",
+                "color_mode": "defaults",
+            },
+            "proxy_url": None,
+            "name": "imageeditor",
+        }
 
 
 class TestImage:


### PR DESCRIPTION
Other minor refactoring as well.

Closes: https://github.com/gradio-app/gradio/issues/6338
Closes: https://github.com/gradio-app/gradio/issues/6634

Note that this doesn't actually surface the documentation (that's a separate issue: #6633)

Edit: thanks to @pngwn's suggestion, now:

Closes: #6784
Closes: https://github.com/gradio-app/gradio/issues/6752