### PR TITLE
Fix JS Client when app is running behind a proxy

### DIFF
--- a/.changeset/bumpy-baths-agree.md
+++ b/.changeset/bumpy-baths-agree.md
@@ -1,0 +1,7 @@
+---
+"@gradio/app": patch
+"@gradio/client": patch
+"gradio": patch
+---
+
+fix:Fix JS Client when app is running behind a proxy

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -461,253 +461,347 @@ export function api_factory(
 					url_params = new URLSearchParams(window.location.search).toString();
 				}
 
-				handle_blob(
-					`${config.root}`,
-					data,
-					api_info,
-					hf_token
-				).then((_payload) => {
-					payload = { data: _payload || [], event_data, fn_index, trigger_id };
-					if (skip_queue(fn_index, config)) {
-						fire_event({
-							type: "status",
-							endpoint: _endpoint,
-							stage: "pending",
-							queue: false,
+				handle_blob(`${config.root}`, data, api_info, hf_token).then(
+					(_payload) => {
+						payload = {
+							data: _payload || [],
+							event_data,
 							fn_index,
-							time: new Date()
-						});
-
-						post_data(
-							`${config.root}/run${
-								_endpoint.startsWith("/") ? _endpoint : `/${_endpoint}`
-							}${url_params ? "?" + url_params : ""}`,
-							{
-								...payload,
-								session_hash
-							},
-							hf_token
-						)
-							.then(([output, status_code]) => {
-								const data = transform_files
-									? transform_output(
-											output.data,
-											api_info,
-											config.root,
-											config.root_url
-									  )
-									: output.data;
-								if (status_code == 200) {
-									fire_event({
-										type: "data",
-										endpoint: _endpoint,
-										fn_index,
-										data: data,
-										time: new Date()
-									});
-
-									fire_event({
-										type: "status",
-										endpoint: _endpoint,
-										fn_index,
-										stage: "complete",
-										eta: output.average_duration,
-										queue: false,
-										time: new Date()
-									});
-								} else {
-									fire_event({
-										type: "status",
-										stage: "error",
-										endpoint: _endpoint,
-										fn_index,
-										message: output.error,
-										queue: false,
-										time: new Date()
-									});
-								}
-							})
-							.catch((e) => {
-								fire_event({
-									type: "status",
-									stage: "error",
-									message: e.message,
-									endpoint: _endpoint,
-									fn_index,
-									queue: false,
-									time: new Date()
-								});
-							});
-					} else if (protocol == "ws") {
-						fire_event({
-							type: "status",
-							stage: "pending",
-							queue: true,
-							endpoint: _endpoint,
-							fn_index,
-							time: new Date()
-						});
-						let url = new URL(`${ws_protocol}://${resolve_root(
-							host,
-							config.path,
-							true
-						)}
-							/queue/join${url_params ? "?" + url_params : ""}`);
-
-						if (jwt) {
-							url.searchParams.set("__sign", jwt);
-						}
-
-						websocket = new WebSocket(url);
-
-						websocket.onclose = (evt) => {
-							if (!evt.wasClean) {
-								fire_event({
-									type: "status",
-									stage: "error",
-									broken: true,
-									message: BROKEN_CONNECTION_MSG,
-									queue: true,
-									endpoint: _endpoint,
-									fn_index,
-									time: new Date()
-								});
-							}
+							trigger_id
 						};
+						if (skip_queue(fn_index, config)) {
+							fire_event({
+								type: "status",
+								endpoint: _endpoint,
+								stage: "pending",
+								queue: false,
+								fn_index,
+								time: new Date()
+							});
 
-						websocket.onmessage = function (event) {
-							const _data = JSON.parse(event.data);
-							const { type, status, data } = handle_message(
-								_data,
-								last_status[fn_index]
-							);
-
-							if (type === "update" && status && !complete) {
-								// call 'status' listeners
-								fire_event({
-									type: "status",
-									endpoint: _endpoint,
-									fn_index,
-									time: new Date(),
-									...status
-								});
-								if (status.stage === "error") {
-									websocket.close();
-								}
-							} else if (type === "hash") {
-								websocket.send(JSON.stringify({ fn_index, session_hash }));
-								return;
-							} else if (type === "data") {
-								websocket.send(JSON.stringify({ ...payload, session_hash }));
-							} else if (type === "complete") {
-								complete = status;
-							} else if (type === "log") {
-								fire_event({
-									type: "log",
-									log: data.log,
-									level: data.level,
-									endpoint: _endpoint,
-									fn_index
-								});
-							} else if (type === "generating") {
-								fire_event({
-									type: "status",
-									time: new Date(),
-									...status,
-									stage: status?.stage!,
-									queue: true,
-									endpoint: _endpoint,
-									fn_index
-								});
-							}
-							if (data) {
-								fire_event({
-									type: "data",
-									time: new Date(),
-									data: transform_files
+							post_data(
+								`${config.root}/run${
+									_endpoint.startsWith("/") ? _endpoint : `/${_endpoint}`
+								}${url_params ? "?" + url_params : ""}`,
+								{
+									...payload,
+									session_hash
+								},
+								hf_token
+							)
+								.then(([output, status_code]) => {
+									const data = transform_files
 										? transform_output(
-												data.data,
+												output.data,
 												api_info,
 												config.root,
 												config.root_url
 										  )
-										: data.data,
-									endpoint: _endpoint,
-									fn_index
-								});
+										: output.data;
+									if (status_code == 200) {
+										fire_event({
+											type: "data",
+											endpoint: _endpoint,
+											fn_index,
+											data: data,
+											time: new Date()
+										});
 
-								if (complete) {
+										fire_event({
+											type: "status",
+											endpoint: _endpoint,
+											fn_index,
+											stage: "complete",
+											eta: output.average_duration,
+											queue: false,
+											time: new Date()
+										});
+									} else {
+										fire_event({
+											type: "status",
+											stage: "error",
+											endpoint: _endpoint,
+											fn_index,
+											message: output.error,
+											queue: false,
+											time: new Date()
+										});
+									}
+								})
+								.catch((e) => {
+									fire_event({
+										type: "status",
+										stage: "error",
+										message: e.message,
+										endpoint: _endpoint,
+										fn_index,
+										queue: false,
+										time: new Date()
+									});
+								});
+						} else if (protocol == "ws") {
+							fire_event({
+								type: "status",
+								stage: "pending",
+								queue: true,
+								endpoint: _endpoint,
+								fn_index,
+								time: new Date()
+							});
+							let url = new URL(`${ws_protocol}://${resolve_root(
+								host,
+								config.path,
+								true
+							)}
+							/queue/join${url_params ? "?" + url_params : ""}`);
+
+							if (jwt) {
+								url.searchParams.set("__sign", jwt);
+							}
+
+							websocket = new WebSocket(url);
+
+							websocket.onclose = (evt) => {
+								if (!evt.wasClean) {
+									fire_event({
+										type: "status",
+										stage: "error",
+										broken: true,
+										message: BROKEN_CONNECTION_MSG,
+										queue: true,
+										endpoint: _endpoint,
+										fn_index,
+										time: new Date()
+									});
+								}
+							};
+
+							websocket.onmessage = function (event) {
+								const _data = JSON.parse(event.data);
+								const { type, status, data } = handle_message(
+									_data,
+									last_status[fn_index]
+								);
+
+								if (type === "update" && status && !complete) {
+									// call 'status' listeners
+									fire_event({
+										type: "status",
+										endpoint: _endpoint,
+										fn_index,
+										time: new Date(),
+										...status
+									});
+									if (status.stage === "error") {
+										websocket.close();
+									}
+								} else if (type === "hash") {
+									websocket.send(JSON.stringify({ fn_index, session_hash }));
+									return;
+								} else if (type === "data") {
+									websocket.send(JSON.stringify({ ...payload, session_hash }));
+								} else if (type === "complete") {
+									complete = status;
+								} else if (type === "log") {
+									fire_event({
+										type: "log",
+										log: data.log,
+										level: data.level,
+										endpoint: _endpoint,
+										fn_index
+									});
+								} else if (type === "generating") {
 									fire_event({
 										type: "status",
 										time: new Date(),
-										...complete,
+										...status,
 										stage: status?.stage!,
 										queue: true,
 										endpoint: _endpoint,
 										fn_index
 									});
-									websocket.close();
 								}
-							}
-						};
+								if (data) {
+									fire_event({
+										type: "data",
+										time: new Date(),
+										data: transform_files
+											? transform_output(
+													data.data,
+													api_info,
+													config.root,
+													config.root_url
+											  )
+											: data.data,
+										endpoint: _endpoint,
+										fn_index
+									});
 
-						// different ws contract for gradio versions older than 3.6.0
-						//@ts-ignore
-						if (semiver(config.version || "2.0.0", "3.6") < 0) {
-							addEventListener("open", () =>
-								websocket.send(JSON.stringify({ hash: session_hash }))
-							);
-						}
-					} else if (protocol == "sse") {
-						fire_event({
-							type: "status",
-							stage: "pending",
-							queue: true,
-							endpoint: _endpoint,
-							fn_index,
-							time: new Date()
-						});
-						var params = new URLSearchParams({
-							fn_index: fn_index.toString(),
-							session_hash: session_hash
-						}).toString();
-						let url = new URL(
-							`${config.root}/queue/join?${url_params ? url_params + "&" : ""}${params}`
-						);
-
-						eventSource = EventSource_factory(url);
-
-						eventSource.onmessage = async function (event) {
-							const _data = JSON.parse(event.data);
-							const { type, status, data } = handle_message(
-								_data,
-								last_status[fn_index]
-							);
-
-							if (type === "update" && status && !complete) {
-								// call 'status' listeners
-								fire_event({
-									type: "status",
-									endpoint: _endpoint,
-									fn_index,
-									time: new Date(),
-									...status
-								});
-								if (status.stage === "error") {
-									eventSource.close();
+									if (complete) {
+										fire_event({
+											type: "status",
+											time: new Date(),
+											...complete,
+											stage: status?.stage!,
+											queue: true,
+											endpoint: _endpoint,
+											fn_index
+										});
+										websocket.close();
+									}
 								}
-							} else if (type === "data") {
-								event_id = _data.event_id as string;
-								let [_, status] = await post_data(
-									`${config.root}/queue/data`,
-									{
-										...payload,
-										session_hash,
-										event_id
-									},
-									hf_token
+							};
+
+							// different ws contract for gradio versions older than 3.6.0
+							//@ts-ignore
+							if (semiver(config.version || "2.0.0", "3.6") < 0) {
+								addEventListener("open", () =>
+									websocket.send(JSON.stringify({ hash: session_hash }))
 								);
-								if (status !== 200) {
+							}
+						} else if (protocol == "sse") {
+							fire_event({
+								type: "status",
+								stage: "pending",
+								queue: true,
+								endpoint: _endpoint,
+								fn_index,
+								time: new Date()
+							});
+							var params = new URLSearchParams({
+								fn_index: fn_index.toString(),
+								session_hash: session_hash
+							}).toString();
+							let url = new URL(
+								`${config.root}/queue/join?${
+									url_params ? url_params + "&" : ""
+								}${params}`
+							);
+
+							eventSource = EventSource_factory(url);
+
+							eventSource.onmessage = async function (event) {
+								const _data = JSON.parse(event.data);
+								const { type, status, data } = handle_message(
+									_data,
+									last_status[fn_index]
+								);
+
+								if (type === "update" && status && !complete) {
+									// call 'status' listeners
+									fire_event({
+										type: "status",
+										endpoint: _endpoint,
+										fn_index,
+										time: new Date(),
+										...status
+									});
+									if (status.stage === "error") {
+										eventSource.close();
+									}
+								} else if (type === "data") {
+									event_id = _data.event_id as string;
+									let [_, status] = await post_data(
+										`${config.root}/queue/data`,
+										{
+											...payload,
+											session_hash,
+											event_id
+										},
+										hf_token
+									);
+									if (status !== 200) {
+										fire_event({
+											type: "status",
+											stage: "error",
+											message: BROKEN_CONNECTION_MSG,
+											queue: true,
+											endpoint: _endpoint,
+											fn_index,
+											time: new Date()
+										});
+										eventSource.close();
+									}
+								} else if (type === "complete") {
+									complete = status;
+								} else if (type === "log") {
+									fire_event({
+										type: "log",
+										log: data.log,
+										level: data.level,
+										endpoint: _endpoint,
+										fn_index
+									});
+								} else if (type === "generating") {
+									fire_event({
+										type: "status",
+										time: new Date(),
+										...status,
+										stage: status?.stage!,
+										queue: true,
+										endpoint: _endpoint,
+										fn_index
+									});
+								}
+								if (data) {
+									fire_event({
+										type: "data",
+										time: new Date(),
+										data: transform_files
+											? transform_output(
+													data.data,
+													api_info,
+													config.root,
+													config.root_url
+											  )
+											: data.data,
+										endpoint: _endpoint,
+										fn_index
+									});
+
+									if (complete) {
+										fire_event({
+											type: "status",
+											time: new Date(),
+											...complete,
+											stage: status?.stage!,
+											queue: true,
+											endpoint: _endpoint,
+											fn_index
+										});
+										eventSource.close();
+									}
+								}
+							};
+						} else if (protocol == "sse_v1") {
+							fire_event({
+								type: "status",
+								stage: "pending",
+								queue: true,
+								endpoint: _endpoint,
+								fn_index,
+								time: new Date()
+							});
+
+							post_data(
+								`${config.root}/queue/join?${url_params}`,
+								{
+									...payload,
+									session_hash
+								},
+								hf_token
+							).then(([response, status]) => {
+								if (status === 503) {
+									fire_event({
+										type: "status",
+										stage: "error",
+										message: QUEUE_FULL_MSG,
+										queue: true,
+										endpoint: _endpoint,
+										fn_index,
+										time: new Date()
+									});
+								} else if (status !== 200) {
 									fire_event({
 										type: "status",
 										stage: "error",
@@ -717,127 +811,107 @@ export function api_factory(
 										fn_index,
 										time: new Date()
 									});
-									eventSource.close();
-								}
-							} else if (type === "complete") {
-								complete = status;
-							} else if (type === "log") {
-								fire_event({
-									type: "log",
-									log: data.log,
-									level: data.level,
-									endpoint: _endpoint,
-									fn_index
-								});
-							} else if (type === "generating") {
-								fire_event({
-									type: "status",
-									time: new Date(),
-									...status,
-									stage: status?.stage!,
-									queue: true,
-									endpoint: _endpoint,
-									fn_index
-								});
-							}
-							if (data) {
-								fire_event({
-									type: "data",
-									time: new Date(),
-									data: transform_files
-										? transform_output(
-												data.data,
-												api_info,
-												config.root,
-												config.root_url
-										  )
-										: data.data,
-									endpoint: _endpoint,
-									fn_index
-								});
+								} else {
+									event_id = response.event_id as string;
+									let callback = async function (_data: object): void {
+										try {
+											const { type, status, data } = handle_message(
+												_data,
+												last_status[fn_index]
+											);
 
-								if (complete) {
-									fire_event({
-										type: "status",
-										time: new Date(),
-										...complete,
-										stage: status?.stage!,
-										queue: true,
-										endpoint: _endpoint,
-										fn_index
-									});
-									eventSource.close();
-								}
-							}
-						};
-					} else if (protocol == "sse_v1") {
-						fire_event({
-							type: "status",
-							stage: "pending",
-							queue: true,
-							endpoint: _endpoint,
-							fn_index,
-							time: new Date()
-						});
+											// TODO: Find out how to print this information
+											// only during testing
+											// console.info("data", type, status, data);
 
-						post_data(
-							`${config.root}/queue/join?${url_params}`,
-							{
-								...payload,
-								session_hash
-							},
-							hf_token
-						).then(([response, status]) => {
-							if (status === 503) {
-								fire_event({
-									type: "status",
-									stage: "error",
-									message: QUEUE_FULL_MSG,
-									queue: true,
-									endpoint: _endpoint,
-									fn_index,
-									time: new Date()
-								});
-							} else if (status !== 200) {
-								fire_event({
-									type: "status",
-									stage: "error",
-									message: BROKEN_CONNECTION_MSG,
-									queue: true,
-									endpoint: _endpoint,
-									fn_index,
-									time: new Date()
-								});
-							} else {
-								event_id = response.event_id as string;
-								let callback = async function (_data: object): void {
-									try {
-										const { type, status, data } = handle_message(
-											_data,
-											last_status[fn_index]
-										);
+											if (type == "heartbeat") {
+												return;
+											}
 
-										// TODO: Find out how to print this information
-										// only during testing
-										// console.info("data", type, status, data);
+											if (type === "update" && status && !complete) {
+												// call 'status' listeners
+												fire_event({
+													type: "status",
+													endpoint: _endpoint,
+													fn_index,
+													time: new Date(),
+													...status
+												});
+											} else if (type === "complete") {
+												complete = status;
+											} else if (type == "unexpected_error") {
+												console.error("Unexpected error", status?.message);
+												fire_event({
+													type: "status",
+													stage: "error",
+													message: "An Unexpected Error Occurred!",
+													queue: true,
+													endpoint: _endpoint,
+													fn_index,
+													time: new Date()
+												});
+											} else if (type === "log") {
+												fire_event({
+													type: "log",
+													log: data.log,
+													level: data.level,
+													endpoint: _endpoint,
+													fn_index
+												});
+												return;
+											} else if (type === "generating") {
+												fire_event({
+													type: "status",
+													time: new Date(),
+													...status,
+													stage: status?.stage!,
+													queue: true,
+													endpoint: _endpoint,
+													fn_index
+												});
+											}
+											if (data) {
+												fire_event({
+													type: "data",
+													time: new Date(),
+													data: transform_files
+														? transform_output(
+																data.data,
+																api_info,
+																config.root,
+																config.root_url
+														  )
+														: data.data,
+													endpoint: _endpoint,
+													fn_index
+												});
 
-										if (type == "heartbeat") {
-											return;
-										}
+												if (complete) {
+													fire_event({
+														type: "status",
+														time: new Date(),
+														...complete,
+														stage: status?.stage!,
+														queue: true,
+														endpoint: _endpoint,
+														fn_index
+													});
+												}
+											}
 
-										if (type === "update" && status && !complete) {
-											// call 'status' listeners
-											fire_event({
-												type: "status",
-												endpoint: _endpoint,
-												fn_index,
-												time: new Date(),
-												...status
-											});
-										} else if (type === "complete") {
-											complete = status;
-										} else if (type == "unexpected_error") {
-											console.error("Unexpected error", status?.message);
+											if (
+												status?.stage === "complete" ||
+												status?.stage === "error"
+											) {
+												if (event_callbacks[event_id]) {
+													delete event_callbacks[event_id];
+													if (Object.keys(event_callbacks).length === 0) {
+														close_stream();
+													}
+												}
+											}
+										} catch (e) {
+											console.error("Unexpected client exception", e);
 											fire_event({
 												type: "status",
 												stage: "error",
@@ -847,94 +921,24 @@ export function api_factory(
 												fn_index,
 												time: new Date()
 											});
-										} else if (type === "log") {
-											fire_event({
-												type: "log",
-												log: data.log,
-												level: data.level,
-												endpoint: _endpoint,
-												fn_index
-											});
-											return;
-										} else if (type === "generating") {
-											fire_event({
-												type: "status",
-												time: new Date(),
-												...status,
-												stage: status?.stage!,
-												queue: true,
-												endpoint: _endpoint,
-												fn_index
-											});
+											close_stream();
 										}
-										if (data) {
-											fire_event({
-												type: "data",
-												time: new Date(),
-												data: transform_files
-													? transform_output(
-															data.data,
-															api_info,
-															config.root,
-															config.root_url
-													  )
-													: data.data,
-												endpoint: _endpoint,
-												fn_index
-											});
-
-											if (complete) {
-												fire_event({
-													type: "status",
-													time: new Date(),
-													...complete,
-													stage: status?.stage!,
-													queue: true,
-													endpoint: _endpoint,
-													fn_index
-												});
-											}
-										}
-
-										if (
-											status?.stage === "complete" ||
-											status?.stage === "error"
-										) {
-											if (event_callbacks[event_id]) {
-												delete event_callbacks[event_id];
-												if (Object.keys(event_callbacks).length === 0) {
-													close_stream();
-												}
-											}
-										}
-									} catch (e) {
-										console.error("Unexpected client exception", e);
-										fire_event({
-											type: "status",
-											stage: "error",
-											message: "An Unexpected Error Occurred!",
-											queue: true,
-											endpoint: _endpoint,
-											fn_index,
-											time: new Date()
-										});
-										close_stream();
+									};
+									if (event_id in pending_stream_messages) {
+										pending_stream_messages[event_id].forEach((msg) =>
+											callback(msg)
+										);
+										delete pending_stream_messages[event_id];
 									}
-								};
-								if (event_id in pending_stream_messages) {
-									pending_stream_messages[event_id].forEach((msg) =>
-										callback(msg)
-									);
-									delete pending_stream_messages[event_id];
+									event_callbacks[event_id] = callback;
+									if (!stream_open) {
+										open_stream();
+									}
 								}
-								event_callbacks[event_id] = callback;
-								if (!stream_open) {
-									open_stream();
-								}
-							}
-						});
+							});
+						}
 					}
-				});
+				);
 
 				function fire_event<K extends EventType>(event: Event<K>): void {
 					const narrowed_listener_map: ListenerMap<K> = listener_map;
@@ -996,14 +1000,11 @@ export function api_factory(
 					}
 
 					try {
-						await fetch_implementation(
-							`${config.root}/reset`,
-							{
-								headers: { "Content-Type": "application/json" },
-								method: "POST",
-								body: JSON.stringify(cancel_request)
-							}
-						);
+						await fetch_implementation(`${config.root}/reset`, {
+							headers: { "Content-Type": "application/json" },
+							method: "POST",
+							body: JSON.stringify(cancel_request)
+						});
 					} catch (e) {
 						console.warn(
 							"The `/reset` endpoint could not be called. Subsequent endpoint results may be unreliable."
@@ -1032,9 +1033,7 @@ export function api_factory(
 				let params = new URLSearchParams({
 					session_hash: session_hash
 				}).toString();
-				let url = new URL(
-					`${config.root}/queue/data?${params}`
-				);
+				let url = new URL(`${config.root}/queue/data?${params}`);
 				event_stream = new EventSource(url);
 				event_stream.onmessage = async function (event) {
 					let _data = JSON.parse(event.data);

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -462,7 +462,7 @@ export function api_factory(
 				}
 
 				handle_blob(
-					`${http_protocol}//${resolve_root(host, config.path, true)}`,
+					`${config.root}`,
 					data,
 					api_info,
 					hf_token
@@ -479,7 +479,7 @@ export function api_factory(
 						});
 
 						post_data(
-							`${http_protocol}//${resolve_root(host, config.path, true)}/run${
+							`${config.root}/run${
 								_endpoint.startsWith("/") ? _endpoint : `/${_endpoint}`
 							}${url_params ? "?" + url_params : ""}`,
 							{
@@ -672,11 +672,7 @@ export function api_factory(
 							session_hash: session_hash
 						}).toString();
 						let url = new URL(
-							`${http_protocol}//${resolve_root(
-								host,
-								config.path,
-								true
-							)}/queue/join?${url_params ? url_params + "&" : ""}${params}`
+							`${config.root}/queue/join?${url_params ? url_params + "&" : ""}${params}`
 						);
 
 						eventSource = EventSource_factory(url);
@@ -703,11 +699,7 @@ export function api_factory(
 							} else if (type === "data") {
 								event_id = _data.event_id as string;
 								let [_, status] = await post_data(
-									`${http_protocol}//${resolve_root(
-										host,
-										config.path,
-										true
-									)}/queue/data`,
+									`${config.root}/queue/data`,
 									{
 										...payload,
 										session_hash,
@@ -789,11 +781,7 @@ export function api_factory(
 						});
 
 						post_data(
-							`${http_protocol}//${resolve_root(
-								host,
-								config.path,
-								true
-							)}/queue/join?${url_params}`,
+							`${config.root}/queue/join?${url_params}`,
 							{
 								...payload,
 								session_hash
@@ -1009,11 +997,7 @@ export function api_factory(
 
 					try {
 						await fetch_implementation(
-							`${http_protocol}//${resolve_root(
-								host,
-								config.path,
-								true
-							)}/reset`,
+							`${config.root}/reset`,
 							{
 								headers: { "Content-Type": "application/json" },
 								method: "POST",
@@ -1049,11 +1033,7 @@ export function api_factory(
 					session_hash: session_hash
 				}).toString();
 				let url = new URL(
-					`${http_protocol}//${resolve_root(
-						host,
-						config.path,
-						true
-					)}/queue/data?${params}`
+					`${config.root}/queue/data?${params}`
 				);
 				event_stream = new EventSource(url);
 				event_stream.onmessage = async function (event) {
@@ -1100,14 +1080,10 @@ export function api_factory(
 				if (component?.props?.root_url) {
 					root_url = component.props.root_url;
 				} else {
-					root_url = `${http_protocol}//${resolve_root(
-						host,
-						config.path,
-						true
-					)}/`;
+					root_url = config.root;
 				}
 				const response = await fetch_implementation(
-					`${root_url}component_server/`,
+					`${root_url}/component_server/`,
 					{
 						method: "POST",
 						body: JSON.stringify({

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -38,7 +38,6 @@
 	export let app: Awaited<ReturnType<typeof client>>;
 	export let space_id: string | null;
 	export let version: string;
-	export let api_url: string;
 	export let js: string | null;
 
 	let loading_status = create_loading_status_store();

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -267,7 +267,7 @@
 					const matching_component = components.find((c) => c.type === name);
 					if (matching_component) {
 						_c = load_component({
-							api_url,
+							api_url: root,
 							name,
 							id: matching_component.component_class_id,
 							variant: "example"
@@ -282,7 +282,7 @@
 			// maybe load custom
 
 			const _c = load_component({
-				api_url,
+				api_url: root,
 				name: c.type,
 				id: c.component_class_id,
 				variant: "component"

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -416,7 +416,6 @@
 			show_footer={!is_embed}
 			{app_mode}
 			{version}
-			{api_url}
 		/>
 	{/if}
 </Embed>

--- a/js/app/test/chatinterface_streaming_echo.spec.ts
+++ b/js/app/test/chatinterface_streaming_echo.spec.ts
@@ -26,7 +26,7 @@ test("chatinterface works with streaming functions and all buttons behave as exp
 	await expect(page.locator(".bot").nth(1)).toContainText("You typed: hi");
 
 	await undo_button.click();
-	await expect.poll(async () => page.locator(".message.bot").count()).toBe(1);
+	await expect.poll(async () => page.locator(".message.bot").count(), {timeout: 5000}).toBe(1);
 	await expect(textbox).toHaveValue("hi");
 
 	await textbox.fill("salaam");
@@ -35,5 +35,5 @@ test("chatinterface works with streaming functions and all buttons behave as exp
 	await expect(page.locator(".bot").nth(1)).toContainText("You typed: salaam");
 
 	await clear_button.click();
-	await expect.poll(async () => page.locator(".bot.message").count()).toBe(0);
+	await expect.poll(async () => page.locator(".bot.message").count(), {timeout: 5000}).toBe(0);
 });

--- a/js/app/test/chatinterface_streaming_echo.spec.ts
+++ b/js/app/test/chatinterface_streaming_echo.spec.ts
@@ -26,7 +26,9 @@ test("chatinterface works with streaming functions and all buttons behave as exp
 	await expect(page.locator(".bot").nth(1)).toContainText("You typed: hi");
 
 	await undo_button.click();
-	await expect.poll(async () => page.locator(".message.bot").count(), {timeout: 5000}).toBe(1);
+	await expect
+		.poll(async () => page.locator(".message.bot").count(), { timeout: 5000 })
+		.toBe(1);
 	await expect(textbox).toHaveValue("hi");
 
 	await textbox.fill("salaam");
@@ -35,5 +37,7 @@ test("chatinterface works with streaming functions and all buttons behave as exp
 	await expect(page.locator(".bot").nth(1)).toContainText("You typed: salaam");
 
 	await clear_button.click();
-	await expect.poll(async () => page.locator(".bot.message").count(), {timeout: 5000}).toBe(0);
+	await expect
+		.poll(async () => page.locator(".bot.message").count(), { timeout: 5000 })
+		.toBe(0);
 });


### PR DESCRIPTION
## Description

The issue is that we were constructing the URL manually but we can just use `config.root` which is the correct url hosting the gradio demo even if it's behind a proxy.

Closes: #6739 
Closes: #6748



I tested several demos when running behind a local nginx reverse proxy

### Vanilla Hello World
<img width="1280" alt="image" src="https://github.com/gradio-app/gradio/assets/41651716/64fbb00d-627e-4979-b694-c33acef140e5">

### Custom Components Hello World
<img width="1287" alt="image" src="https://github.com/gradio-app/gradio/assets/41651716/9e0a3ab6-572c-4710-a1b1-72edfd48fbad">


### File Explorer
<img width="1279" alt="image" src="https://github.com/gradio-app/gradio/assets/41651716/9ae2fcba-9bf6-439a-9f6c-f3c0928e9098">

### Iterator + Cancel
<img width="1297" alt="image" src="https://github.com/gradio-app/gradio/assets/41651716/a579dd9b-658e-40d4-8ab7-9251c1534972">

This is the nginx.conf

```
# nginx Configuration File
# https://www.nginx.com/resources/wiki/start/topics/examples/full/
# http://nginx.org/en/docs/dirindex.html
# https://www.nginx.com/resources/wiki/start/

# Run as a unique, less privileged user for security.
# user nginx www-data;  ## Default: nobody

# If using supervisord init system, do not run in deamon mode.
# Bear in mind that non-stop upgrade is not an option with "daemon off".
daemon off;

# Sets the worker threads to the number of CPU cores available in the system
# for best performance.
# Should be > the number of CPU cores.
# Maximum number of connections = worker_processes * worker_connections
worker_processes auto;  ## Default: 1

# Maximum number of open files per worker process.
# Should be > worker_connections.
# http://blog.martinfjordvald.com/2011/04/optimizing-nginx-for-high-traffic-loads/
# http://stackoverflow.com/a/8217856/2127762
# Each connection needs a filehandle (or 2 if you are proxying).
worker_rlimit_nofile 8192;

events {
  # If you need more connections than this, you start optimizing your OS.
  # That's probably the point at which you hire people who are smarter than
  # you as this is *a lot* of requests.
  # Should be < worker_rlimit_nofile.
  worker_connections 8000;
}

# Log errors and warnings to this file
# This is only used when you don't override it on a server{} level
#error_log  logs/error.log  notice;
#error_log  logs/error.log  info;
error_log  var/log/nginx/error.log warn;

# The file storing the process ID of the main process
pid var/run/nginx.pid;


http {
  # Log access to this file
  # This is only used when you don't override it on a server{} level
  access_log var/log/nginx/access.log;

  # Hide nginx version information.
  server_tokens off;

  # Controls the maximum length of a virtual host entry (ie the length
  # of the domain name).
  server_names_hash_bucket_size 64;

  # Specify MIME types for files.
  include mime.types;
  default_type application/octet-stream;

  # How long to allow each connection to stay idle.
  # Longer values are better for each individual client, particularly for SSL,
  # but means that worker connections are tied up longer.
  keepalive_timeout 20s;

  # Speed up file transfers by using sendfile() to copy directly
  # between descriptors rather than using read()/write().
  # For performance reasons, on FreeBSD systems w/ ZFS
  # this option should be disabled as ZFS's ARC caches
  # frequently used files in RAM by default.
  sendfile on;

  # Don't send out partial frames; this increases throughput
  # since TCP frames are filled up before being sent out.
  tcp_nopush on;

  # Enable gzip compression.
  gzip on;

  # Compression level (1-9).
  # 5 is a perfect compromise between size and CPU usage, offering about
  # 75% reduction for most ASCII files (almost identical to level 9).
  gzip_comp_level 5;

  # Don't compress anything that's already small and unlikely to shrink much
  # if at all (the default is 20 bytes, which is bad as that usually leads to
  # larger files after gzipping).
  gzip_min_length 256;

  # Compress data even for clients that are connecting to us via proxies,
  # identified by the "Via" header (required for CloudFront).
  gzip_proxied any;

  # Tell proxies to cache both the gzipped and regular version of a resource
  # whenever the client's Accept-Encoding capabilities header varies;
  # Avoids the issue where a non-gzip capable client (which is extremely rare
  # today) would display gibberish if their proxy gave them the gzipped version.
  gzip_vary on;

  # Compress all output labeled with one of the following MIME-types.
  gzip_types
    application/atom+xml
    application/javascript
    application/json
    application/ld+json
    application/manifest+json
    application/rss+xml
    application/vnd.geo+json
    application/vnd.ms-fontobject
    application/x-font-ttf
    application/x-web-app-manifest+json
    application/xhtml+xml
    application/xml
    font/opentype
    image/bmp
    image/svg+xml
    image/x-icon
    text/cache-manifest
    text/css
    text/plain
    text/vcard
    text/vnd.rim.location.xloc
    text/vtt
    text/x-component
    text/x-cross-domain-policy;
  # text/html is always compressed by gzip module

  # This should be turned on if you are going to have pre-compressed copies (.gz) of
  # static files available. If not it should be left off as it will cause extra I/O
  # for the check. It is best if you enable this in a location{} block for
  # a specific directory, or on an individual server{} level.
  # gzip_static on;

  include sites.d/*.conf;

server {
    listen 80;
    server_name subdomain.local;
    location /gradio-demo/ {  # Change this if you'd like to server your Gradio app on a different path
        proxy_pass http://127.0.0.1:7860/; # Change this if your Gradio app will be running on a different port
        proxy_buffering off;
        proxy_redirect off;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";
        proxy_set_header Host $host;
    }

    location /custom-component/ {  # Change this if you'd like to server your Gradio app on a different path
        proxy_pass http://127.0.0.1:7861/; # Change this if your Gradio app will be running on a different port
        proxy_buffering off;
        proxy_redirect off;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";
        proxy_set_header Host $host;
    }

    location /file-explorer/ {  # Change this if you'd like to server your Gradio app on a different path
        proxy_pass http://127.0.0.1:7862/; # Change this if your Gradio app will be running on a different port
        proxy_buffering off;
        proxy_redirect off;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";
        proxy_set_header Host $host;
    }

    location /cancel-events/ {  # Change this if you'd like to server your Gradio app on a different path
        proxy_pass http://127.0.0.1:7863/; # Change this if your Gradio app will be running on a different port
        proxy_buffering off;
        proxy_redirect off;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";
        proxy_set_header Host $host;
    }
}

}
```


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
