### PR TITLE
fix issue 6873: File with file_count='directory' bug

### DIFF
--- a/.changeset/nasty-eagles-do.md
+++ b/.changeset/nasty-eagles-do.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:fix issue 6873: File with file_count='directory' bug

--- a/gradio/components/file.py
+++ b/gradio/components/file.py
@@ -79,7 +79,7 @@ class File(Component):
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
         """
         self.file_count = file_count
-        if self.file_count == "multiple":
+        if self.file_count in ["multiple", "directory"]:
             self.data_model = ListFiles
         else:
             self.data_model = FileData

--- a/gradio/components/file.py
+++ b/gradio/components/file.py
@@ -5,26 +5,16 @@ from __future__ import annotations
 import tempfile
 import warnings
 from pathlib import Path
-from typing import Any, Callable, List, Literal
+from typing import Any, Callable, Literal
 
 from gradio_client.documentation import document, set_documentation_group
 
 from gradio.components.base import Component
-from gradio.data_classes import FileData, GradioRootModel
+from gradio.data_classes import FileData, ListFiles
 from gradio.events import Events
 from gradio.utils import NamedString
 
 set_documentation_group("component")
-
-
-class ListFiles(GradioRootModel):
-    root: List[FileData]
-
-    def __getitem__(self, index):
-        return self.root[index]
-
-    def __iter__(self):
-        return iter(self.root)
 
 
 @document()

--- a/gradio/components/upload_button.py
+++ b/gradio/components/upload_button.py
@@ -5,26 +5,16 @@ from __future__ import annotations
 import tempfile
 import warnings
 from pathlib import Path
-from typing import Any, Callable, List, Literal
+from typing import Any, Callable, Literal
 
 from gradio_client.documentation import document, set_documentation_group
 
 from gradio.components.base import Component
-from gradio.data_classes import FileData, GradioRootModel
+from gradio.data_classes import FileData, ListFiles
 from gradio.events import Events
 from gradio.utils import NamedString
 
 set_documentation_group("component")
-
-
-class ListFiles(GradioRootModel):
-    root: List[FileData]
-
-    def __getitem__(self, index):
-        return self.root[index]
-
-    def __iter__(self):
-        return iter(self.root)
 
 
 @document()
@@ -95,7 +85,7 @@ class UploadButton(Component):
             raise ValueError(
                 f"Parameter file_types must be a list. Received {file_types.__class__.__name__}"
             )
-        if self.file_count == "multiple":
+        if self.file_count in ["multiple", "directory"]:
             self.data_model = ListFiles
         else:
             self.data_model = FileData

--- a/gradio/data_classes.py
+++ b/gradio/data_classes.py
@@ -204,3 +204,13 @@ class FileData(GradioModel):
             except (TypeError, ValidationError):
                 return False
         return False
+
+
+class ListFiles(GradioRootModel):
+    root: List[FileData]
+
+    def __getitem__(self, index):
+        return self.root[index]
+
+    def __iter__(self):
+        return iter(self.root)

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -34,7 +34,7 @@ from gradio.components.dataframe import DataframeData
 from gradio.components.file_explorer import FileExplorerData
 from gradio.components.image_editor import EditorData
 from gradio.components.video import VideoData
-from gradio.data_classes import FileData
+from gradio.data_classes import FileData, ListFiles
 
 os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
 
@@ -991,6 +991,14 @@ class TestFile:
         output2 = file_input.postprocess("test/test_files/sample_file.pdf")
         assert output1 == output2
 
+    def test_preprocess_with_multiple_files(self):
+        file_data = FileData(path=media_data.BASE64_FILE["path"])
+        list_file_data = ListFiles(root=[file_data, file_data])
+        file_input = gr.File(file_count="directory")
+        output = file_input.preprocess(list_file_data)
+        assert isinstance(output, list)
+        assert isinstance(output[0], str)
+
     def test_file_type_must_be_list(self):
         with pytest.raises(
             ValueError, match="Parameter file_types must be a list. Received str"
@@ -1043,6 +1051,14 @@ class TestUploadButton:
             ValueError, match="Parameter file_types must be a list. Received int"
         ):
             gr.UploadButton(file_types=2)
+
+    def test_preprocess_with_multiple_files(self):
+        file_data = FileData(path=media_data.BASE64_FILE["path"])
+        list_file_data = ListFiles(root=[file_data, file_data])
+        upload_input = gr.UploadButton(file_count="directory")
+        output = upload_input.preprocess(list_file_data)
+        assert isinstance(output, list)
+        assert isinstance(output[0], str)
 
 
 class TestDataframe:


### PR DESCRIPTION
## Description
Specifies that if file_count is set to directory when using File we should expect a list of files rather than a single file.
Closes: #6873 