### PR TITLE
Fix the Wasm worker to initialize the app directories

### DIFF
--- a/.changeset/tender-parks-change.md
+++ b/.changeset/tender-parks-change.md
@@ -1,0 +1,6 @@
+---
+"@gradio/wasm": minor
+"gradio": minor
+---
+
+feat:Fix the Wasm worker to initialize the app directories

--- a/.changeset/tender-parks-change.md
+++ b/.changeset/tender-parks-change.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/wasm": minor
-"gradio": minor
+"@gradio/wasm": patch
+"gradio": patch
 ---
 
 feat:Fix the Wasm worker to initialize the app directories

--- a/js/wasm/src/webworker/index.ts
+++ b/js/wasm/src/webworker/index.ts
@@ -187,6 +187,13 @@ async function initializeApp(
 	options: InMessageInitApp["data"],
 	updateProgress: (log: string) => void
 ): Promise<void> {
+	const appHomeDir = getAppHomeDir(appId);
+	console.debug("Creating a home directory for the app.", {
+		appId,
+		appHomeDir
+	});
+	pyodide.FS.mkdir(appHomeDir);
+
 	console.debug("Mounting files.", options.files);
 	updateProgress("Mounting files");
 	await Promise.all(
@@ -248,6 +255,8 @@ function setupMessageHandler(receiver: MessageTransceiver): void {
 	// One app also has one Gradio server app which is managed by the `gradio.wasm_utils` module.`
 	// This multi-app mechanism was introduced for a SharedWorker, but the same mechanism is used for a DedicatedWorker as well.
 	const appId = generateRandomString(8);
+
+	console.debug("Set up a new app.", { appId });
 
 	const updateProgress = (log: string): void => {
 		const message: OutMessage = {


### PR DESCRIPTION
## Description

Fixes an error reported in https://github.com/gradio-app/gradio/pull/6870#issuecomment-1869749020.

#6432 was not sufficient as the app home directory (`/home/pyodide/<appId>`) is only created when at least one file is mounted [here](https://github.com/gradio-app/gradio/blob/31c23166f0113ab6506575f345c31c952e57e137/js/wasm/src/webworker/index.ts#L209), so the app home directory won't exist for example when using `run_code()` and it's the reason of the error above.

