### PR TITLE
replacing distutils.StrictVersion dependency for Python 3.12

### DIFF
--- a/.changeset/fruity-taxis-sit.md
+++ b/.changeset/fruity-taxis-sit.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:replacing distutils.StrictVersion dependency for Python 3.12

--- a/.changeset/fruity-taxis-sit.md
+++ b/.changeset/fruity-taxis-sit.md
@@ -1,4 +1,5 @@
 ---
+"@gradio/wasm": patch
 "gradio": patch
 ---
 

--- a/gradio/analytics.py
+++ b/gradio/analytics.py
@@ -7,7 +7,7 @@ import os
 import threading
 import urllib.parse
 import warnings
-from distutils.version import StrictVersion
+from packaging.version import Version
 from typing import Any
 
 import httpx
@@ -88,7 +88,7 @@ def version_check():
     try:
         current_pkg_version = get_package_version()
         latest_pkg_version = httpx.get(url=PKG_VERSION_URL, timeout=3).json()["version"]
-        if StrictVersion(latest_pkg_version) > StrictVersion(current_pkg_version):
+        if Version(latest_pkg_version) > Version(current_pkg_version):
             print(
                 f"IMPORTANT: You are using gradio version {current_pkg_version}, "
                 f"however version {latest_pkg_version} is available, please upgrade."

--- a/js/wasm/src/webworker/index.ts
+++ b/js/wasm/src/webworker/index.ts
@@ -75,7 +75,7 @@ async function initializeEnvironment(
 	updateProgress("Loading Gradio wheels");
 	await micropip.add_mock_package("ffmpy", "0.3.0");
 	await micropip.add_mock_package("aiohttp", "3.8.4");
-	await pyodide.loadPackage(["ssl", "distutils", "setuptools"]);
+	await pyodide.loadPackage(["ssl", "setuptools"]);
 	await micropip.install(["typing-extensions>=4.8.0"]); // Typing extensions needs to be installed first otherwise the versions from the pyodide lockfile is used which is incompatible with the latest fastapi.
 	await micropip.install(["markdown-it-py[linkify]~=2.2.0"]); // On 3rd June 2023, markdown-it-py 3.0.0 has been released. The `gradio` package depends on its `>=2.0.0` version so its 3.x will be resolved. However, it conflicts with `mdit-py-plugins`'s dependency `markdown-it-py >=1.0.0,<3.0.0` and micropip currently can't resolve it. So we explicitly install the compatible version of the library here.
 	await micropip.install(["anyio==3.*"]); // `fastapi` depends on `anyio>=3.4.0,<5` so its 4.* can be installed, but it conflicts with the anyio version `httpx` depends on, `==3.*`. Seems like micropip can't resolve it for now, so we explicitly install the compatible version of the library here.


### PR DESCRIPTION
…ersion after distutils deprecation (in 3.10) and removal in Python 3.12 (see https://docs.python.org/3.10/whatsnew/3.10.html#distutils-deprecated)

## Description

gradio had an error on startup on Python 3.12.1:

```
(.venv) daniel@Daniels-MacBook-Pro gradio_dev % python main.py
Traceback (most recent call last):
  File "/Users/daniel/git/gradio_dev/main.py", line 1, in <module>
    import gradio as gr
  File "/Users/daniel/git/gradio_dev/.venv/lib/python3.12/site-packages/gradio/__init__.py", line 3, in <module>
    import gradio._simple_templates
  File "/Users/daniel/git/gradio_dev/.venv/lib/python3.12/site-packages/gradio/_simple_templates/__init__.py", line 1, in <module>
    from .simpledropdown import SimpleDropdown
  File "/Users/daniel/git/gradio_dev/.venv/lib/python3.12/site-packages/gradio/_simple_templates/simpledropdown.py", line 6, in <module>
    from gradio.components.base import FormComponent
  File "/Users/daniel/git/gradio_dev/.venv/lib/python3.12/site-packages/gradio/components/__init__.py", line 1, in <module>
    from gradio.components.annotated_image import AnnotatedImage
  File "/Users/daniel/git/gradio_dev/.venv/lib/python3.12/site-packages/gradio/components/annotated_image.py", line 12, in <module>
    from gradio.components.base import Component
  File "/Users/daniel/git/gradio_dev/.venv/lib/python3.12/site-packages/gradio/components/base.py", line 21, in <module>
    from gradio.blocks import Block, BlockContext
  File "/Users/daniel/git/gradio_dev/.venv/lib/python3.12/site-packages/gradio/blocks.py", line 29, in <module>
    from gradio import (
  File "/Users/daniel/git/gradio_dev/.venv/lib/python3.12/site-packages/gradio/analytics.py", line 10, in <module>
    from distutils.version import StrictVersion
ModuleNotFoundError: No module named 'distutils'
```

```
(.venv) daniel@Daniels-MacBook-Pro gradio_dev % python --version
Python 3.12.1
```

Closes: #6937

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

I couldn't run the full test suite locally due to complications with `bash scripts/build_frontend.sh` (on macOS). I tested by adjusting the file and running the demo app with Python 3.12.1
  
