### PR TITLE
Fix returning copies of a component instance from a prediction function

### DIFF
--- a/.changeset/tangy-spoons-hug.md
+++ b/.changeset/tangy-spoons-hug.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix returning copies of a component instance from a prediction function

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1429,7 +1429,7 @@ Received outputs:
                     )
 
                 if isinstance(prediction_value, Block):
-                    prediction_value = prediction_value.constructor_args
+                    prediction_value = prediction_value.constructor_args.copy()
                     prediction_value["__type__"] = "update"
                 if utils.is_update(prediction_value):
                     if output_id in state:

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1603,3 +1603,24 @@ def test_emptry_string_api_name_gets_set_as_fn_name():
         t1.change(test_fn, t1, t2, api_name="")
 
     assert demo.dependencies[0]["api_name"] == "test_fn"
+
+
+def test_blocks_postprocessing_with_copies_of_component_instance():
+    # Test for: https://github.com/gradio-app/gradio/issues/6608
+    with gr.Blocks() as demo:
+        chatbot = gr.Chatbot()
+        chatbot2 = gr.Chatbot()
+        chatbot3 = gr.Chatbot()
+        clear = gr.Button("Clear")
+
+        def clear_func():
+            return tuple([gr.Chatbot(value=[])] * 3)
+
+        clear.click(
+            fn=clear_func, outputs=[chatbot, chatbot2, chatbot3], api_name="clear"
+        )
+
+        assert (
+            demo.postprocess_data(0, [gr.Chatbot(value=[])] * 3, None)
+            == [{"value": [], "__type__": "update"}] * 3
+        )


### PR DESCRIPTION
Closes: #6608

Repro: 

```py
import gradio as gr
import random
import time

with gr.Blocks() as demo:
    chatbot = gr.Chatbot()
    chatbot2 = gr.Chatbot()
    chatbot3 = gr.Chatbot()
    msg = gr.Textbox()
    clear = gr.Button("Clear")

    def user(user_message, history):
        return "", history + [[user_message, None]]

    def bot(history):
        bot_message = ' '.join(['a'] * 1)
        history[-1][1] = bot_message
        yield history, history, history

    msg.submit(user, [msg, chatbot], [msg, chatbot], queue=False).then(
        fn=bot, inputs=chatbot, outputs=[chatbot, chatbot2, chatbot3], api_name='bot',
    )
    def clear_func():
        return tuple([gr.Chatbot(value=[])]*3)
    clear.click(fn=clear_func, outputs=[chatbot, chatbot2, chatbot3], api_name='clear')

demo.queue()
demo.launch()
```