### PR TITLE
Fix dropdown warning

### DIFF
--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -158,7 +158,7 @@ class Dropdown(FormComponent):
             )
 
     def _warn_if_invalid_choice(self, value):
-        if self.allow_custom_value or value in [value for _, value in self.choices]:
+        if self.allow_custom_value or value in [v for pair in self.choices for v in pair]:
             return
         warnings.warn(
             f"The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: {value} or set allow_custom_value=True."


### PR DESCRIPTION
## Description

The dropdown component accepts a list of `(name, value)` tuples for the `choices` argument, the `name` component is displayed in the dropdown, and the `value` item is returned.
When `name != value`, when we select an item from the dropdown, we get the following error:

```
UserWarning: The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: [<name>]
```

This happens because the `dropdown` component is trying to find `name` in the list of `value`s.
This PR fixes that.

Closes: Can't find an existing issue for this.
  
