### PR TITLE
added examples label for chatinterface

### DIFF
--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -76,6 +76,7 @@ class ChatInterface(Blocks):
         clear_btn: str | None | Button = "🗑️  Clear",
         autofocus: bool = True,
         concurrency_limit: int | None | Literal["default"] = "default",
+        examples_label:str | None = None,
     ):
         """
         Parameters:
@@ -99,6 +100,7 @@ class ChatInterface(Blocks):
             clear_btn: Text to display on the clear button. If None, no button will be displayed. If a Button object, that button will be used.
             autofocus: If True, autofocuses to the textbox when the page loads.
             concurrency_limit: If set, this this is the maximum number of chatbot submissions that can be running simultaneously. Can be set to None to mean no limit (any number of chatbot submissions can be running simultaneously). Set to "default" to use the default concurrency limit (defined by the `default_concurrency_limit` parameter in `.queue()`, which is 1 by default).
+            examples_label: a label for the examples block. If not provided, defaults to "Examples".
         """
         super().__init__(
             analytics_enabled=analytics_enabled,
@@ -252,11 +254,16 @@ class ChatInterface(Blocks):
                 else:
                     examples_fn = self._examples_fn
 
+                if examples_label is None:
+                    # if examples_label is not provided, use the default label for examples block
+                    examples_label = "Examples"
+
                 self.examples_handler = Examples(
                     examples=examples,
                     inputs=[self.textbox] + self.additional_inputs,
                     outputs=self.chatbot,
                     fn=examples_fn,
+                    label=examples_label # add a custom label for examples block!
                 )
 
             any_unrendered_inputs = any(


### PR DESCRIPTION
why? because this way you can have a customized label for the block title Examples (translation, other uses, etc)

## Description

The main idea is to have control of the example block label from the chatinterface config

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

I couldnt find one so i made this pull request.

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
