### PR TITLE
Lite: Fix and improve the file upload progress SSE

### DIFF
--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -731,11 +731,11 @@ class App(FastAPI):
                     heartbeat_rate = 15
                     check_rate = 0.05
                     try:
-                        update = file_upload_statuses.status(upload_id).popleft()
-                        if update.is_done:
+                        if file_upload_statuses.is_done(upload_id):
                             message = {"msg": "done"}
                             is_done = True
                         else:
+                            update = file_upload_statuses.status(upload_id).pop()
                             message = {
                                 "msg": "update",
                                 "orig_name": update.filename,

--- a/js/app/src/lite/fetch.ts
+++ b/js/app/src/lite/fetch.ts
@@ -44,16 +44,12 @@ export async function wasm_proxied_fetch(
 		headers[key] = value;
 	});
 
-	const bodyArrayBuffer = await new Response(request.body).arrayBuffer();
-	const body: Parameters<WorkerProxy["httpRequest"]>[0]["body"] =
-		new Uint8Array(bodyArrayBuffer);
-
 	const response = await workerProxy.httpRequest({
 		path: url.pathname,
 		query_string: url.search,
 		method,
 		headers,
-		body
+		body: request.body
 	});
 	return new Response(response.body, {
 		status: response.status,

--- a/js/app/src/lite/fetch.ts
+++ b/js/app/src/lite/fetch.ts
@@ -46,7 +46,7 @@ export async function wasm_proxied_fetch(
 
 	const response = await workerProxy.httpRequest({
 		path: url.pathname,
-		query_string: url.search,
+		query_string: url.searchParams.toString(), // The `query_string` field in the ASGI spec must not contain the leading `?`.
 		method,
 		headers,
 		body: request.body

--- a/js/wasm/src/http.ts
+++ b/js/wasm/src/http.ts
@@ -1,7 +1,7 @@
 export interface HttpRequest {
 	method: "GET" | "POST" | "PUT" | "DELETE";
 	path: string;
-	query_string: string;
+	query_string: string; // This field must not contain the leading `?`, as it's directly used in the ASGI spec which requires this.
 	headers: Record<string, string>;
 	body?: Uint8Array | ReadableStream<Uint8Array> | null;
 }

--- a/js/wasm/src/http.ts
+++ b/js/wasm/src/http.ts
@@ -3,7 +3,7 @@ export interface HttpRequest {
 	path: string;
 	query_string: string;
 	headers: Record<string, string>;
-	body?: Uint8Array;
+	body?: Uint8Array | ReadableStream<Uint8Array> | null;
 }
 export interface HttpResponse {
 	status: number;


### PR DESCRIPTION
## Description

This PR solves a problem in [this comment](https://github.com/gradio-app/gradio/pull/6965#issuecomment-1881385151) that the upload progress spinner doesn't work in the Wasm mode.

The base branch of this PR is set to #6965 because this is a successive work and the code changes in #6965 is convenient for testing of this PR,
while I made this a separate PR as it can/should be reviewed and merged independently.

This PR contains following parts:
1. 23dd40a: Enhancing the HTTP emulation in the Wasm mode to handle `ReadableStream`. This is needed to upload the files in chunks in the Wasm mode
2. ca1d48b: Bug fix in the Wasm code. Due to this bug, `upload_id` has not been sent to the server previously.
3. 583dfce: Improving the `/upload_progress` endpoint in the Python server. In the Wasm setup, the emulated SSE takes longer time so consuming all the queue items in `FileUploadProgress` and sending them to the frontend via SSE don't finish before uploading the files finishes, and it was the reason why the upload progress spinner wasn't updated even after fixing the Wasm code as 1 and 2.
In this change, multiple `FileUploadProgressUnit` instances who has the same `filename` in the queue are aggregated into one item before popped and sent to the frontend. It reduces the number of SSE messages so fixes the problem above.
4. 65231d4 and later: Refactoring.