### PR TITLE
Fix for issue 6730: gr.on() without triggers

### DIFF
--- a/.changeset/grumpy-garlics-joke.md
+++ b/.changeset/grumpy-garlics-joke.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix for issue 6730: gr.on() without triggers

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -399,7 +399,7 @@ def on(
         triggers = (
             [EventListenerMethod(input, "change") for input in inputs]
             if inputs is not None
-            else []
+            else [EventListenerMethod(Context.root_block, "change")]
         )  # type: ignore
     else:
         triggers = [


### PR DESCRIPTION
## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #6730 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
