### PR TITLE
Revert install ffmpeg action to version 2

### DIFF
--- a/.github/actions/install-all-deps/action.yml
+++ b/.github/actions/install-all-deps/action.yml
@@ -45,7 +45,7 @@ runs:
         python -m pip install -e client/python
         python -m pip install -e .
     - name: Install ffmpeg
-      uses: FedericoCarboni/setup-ffmpeg@v3
+      uses: FedericoCarboni/setup-ffmpeg@v2
     - name: install-frontend
       uses: "./.github/actions/install-frontend-deps"
       with:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -106,7 +106,7 @@ jobs:
         . venv/bin/activate
         python -m pip install -r client/python/test/requirements.txt
     - name: Install ffmpeg
-      uses: FedericoCarboni/setup-ffmpeg@v3
+      uses: FedericoCarboni/setup-ffmpeg@v2
     - name: Install Gradio and Client Libraries Locally (Linux)
       if: runner.os == 'Linux'
       run: |
@@ -207,7 +207,7 @@ jobs:
         . venv/bin/activate
         bash scripts/install_test_requirements.sh
     - name: Install ffmpeg
-      uses: FedericoCarboni/setup-ffmpeg@v3
+      uses: FedericoCarboni/setup-ffmpeg@v2
     - name: Lint (Linux)
       if: runner.os == 'Linux'
       run: |


### PR DESCRIPTION
## Description

Closes: #7001

I haven't seen this action flake yet but I figure it's easy enough to just revert it rather than implement it ourselves. Don't think there's a reason we need to be on v3.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
