### PR TITLE
Fix bug preventing layout components to be used as custom components

### DIFF
--- a/.changeset/cruel-games-wash.md
+++ b/.changeset/cruel-games-wash.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix bug preventing layout components to be used as custom components

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -618,9 +618,9 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
 
         self.queue()
 
-    def get_component(self, id: int) -> Component:
+    def get_component(self, id: int) -> Component | BlockContext:
         comp = self.blocks[id]
-        assert isinstance(comp, components.Component), f"{comp}"
+        assert isinstance(comp, (components.Component, BlockContext)), f"{comp}"
         return comp
 
     @property

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2307,8 +2307,10 @@ Received outputs:
                 # The config has the most specific API info (taking into account the parameters
                 # of the component), so we use that if it exists. Otherwise, we fallback to the
                 # Serializer's API info.
-                info = self.get_component(component["id"]).api_info()
-                example = self.get_component(component["id"]).example_inputs()
+                comp = self.get_component(component["id"])
+                assert isinstance(comp, components.Component)
+                info = comp.api_info()
+                example = comp.example_inputs()
                 python_type = client_utils.json_schema_to_python_type(info)
                 dependency_info["parameters"].append(
                     {
@@ -2335,8 +2337,10 @@ Received outputs:
                 if self.blocks[component["id"]].skip_api:
                     continue
                 label = component["props"].get("label", f"value_{o}")
-                info = self.get_component(component["id"]).api_info()
-                example = self.get_component(component["id"]).example_inputs()
+                comp = self.get_component(component["id"])
+                assert isinstance(comp, components.Component)
+                info = comp.api_info()
+                example = comp.example_inputs()
                 python_type = client_utils.json_schema_to_python_type(info)
                 dependency_info["returns"].append(
                     {


### PR DESCRIPTION
## Description

Closes: #6782

You can test with the same repro from the issue.



## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
