### PR TITLE
Add encoding to open/writing files on the deploy_discord function

### DIFF
--- a/.changeset/modern-pugs-allow.md
+++ b/.changeset/modern-pugs-allow.md
@@ -1,0 +1,6 @@
+---
+"gradio": minor
+"gradio_client": minor
+---
+
+feat:Add encoding to open/writing files on the deploy_discord function

--- a/.changeset/modern-pugs-allow.md
+++ b/.changeset/modern-pugs-allow.md
@@ -1,6 +1,6 @@
 ---
-"gradio": minor
-"gradio_client": minor
+"gradio": patch
+"gradio_client": patch
 ---
 
 feat:Add encoding to open/writing files on the deploy_discord function

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -847,7 +847,7 @@ class Client:
         app = app.replace("<<api-name>>", api_names[0][0])
         app = app.replace("<<command-name>>", api_names[0][1])
 
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as app_file:
+        with tempfile.NamedTemporaryFile(mode="w", delete=False,encoding="utf-8") as app_file:
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as requirements:
                 app_file.write(app)
                 requirements.write("\n".join(["discord.py==2.3.1"]))

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -841,7 +841,7 @@ class Client:
                 metadata={"tags": ["gradio-discord-bot"]},
             )
 
-        with open(str(Path(__file__).parent / "templates" / "discord_chat.py")) as f:
+        with open(str(Path(__file__).parent / "templates" / "discord_chat.py"),encoding="utf-8") as f:
             app = f.read()
         app = app.replace("<<app-src>>", self.src)
         app = app.replace("<<api-name>>", api_names[0][0])


### PR DESCRIPTION
## Description

Adds an encoding to the file open, temp file on line 844, 850. These are .py files so utf-8 encoding should be safe

## 🎯 PRs Should Target Issues

When running deploy_discord on a windows machine, the windows CP1252 encoding does not encapsulate all characters, forcing an encoding=utf-8 allows the deploy_discord call to work on windows jupyter notebooks

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
