### PR TITLE
Remove flag_dir from read_from_flag()

### DIFF
--- a/.changeset/slow-bikes-thank.md
+++ b/.changeset/slow-bikes-thank.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Remove flag_dir from read_from_flag()

--- a/gradio/components/base.py
+++ b/gradio/components/base.py
@@ -101,11 +101,7 @@ class ComponentBase(ABC, metaclass=ComponentMeta):
         pass
 
     @abstractmethod
-    def read_from_flag(
-        self,
-        payload: Any,
-        flag_dir: str | Path | None = None,
-    ) -> GradioDataModel | Any:
+    def read_from_flag(self, payload: Any) -> GradioDataModel | Any:
         """
         Convert the data from the csv or jsonl file into the component state.
         """
@@ -288,11 +284,7 @@ class Component(ComponentBase, Block):
             return payload.copy_to_dir(flag_dir).model_dump_json()
         return payload
 
-    def read_from_flag(
-        self,
-        payload: Any,
-        flag_dir: str | Path | None = None,
-    ):
+    def read_from_flag(self, payload: Any):
         """
         Convert the data from the csv or jsonl file into the component state.
         """

--- a/gradio/components/base.py
+++ b/gradio/components/base.py
@@ -283,9 +283,6 @@ class Component(ComponentBase, Block):
         return payload
 
     def read_from_flag(self, payload: Any):
-        self,
-        payload: Any,
-    ):
         """
         Convert the data from the csv or jsonl file into the component state.
         """

--- a/gradio/components/json_component.py
+++ b/gradio/components/json_component.py
@@ -96,7 +96,7 @@ class JSON(Component):
     def flag(self, payload: Any, flag_dir: str | Path = "") -> str:
         return json.dumps(payload)
 
-    def read_from_flag(self, payload: Any, flag_dir: str | Path | None = None):
+    def read_from_flag(self, payload: Any):
         return json.loads(payload)
 
     def api_info(self) -> dict[str, Any]:

--- a/gradio/components/state.py
+++ b/gradio/components/state.py
@@ -28,7 +28,7 @@ class State(Component):
     def __init__(
         self,
         value: Any = None,
-        render: bool = True,  # noqa: ARG002
+        render: bool = True,
     ):
         """
         Parameters:

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -423,12 +423,7 @@ class Examples:
                 assert utils.is_update(value_as_dict)
                 output.append(value_as_dict)
             except (ValueError, TypeError, SyntaxError, AssertionError):
-                output.append(
-                    component.read_from_flag(
-                        value_to_use,
-                        self.cached_folder,
-                    )
-                )
+                output.append(component.read_from_flag(value_to_use))
         return output
 
 

--- a/guides/05_custom-components/04_backend.md
+++ b/guides/05_custom-components/04_backend.md
@@ -126,7 +126,6 @@ The `data_model` in the following section.
 def read_from_flag(
     self,
     x: Any,
-    flag_dir: str | Path | None = None,
 ) -> GradioDataModel | Any:
     """
     Convert the data from the csv or jsonl file into the component state.


### PR DESCRIPTION
## Description

The argument isn't used by the function, and [it doesn't seem to be used by external code across GitHub either](https://github.com/search?q=read_from_flag+language%3APython&type=code&l=Python&p=1).

This was flagged by Ruff's ARG lint.
