### PR TITLE
Themes: fix bogus header image URL

### DIFF
--- a/.changeset/tame-cloths-cough.md
+++ b/.changeset/tame-cloths-cough.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Themes: fix bogus header image URL

--- a/gradio/themes/app.py
+++ b/gradio/themes/app.py
@@ -73,7 +73,7 @@ with gr.Blocks(theme=gr.themes.Default()) as demo:
 
                 def go(*args):
                     time.sleep(3)
-                    return "https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpgjpg"
+                    return "https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg"
 
                 go_btn.click(go, [radio, drop, drop_2, check, name], img, api_name="go")
 


### PR DESCRIPTION
## Description

https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpgjpg does not exist.

https://gradio-static-files.s3.us-west-2.amazonaws.com/header-image.jpg does.
