### PR TITLE
Determine documentation group automatically

### DIFF
--- a/.changeset/easy-nights-fly.md
+++ b/.changeset/easy-nights-fly.md
@@ -1,0 +1,6 @@
+---
+"gradio": minor
+"gradio_client": minor
+---
+
+feat:Determine documentation group automatically

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -31,7 +31,7 @@ from huggingface_hub.utils import (
 from packaging import version
 
 from gradio_client import serializing, utils
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 from gradio_client.exceptions import SerializationSetupError
 from gradio_client.utils import (
     Communicator,
@@ -42,9 +42,6 @@ from gradio_client.utils import (
     Status,
     StatusUpdate,
 )
-
-set_documentation_group("py-client")
-
 
 DEFAULT_TEMP_DIR = os.environ.get("GRADIO_TEMP_DIR") or str(
     Path(tempfile.gettempdir()) / "gradio"

--- a/gradio/_simple_templates/simpleimage.py
+++ b/gradio/_simple_templates/simpleimage.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component
 from gradio.data_classes import FileData
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -24,7 +24,7 @@ import anyio
 import httpx
 from anyio import CapacityLimiter
 from gradio_client import utils as client_utils
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio import (
     analytics,
@@ -77,7 +77,6 @@ try:
 except Exception:
     spaces = None
 
-set_documentation_group("blocks")
 
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
     from fastapi.applications import FastAPI

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -10,7 +10,7 @@ from typing import AsyncGenerator, Callable, Literal, Union, cast
 
 import anyio
 from gradio_client import utils as client_utils
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.blocks import Blocks
 from gradio.components import (
@@ -29,8 +29,6 @@ from gradio.layouts import Accordion, Column, Group, Row
 from gradio.routes import Request
 from gradio.themes import ThemeClass as Theme
 from gradio.utils import SyncToAsyncIterator, async_iteration
-
-set_documentation_group("chatinterface")
 
 
 @document()

--- a/gradio/components/annotated_image.py
+++ b/gradio/components/annotated_image.py
@@ -6,14 +6,14 @@ from typing import Any, List
 
 import numpy as np
 import PIL.Image
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio import processing_utils, utils
 from gradio.components.base import Component
 from gradio.data_classes import FileData, GradioModel
 from gradio.events import Events
 
-set_documentation_group("component")
+PIL.Image.init()  # fixes https://github.com/gradio-app/gradio/issues/2843
 
 
 class Annotation(GradioModel):

--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -9,15 +9,13 @@ from typing import Any, Callable, Literal
 import httpx
 import numpy as np
 from gradio_client import utils as client_utils
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio import processing_utils, utils
 from gradio.components.base import Component, StreamingInput, StreamingOutput
 from gradio.data_classes import FileData
 from gradio.events import Events
 from gradio.exceptions import Error
-
-set_documentation_group("component")
 
 
 @dataclasses.dataclass

--- a/gradio/components/bar_plot.py
+++ b/gradio/components/bar_plot.py
@@ -6,11 +6,9 @@ from typing import Any, Callable, Literal
 
 import altair as alt
 import pandas as pd
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.plot import AltairPlot, AltairPlotData, Plot
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/base.py
+++ b/gradio/components/base.py
@@ -14,8 +14,6 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
-from gradio_client.documentation import set_documentation_group
-
 from gradio import utils
 from gradio.blocks import Block, BlockContext
 from gradio.component_meta import ComponentMeta
@@ -30,9 +28,6 @@ if TYPE_CHECKING:
     class DataframeData(TypedDict):
         headers: list[str]
         data: list[list[str | int | bool]]
-
-
-set_documentation_group("component")
 
 
 class _Keywords(Enum):

--- a/gradio/components/button.py
+++ b/gradio/components/button.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from typing import Any, Callable, Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -7,14 +7,12 @@ from pathlib import Path
 from typing import Any, Callable, List, Literal, Optional, Tuple, Union
 
 from gradio_client import utils as client_utils
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio import processing_utils, utils
 from gradio.components.base import Component
 from gradio.data_classes import FileData, GradioModel, GradioRootModel
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 class FileMessage(GradioModel):

--- a/gradio/components/checkbox.py
+++ b/gradio/components/checkbox.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import FormComponent
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/checkboxgroup.py
+++ b/gradio/components/checkboxgroup.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from typing import Any, Callable, Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import FormComponent
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/clear_button.py
+++ b/gradio/components/clear_button.py
@@ -6,14 +6,12 @@ import copy
 import json
 from typing import Any, Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components import Button, Component
 from gradio.context import Context
 from gradio.data_classes import GradioModel, GradioRootModel
 from gradio.utils import resolve_singleton
-
-set_documentation_group("component")
 
 
 @document("add")

--- a/gradio/components/code.py
+++ b/gradio/components/code.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document("languages")

--- a/gradio/components/color_picker.py
+++ b/gradio/components/color_picker.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -18,7 +18,7 @@ from typing import (
 import numpy as np
 import pandas as pd
 import semantic_version
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 from pandas.io.formats.style import Styler
 
 from gradio.components import Component
@@ -46,9 +46,6 @@ class DataframeData(GradioModel):
     headers: List[str]
     data: Union[List[List[Any]], List[Tuple[Any, ...]]]
     metadata: Optional[Dict[str, Optional[List[Any]]]] = None
-
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/dataset.py
+++ b/gradio/components/dataset.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio import processing_utils
 from gradio.components.base import (
@@ -12,8 +12,6 @@ from gradio.components.base import (
     get_component_instance,
 )
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import warnings
 from typing import Any, Callable, Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import FormComponent
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/duplicate_button.py
+++ b/gradio/components/duplicate_button.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 from typing import Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components import Button
 from gradio.context import Context
 from gradio.utils import get_space
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/file.py
+++ b/gradio/components/file.py
@@ -7,14 +7,12 @@ import warnings
 from pathlib import Path
 from typing import Any, Callable, Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component
 from gradio.data_classes import FileData, ListFiles
 from gradio.events import Events
 from gradio.utils import NamedString
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/file_explorer.py
+++ b/gradio/components/file_explorer.py
@@ -9,12 +9,10 @@ import warnings
 from pathlib import Path
 from typing import Any, Callable, List, Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component, server
 from gradio.data_classes import GradioRootModel
-
-set_documentation_group("component")
 
 
 class FileExplorerData(GradioRootModel):

--- a/gradio/components/gallery.py
+++ b/gradio/components/gallery.py
@@ -8,16 +8,13 @@ from urllib.parse import urlparse
 
 import numpy as np
 import PIL.Image
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 from gradio_client.utils import is_http_url_like
 
 from gradio import processing_utils, utils
 from gradio.components.base import Component
 from gradio.data_classes import FileData, GradioModel, GradioRootModel
 from gradio.events import Events
-
-set_documentation_group("component")
-
 
 GalleryImageType = Union[np.ndarray, PIL.Image.Image, Path, str]
 CaptionedGalleryImageType = Tuple[GalleryImageType, str]

--- a/gradio/components/highlighted_text.py
+++ b/gradio/components/highlighted_text.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 from typing import Any, Callable, List, Union
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component
 from gradio.data_classes import GradioModel, GradioRootModel
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 class HighlightedToken(GradioModel):

--- a/gradio/components/html.py
+++ b/gradio/components/html.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, cast
 
 import numpy as np
 import PIL.Image
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 from PIL import ImageOps
 
 from gradio import image_utils, utils
@@ -16,7 +16,7 @@ from gradio.components.base import Component, StreamingInput
 from gradio.data_classes import FileData
 from gradio.events import Events
 
-set_documentation_group("component")
+PIL.Image.init()  # fixes https://github.com/gradio-app/gradio/issues/2843
 
 
 @document()

--- a/gradio/components/image_editor.py
+++ b/gradio/components/image_editor.py
@@ -9,15 +9,12 @@ from typing import Any, Iterable, List, Literal, Optional, TypedDict, Union, cas
 
 import numpy as np
 import PIL.Image
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio import image_utils, utils
 from gradio.components.base import Component
 from gradio.data_classes import FileData, GradioModel
 from gradio.events import Events
-
-set_documentation_group("component")
-
 
 ImageType = Union[np.ndarray, PIL.Image.Image, str]
 

--- a/gradio/components/json_component.py
+++ b/gradio/components/json_component.py
@@ -6,12 +6,10 @@ import json
 from pathlib import Path
 from typing import Any, Callable
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/label.py
+++ b/gradio/components/label.py
@@ -7,13 +7,11 @@ import operator
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Union
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component
 from gradio.data_classes import GradioModel
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 class LabelConfidence(GradioModel):

--- a/gradio/components/line_plot.py
+++ b/gradio/components/line_plot.py
@@ -6,11 +6,9 @@ from typing import Any, Callable, Literal
 
 import altair as alt
 import pandas as pd
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.plot import AltairPlot, AltairPlotData, Plot
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/login_button.py
+++ b/gradio/components/login_button.py
@@ -5,13 +5,11 @@ import json
 import warnings
 from typing import Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components import Button
 from gradio.context import Context
 from gradio.routes import Request
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/logout_button.py
+++ b/gradio/components/logout_button.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 import warnings
 from typing import Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components import Button
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/markdown.py
+++ b/gradio/components/markdown.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import inspect
 from typing import Any, Callable
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/model3d.py
+++ b/gradio/components/model3d.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Callable
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component
 from gradio.data_classes import FileData
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/number.py
+++ b/gradio/components/number.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import FormComponent
 from gradio.events import Events
 from gradio.exceptions import Error
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/paramviewer.py
+++ b/gradio/components/paramviewer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal, TypedDict
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component
 from gradio.events import Events
@@ -12,9 +12,6 @@ class Parameter(TypedDict):
     type: str
     description: str
     default: str | None
-
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/plot.py
+++ b/gradio/components/plot.py
@@ -7,14 +7,12 @@ from types import ModuleType
 from typing import Any, Literal
 
 import altair as alt
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio import processing_utils
 from gradio.components.base import Component
 from gradio.data_classes import GradioModel
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 class PlotData(GradioModel):

--- a/gradio/components/radio.py
+++ b/gradio/components/radio.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import FormComponent
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/scatter_plot.py
+++ b/gradio/components/scatter_plot.py
@@ -6,12 +6,10 @@ from typing import Any, Callable, Literal
 
 import altair as alt
 import pandas as pd
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 from pandas.api.types import is_numeric_dtype
 
 from gradio.components.plot import AltairPlot, AltairPlotData, Plot
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/slider.py
+++ b/gradio/components/slider.py
@@ -6,12 +6,10 @@ import math
 import random
 from typing import Any, Callable
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import FormComponent
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/state.py
+++ b/gradio/components/state.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/textbox.py
+++ b/gradio/components/textbox.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from typing import Any, Callable, Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import FormComponent
 from gradio.events import Events
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/upload_button.py
+++ b/gradio/components/upload_button.py
@@ -7,14 +7,12 @@ import warnings
 from pathlib import Path
 from typing import Any, Callable, Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.components.base import Component
 from gradio.data_classes import FileData, ListFiles
 from gradio.events import Events
 from gradio.utils import NamedString
-
-set_documentation_group("component")
 
 
 @document()

--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Callable, Literal, Optional
 
 from gradio_client import utils as client_utils
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 import gradio as gr
 from gradio import processing_utils, utils, wasm_utils
@@ -19,8 +19,6 @@ from gradio.events import Events
 if not wasm_utils.IS_WASM:
     # TODO: Support ffmpeg on Wasm
     from ffmpy import FFmpeg
-
-set_documentation_group("component")
 
 
 class VideoData(GradioModel):

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -1,6 +1,4 @@
-from gradio_client.documentation import document, set_documentation_group
-
-set_documentation_group("helpers")
+from gradio_client.documentation import document
 
 
 class DuplicateBlockError(ValueError):
@@ -61,10 +59,8 @@ class GradioVersionIncompatibleError(Exception):
 
 InvalidApiName = InvalidApiNameError  # backwards compatibility
 
-set_documentation_group("modals")
 
-
-@document()
+@document(documentation_group="modals")
 class Error(Exception):
     """
     This class allows you to pass custom error messages to the user. You can do so by raising a gr.Error("custom message") anywhere in the code, and when that line is executed the custom message will appear in a modal on the demo.

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -15,7 +15,7 @@ import httpx
 from gradio_client import Client
 from gradio_client import utils as client_utils
 from gradio_client.client import Endpoint
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 from packaging import version
 
 import gradio
@@ -40,9 +40,6 @@ from gradio.processing_utils import extract_base64_data, save_base64_to_cache, t
 if TYPE_CHECKING:
     from gradio.blocks import Blocks
     from gradio.interface import Interface
-
-
-set_documentation_group("helpers")
 
 
 @document()

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -14,15 +14,13 @@ from typing import TYPE_CHECKING, Any
 import filelock
 import huggingface_hub
 from gradio_client import utils as client_utils
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 import gradio as gr
 from gradio import utils
 
 if TYPE_CHECKING:
     from gradio.components import Component
-
-set_documentation_group("flagging")
 
 
 class FlaggingCallback(ABC):

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -19,7 +19,7 @@ import numpy as np
 import PIL
 import PIL.Image
 from gradio_client import utils as client_utils
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio import components, oauth, processing_utils, routes, utils, wasm_utils
 from gradio.context import Context, LocalContext
@@ -32,8 +32,6 @@ if TYPE_CHECKING:  # Only import for type checking (to avoid circular imports).
     from gradio.components import Component
 
 LOG_FILE = "log.csv"
-
-set_documentation_group("helpers")
 
 
 def create_examples(
@@ -1118,10 +1116,7 @@ def log_message(message: str, level: Literal["info", "warning"] = "info"):
     blocks._queue.log_message(event_id=event_id, log=message, level=level)
 
 
-set_documentation_group("modals")
-
-
-@document()
+@document(documentation_group="modals")
 def Warning(message: str = "Warning issued."):  # noqa: N802
     """
     This function allows you to pass custom warning messages to the user. You can do so simply by writing `gr.Warning('message here')` in your function, and when that line is executed the custom message will appear in a modal on the demo. The modal is yellow by default and has the heading: "Warning." Queue must be enabled for this behavior; otherwise, the warning will be printed to the console using the `warnings` library.
@@ -1141,7 +1136,7 @@ def Warning(message: str = "Warning issued."):  # noqa: N802
     log_message(message, level="warning")
 
 
-@document()
+@document(documentation_group="modals")
 def Info(message: str = "Info issued."):  # noqa: N802
     """
     This function allows you to pass custom info messages to the user. You can do so simply by writing `gr.Info('message here')` in your function, and when that line is executed the custom message will appear in a modal on the demo. The modal is gray by default and has the heading: "Info." Queue must be enabled for this behavior; otherwise, the message will be printed to the console.

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -11,7 +11,7 @@ import warnings
 import weakref
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio import Examples, utils
 from gradio.blocks import Blocks
@@ -31,8 +31,6 @@ from gradio.flagging import CSVLogger, FlaggingCallback, FlagMethod
 from gradio.layouts import Accordion, Column, Row, Tab, Tabs
 from gradio.pipelines import load_from_pipeline
 from gradio.themes import ThemeClass as Theme
-
-set_documentation_group("interface")
 
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
     from transformers.pipelines.base import Pipeline

--- a/gradio/layouts/accordion.py
+++ b/gradio/layouts/accordion.py
@@ -2,15 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.blocks import BlockContext
 from gradio.component_meta import ComponentMeta
 
 if TYPE_CHECKING:
     pass
-
-set_documentation_group("layout")
 
 
 @document()

--- a/gradio/layouts/column.py
+++ b/gradio/layouts/column.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import warnings
 from typing import Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.blocks import BlockContext
 from gradio.component_meta import ComponentMeta
-
-set_documentation_group("layout")
 
 
 @document()

--- a/gradio/layouts/form.py
+++ b/gradio/layouts/form.py
@@ -2,16 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from gradio_client.documentation import set_documentation_group
-
 from gradio.blocks import BlockContext
 from gradio.component_meta import ComponentMeta
 from gradio.layouts.row import Row
 
 if TYPE_CHECKING:
     from gradio.blocks import Block
-
-set_documentation_group("layout")
 
 
 class Form(BlockContext, metaclass=ComponentMeta):

--- a/gradio/layouts/group.py
+++ b/gradio/layouts/group.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.blocks import BlockContext
 from gradio.component_meta import ComponentMeta
-
-set_documentation_group("layout")
 
 
 @document()

--- a/gradio/layouts/row.py
+++ b/gradio/layouts/row.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 from typing import Literal
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.blocks import BlockContext
 from gradio.component_meta import ComponentMeta
-
-set_documentation_group("layout")
 
 
 @document()

--- a/gradio/layouts/tabs.py
+++ b/gradio/layouts/tabs.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 
 from gradio.blocks import BlockContext
 from gradio.component_meta import ComponentMeta
 from gradio.events import Events
-
-set_documentation_group("layout")
 
 
 class Tabs(BlockContext, metaclass=ComponentMeta):

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, AsyncGenerator, BinaryIO, List, Optional, Tupl
 import fastapi
 import httpx
 import multipart
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 from multipart.multipart import parse_options_header
 from starlette.datastructures import FormData, Headers, UploadFile
 from starlette.formparsers import MultiPartException, MultipartPart
@@ -24,8 +24,6 @@ from gradio.state_holder import SessionState
 if TYPE_CHECKING:
     from gradio.blocks import Blocks
     from gradio.routes import App
-
-set_documentation_group("routes")
 
 
 class Obj:

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -41,7 +41,7 @@ from fastapi.responses import (
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi.templating import Jinja2Templates
 from gradio_client import utils as client_utils
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 from gradio_client.utils import ServerMessage
 from jinja2.exceptions import TemplateNotFound
 from multipart.multipart import parse_options_header
@@ -885,9 +885,6 @@ def get_types(cls_set: List[Type]):
                 types.append(line.split("value (")[1].split(")")[0])
         docset.append(doc_lines[1].split(":")[-1])
     return docset, types
-
-
-set_documentation_group("routes")
 
 
 @document()

--- a/gradio/themes/base.py
+++ b/gradio/themes/base.py
@@ -10,7 +10,7 @@ from typing import Iterable
 
 import huggingface_hub
 import semantic_version as semver
-from gradio_client.documentation import document, set_documentation_group
+from gradio_client.documentation import document
 from huggingface_hub import CommitOperationAdd
 
 from gradio.themes.utils import (
@@ -21,8 +21,6 @@ from gradio.themes.utils import (
     sizes,
 )
 from gradio.themes.utils.readme_content import README_CONTENT
-
-set_documentation_group("themes")
 
 
 class ThemeClass:

--- a/guides/05_custom-components/04_backend.md
+++ b/guides/05_custom-components/04_backend.md
@@ -21,7 +21,7 @@ Tip: If you inherit from `BlockContext`, you also need to set the metaclass to b
 from gradio.blocks import BlockContext
 from gradio.component_meta import ComponentMeta
 
-set_documentation_group("layout")
+
 
 
 @document()


### PR DESCRIPTION
## Description

This avoids the global state `documentation_group` for a nearly 50% code reduction.

It also fixes a small bug where `gradio/events.py` used `document()` without setting a documentation group, hence things documented there implicitly used the documentation group from whatever had been imported before that module. 😁 
