### PR TITLE
Improve rapid generation performance via UI throttling

### DIFF
--- a/.changeset/flat-suns-cry.md
+++ b/.changeset/flat-suns-cry.md
@@ -1,0 +1,6 @@
+---
+"@gradio/app": minor
+"gradio": minor
+---
+
+feat:Improve rapid generation performance via UI throttling


### PR DESCRIPTION
As reported by @oobabooga in #6847, there is considerable lag when there's very high rate of UI updates, e.g. when streaming text to a chatbot. This is because we re-render the UI on every update, which is expensive. A low hanging fruit is throttling the maximum rate of UI updates to once per 50ms. In the demo code below, I see speed increases of over 10x, from 37s to 2.5s:

```python
import gradio as gr
import random
import time

with gr.Blocks() as demo:
    chatbot = gr.Chatbot()
    msg = gr.Textbox()
    clear = gr.ClearButton([msg, chatbot])

    def respond(message, chat_history):
        bot_message = "How are you?" * 10000
        chat_history.append((message, bot_message))
        for i in range(2000):
            chat_history[-1] = (chat_history[-1][0], chat_history[-1][1] + " " + str(i))
            yield "", chat_history

        print("done")

    msg.submit(respond, [msg, chatbot], [msg, chatbot])

demo.launch(server_name='0.0.0.0')
```