### PR TITLE
Fixes excessive CPU use by client while it waits for server to send messages during streaming

### DIFF
--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -1559,6 +1559,7 @@ class Job(Future):
                     return o
                 if self.communicator.job.latest_status.code == Status.FINISHED:
                     raise StopIteration()
+                time.sleep(0.001)
 
     def result(self, timeout: float | None = None) -> Any:
         """


### PR DESCRIPTION
## Description

Without this fix, as long as client is waiting for server messages, the client consumes 100% of 1 core due to rapid looping.  Added small ms sleep that avoids that wasteful use of CPU.

Closes: https://github.com/gradio-app/gradio/issues/7086

## 🎯 PRs Should Target Issues

https://github.com/gradio-app/gradio/issues/7086

## Tests

```
def test_hang():
    import gradio as gr
    import time

    with gr.Blocks() as demo:
        chatbot = gr.Chatbot()
        msg = gr.Textbox()

        def respond(message, chat_history):
            time.sleep(10000)
            if not chat_history:
                chat_history = [[message, '']]
            chat_history[-1][1] = message
            for fake in range(0, 1000):
                chat_history[-1][1] += str(fake)
                time.sleep(0.1)
                yield "", chat_history
            return

        msg.submit(respond, [msg, chatbot], [msg, chatbot], api_name='submit')

    demo.queue(api_open=True)
    demo.launch(prevent_thread_lock=True, show_error=True, )

    from gradio_client import Client

    client = Client('http://localhost:7860')
    job = client.submit('', None, api_name='/submit')

    for res in job:
        print("Reached inside loop: %s" % res)
```