### PR TITLE
generate docs when running `gradio cc build`

### DIFF
--- a/.changeset/lazy-things-accept.md
+++ b/.changeset/lazy-things-accept.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:add docs command to build
+feat:generate docs when running `graido cc build`

--- a/.changeset/lazy-things-accept.md
+++ b/.changeset/lazy-things-accept.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:generate docs when running `graido cc build`
+feat:generate docs when running `gradio cc build`

--- a/.changeset/lazy-things-accept.md
+++ b/.changeset/lazy-things-accept.md
@@ -1,4 +1,5 @@
 ---
+"@gradio/paramviewer": minor
 "gradio": minor
 ---
 

--- a/.changeset/lazy-things-accept.md
+++ b/.changeset/lazy-things-accept.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:add docs command to build

--- a/gradio/cli/commands/components/build.py
+++ b/gradio/cli/commands/components/build.py
@@ -29,6 +29,9 @@ def _build(
     bump_version: Annotated[
         bool, typer.Option(help="Whether to bump the version number automatically.")
     ] = False,
+    generate_docs: Annotated[
+        bool, typer.Option(help="Whether to generate the documentation as well.")
+    ] = True,
 ):
     name = Path(path).resolve()
     if not (name / "pyproject.toml").exists():
@@ -71,26 +74,27 @@ def _build(
                 "Set [bold][magenta]--bump-version[/][/] to automatically bump the version number."
             )
 
-        _demo_dir = Path("demo").resolve()
-        _demo_name = "app.py"
-        _demo_path = _demo_dir / _demo_name
-        _readme_path = name / "README.md"
+        if generate_docs:
+            _demo_dir = Path("demo").resolve()
+            _demo_name = "app.py"
+            _demo_path = _demo_dir / _demo_name
+            _readme_path = name / "README.md"
 
-        run_command(
-            live=live,
-            name=package_name,
-            suppress_demo_check=False,
-            pyproject_toml=pyproject_toml,
-            generate_space=True,
-            generate_readme=True,
-            type_mode="simple",
-            _demo_path=_demo_path,
-            _demo_dir=_demo_dir,
-            _readme_path=_readme_path,
-            space_url=None,
-            _component_dir=name,
-            simple=True,
-        )
+            run_command(
+                live=live,
+                name=package_name,
+                suppress_demo_check=False,
+                pyproject_toml=pyproject_toml,
+                generate_space=True,
+                generate_readme=True,
+                type_mode="simple",
+                _demo_path=_demo_path,
+                _demo_dir=_demo_dir,
+                _readme_path=_readme_path,
+                space_url=None,
+                _component_dir=name,
+                simple=True,
+            )
 
         if build_frontend:
             live.update(":art: Building frontend")

--- a/gradio/cli/commands/components/build.py
+++ b/gradio/cli/commands/components/build.py
@@ -9,6 +9,10 @@ from tomlkit import dump, parse
 from typing_extensions import Annotated
 
 import gradio
+from gradio.cli.commands.components._docs_utils import (
+    get_deep,
+)
+from gradio.cli.commands.components.docs import run_command
 from gradio.cli.commands.display import LivePanelDisplay
 
 gradio_template_path = Path(gradio.__file__).parent / "templates" / "frontend"
@@ -35,7 +39,12 @@ def _build(
             f":package: Building package in [orange3]{str(name.name)}[/]", add_sleep=0.2
         )
         pyproject_toml = parse((path / "pyproject.toml").read_text())
-        package_name = pyproject_toml["project"]["name"]  # type: ignore
+        package_name = get_deep(pyproject_toml, ["project", "name"])
+
+        if not isinstance(package_name, str):
+            raise ValueError(
+                "Your pyproject.toml file does not have a [project] name field!"
+            )
         try:
             importlib.import_module(package_name)  # type: ignore
         except ModuleNotFoundError as e:
@@ -61,6 +70,27 @@ def _build(
                 f":1234: Package will use version [bold][magenta]{version}[/][/] defined in pyproject.toml file. "
                 "Set [bold][magenta]--bump-version[/][/] to automatically bump the version number."
             )
+
+        _demo_dir = Path("demo").resolve()
+        _demo_name = "app.py"
+        _demo_path = _demo_dir / _demo_name
+        _readme_path = name / "README.md"
+
+        run_command(
+            live=live,
+            name=package_name,
+            suppress_demo_check=False,
+            pyproject_toml=pyproject_toml,
+            generate_space=True,
+            generate_readme=True,
+            type_mode="simple",
+            _demo_path=_demo_path,
+            _demo_dir=_demo_dir,
+            _readme_path=_readme_path,
+            space_url=None,
+            _component_dir=name,
+            simple=True,
+        )
 
         if build_frontend:
             live.update(":art: Building frontend")

--- a/gradio/cli/commands/components/docs.py
+++ b/gradio/cli/commands/components/docs.py
@@ -83,20 +83,20 @@ def _docs(
         if not isinstance(name, str):
             raise ValueError("Name not found in pyproject.toml")
 
-    run_command(
-        live=live,
-        name=name,
-        suppress_demo_check=suppress_demo_check,
-        pyproject_toml=data,
-        generate_space=generate_space,
-        generate_readme=generate_readme,
-        type_mode="simple",
-        _demo_path=_demo_path,
-        _demo_dir=_demo_dir,
-        _readme_path=_readme_path,
-        space_url=space_url,
-        _component_dir=_component_dir,
-    )
+        run_command(
+            live=live,
+            name=name,
+            suppress_demo_check=suppress_demo_check,
+            pyproject_toml=data,
+            generate_space=generate_space,
+            generate_readme=generate_readme,
+            type_mode="simple",
+            _demo_path=_demo_path,
+            _demo_dir=_demo_dir,
+            _readme_path=_readme_path,
+            space_url=space_url,
+            _component_dir=_component_dir,
+        )
 
 
 def run_command(
@@ -179,7 +179,7 @@ def run_command(
                 )
     if simple:
         short_readme_path = Path(_readme_path).relative_to(_component_dir)
-        short_demo_path = Path(_demo_path).relative_to(_component_dir)
+        short_demo_path = Path(_demo_dir / "space.py").relative_to(_component_dir)
         live.update(
             f":white_check_mark: Documention generated in [orange3]{short_demo_path}[/] and [orange3]{short_readme_path}[/]. Pass --no-generate-docs to disable auto documentation."
         )

--- a/gradio/cli/commands/components/docs.py
+++ b/gradio/cli/commands/components/docs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import requests
 import tomlkit as toml
@@ -77,67 +77,118 @@ def _docs(
 
         with open(_component_dir / "pyproject.toml") as f:
             data = toml.loads(f.read())
-        with open(_demo_path) as f:
-            demo = f.read()
 
         name = get_deep(data, ["project", "name"])
 
         if not isinstance(name, str):
             raise ValueError("Name not found in pyproject.toml")
 
-        pypi_exists = requests.get(f"https://pypi.org/pypi/{name}/json").status_code
+    run_command(
+        live=live,
+        name=name,
+        suppress_demo_check=suppress_demo_check,
+        pyproject_toml=data,
+        generate_space=generate_space,
+        generate_readme=generate_readme,
+        type_mode="simple",
+        _demo_path=_demo_path,
+        _demo_dir=_demo_dir,
+        _readme_path=_readme_path,
+        space_url=space_url,
+        _component_dir=_component_dir,
+    )
 
-        pypi_exists = pypi_exists == 200 or False
 
-        local_version = get_deep(data, ["project", "version"])
-        description = str(get_deep(data, ["project", "description"]) or "")
-        repo = get_deep(data, ["project", "urls", "repository"])
-        space = space_url if space_url else get_deep(data, ["project", "urls", "space"])
+def run_command(
+    live: LivePanelDisplay,
+    name: str,
+    pyproject_toml: dict[str, Any],
+    suppress_demo_check: bool,
+    generate_space: bool,
+    generate_readme: bool,
+    type_mode: str,
+    _demo_path: Path,
+    _demo_dir: Path,
+    _readme_path: Path,
+    space_url: str | None,
+    _component_dir: Path,
+    simple: bool = False,
+):
+    if simple:
+        live.update(
+            f":page_facing_up: Generating documentation for [orange3]{_component_dir.name}[/]",
+            add_sleep=0.2,
+        )
 
-        if not local_version and not pypi_exists:
-            raise ValueError(
-                f"Cannot find version in pyproject.toml or on PyPI for [orange3]{name}[/].\nIf you have just published to PyPI, please wait a few minutes and try again."
-            )
+    with open(_demo_path) as f:
+        demo = f.read()
 
-        module = importlib.import_module(name)
-        (docs, type_mode) = extract_docstrings(module)
+    pypi_exists = requests.get(f"https://pypi.org/pypi/{name}/json").status_code
 
-        if generate_space:
+    pypi_exists = pypi_exists == 200 or False
+
+    local_version = get_deep(pyproject_toml, ["project", "version"])
+    description = str(get_deep(pyproject_toml, ["project", "description"]) or "")
+    repo = get_deep(pyproject_toml, ["project", "urls", "repository"])
+    space = (
+        space_url
+        if space_url
+        else get_deep(pyproject_toml, ["project", "urls", "space"])
+    )
+
+    if not local_version and not pypi_exists:
+        raise ValueError(
+            f"Cannot find version in pyproject.toml or on PyPI for [orange3]{name}[/].\nIf you have just published to PyPI, please wait a few minutes and try again."
+        )
+    module = importlib.import_module(name)
+    (docs, type_mode) = extract_docstrings(module)
+
+    if generate_space:
+        if not simple:
             live.update(":computer: [blue]Generating space.[/]")
 
-            source = make_space(
-                docs=docs,
-                name=name,
-                description=description,
-                local_version=local_version
-                if local_version is None
-                else str(local_version),
-                demo=demo,
-                space=space if space is None else str(space),
-                repo=repo if repo is None else str(repo),
-                pypi_exists=pypi_exists,
-                suppress_demo_check=suppress_demo_check,
-            )
+        source = make_space(
+            docs=docs,
+            name=name,
+            description=description,
+            local_version=local_version
+            if local_version is None
+            else str(local_version),
+            demo=demo,
+            space=space if space is None else str(space),
+            repo=repo if repo is None else str(repo),
+            pypi_exists=pypi_exists,
+            suppress_demo_check=suppress_demo_check,
+        )
 
-            with open(_demo_dir / "space.py", "w") as f:
-                f.write(source)
+        with open(_demo_dir / "space.py", "w") as f:
+            f.write(source)
+            if not simple:
                 live.update(
                     f":white_check_mark: Space created in [orange3]{_demo_dir}/space.py[/]\n"
                 )
-            with open(_demo_dir / "css.css", "w") as f:
-                f.write(css)
+        with open(_demo_dir / "css.css", "w") as f:
+            f.write(css)
 
-        if generate_readme:
+    if generate_readme:
+        if not simple:
             live.update(":pencil: [blue]Generating README.[/]")
-            readme = make_markdown(
-                docs, name, description, local_version, demo, space, repo, pypi_exists
-            )
+        readme = make_markdown(
+            docs, name, description, local_version, demo, space, repo, pypi_exists
+        )
 
-            with open(_readme_path, "w") as f:
-                f.write(readme)
+        with open(_readme_path, "w") as f:
+            f.write(readme)
+            if not simple:
                 live.update(
                     f":white_check_mark: README generated in [orange3]{_readme_path}[/]"
                 )
+    if simple:
+        short_readme_path = Path(_readme_path).relative_to(_component_dir)
+        short_demo_path = Path(_demo_path).relative_to(_component_dir)
+        live.update(
+            f":white_check_mark: Documention generated in [orange3]{short_demo_path}[/] and [orange3]{short_readme_path}[/]."
+        )
 
     if type_mode == "simple":
         print(

--- a/gradio/cli/commands/components/docs.py
+++ b/gradio/cli/commands/components/docs.py
@@ -181,7 +181,7 @@ def run_command(
         short_readme_path = Path(_readme_path).relative_to(_component_dir)
         short_demo_path = Path(_demo_path).relative_to(_component_dir)
         live.update(
-            f":white_check_mark: Documention generated in [orange3]{short_demo_path}[/] and [orange3]{short_readme_path}[/]. Pass `--no-generate-docs` to disable auto documentation."
+            f":white_check_mark: Documention generated in [orange3]{short_demo_path}[/] and [orange3]{short_readme_path}[/]. Pass --no-generate-docs to disable auto documentation."
         )
 
     if type_mode == "simple":

--- a/gradio/cli/commands/components/docs.py
+++ b/gradio/cli/commands/components/docs.py
@@ -114,12 +114,6 @@ def run_command(
     _component_dir: Path,
     simple: bool = False,
 ):
-    if simple:
-        live.update(
-            f":page_facing_up: Generating documentation for [orange3]{_component_dir.name}[/]",
-            add_sleep=0.2,
-        )
-
     with open(_demo_path) as f:
         demo = f.read()
 
@@ -187,10 +181,10 @@ def run_command(
         short_readme_path = Path(_readme_path).relative_to(_component_dir)
         short_demo_path = Path(_demo_path).relative_to(_component_dir)
         live.update(
-            f":white_check_mark: Documention generated in [orange3]{short_demo_path}[/] and [orange3]{short_readme_path}[/]."
+            f":white_check_mark: Documention generated in [orange3]{short_demo_path}[/] and [orange3]{short_readme_path}[/]. Pass `--no-generate-docs` to disable auto documentation."
         )
 
     if type_mode == "simple":
-        print(
+        live.update(
             "\n:orange_circle: [red]The docs were generated in simple mode. Updating python to a version greater than 3.9 will result in richer documentation.[/]"
         )

--- a/js/paramviewer/ParamViewer.svelte
+++ b/js/paramviewer/ParamViewer.svelte
@@ -69,6 +69,7 @@
 					<button
 						on:click={() => (show_desc[i] = !show_desc[i])}
 						class="arrow"
+						class:disabled={!description && !_default}
 						class:hidden={!show_desc[i]}>▲</button
 					>
 				</div>
@@ -92,6 +93,10 @@
 	.default :global(pre),
 	.default :global(.highlight) {
 		display: inline-block;
+	}
+
+	.disbaled {
+		opacity: 0;
 	}
 
 	.wrap :global(pre),


### PR DESCRIPTION
## Description

Runs the docs generator as part of the build. This only provides defaults with no options (so as not to bloat the build command). If you users wish to customise the behaviour, they can use the `docs` command.

Added new arg to `build` to optionally disbale the docs gen:

```bash
gradio cc build --no-generate-docs
```

Related to #7080.

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
