### PR TITLE
Support audio data in `np.int8` format in the `gr.Audio` component

### DIFF
--- a/.changeset/big-bananas-sell.md
+++ b/.changeset/big-bananas-sell.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Support audio data in `np.int8` format in the `gr.Audio` component

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -343,7 +343,7 @@ def convert_to_16_bit_wav(data):
         data = data.astype(np.int16)
     elif data.dtype == np.int32:
         warnings.warn(warning.format(data.dtype))
-        data = data / 65538
+        data = data / 65536
         data = data.astype(np.int16)
     elif data.dtype == np.int16:
         pass
@@ -357,7 +357,7 @@ def convert_to_16_bit_wav(data):
         data = data.astype(np.int16)
     elif data.dtype == np.int8:
         warnings.warn(warning.format(data.dtype))
-        data = data * 257 - 32768
+        data = data * 256
         data = data.astype(np.int16)    
     else:
         raise ValueError(

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -358,7 +358,7 @@ def convert_to_16_bit_wav(data):
     elif data.dtype == np.int8:
         warnings.warn(warning.format(data.dtype))
         data = data * 256
-        data = data.astype(np.int16)    
+        data = data.astype(np.int16)
     else:
         raise ValueError(
             "Audio data cannot be converted automatically from "

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -355,6 +355,10 @@ def convert_to_16_bit_wav(data):
         warnings.warn(warning.format(data.dtype))
         data = data * 257 - 32768
         data = data.astype(np.int16)
+    elif data.dtype == np.int8:
+        warnings.warn(warning.format(data.dtype))
+        data = data * 257 - 32768
+        data = data.astype(np.int16)    
     else:
         raise ValueError(
             "Audio data cannot be converted automatically from "


### PR DESCRIPTION
Fix for Audio data cannot be converted automatically from int8 to 16-bit int format

Closes: https://github.com/gradio-app/gradio/issues/7099

## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
