### PR TITLE
Reduce CPU usage of dev mode

### DIFF
--- a/.changeset/petite-islands-follow.md
+++ b/.changeset/petite-islands-follow.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Reduce CPU usage of dev mode

--- a/gradio/cli/commands/reload.py
+++ b/gradio/cli/commands/reload.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import inspect
 import os
 import re
+import site
 import subprocess
 import sys
 import threading
@@ -63,9 +64,14 @@ def _setup_config(
 
     watching_dirs = []
     if str(gradio_folder).strip():
-        watching_dirs.append(gradio_folder)
-        message += f" '{gradio_folder}'"
-        message_change_count += 1
+        package_install = any(
+            utils.is_in_or_equal(gradio_folder, d) for d in site.getsitepackages()
+        )
+        if not package_install:
+            # This is a source install
+            watching_dirs.append(gradio_folder)
+            message += f" '{gradio_folder}'"
+            message_change_count += 1
 
     abs_parent = abs_original_path.parent
     if str(abs_parent).strip():

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -14,6 +14,7 @@ import os
 import pkgutil
 import re
 import threading
+import time
 import traceback
 import typing
 import urllib.parse
@@ -223,6 +224,7 @@ def watchfn(reloader: SourceFileReloader):
             else:
                 reloader.swap_blocks(demo)
             mtimes = {}
+        time.sleep(0.05)
 
 
 def colab_check() -> bool:


### PR DESCRIPTION
## Description

Closes: #7095

We're watching the files of the gradio source code in addition to the demo. This increases the number of files that are polled for changes by an order of magnitude and most users are not installing gradio from source and making changes to the source code. 

Fix:
- Only watch the gradio source code if installed in edit mode from source. There isn't a foolproof way to determine this but I have implemented a heuristic that should work most of the time. This change will only be "breaking" users who install gradio from pypi and who edit the source code in the `site-packages` directory. I think that's a small proportion of users and they can always do an editable install to get around this.
- Introduce a short sleep between watch iterations. I'm using 0.05 seconds which should be fast enough so that users can't notice while freeing up the CPU core running the watch thread a bit.

There are other watch file algorithms we can use (https://pypi.org/project/watchfiles/) that are potentially more efficient but they would require installing other dependencies. With this change CPU usage is about 2% which I think is ok.

### utilization in this PR
<img width="949" alt="Screenshot 2024-01-22 at 6 21 27 PM" src="https://github.com/gradio-app/gradio/assets/41651716/2fad68a1-f772-49ea-a928-6666db46dc93">


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
