### PR TITLE
Programmatically determine max wheel version to push to spaces

### DIFF
--- a/.changeset/famous-mammals-attend.md
+++ b/.changeset/famous-mammals-attend.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Programmatically determine max wheel version to push to spaces

--- a/gradio/cli/commands/components/publish.py
+++ b/gradio/cli/commands/components/publish.py
@@ -131,7 +131,6 @@ def _publish(
         (p for p in distribution_files if p.suffix == ".whl"),
         key=lambda s: semantic_version.Version(str(s).split("-")[1]),
     )
-    breakpoint()
     if not wheel_file:
         raise ValueError(
             "A wheel file was not found in the distribution directory. "

--- a/gradio/cli/commands/components/publish.py
+++ b/gradio/cli/commands/components/publish.py
@@ -125,9 +125,17 @@ def _publish(
     if not dist_dir.is_dir():
         raise ValueError(f"{dist_dir} is not a directory")
     distribution_files = [
-        p.resolve() for p in Path(dist_dir).glob("*") if p.suffix in {".whl", ".gz"}
+        (p.resolve(), semantic_version.Version(str(p).split("-")[1]))
+        for p in Path(dist_dir).glob("*")
+        if p.suffix
+        in {
+            ".whl",
+        }
     ]
-    wheel_file = next((p for p in distribution_files if p.suffix == ".whl"), None)
+    wheel_file = max(
+        (p for p in distribution_files if p[0].suffix == ".whl"), key=lambda s: s[1]
+    )[0]
+    breakpoint()
     if not wheel_file:
         raise ValueError(
             "A wheel file was not found in the distribution directory. "

--- a/gradio/cli/commands/components/publish.py
+++ b/gradio/cli/commands/components/publish.py
@@ -125,16 +125,13 @@ def _publish(
     if not dist_dir.is_dir():
         raise ValueError(f"{dist_dir} is not a directory")
     distribution_files = [
-        (p.resolve(), semantic_version.Version(str(p).split("-")[1]))
-        for p in Path(dist_dir).glob("*")
-        if p.suffix
-        in {
-            ".whl",
-        }
+        p.resolve() for p in Path(dist_dir).glob("*") if p.suffix in {".whl", ".gz"}
     ]
     wheel_file = max(
-        (p for p in distribution_files if p[0].suffix == ".whl"), key=lambda s: s[1]
-    )[0]
+        (p for p in distribution_files if p.suffix == ".whl"),
+        key=lambda s: semantic_version.Version(str(s).split("-")[1]),
+    )
+    breakpoint()
     if not wheel_file:
         raise ValueError(
             "A wheel file was not found in the distribution directory. "

--- a/gradio/cli/commands/components/publish.py
+++ b/gradio/cli/commands/components/publish.py
@@ -135,7 +135,6 @@ def _publish(
     wheel_file = max(
         (p for p in distribution_files if p[0].suffix == ".whl"), key=lambda s: s[1]
     )[0]
-    breakpoint()
     if not wheel_file:
         raise ValueError(
             "A wheel file was not found in the distribution directory. "


### PR DESCRIPTION
## Description

Closes: #7106

Fix is to programmatically determine the most recent wheel version to push to spaces.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
