### PR TITLE
Remove kwargs from template components

### DIFF
--- a/.changeset/few-things-smash.md
+++ b/.changeset/few-things-smash.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Remove kwargs from template components

--- a/gradio/templates.py
+++ b/gradio/templates.py
@@ -294,7 +294,7 @@ class PlayableVideo(components.Video):
         | Callable
         | None = None,
         *,
-        format: str | None = "mp4",
+        format: Literal["mp4"] = "mp4",
         sources: list[Literal["upload", "webcam"]] | None = None,
         height: int | str | None = None,
         width: int | str | None = None,
@@ -356,7 +356,7 @@ class Microphone(components.Audio):
         self,
         value: str | Path | tuple[int, np.ndarray] | Callable | None = None,
         *,
-        sources: list[Literal["microphone"]] | None = None,
+        sources: list[Literal["upload", "microphone"]] | None = None,
         type: Literal["numpy", "filepath"] = "numpy",
         label: str | None = None,
         every: float | None = None,
@@ -382,7 +382,7 @@ class Microphone(components.Audio):
         sources = ["microphone"]
         super().__init__(
             value,
-            sources=sources,  # type: ignore
+            sources=sources,
             type=type,
             label=label,
             every=every,
@@ -418,7 +418,7 @@ class Files(components.File):
         self,
         value: str | list[str] | Callable | None = None,
         *,
-        file_count: Literal["single", "multiple"] = "multiple",
+        file_count: Literal["multiple"] = "multiple",
         file_types: list[str] | None = None,
         type: Literal["filepath", "binary"] = "filepath",
         label: str | None = None,
@@ -581,7 +581,7 @@ class List(components.Dataframe):
         *,
         headers: list[str] | None = None,
         row_count: int | tuple[int, str] = (1, "dynamic"),
-        col_count: int | tuple[int, str] | None = 1,
+        col_count: Literal[1] = 1,
         datatype: str | list[str] = "str",
         type: Literal["array"] = "array",
         latex_delimiters: list[dict[str, str | bool]] | None = None,

--- a/gradio/templates.py
+++ b/gradio/templates.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Callable, Iterable, Literal
 
 import numpy as np
 from PIL import Image as _Image  # using _ to minimize namespace pollution
 
 from gradio import components
+from gradio.components.audio import WaveformOptions
 from gradio.components.image_editor import Brush, Eraser
 
 
@@ -24,11 +26,23 @@ class TextArea(components.Textbox):
         max_lines: int = 20,
         placeholder: str | None = None,
         label: str | None = None,
-        show_label: bool = True,
+        info: str | None = None,
+        every: float | None = None,
+        show_label: bool | None = None,
+        container: bool = True,
+        scale: int | None = None,
+        min_width: int = 160,
         interactive: bool | None = None,
         visible: bool = True,
         elem_id: str | None = None,
-        **kwargs,
+        autofocus: bool = False,
+        autoscroll: bool = True,
+        elem_classes: list[str] | str | None = None,
+        render: bool = True,
+        type: Literal["text", "password", "email"] = "text",
+        text_align: Literal["left", "right"] | None = None,
+        rtl: bool = False,
+        show_copy_button: bool = False,
     ):
         super().__init__(
             value=value,
@@ -36,11 +50,23 @@ class TextArea(components.Textbox):
             max_lines=max_lines,
             placeholder=placeholder,
             label=label,
+            info=info,
+            every=every,
             show_label=show_label,
+            container=container,
+            scale=scale,
+            min_width=min_width,
             interactive=interactive,
             visible=visible,
             elem_id=elem_id,
-            **kwargs,
+            autofocus=autofocus,
+            autoscroll=autoscroll,
+            elem_classes=elem_classes,
+            render=render,
+            type=type,
+            text_align=text_align,
+            rtl=rtl,
+            show_copy_button=show_copy_button,
         )
 
 
@@ -262,31 +288,60 @@ class PlayableVideo(components.Video):
 
     def __init__(
         self,
-        value: str | Callable | None = None,
+        value: str
+        | Path
+        | tuple[str | Path, str | Path | None]
+        | Callable
+        | None = None,
         *,
-        format: Literal["mp4"] | None = "mp4",
-        sources: list[Literal["upload", "webcam"]] = ["upload"],  # noqa: B006
+        format: str | None = "mp4",
+        sources: list[Literal["upload", "webcam"]] | None = None,
+        height: int | str | None = None,
+        width: int | str | None = None,
         label: str | None = None,
-        show_label: bool = True,
+        every: float | None = None,
+        show_label: bool | None = None,
+        container: bool = True,
+        scale: int | None = None,
+        min_width: int = 160,
         interactive: bool | None = None,
         visible: bool = True,
         elem_id: str | None = None,
+        elem_classes: list[str] | str | None = None,
+        render: bool = True,
         mirror_webcam: bool = True,
         include_audio: bool | None = None,
-        **kwargs,
+        autoplay: bool = False,
+        show_share_button: bool | None = None,
+        show_download_button: bool | None = None,
+        min_length: int | None = None,
+        max_length: int | None = None,
     ):
+        sources = ["upload"]
         super().__init__(
             value=value,
             format=format,
-            sources=sources,
+            sources=sources,  # type: ignore
+            height=height,
+            width=width,
             label=label,
+            every=every,
             show_label=show_label,
+            container=container,
+            scale=scale,
+            min_width=min_width,
             interactive=interactive,
             visible=visible,
             elem_id=elem_id,
+            elem_classes=elem_classes,
+            render=render,
             mirror_webcam=mirror_webcam,
             include_audio=include_audio,
-            **kwargs,
+            autoplay=autoplay,
+            show_share_button=show_share_button,
+            show_download_button=show_download_button,
+            min_length=min_length,
+            max_length=max_length,
         )
 
 
@@ -299,29 +354,56 @@ class Microphone(components.Audio):
 
     def __init__(
         self,
-        value: str | tuple[int, np.ndarray] | Callable | None = None,
+        value: str | Path | tuple[int, np.ndarray] | Callable | None = None,
         *,
-        sources: list[Literal["upload", "microphone"]] | None = ["microphone"],  # noqa: B006
+        sources: list[Literal["microphone"]] | None = None,
         type: Literal["numpy", "filepath"] = "numpy",
         label: str | None = None,
-        show_label: bool = True,
+        every: float | None = None,
+        show_label: bool | None = None,
+        container: bool = True,
+        scale: int | None = None,
+        min_width: int = 160,
         interactive: bool | None = None,
         visible: bool = True,
         streaming: bool = False,
         elem_id: str | None = None,
-        **kwargs,
+        elem_classes: list[str] | str | None = None,
+        render: bool = True,
+        format: Literal["wav", "mp3"] = "wav",
+        autoplay: bool = False,
+        show_download_button: bool | None = None,
+        show_share_button: bool | None = None,
+        editable: bool = True,
+        min_length: int | None = None,
+        max_length: int | None = None,
+        waveform_options: WaveformOptions | dict | None = None,
     ):
+        sources = ["microphone"]
         super().__init__(
-            value=value,
-            sources=sources,
+            value,
+            sources=sources,  # type: ignore
             type=type,
             label=label,
+            every=every,
             show_label=show_label,
+            container=container,
+            scale=scale,
+            min_width=min_width,
             interactive=interactive,
             visible=visible,
             streaming=streaming,
             elem_id=elem_id,
-            **kwargs,
+            elem_classes=elem_classes,
+            render=render,
+            format=format,
+            autoplay=autoplay,
+            show_download_button=show_download_button,
+            show_share_button=show_share_button,
+            editable=editable,
+            min_length=min_length,
+            max_length=max_length,
+            waveform_options=waveform_options,
         )
 
 
@@ -336,25 +418,39 @@ class Files(components.File):
         self,
         value: str | list[str] | Callable | None = None,
         *,
-        file_count: Literal["multiple"] = "multiple",
+        file_count: Literal["single", "multiple"] = "multiple",
+        file_types: list[str] | None = None,
         type: Literal["filepath", "binary"] = "filepath",
         label: str | None = None,
-        show_label: bool = True,
+        every: float | None = None,
+        show_label: bool | None = None,
+        container: bool = True,
+        scale: int | None = None,
+        min_width: int = 160,
+        height: int | float | None = None,
         interactive: bool | None = None,
         visible: bool = True,
         elem_id: str | None = None,
-        **kwargs,
+        elem_classes: list[str] | str | None = None,
+        render: bool = True,
     ):
         super().__init__(
-            value=value,
+            value,
             file_count=file_count,
+            file_types=file_types,
             type=type,
             label=label,
+            every=every,
             show_label=show_label,
+            container=container,
+            scale=scale,
+            min_width=min_width,
+            height=height,
             interactive=interactive,
             visible=visible,
             elem_id=elem_id,
-            **kwargs,
+            elem_classes=elem_classes,
+            render=render,
         )
 
 
@@ -374,13 +470,21 @@ class Numpy(components.Dataframe):
         col_count: int | tuple[int, str] | None = None,
         datatype: str | list[str] = "str",
         type: Literal["numpy"] = "numpy",
+        latex_delimiters: list[dict[str, str | bool]] | None = None,
         label: str | None = None,
-        show_label: bool = True,
+        show_label: bool | None = None,
+        every: float | None = None,
+        height: int = 500,
+        scale: int | None = None,
+        min_width: int = 160,
         interactive: bool | None = None,
         visible: bool = True,
         elem_id: str | None = None,
+        elem_classes: list[str] | str | None = None,
+        render: bool = True,
         wrap: bool = False,
-        **kwargs,
+        line_breaks: bool = True,
+        column_widths: list[str | int] | None = None,
     ):
         super().__init__(
             value=value,
@@ -395,7 +499,15 @@ class Numpy(components.Dataframe):
             visible=visible,
             elem_id=elem_id,
             wrap=wrap,
-            **kwargs,
+            elem_classes=elem_classes,
+            render=render,
+            line_breaks=line_breaks,
+            column_widths=column_widths,
+            every=every,
+            height=height,
+            scale=scale,
+            latex_delimiters=latex_delimiters,
+            min_width=min_width,
         )
 
 
@@ -415,13 +527,21 @@ class Matrix(components.Dataframe):
         col_count: int | tuple[int, str] | None = None,
         datatype: str | list[str] = "str",
         type: Literal["array"] = "array",
+        latex_delimiters: list[dict[str, str | bool]] | None = None,
         label: str | None = None,
-        show_label: bool = True,
+        show_label: bool | None = None,
+        every: float | None = None,
+        height: int = 500,
+        scale: int | None = None,
+        min_width: int = 160,
         interactive: bool | None = None,
         visible: bool = True,
         elem_id: str | None = None,
+        elem_classes: list[str] | str | None = None,
+        render: bool = True,
         wrap: bool = False,
-        **kwargs,
+        line_breaks: bool = True,
+        column_widths: list[str | int] | None = None,
     ):
         super().__init__(
             value=value,
@@ -436,7 +556,15 @@ class Matrix(components.Dataframe):
             visible=visible,
             elem_id=elem_id,
             wrap=wrap,
-            **kwargs,
+            elem_classes=elem_classes,
+            render=render,
+            line_breaks=line_breaks,
+            column_widths=column_widths,
+            every=every,
+            height=height,
+            scale=scale,
+            latex_delimiters=latex_delimiters,
+            min_width=min_width,
         )
 
 
@@ -453,16 +581,24 @@ class List(components.Dataframe):
         *,
         headers: list[str] | None = None,
         row_count: int | tuple[int, str] = (1, "dynamic"),
-        col_count: Literal[1] = 1,
+        col_count: int | tuple[int, str] | None = 1,
         datatype: str | list[str] = "str",
         type: Literal["array"] = "array",
+        latex_delimiters: list[dict[str, str | bool]] | None = None,
         label: str | None = None,
-        show_label: bool = True,
+        show_label: bool | None = None,
+        every: float | None = None,
+        height: int = 500,
+        scale: int | None = None,
+        min_width: int = 160,
         interactive: bool | None = None,
         visible: bool = True,
         elem_id: str | None = None,
+        elem_classes: list[str] | str | None = None,
+        render: bool = True,
         wrap: bool = False,
-        **kwargs,
+        line_breaks: bool = True,
+        column_widths: list[str | int] | None = None,
     ):
         super().__init__(
             value=value,
@@ -477,7 +613,15 @@ class List(components.Dataframe):
             visible=visible,
             elem_id=elem_id,
             wrap=wrap,
-            **kwargs,
+            elem_classes=elem_classes,
+            render=render,
+            line_breaks=line_breaks,
+            column_widths=column_widths,
+            every=every,
+            height=height,
+            scale=scale,
+            latex_delimiters=latex_delimiters,
+            min_width=min_width,
         )
 
 

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -5,6 +5,7 @@ Tests for all of the components defined in components.py. Tests are divided into
 """
 
 import filecmp
+import inspect
 import json
 import os
 import shutil
@@ -2955,3 +2956,12 @@ def test_constructor_args():
         "visible": False,
         "value": "Log in please",
     }
+
+
+def test_template_component_configs(io_components):
+    template_components = [c for c in io_components if getattr(c, "is_template", False)]
+    for component in template_components:
+        component_parent_class = inspect.getmro(component)[1]
+        template_config = component().get_config()
+        parent_config = component_parent_class().get_config()
+        assert set(parent_config.keys()).issubset(set(template_config.keys()))


### PR DESCRIPTION
## Description

Closes: #7137

The issue is that only props that are explicitly listed in the __init__ are saved to the config. For this reason we removed **kwargs from the main components. We kept them in the templates by mistake.

I removed kwargs from the templates and made sure every parameter listed in the parent component is also listed in the template component. Also added a unit test to prevent this in the future.

Repro from original issue

```python
import gradio as gr

  

with gr.Blocks() as demo:

    files = gr.Files(interactive=True, file_types=["image"])

  

demo.launch(share=True)
```

Go to share link from your phone and upload a photo. You should be able to select from photo gallery.


https://github.com/gradio-app/gradio/assets/41651716/575c0798-d593-4c47-839a-953a77d88503



## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
