### PR TITLE
docs: more explicit pharsing for gr.on

### DIFF
--- a/guides/03_building-with-blocks/01_blocks-and-event-listeners.md
+++ b/guides/03_building-with-blocks/01_blocks-and-event-listeners.md
@@ -192,7 +192,7 @@ You can use decorator syntax as well:
 
 $code_on_listener_decorator
 
-You can use `gr.on` to create "live" events by binding to the change event of all components. If you do not specify any triggers, the function will automatically bind to the change event of all input components. 
+You can use `gr.on` to create "live" events by binding to the `change` event of components that implement it. If you do not specify any triggers, the function will automatically bind to all `change` event of all input components that include a `change` event (for example `gr.Textbox` has a `change` event whereas `gr.Button` does not).
 
 $code_on_listener_live
 $demo_on_listener_live


### PR DESCRIPTION
Signed-off-by: thiswillbeyourgithub <26625900+thiswillbeyourgithub@users.noreply.github.com>

## Description

Rephrase the docs of `gr.on` as it was a bit misleading, as evidenced by #6730.
This PR was requested by @abidlabs [here](https://github.com/gradio-app/gradio/issues/6730#issuecomment-1903435699)

Closes: #6730

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
