### PR TITLE
Optimize client view_api method

### DIFF
--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -146,7 +146,7 @@ class Client:
         self.upload_url = urllib.parse.urljoin(self.src, utils.UPLOAD_URL)
         self.reset_url = urllib.parse.urljoin(self.src, utils.RESET_URL)
         self.app_version = version.parse(self.config.get("version", "2.0"))
-        self._info = self._get_api_info()
+        self._info = None
         self.session_hash = str(uuid.uuid4())
 
         endpoint_class = (
@@ -556,6 +556,8 @@ class Client:
             }
 
         """
+        if not self._info:
+            self._info = self._get_api_info()
         num_named_endpoints = len(self._info["named_endpoints"])
         num_unnamed_endpoints = len(self._info["unnamed_endpoints"])
         if num_named_endpoints == 0 and all_endpoints is None:

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2304,12 +2304,9 @@ Received outputs:
                 if self.blocks[component["id"]].skip_api:
                     continue
                 label = component["props"].get("label", f"parameter_{i}")
-                # The config has the most specific API info (taking into account the parameters
-                # of the component), so we use that if it exists. Otherwise, we fallback to the
-                # Serializer's API info.
                 comp = self.get_component(component["id"])
                 assert isinstance(comp, components.Component)
-                info = comp.api_info()
+                info = component["api_info"]
                 example = comp.example_inputs()
                 python_type = client_utils.json_schema_to_python_type(info)
                 dependency_info["parameters"].append(
@@ -2339,7 +2336,7 @@ Received outputs:
                 label = component["props"].get("label", f"value_{o}")
                 comp = self.get_component(component["id"])
                 assert isinstance(comp, components.Component)
-                info = comp.api_info()
+                info = component["api_info"]
                 example = comp.example_inputs()
                 python_type = client_utils.json_schema_to_python_type(info)
                 dependency_info["returns"].append(


### PR DESCRIPTION
## Description

Closes: #7169

Notes:
* Defer the api request to `/api_info` until `view_api` is called and cache the result as opposed to making it during the init. This gets the ~0.5 seconds reported on gradio 3.x
* In the blocks `get_api_info` method, instead of calling `block.api_info()` get the api_info from the config since it's already stored there. This cuts down the time to complete the `view_api` method in half by my rough estimate (0.5 seconds to 0.25 seconds).


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
