### PR TITLE
fix: remove new lines from latex delimiter

### DIFF
--- a/.changeset/mean-aliens-warn.md
+++ b/.changeset/mean-aliens-warn.md
@@ -1,0 +1,6 @@
+---
+"@gradio/markdown": patch
+"gradio": patch
+---
+
+fix:fix: remove new lines from latex delimiter

--- a/js/markdown/shared/MarkdownCode.svelte
+++ b/js/markdown/shared/MarkdownCode.svelte
@@ -3,7 +3,7 @@
 	import DOMPurify from "dompurify";
 	import render_math_in_element from "katex/dist/contrib/auto-render.js";
 	import "katex/dist/katex.min.css";
-	import { create_marked } from "./utils";
+	import { create_marked, clean_latex_newline } from "./utils";
 
 	import "./prism.css";
 
@@ -24,7 +24,7 @@
 
 	const marked = create_marked({
 		header_links,
-		line_breaks
+		line_breaks,
 	});
 
 	const is_external_url = (link: string | null): boolean => {
@@ -46,6 +46,7 @@
 
 	function process_message(value: string): string {
 		if (render_markdown) {
+			value = clean_latex_newline(value);
 			value = marked.parse(value) as string;
 		}
 		if (sanitize_html) {
@@ -63,7 +64,7 @@
 		if (latex_delimiters.length > 0 && value) {
 			render_math_in_element(el, {
 				delimiters: latex_delimiters,
-				throwOnError: false
+				throwOnError: false,
 			});
 		}
 	}

--- a/js/markdown/shared/utils.ts
+++ b/js/markdown/shared/utils.ts
@@ -218,3 +218,9 @@ async function copy_to_clipboard(value: string): Promise<boolean> {
 
 	return copied;
 }
+
+export const clean_latex_newline = (str: string): string => {
+	return str.replace(/\$\$([\s\S]*?)\$\$/g, (match, group) => {
+		return "$$" + group.replace(/\n/g, "") + "$$";
+	});
+};


### PR DESCRIPTION
## Description

having newlines caused latex to not be rendered so I just remove them using regex.

Closes: #7146 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
