### PR TITLE
Fix hyphen-bug in gradio cc publish

### DIFF
--- a/.changeset/spicy-rabbits-check.md
+++ b/.changeset/spicy-rabbits-check.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Fix hyphen-bug in gradio cc publish

--- a/.changeset/spicy-rabbits-check.md
+++ b/.changeset/spicy-rabbits-check.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix hyphen-bug in gradio cc publish

--- a/gradio/cli/commands/components/publish.py
+++ b/gradio/cli/commands/components/publish.py
@@ -141,7 +141,7 @@ def _publish(
     ]
     wheel_file = max(
         (p for p in distribution_files if p.suffix == ".whl"),
-        key=lambda s: semantic_version.Version(str(s).split("-")[1]),
+        key=lambda s: semantic_version.Version(str(s.name).split("-")[1]),
     )
     if not wheel_file:
         raise ValueError(


### PR DESCRIPTION
## Description

Partially closes #7213 

If there was a hyphen in a parent directory, the publish command would fail.


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
