### PR TITLE
CI: update GitHub Actions versions

### DIFF
--- a/.github/actions/changes/action.yml
+++ b/.github/actions/changes/action.yml
@@ -51,7 +51,7 @@ runs:
       uses: "gradio-app/github/actions/find-pr@main"
       with:
         github_token: ${{ inputs.token }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: ${{ steps.pr.outputs.source_repo }}
         ref: ${{ steps.pr.outputs.source_branch }}

--- a/.github/workflows/delete-stale-spaces.yml
+++ b/.github/workflows/delete-stale-spaces.yml
@@ -15,7 +15,7 @@ jobs:
   delete-old-spaces:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/deploy+test-visual.yml
+++ b/.github/workflows/deploy+test-visual.yml
@@ -27,7 +27,7 @@ jobs:
       labels: ${{ steps.changes.outputs.labels }}
       mergeable: ${{ steps.changes.outputs.mergeable }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: "gradio-app/gradio/.github/actions/changes@main"
         id: changes
         with:
@@ -60,7 +60,7 @@ jobs:
       storybook_url: ${{ steps.publish-chromatic.outputs.storybookUrl }}
       build_url: ${{ steps.publish-chromatic.outputs.buildUrl }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
             fetch-depth: 0
             ref: ${{ needs.changes.outputs.sha }}

--- a/.github/workflows/deploy-spaces.yml
+++ b/.github/workflows/deploy-spaces.yml
@@ -25,7 +25,7 @@ jobs:
       merge_sha: ${{ steps.changes.outputs.merge_sha }}
       mergeable: ${{ steps.changes.outputs.mergeable }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: "gradio-app/gradio/.github/actions/changes@main"
         id: changes
         with:
@@ -53,7 +53,7 @@ jobs:
     if: ${{ needs.changes.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ needs.changes.outputs.merge_sha }}
         repository: ${{ needs.changes.outputs.mergeable == 'true' &&  github.repository || needs.changes.outputs.source_repo }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -32,7 +32,7 @@ jobs:
       found_pr: ${{ steps.changes.outputs.found_pr }}
       mergeable: ${{ steps.changes.outputs.mergeable }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: "gradio-app/gradio/.github/actions/changes@main"
         id: changes
         with:
@@ -59,7 +59,7 @@ jobs:
     outputs:
       vercel_url: ${{ steps.output_url.outputs.vercel_url }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.changes.outputs.merge_sha }}
           repository: ${{ needs.changes.outputs.mergeable == 'true' &&  github.repository || needs.changes.outputs.source_repo }}

--- a/.github/workflows/generate-changeset.yml
+++ b/.github/workflows/generate-changeset.yml
@@ -50,7 +50,7 @@ jobs:
       skipped: ${{ steps.version.outputs.skipped }}
       comment_url: ${{ steps.version.outputs.comment_url }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: ${{ needs.get-pr.outputs.source_repo }}
           ref: ${{ needs.get-pr.outputs.source_branch }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/test-functional.yml
+++ b/.github/workflows/test-functional.yml
@@ -26,7 +26,7 @@ jobs:
       source_repo: ${{ steps.changes.outputs.source_repo }}
       mergeable: ${{ steps.changes.outputs.mergeable }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: "gradio-app/gradio/.github/actions/changes@main"
         id: changes
         with:
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.changes.outputs.merge_sha }}
           repository: ${{ needs.changes.outputs.mergeable == 'true' &&  github.repository || needs.changes.outputs.source_repo }}

--- a/.github/workflows/test-hygiene.yml
+++ b/.github/workflows/test-hygiene.yml
@@ -26,7 +26,7 @@ jobs:
       merge_sha: ${{ steps.changes.outputs.merge_sha }}
       mergeable: ${{ steps.changes.outputs.mergeable }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: "gradio-app/gradio/.github/actions/changes@main"
         id: changes
         with:
@@ -42,7 +42,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.changes.outputs.merge_sha }}
           repository: ${{ needs.changes.outputs.mergeable == 'true' &&  github.repository || needs.changes.outputs.source_repo }}

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -32,7 +32,7 @@ jobs:
       labels: ${{ steps.changes.outputs.labels }}
       mergeable: ${{ steps.changes.outputs.mergeable }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: "gradio-app/gradio/.github/actions/changes@main"
         id: changes
         with:
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ needs.changes.outputs.merge_sha }}
         repository: ${{ needs.changes.outputs.mergeable == 'true' &&  github.repository || needs.changes.outputs.source_repo }}

--- a/.github/workflows/tests-js.yml
+++ b/.github/workflows/tests-js.yml
@@ -33,7 +33,7 @@ jobs:
       source_repo: ${{ steps.changes.outputs.source_repo }}
       mergeable: ${{ steps.changes.outputs.mergeable }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: "gradio-app/gradio/.github/actions/changes@main"
         id: changes
         with:
@@ -49,7 +49,7 @@ jobs:
     name: test-js
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.changes.outputs.merge_sha }}
           repository: ${{ needs.changes.outputs.mergeable == 'true' &&  github.repository || needs.changes.outputs.source_repo }}
@@ -80,4 +80,3 @@ jobs:
           name: "test / js"
           result: ${{ job.status }}
           job_id: "test-js"  
- 


### PR DESCRIPTION
## Description

Updates `action/checkout` to avoid the Node 16 warning on every CI run.

Executed with [`gha-tools`](https://github.com/akx/gha-tools) `autoupdate`.

In addition, there's a couple more upgrades available that I didn't include here:

* `FedericoCarboni/setup-ffmpeg@v2` => `FedericoCarboni/setup-ffmpeg@v3`
* `dorny/paths-filter@v2` => `dorny/paths-filter@v3`

## 🎯 PRs Should Target Issues

Follows up on #7233, #7243, #7244, #7245, #7246, #7248.
