### PR TITLE
Escape triple quotes when creating `space.py` for custom components

### DIFF
--- a/.changeset/light-lemons-shout.md
+++ b/.changeset/light-lemons-shout.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Escape triple quotes when creating `space.py` for custom components

--- a/gradio/cli/commands/components/_docs_utils.py
+++ b/gradio/cli/commands/components/_docs_utils.py
@@ -837,6 +837,7 @@ if __name__ == '__main__':
 
 To ignore this error pass `--suppress-demo-check` to the docs command."""
         )
+    demo = demo.replace('"""', '\\"\\"\\"')
 
     source = """
 import gradio as gr


### PR DESCRIPTION
Closes: https://github.com/gradio-app/gradio/issues/7239