### PR TITLE
fix: Code component not accepting type Callable on value parameter

### DIFF
--- a/gradio/components/code.py
+++ b/gradio/components/code.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 from gradio_client.documentation import document, set_documentation_group
 
@@ -43,7 +43,7 @@ class Code(Component):
 
     def __init__(
         self,
-        value: str | tuple[str] | None = None,
+        value: str | Callable | tuple[str] | None = None,
         language: Literal[
             "python",
             "markdown",


### PR DESCRIPTION
## Description

The Code component can accept a Callable as value, as said on the documentation, but the typing on that parameter wasn't following that.
