### PR TITLE
Handle httpx.InvalidURL when setting non-URL article strings

### DIFF
--- a/.changeset/red-turkeys-make.md
+++ b/.changeset/red-turkeys-make.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Handle httpx.InvalidURL when setting non-URL article strings

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -291,7 +291,7 @@ def readme_to_html(article: str) -> str:
         response = httpx.get(article, timeout=3)
         if response.status_code == httpx.codes.OK:  # pylint: disable=no-member
             article = response.text
-    except httpx.RequestError:
+    except (httpx.InvalidURL, httpx.RequestError):
         pass
     return article
 


### PR DESCRIPTION
## Description

The `article` parameter of `gradio.Interface` takes both an URL and markdown/HTML text. The constructor first tries to use article string as URL, and if that throws an `httpx.RequestError`, the article string is used directly. This does not work if the article string is longer than `httpx._urlparse.MAX_URL_LENGTH` or contains non-printable characters, in which case `httpx.InvalidURL` is raised. This PR handles this error.
