### PR TITLE
Update Pydantic patch for Lite that emulates PydanticV2 API using V1

### DIFF
--- a/.changeset/two-pants-flow.md
+++ b/.changeset/two-pants-flow.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Update Pydantic patch for Lite that emulates PydanticV2 API using V1

--- a/gradio/data_classes.py
+++ b/gradio/data_classes.py
@@ -28,16 +28,16 @@ else:
     # Map V2 method calls to V1 implementations.
     # Ref: https://docs.pydantic.dev/latest/migration/#changes-to-pydanticbasemodel
     class BaseModelMeta(type(BaseModelV1)):
-        def __new__(mcs, name, bases, dct):  # noqa: N804
+        def __new__(cls, name, bases, dct):
             # Override `dct` to dynamically create a `Config` class based on `model_config`.
             if "model_config" in dct:
-                ConfigClass = type("Config", (), {})  # noqa: N806
+                config_class = type("Config", (), {})
                 for key, value in dct["model_config"].items():
-                    setattr(ConfigClass, key, value)
-                dct["Config"] = ConfigClass
+                    setattr(config_class, key, value)
+                dct["Config"] = config_class
 
-            cls = super().__new__(mcs, name, bases, dct)
-            return cls
+            model_class = super().__new__(cls, name, bases, dct)
+            return model_class
 
     class BaseModel(BaseModelV1, metaclass=BaseModelMeta):
         pass

--- a/gradio/data_classes.py
+++ b/gradio/data_classes.py
@@ -35,6 +35,7 @@ else:
                 for key, value in dct["model_config"].items():
                     setattr(config_class, key, value)
                 dct["Config"] = config_class
+                del dct["model_config"]
 
             model_class = super().__new__(cls, name, bases, dct)
             return model_class

--- a/gradio/data_classes.py
+++ b/gradio/data_classes.py
@@ -7,7 +7,7 @@ import secrets
 import shutil
 from abc import ABC, abstractmethod
 from enum import Enum, auto
-from typing import Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from fastapi import Request
 from gradio_client.utils import traverse
@@ -15,7 +15,7 @@ from typing_extensions import Literal
 
 from . import wasm_utils
 
-if not wasm_utils.IS_WASM:
+if not wasm_utils.IS_WASM or TYPE_CHECKING:
     from pydantic import BaseModel, RootModel, ValidationError  # type: ignore
 else:
     # XXX: Currently Pyodide V2 is not available on Pyodide,

--- a/gradio/data_classes.py
+++ b/gradio/data_classes.py
@@ -16,7 +16,7 @@ from typing_extensions import Literal
 from . import wasm_utils
 
 if not wasm_utils.IS_WASM or TYPE_CHECKING:
-    from pydantic import BaseModel, RootModel, ValidationError  # type: ignore
+    from pydantic import BaseModel, RootModel, ValidationError
 else:
     # XXX: Currently Pyodide V2 is not available on Pyodide,
     # so we install V1 for the Wasm version.


### PR DESCRIPTION
## Description

The following error started to occur on Lite after #7333.
Because Pydantic V2 is not available on Pyodide yet, Lite still uses Pydantic V1 with patches bridging the V1 APIs to V2 interfaces so the original Gradio code relying on the V2 API works.
The patch didn't support the `Config` class API V1, which is deprecated in V2 and #7333 switched from to the new one. This PR updates the patch to support the configuration interface in V2 using the V1 API.

```
Error
Traceback (most recent call last): File "/lib/python311.zip/_pyodide/_base.py", line 571, in eval_code_async await CodeRunner( File "/lib/python311.zip/_pyodide/_base.py", line 394, in run_async coroutine = eval(self.code, globals, locals) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "<exec>", line 1, in <module> File "/lib/python3.11/site-packages/gradio/__init__.py", line 3, in <module> import gradio._simple_templates File "/lib/python3.11/site-packages/gradio/_simple_templates/__init__.py", line 1, in <module> from .simpledropdown import SimpleDropdown File "/lib/python3.11/site-packages/gradio/_simple_templates/simpledropdown.py", line 6, in <module> from gradio.components.base import FormComponent File "/lib/python3.11/site-packages/gradio/components/__init__.py", line 1, in <module> from gradio.components.annotated_image import AnnotatedImage File "/lib/python3.11/site-packages/gradio/components/annotated_image.py", line 11, in <module> from gradio import processing_utils, utils File "/lib/python3.11/site-packages/gradio/processing_utils.py", line 22, in <module> from gradio.data_classes import FileData, GradioModel, GradioRootModel File "/lib/python3.11/site-packages/gradio/data_classes.py", line 65, in <module> class PredictBody(BaseModel): File "/lib/python3.11/site-packages/pydantic/main.py", line 197, in __new__ fields[ann_name] = ModelField.infer( ^^^^^^^^^^^^^^^^^ File "/lib/python3.11/site-packages/pydantic/fields.py", line 506, in infer return cls( ^^^^ File "/lib/python3.11/site-packages/pydantic/fields.py", line 436, in __init__ self.prepare() File "/lib/python3.11/site-packages/pydantic/fields.py", line 557, in prepare self.populate_validators() File "/lib/python3.11/site-packages/pydantic/fields.py", line 831, in populate_validators *(get_validators() if get_validators else list(find_validators(self.type_, self.model_config))), ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/lib/python3.11/site-packages/pydantic/validators.py", line 765, in find_validators raise RuntimeError(f'no validator found for {type_}, see `arbitrary_types_allowed` in Config') RuntimeError: no validator found for <class 'starlette.requests.Request'>, see `arbitrary_types_allowed` in Config

PythonError: Traceback (most recent call last):
  File "/lib/python311.zip/_pyodide/_base.py", line 571, in eval_code_async
    await CodeRunner(
  File "/lib/python311.zip/_pyodide/_base.py", line 394, in run_async
    coroutine = eval(self.code, globals, locals)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<exec>", line 1, in <module>
  File "/lib/python3.11/site-packages/gradio/__init__.py", line 3, in <module>
    import gradio._simple_templates
  File "/lib/python3.11/site-packages/gradio/_simple_templates/__init__.py", line 1, in <module>
    from .simpledropdown import SimpleDropdown
  File "/lib/python3.11/site-packages/gradio/_simple_templates/simpledropdown.py", line 6, in <module>
    from gradio.components.base import FormComponent
  File "/lib/python3.11/site-packages/gradio/components/__init__.py", line 1, in <module>
    from gradio.components.annotated_image import AnnotatedImage
  File "/lib/python3.11/site-packages/gradio/components/annotated_image.py", line 11, in <module>
    from gradio import processing_utils, utils
  File "/lib/python3.11/site-packages/gradio/processing_utils.py", line 22, in <module>
    from gradio.data_classes import FileData, GradioModel, GradioRootModel
  File "/lib/python3.11/site-packages/gradio/data_classes.py", line 65, in <module>
    class PredictBody(BaseModel):
  File "/lib/python3.11/site-packages/pydantic/main.py", line 197, in __new__
    fields[ann_name] = ModelField.infer(
                       ^^^^^^^^^^^^^^^^^
  File "/lib/python3.11/site-packages/pydantic/fields.py", line 506, in infer
    return cls(
           ^^^^
  File "/lib/python3.11/site-packages/pydantic/fields.py", line 436, in __init__
    self.prepare()
  File "/lib/python3.11/site-packages/pydantic/fields.py", line 557, in prepare
    self.populate_validators()
  File "/lib/python3.11/site-packages/pydantic/fields.py", line 831, in populate_validators
    *(get_validators() if get_validators else list(find_validators(self.type_, self.model_config))),
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.11/site-packages/pydantic/validators.py", line 765, in find_validators
    raise RuntimeError(f'no validator found for {type_}, see `arbitrary_types_allowed` in Config')
RuntimeError: no validator found for <class 'starlette.requests.Request'>, see `arbitrary_types_allowed` in Config

    at new_error (https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.js:9:12519)
    at https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.wasm:wasm-function[295]:0x158827
    at https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.wasm:wasm-function[452]:0x15fcd5
    at _PyCFunctionWithKeywords_TrampolineCall (https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.js:9:123040)
    at https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.wasm:wasm-function[1057]:0x1a3091
    at https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.wasm:wasm-function[3387]:0x289e4d
    at https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.wasm:wasm-function[2037]:0x1e3f77
    at https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.wasm:wasm-function[1064]:0x1a3579
    at https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.wasm:wasm-function[1067]:0x1a383a
    at https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.wasm:wasm-function[1068]:0x1a38dc
    at https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.wasm:wasm-function[3200]:0x2685c5
    at https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.wasm:wasm-function[3201]:0x26e3d0
    at https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.wasm:wasm-function[1070]:0x1a3a04
    at https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.wasm:wasm-function[1065]:0x1a3694
    at https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.wasm:wasm-function[440]:0x15f45e
    at Module.callPyObjectKwargs (https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.js:9:81732)
    at Module.callPyObject (https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.js:9:82066)
    at wrapper (https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.asm.js:9:58562)
```