### PR TITLE
Remove the `@gradio/wasm` dependency from `@gradio/gallery` that is not used

### DIFF
--- a/.changeset/social-loops-send.md
+++ b/.changeset/social-loops-send.md
@@ -1,0 +1,6 @@
+---
+"@gradio/gallery": patch
+"gradio": patch
+---
+
+feat:Remove the `@gradio/wasm` dependency from `@gradio/gallery` that is not used

--- a/js/gallery/package.json
+++ b/js/gallery/package.json
@@ -14,7 +14,6 @@
 		"@gradio/statustracker": "workspace:^",
 		"@gradio/upload": "workspace:^",
 		"@gradio/utils": "workspace:^",
-		"@gradio/wasm": "workspace:^",
 		"@gradio/file": "workspace:^",
 		"dequal": "^2.0.2"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -953,9 +953,6 @@ importers:
       '@gradio/utils':
         specifier: workspace:^
         version: link:../utils
-      '@gradio/wasm':
-        specifier: workspace:^
-        version: link:../wasm
       dequal:
         specifier: ^2.0.2
         version: 2.0.2


### PR DESCRIPTION
## Description

Clean-up.

I added the `@gradio/wasm` dependency to the `@gradio/gallery` package during the work on #6967, but finally the Wasm feature of the package relies on the image module and this dependency is no longer needed.