### PR TITLE
Make set_documentation_group a no-op

### DIFF
--- a/.changeset/rare-months-guess.md
+++ b/.changeset/rare-months-guess.md
@@ -1,0 +1,6 @@
+---
+"gradio": minor
+"gradio_client": minor
+---
+
+feat:Make set_documentation_group a no-op

--- a/.changeset/rare-months-guess.md
+++ b/.changeset/rare-months-guess.md
@@ -1,6 +1,6 @@
 ---
-"gradio": minor
-"gradio_client": minor
+"gradio": patch
+"gradio_client": patch
 ---
 
 feat:Make set_documentation_group a no-op

--- a/client/python/gradio_client/documentation.py
+++ b/client/python/gradio_client/documentation.py
@@ -12,6 +12,11 @@ classes_to_document = defaultdict(list)
 classes_inherit_documentation = {}
 
 
+def set_documentation_group(m):  # noqa: ARG001
+    """A no-op for backwards compatibility of custom components published prior to 4.16.0"""
+    pass
+
+
 def extract_instance_attr_doc(cls, attr):
     code = inspect.getsource(cls.__init__)
     lines = [line.strip() for line in code.split("\n")]

--- a/client/python/gradio_client/documentation.py
+++ b/client/python/gradio_client/documentation.py
@@ -56,7 +56,7 @@ _module_prefixes = [
     ("gradio.layout", "layout"),
     ("gradio.route", "routes"),
     ("gradio.theme", "themes"),
-    ("gradio_client", "py-client"),
+    ("gradio_client.", "py-client"),
 ]
 
 
@@ -91,7 +91,13 @@ def document(*fns, inherit=False, documentation_group=None):
         if _documentation_group is None:
             try:
                 modname = inspect.getmodule(cls).__name__  # type: ignore
-                documentation_group = _get_module_documentation_group(modname)
+                if modname.startswith("gradio.") or modname.startswith(
+                    "gradio_client."
+                ):
+                    documentation_group = _get_module_documentation_group(modname)
+                else:
+                    # Then this is likely a custom Gradio component that we do not include in the documentation
+                    pass
             except Exception as exc:
                 warnings.warn(f"Could not get documentation group for {cls}: {exc}")
         classes_to_document[documentation_group].append((cls, functions))

--- a/gradio/cli/commands/components/_create_utils.py
+++ b/gradio/cli/commands/components/_create_utils.py
@@ -289,7 +289,7 @@ def _replace_old_class_name(old_class_name: str, new_class_name: str, content: s
 
 def _strip_document_lines(content: str):
     return "\n".join(
-        [line for line in content.split("\n") if not line.startswith("@document()")]
+        [line for line in content.split("\n") if not line.startswith("@document(")]
     )
 
 

--- a/gradio/cli/commands/components/_create_utils.py
+++ b/gradio/cli/commands/components/_create_utils.py
@@ -287,6 +287,12 @@ def _replace_old_class_name(old_class_name: str, new_class_name: str, content: s
     return re.sub(pattern, new_class_name, content)
 
 
+def _strip_document_lines(content: str):
+    return "\n".join(
+        [line for line in content.split("\n") if not line.startswith("@document()")]
+    )
+
+
 def _create_backend(
     name: str, component: ComponentFiles, directory: Path, package_name: str
 ):
@@ -388,11 +394,11 @@ __all__ = ['{name}']
         shutil.copy(str(source_pyi_file), str(pyi_file))
 
     content = python_file.read_text()
-    python_file.write_text(
-        _replace_old_class_name(correct_cased_template, name, content)
-    )
+    content = _replace_old_class_name(correct_cased_template, name, content)
+    content = _strip_document_lines(content)
+    python_file.write_text(content)
     if pyi_file.exists():
         pyi_content = pyi_file.read_text()
-        pyi_file.write_text(
-            _replace_old_class_name(correct_cased_template, name, pyi_content)
-        )
+        pyi_content = _replace_old_class_name(correct_cased_template, name, content)
+        pyi_content = _strip_document_lines(pyi_content)
+        pyi_file.write_text(pyi_content)

--- a/test/test_gradio_component_cli.py
+++ b/test/test_gradio_component_cli.py
@@ -58,6 +58,10 @@ if __name__ == "__main__":
     )
     assert app.strip() == answer.strip()
     assert (tmp_path / "backend" / "gradio_mycomponent" / "mycomponent.py").exists()
+    source_code = (
+        tmp_path / "backend" / "gradio_mycomponent" / "mycomponent.py"
+    ).read_text()
+    assert "@document()" not in source_code
 
 
 def test_raise_error_component_template_does_not_exist(tmp_path):


### PR DESCRIPTION
## Description

Also strips the `\@document()` call from custom component templates so authors don't get a warning about the documentation group not being found.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
