### PR TITLE
Fix File Explorer interactivity

### DIFF
--- a/.changeset/solid-coats-sort.md
+++ b/.changeset/solid-coats-sort.md
@@ -1,5 +1,4 @@
 ---
-"@gradio/fileexplorer": patch
 "gradio": patch
 ---
 

--- a/gradio/components/file_explorer.py
+++ b/gradio/components/file_explorer.py
@@ -66,7 +66,7 @@ class FileExplorer(Component):
             scale: relative size compared to adjacent Components. For example if Components A and B are in a Row, and A has scale=2, and B has scale=1, A will be twice as wide as B. Should be an integer. scale applies in Rows, and to top-level Components in Blocks where fill_height=True.
             min_width: minimum pixel width, will wrap if not sufficient screen space to satisfy this value. If a certain scale value results in this Component being narrower than min_width, the min_width parameter will be respected first.
             height: The maximum height of the file component, specified in pixels if a number is passed, or in CSS units if a string is passed. If more files are uploaded than can fit in the height, a scrollbar will appear.
-            interactive: if True, will allow users to upload a file; if False, can only be used to display files. If not provided, this is inferred based on whether the component is used as an input or output.
+            interactive: if True, will allow users to select a file; if False, will only display files. If not provided, this is inferred based on whether the component is used as an input or output.
             visible: If False, component will be hidden.
             elem_id: An optional string that is assigned as the id of this component in the HTML DOM. Can be used for targeting CSS styles.
             elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.

--- a/js/fileexplorer/shared/FileTree.svelte
+++ b/js/fileexplorer/shared/FileTree.svelte
@@ -67,24 +67,25 @@
 	{#each content as { type, name, valid }, i}
 		<li>
 			<span class="wrap">
-				<Checkbox
-					disabled={!interactive ||
-						(type === "folder" && file_count === "single")}
-					value={(type === "file" ? selected_files : selected_folders).some(
-						(x) => x[0] === name && x.length === 1
-					)}
-					on:change={(e) => {
-						let checked = e.detail;
-						dispatch("check", {
-							path: [...path, name],
-							checked,
-							type
-						});
-						if (type === "folder" && checked) {
-							open_folder(i);
-						}
-					}}
-				/>
+				{#if interactive}
+					<Checkbox
+						disabled={type === "folder" && file_count === "single"}
+						value={(type === "file" ? selected_files : selected_folders).some(
+							(x) => x[0] === name && x.length === 1
+						)}
+						on:change={(e) => {
+							let checked = e.detail;
+							dispatch("check", {
+								path: [...path, name],
+								checked,
+								type
+							});
+							if (type === "folder" && checked) {
+								open_folder(i);
+							}
+						}}
+					/>
+				{/if}
 
 				{#if type === "folder"}
 					<span

--- a/js/fileexplorer/shared/FileTree.svelte
+++ b/js/fileexplorer/shared/FileTree.svelte
@@ -67,25 +67,24 @@
 	{#each content as { type, name, valid }, i}
 		<li>
 			<span class="wrap">
-				{#if interactive}
-					<Checkbox
-						disabled={type === "folder" && file_count === "single"}
-						value={(type === "file" ? selected_files : selected_folders).some(
-							(x) => x[0] === name && x.length === 1
-						)}
-						on:change={(e) => {
-							let checked = e.detail;
-							dispatch("check", {
-								path: [...path, name],
-								checked,
-								type
-							});
-							if (type === "folder" && checked) {
-								open_folder(i);
-							}
-						}}
-					/>
-				{/if}
+				<Checkbox
+					disabled={!interactive ||
+						(type === "folder" && file_count === "single")}
+					value={(type === "file" ? selected_files : selected_folders).some(
+						(x) => x[0] === name && x.length === 1
+					)}
+					on:change={(e) => {
+						let checked = e.detail;
+						dispatch("check", {
+							path: [...path, name],
+							checked,
+							type
+						});
+						if (type === "folder" && checked) {
+							open_folder(i);
+						}
+					}}
+				/>
 
 				{#if type === "folder"}
 					<span


### PR DESCRIPTION
Fixes #6627 

When FileExplorer is not interactive, checkboxes are hidden