### PR TITLE
Fixes #4016 by using websockets with callback so user can manage freeing up of state objects

### DIFF
--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -283,6 +283,30 @@ export function api_factory(
 				await process_endpoint(app_reference, hf_token);
 
 			const session_hash = Math.random().toString(36).substring(2);
+
+			// WebSocket setup using the session_hash to check for alive state of client
+			const wsUrl = `${ws_protocol}://${host}/ws?session_hash=${session_hash}`;
+			const ws = new WebSocket(wsUrl);
+
+			ws.onopen = () => {
+						console.log("WebSocket connected with session_hash:", session_hash);
+						// Optionally send a message or perform an action upon connection
+			};
+
+			ws.onmessage = (event) => {
+						console.log("Received message:", event.data);
+						// Handle incoming WebSocket messages
+			};
+
+			ws.onerror = (error) => {
+						console.error("WebSocket error:", error);
+			};
+
+			ws.onclose = () => {
+						console.log("WebSocket connection closed");
+						// Optionally perform cleanup or reconnection logic
+			};
+
 			const last_status: Record<string, Status["stage"]> = {};
 			let stream_open = false;
 			let pending_stream_messages: Record<string, any[]> = {}; // Event messages may be received by the SSE stream before the initial data POST request is complete. To resolve this race condition, we store the messages in a dictionary and process them when the POST request is complete.

--- a/gradio/components/state.py
+++ b/gradio/components/state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Any
+from typing import Any, Callable
 
 from gradio_client.documentation import document
 
@@ -27,6 +27,7 @@ class State(Component):
         self,
         value: Any = None,
         render: bool = True,
+        callback: Callable = None,
     ):
         """
         Parameters:
@@ -40,6 +41,7 @@ class State(Component):
             raise TypeError(
                 f"The initial value of `gr.State` must be able to be deepcopied. The initial value of type {type(value)} cannot be deepcopied."
             ) from err
+        self.callback = callback
         super().__init__(value=self.value, render=render)
 
     def preprocess(self, payload: Any) -> Any:


### PR DESCRIPTION
## Description

Fixes #4016 by using websockets with callback so user can manage freeing up of state objects.

Closes: #4016 

## 🎯 PRs Should Target Issues

## Tests

I'd prefer to not add specific tests or other things until there is high likelihood of being merged if tests were added.

Example use cases we could test:
* Chroma database in state, callback removes the database and garbage collects to release the state
* Torch model state is in state on CUDA device, callback moves to cpu(), clears torch cache, then garbage collects to release GPU memory
