### PR TITLE
build(deps): 📦 remove ruff as dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ typing_extensions~=4.0
 uvicorn>=0.14.0
 typer[all]>=0.9,<1.0
 tomlkit==0.12.0
-ruff >= 0.1.7
+# ruff >= 0.1.7


### PR DESCRIPTION

## Description

Gradio technically for production not require to install ruff as dependencies. It is for linter,formatter etc. It should be install for development purpose but not as main dependency. It may need extra change for certain workflow but I want to start PR for discuss as well. 

Thank you.
