### PR TITLE
Prevent timing attacks to guess Gradio passwords

### DIFF
--- a/.changeset/fine-pets-switch.md
+++ b/.changeset/fine-pets-switch.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Prevent timing attacks to guess Gradio passwords

--- a/.changeset/fine-pets-switch.md
+++ b/.changeset/fine-pets-switch.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Prevent timing attacks to guess Gradio passwords

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import shutil
 from collections import deque
@@ -574,3 +575,7 @@ def update_root_in_config(config: dict, root: str) -> dict:
         config["root"] = root
         config = processing_utils.add_root_url(config, root, previous_root)
     return config
+
+
+def compare_passwords_securely(input_password: str, correct_password: str) -> bool:
+    return hmac.compare_digest(input_password, correct_password)

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -570,7 +570,7 @@ def update_root_in_config(config: dict, root: str) -> dict:
     root url has changed, all of the urls in the config that correspond to component
     file urls are updated to use the new root url.
     """
-    previous_root = config.get("root", None)
+    previous_root = config.get("root")
     if previous_root is None or previous_root != root:
         config["root"] = root
         config = processing_utils.add_root_url(config, root, previous_root)
@@ -578,4 +578,4 @@ def update_root_in_config(config: dict, root: str) -> dict:
 
 
 def compare_passwords_securely(input_password: str, correct_password: str) -> bool:
-    return hmac.compare_digest(input_password, correct_password)
+    return hmac.compare_digest(input_password.encode(), correct_password.encode())

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -63,6 +63,7 @@ from gradio.route_utils import (  # noqa: F401
     GradioUploadFile,
     MultiPartException,
     Request,
+    compare_passwords_securely,
     move_uploaded_files_to_cache,
 )
 from gradio.state_holder import StateHolder
@@ -271,7 +272,7 @@ class App(FastAPI):
             if (
                 not callable(app.auth)
                 and username in app.auth
-                and app.auth[username] == password
+                and compare_passwords_securely(password, app.auth[username])  # type: ignore
             ) or (callable(app.auth) and app.auth.__call__(username, password)):
                 token = secrets.token_urlsafe(16)
                 app.tokens[token] = username

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -25,7 +25,11 @@ from gradio import (
     routes,
     wasm_utils,
 )
-from gradio.route_utils import FnIndexInferError, get_root_url
+from gradio.route_utils import (
+    FnIndexInferError,
+    compare_passwords_securely,
+    get_root_url,
+)
 
 
 @pytest.fixture()
@@ -921,3 +925,11 @@ def test_component_server_endpoints(connect):
 def test_get_root_url(request_url, route_path, root_path, expected_root_url):
     request = Request({"path": request_url, "type": "http", "headers": {}})
     assert get_root_url(request, route_path, root_path) == expected_root_url
+
+
+def test_compare_passwords_securely():
+    password1 = "password"
+    password2 = "pässword"
+    assert compare_passwords_securely(password1, password1)
+    assert not compare_passwords_securely(password1, password2)
+    assert compare_passwords_securely(password2, password2)


### PR DESCRIPTION
This way we compare passwords is vulnerable to timing attack to guess the password. This PR uses `hmac` to prevent that, as described here: https://sqreen.github.io/DevelopersSecurityBestPractices/timing-attack/python