### PR TITLE
Replace `pip` with `uv` in our CI

### DIFF
--- a/.github/actions/install-all-deps/action.yml
+++ b/.github/actions/install-all-deps/action.yml
@@ -73,8 +73,8 @@ runs:
       shell: bash
       run: |
         . ${{ env.VENV_ACTIVATE }}
-        python -m uv pip install -e client/python  
-        python -m uv pip install -e ".[oauth]"
+        uv pip install -e client/python  
+        uv pip install -e ".[oauth]"
     - name: Install ffmpeg
       uses: FedericoCarboni/setup-ffmpeg@v2
     - name: Install test dependencies
@@ -82,8 +82,8 @@ runs:
       shell: bash
       run: |
         . ${{ env.VENV_ACTIVATE }}
-        python -m uv pip install -r test/requirements.txt
-        python -m uv pip install -r client/python/test/requirements.txt
+        uv pip install -r test/requirements.txt
+        uv pip install -r client/python/test/requirements.txt
     - name: install-frontend
       uses: "gradio-app/gradio/.github/actions/install-frontend-deps@main"
       with:

--- a/.github/actions/install-all-deps/action.yml
+++ b/.github/actions/install-all-deps/action.yml
@@ -58,8 +58,8 @@ runs:
     - name: Create env
       shell: bash
       run: |
-        python -m pip install --upgrade virtualenv
-        python -m virtualenv venv
+        python -m pip install --upgrade uv
+        uv venv venv
     - uses: actions/cache@v4
       id: cache
       with:
@@ -73,8 +73,8 @@ runs:
       shell: bash
       run: |
         . ${{ env.VENV_ACTIVATE }}
-        python -m pip install -e client/python  
-        python -m pip install -e ".[oauth]"
+        python -m uv pip install -e client/python  
+        python -m uv pip install -e ".[oauth]"
     - name: Install ffmpeg
       uses: FedericoCarboni/setup-ffmpeg@v2
     - name: Install test dependencies
@@ -82,8 +82,8 @@ runs:
       shell: bash
       run: |
         . ${{ env.VENV_ACTIVATE }}
-        python -m pip install -r test/requirements.txt
-        python -m pip install -r client/python/test/requirements.txt
+        python -m uv pip install -r test/requirements.txt
+        python -m uv pip install -r client/python/test/requirements.txt
     - name: install-frontend
       uses: "gradio-app/gradio/.github/actions/install-frontend-deps@main"
       with:


### PR DESCRIPTION
I tested `uv` on a fork of `gradio` and found that when a PR requires refreshing the cache, it shaves ~30 seconds off of the python action in our CI.

Here are the approximate runtimes:

| Package manager | No caching |  Caching | 
| ------------- | ------------- | --- |
| `pip`  | [7 min 31 seconds](https://github.com/gradio-app/gradio/pull/7443)  | [6 min 10 seconds](https://github.com/gradio-app/gradio/pull/7407) |
| `uv`  | [6 min 56 seconds](https://github.com/abidlabs/gradio/pull/17)  | [6 min 6 seconds](https://github.com/abidlabs/gradio/pull/18) |

Closes: https://github.com/gradio-app/gradio/issues/7442