### PR TITLE
Fix z-index layer of orange generating border

### DIFF
--- a/.changeset/nine-drinks-clap.md
+++ b/.changeset/nine-drinks-clap.md
@@ -1,0 +1,6 @@
+---
+"@gradio/statustracker": patch
+"gradio": patch
+---
+
+fix:Fix z-index layer of orange generating border

--- a/js/statustracker/static/index.svelte
+++ b/js/statustracker/static/index.svelte
@@ -314,6 +314,7 @@
 		animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 		border: 2px solid var(--color-accent);
 		background: transparent;
+		z-index: var(--layer-1);
 	}
 
 	.translucent {


### PR DESCRIPTION
## Description

This fixes #7368 and works fine from what I tested, I just don't know exactly all the implications of changing this `z-index` 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
