### PR TITLE
Fixed typo in example: client -> app

### DIFF
--- a/guides/08_gradio-clients-and-lite/02_getting-started-with-the-js-client.md
+++ b/guides/08_gradio-clients-and-lite/02_getting-started-with-the-js-client.md
@@ -178,7 +178,7 @@ const response = await fetch(
 const audio_file = await response.blob();
 
 const app = await client("abidlabs/whisper");
-const result = await client.predict("/predict", [audio_file]);
+const result = await app.predict("/predict", [audio_file]);
 ```
 
 ## Using events


### PR DESCRIPTION
I was trying to run this example, but it failed.  predict() is a method of the app object, not client.  Fixed!
