### PR TITLE
ensure Dataframe headers are aligned with content when scrolling

### DIFF
--- a/.changeset/spicy-zebras-lay.md
+++ b/.changeset/spicy-zebras-lay.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": patch
+"gradio": patch
+---
+
+fix:ensure Dataframe headers are aligned with content when scrolling

--- a/js/dataframe/shared/VirtualTable.svelte
+++ b/js/dataframe/shared/VirtualTable.svelte
@@ -328,5 +328,6 @@
 		left: 0;
 		z-index: var(--layer-1);
 		box-shadow: var(--shadow-drop);
+		overflow: hidden;
 	}
 </style>


### PR DESCRIPTION
## Description

Closes #5458

I'm not really sure why this was happening, i think it something to do with reasons.

What I do know is that it isn't reproducible with headers and content of consistent length, it is only when I used more organic data that the bug surfaced.

With the below reproduction this is reproducible in all browsers (that I have access to).

Simple reproduction: https://huggingface.co/spaces/pngwn/df_scroll_bug_repo

Same demo with fix: https://huggingface.co/spaces/pngwn/df_scroll_bug_fix

@clefourrier @tomaarsen @ThiloteE @19kmunz @severo if you have the time could you check my simple reproduction reproduces the issue you have seen in whatever browsers you are using and also check the fix does indeed fix the issue.

Thanks!



