### PR TITLE
Streaming example for the updated OpenAI API

### DIFF
--- a/guides/04_chatbots/01_creating-a-chatbot-fast.md
+++ b/guides/04_chatbots/01_creating-a-chatbot-fast.md
@@ -198,10 +198,11 @@ gr.ChatInterface(predict).launch()
 Of course, we could also use the `openai` library directy. Here a similar example, but this time with streaming results as well:
 
 ```python
-import openai
+from openai import OpenAI
 import gradio as gr
 
-openai.api_key = "sk-..."  # Replace with your key
+api_key = "sk-..."  # Replace with your key
+client = OpenAI(api_key)
 
 def predict(message, history):
     history_openai_format = []
@@ -209,19 +210,17 @@ def predict(message, history):
         history_openai_format.append({"role": "user", "content": human })
         history_openai_format.append({"role": "assistant", "content":assistant})
     history_openai_format.append({"role": "user", "content": message})
-
-    response = openai.ChatCompletion.create(
-        model='gpt-3.5-turbo',
-        messages= history_openai_format,
-        temperature=1.0,
-        stream=True
-    )
+  
+    response = client.chat.completions.create(model='gpt-3.5-turbo',
+    messages= history_openai_format,
+    temperature=1.0,
+    stream=True)
 
     partial_message = ""
     for chunk in response:
-        if len(chunk['choices'][0]['delta']) != 0:
-            partial_message = partial_message + chunk['choices'][0]['delta']['content']
-            yield partial_message
+        if chunk.choices[0].delta.content is not None:
+              partial_message = partial_message + chunk.choices[0].delta.content
+              yield partial_message
 
 gr.ChatInterface(predict).launch()
 ```

--- a/guides/04_chatbots/01_creating-a-chatbot-fast.md
+++ b/guides/04_chatbots/01_creating-a-chatbot-fast.md
@@ -202,7 +202,7 @@ from openai import OpenAI
 import gradio as gr
 
 api_key = "sk-..."  # Replace with your key
-client = OpenAI(api_key)
+client = OpenAI(api_key=api_key)
 
 def predict(message, history):
     history_openai_format = []


### PR DESCRIPTION
## Description
This PR updates the usage of the OpenAI API in accordance with the changes in version 1.0.0. The deprecated `openai.ChatCompletion` has been replaced with `client.ChatCompletion.create()`.

Additionally, the way we extract the content from the API response has been updated. Previously, we checked if the length of `chunk['choices'][0]['delta']` was not zero. Now, we check if `chunk.choices[0].delta.content` is not `None` before appending it to `partial_message`.

Closes: #7242 

  
