### PR TITLE
Fix incorrect relative mouse coordinates for `Gallery` preview overlay

### DIFF
--- a/js/gallery/shared/Gallery.svelte
+++ b/js/gallery/shared/Gallery.svelte
@@ -82,7 +82,7 @@
 
 	function handle_preview_click(event: MouseEvent): void {
 		const element = event.target as HTMLElement;
-		const x = event.clientX;
+		const x = event.offsetX;
 		const width = element.offsetWidth;
 		const centerX = width / 2;
 


### PR DESCRIPTION
Fix incorrect relative mouse coordinates for `Gallery` preview overlay.

This fixes navigation issues in `Gallery`. The issue doesn't occur in Spaces because `clientX` and `offsetX` aren't so different, but it does in documentation websites.

https://github.com/gradio-app/gradio/assets/28616020/ff9f8c49-8a9e-4941-bfaf-ed2e00f7fdd5

---

| Before | After |
| ------ | ----- |
| ![Before](https://github.com/gradio-app/gradio/assets/28616020/05368add-ae79-428d-b203-baf11125a0e1) | ![After](https://github.com/gradio-app/gradio/assets/28616020/9650ecd4-6f60-418d-8e84-a36f50a65979) |

### Testing
```python3
import gradio as gr 

with gr.Blocks() as demo:
    cheetahs = [
        "https://upload.wikimedia.org/wikipedia/commons/0/09/TheCheethcat.jpg",
        "https://nationalzoo.si.edu/sites/default/files/animals/cheetah-003.jpg",
        "https://img.etimg.com/thumb/msid-50159822,width-650,imgsize-129520,,resizemode-4,quality-100/.jpg",
        "https://nationalzoo.si.edu/sites/default/files/animals/cheetah-002.jpg",
        "https://images.theconversation.com/files/375893/original/file-20201218-13-a8h8uq.jpg?ixlib=rb-1.1.0&rect=16%2C407%2C5515%2C2924&q=45&auto=format&w=496&fit=clip",
    ]
    with gr.Row():
        gr.Group()  # for padding
        gr.Gallery(value=cheetahs, columns=4)

demo.launch()
```