### PR TITLE
Upload files from iPhone fix

### DIFF
--- a/.changeset/eager-pugs-retire.md
+++ b/.changeset/eager-pugs-retire.md
@@ -1,0 +1,6 @@
+---
+"@gradio/upload": patch
+"gradio": patch
+---
+
+fix:Upload files from iPhone fix

--- a/js/upload/src/Upload.svelte
+++ b/js/upload/src/Upload.svelte
@@ -133,8 +133,12 @@
 	async function loadFilesFromDrop(e: DragEvent): Promise<void> {
 		dragging = false;
 		if (!e.dataTransfer?.files) return;
+		const isIphone = /iPhone|iPod/.test(navigator.userAgent);
 		const files_to_load = Array.from(e.dataTransfer.files).filter((file) => {
 			const file_extension = "." + file.name.split(".").pop();
+			if (isIphone) {
+				return true;
+			}
 			if (
 				file_extension &&
 				is_valid_mimetype(filetype, file_extension, file.type)


### PR DESCRIPTION
## Description

Skips `mime_type` check when uploading files from iPhone, since mime types are not always guaranteed with iPhone upload. 

Closes: #7471

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
