### PR TITLE
Performance improvements for fast yields

### DIFF
--- a/.changeset/eighty-peas-teach.md
+++ b/.changeset/eighty-peas-teach.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Performance improvements for fast yields


### PR DESCRIPTION
This PR improves performance in cases where generative functions are yielding so fast that a function is yielding faster than gradio can send these updates to the frontend. This can also occur even if the yielding is not absurdly fast but gradio is handling so many connections that yielding is happening faster than gradio can send updates to the frontend.

The solution is basically that if multiple yields accumalate in the backend that gradio needs to send to the frontend, gradio groups them all and sends them together as one message, rather than sending a message for each yield.