### PR TITLE
Fixed redirects and reformatted code in creating-a-fast-chatbot guide

### DIFF
--- a/guides/04_chatbots/01_creating-a-chatbot-fast.md
+++ b/guides/04_chatbots/01_creating-a-chatbot-fast.md
@@ -248,11 +248,10 @@ class StopOnTokens(StoppingCriteria):
         return False
 
 def predict(message, history):
-
     history_transformer_format = history + [[message, ""]]
     stop = StopOnTokens()
 
-    messages = "".join(["".join(["\n<human>:"+item[0], "\n<bot>:"+item[1]])  #curr_system_message +
+    messages = "".join(["".join(["\n<human>:"+item[0], "\n<bot>:"+item[1]])
                 for item in history_transformer_format])
 
     model_inputs = tokenizer([messages], return_tensors="pt").to("cuda")
@@ -271,12 +270,11 @@ def predict(message, history):
     t = Thread(target=model.generate, kwargs=generate_kwargs)
     t.start()
 
-    partial_message  = ""
+    partial_message = ""
     for new_token in streamer:
         if new_token != '<':
             partial_message += new_token
             yield partial_message
-
 
 gr.ChatInterface(predict).launch()
 ```

--- a/guides/04_chatbots/01_creating-a-chatbot-fast.md
+++ b/guides/04_chatbots/01_creating-a-chatbot-fast.md
@@ -87,7 +87,7 @@ def slow_echo(message, history):
 gr.ChatInterface(slow_echo).launch()
 ```
 
-Notice that we've [enabled queuing](/guides/01_getting-started/02_key-features#queuing), which is required to use generator functions. While the response is streaming, the "Submit" button turns into a "Stop" button that can be used to stop the generator function. You can customize the appearance and behavior of the "Stop" button using the `stop_btn` parameter.
+Notice that we've [enabled queuing](/guides/key-features#queuing), which is required to use generator functions. While the response is streaming, the "Submit" button turns into a "Stop" button that can be used to stop the generator function. You can customize the appearance and behavior of the "Stop" button using the `stop_btn` parameter.
 
 ## Customizing your chatbot
 
@@ -157,7 +157,7 @@ with gr.Blocks() as demo:
 demo.launch()
 ```
 
-If you need to create something even more custom, then its best to construct the chatbot UI using the low-level `gr.Blocks()` API. We have [a dedicated guide for that here](/guides/04_chatbots/02_creating-a-custom-chatbot-with-blocks).
+If you need to create something even more custom, then its best to construct the chatbot UI using the low-level `gr.Blocks()` API. We have [a dedicated guide for that here](/guides/creating-a-custom-chatbot-with-blocks).
 
 ## Using your chatbot via an API
 
@@ -165,7 +165,7 @@ Once you've built your Gradio chatbot and are hosting it on [Hugging Face Spaces
 
 [](https://github.com/gradio-app/gradio/assets/1778297/7b10d6db-6476-4e2e-bebd-ecda802c3b8f)
 
-To use the endpoint, you should use either the [Gradio Python Client](/guides/08_gradio-clients-and-lite/01_getting-started-with-the-python-client) or the [Gradio JS client](/guides/08_gradio-clients-and-lite/02_getting-started-with-the-js-client).
+To use the endpoint, you should use either the [Gradio Python Client](/guides/getting-started-with-the-python-client) or the [Gradio JS client](/guides/getting-started-with-the-js-client).
 
 ## A `langchain` example
 
@@ -279,4 +279,4 @@ def predict(message, history):
 gr.ChatInterface(predict).launch()
 ```
 
-With those examples, you should be all set to create your own Gradio Chatbot demos soon! For building even more custom Chatbot applications, check out [a dedicated guide](/guides/04_chatbots/creating-a-custom-chatbot-with-blocks) using the low-level `gr.Blocks()` API.
+With those examples, you should be all set to create your own Gradio Chatbot demos soon! For building even more custom Chatbot applications, check out [a dedicated guide](/guides/creating-a-custom-chatbot-with-blocks) using the low-level `gr.Blocks()` API.

--- a/guides/04_chatbots/01_creating-a-chatbot-fast.md
+++ b/guides/04_chatbots/01_creating-a-chatbot-fast.md
@@ -87,7 +87,7 @@ def slow_echo(message, history):
 gr.ChatInterface(slow_echo).launch()
 ```
 
-Notice that we've [enabled queuing](/guides/key-features#queuing), which is required to use generator functions. While the response is streaming, the "Submit" button turns into a "Stop" button that can be used to stop the generator function. You can customize the appearance and behavior of the "Stop" button using the `stop_btn` parameter.
+Notice that we've [enabled queuing](/guides/01_getting-started/02_key-features#queuing), which is required to use generator functions. While the response is streaming, the "Submit" button turns into a "Stop" button that can be used to stop the generator function. You can customize the appearance and behavior of the "Stop" button using the `stop_btn` parameter.
 
 ## Customizing your chatbot
 
@@ -157,7 +157,7 @@ with gr.Blocks() as demo:
 demo.launch()
 ```
 
-If you need to create something even more custom, then its best to construct the chatbot UI using the low-level `gr.Blocks()` API. We have [a dedicated guide for that here](/guides/creating-a-custom-chatbot-with-blocks).
+If you need to create something even more custom, then its best to construct the chatbot UI using the low-level `gr.Blocks()` API. We have [a dedicated guide for that here](/guides/04_chatbots/02_creating-a-custom-chatbot-with-blocks).
 
 ## Using your chatbot via an API
 

--- a/guides/04_chatbots/01_creating-a-chatbot-fast.md
+++ b/guides/04_chatbots/01_creating-a-chatbot-fast.md
@@ -279,4 +279,4 @@ def predict(message, history):
 gr.ChatInterface(predict).launch()
 ```
 
-With those examples, you should be all set to create your own Gradio Chatbot demos soon! For building even more custom Chatbot applications, check out [a dedicated guide](/guides/creating-a-custom-chatbot-with-blocks) using the low-level `gr.Blocks()` API.
+With those examples, you should be all set to create your own Gradio Chatbot demos soon! For building even more custom Chatbot applications, check out [a dedicated guide](/guides/04_chatbots/creating-a-custom-chatbot-with-blocks) using the low-level `gr.Blocks()` API.

--- a/guides/04_chatbots/01_creating-a-chatbot-fast.md
+++ b/guides/04_chatbots/01_creating-a-chatbot-fast.md
@@ -165,7 +165,7 @@ Once you've built your Gradio chatbot and are hosting it on [Hugging Face Spaces
 
 [](https://github.com/gradio-app/gradio/assets/1778297/7b10d6db-6476-4e2e-bebd-ecda802c3b8f)
 
-To use the endpoint, you should use either the [Gradio Python Client](/guides/getting-started-with-the-python-client) or the [Gradio JS client](/guides/getting-started-with-the-js-client).
+To use the endpoint, you should use either the [Gradio Python Client](/guides/08_gradio-clients-and-lite/01_getting-started-with-the-python-client) or the [Gradio JS client](/guides/08_gradio-clients-and-lite/02_getting-started-with-the-js-client).
 
 ## A `langchain` example
 


### PR DESCRIPTION
## Description

The changes only affect a single markdown page in `guides/`.

In the end, my PR only addresses a single code example in a single guide.

---
EDIT: After reading through the CI logs, I realised that the redirect fixes I proposed were faulty. I thus reverted these.