### PR TITLE
Fixes method to resolve the `root` URLs

### DIFF
--- a/.changeset/deep-teeth-sleep.md
+++ b/.changeset/deep-teeth-sleep.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fixes method to resolve the `root` URLs

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -299,10 +299,11 @@ def move_files_to_cache(
 
 def add_root_url(data: dict, root_url: str, previous_root_url: str | None) -> dict:
     def _add_root_url(file_dict: dict):
-        if not client_utils.is_http_url_like(file_dict["url"]):
-            if previous_root_url and file_dict["url"].startswith(previous_root_url):
-                file_dict["url"] = file_dict["url"][len(previous_root_url) :]
-            file_dict["url"] = f'{root_url}{file_dict["url"]}'
+        if previous_root_url and file_dict["url"].startswith(previous_root_url):
+            file_dict["url"] = file_dict["url"][len(previous_root_url) :]
+        elif client_utils.is_http_url_like(file_dict["url"]):
+            return file_dict
+        file_dict["url"] = f'{root_url}{file_dict["url"]}'
         return file_dict
 
     return client_utils.traverse(data, _add_root_url, client_utils.is_file_obj_with_url)

--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -361,7 +361,7 @@ def test_add_root_url():
     new_expected = {
         "file": {
             "path": "path",
-            "url": f"{root_url}/file=path",
+            "url": f"{new_root_url}/file=path",
         },
         "file2": {
             "path": "path2",

--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -369,5 +369,5 @@ def test_add_root_url():
         },
     }
     assert (
-        processing_utils.add_root_url(expected, root_url, new_root_url) == new_expected
+        processing_utils.add_root_url(expected, new_root_url, root_url) == new_expected
     )


### PR DESCRIPTION
There was a mistake in how we were updating the `root` url, so that they weren't being updated correctly after the first time, which was leading to issues like this: https://github.com/gradio-app/gradio/issues/7531

Test with:

```py
import gradio as gr

with gr.Blocks() as demo:
    gr.Audio("https://file-examples.com/storage/fe98e6ab1965df346a899de/2017/11/file_example_MP3_700KB.mp3")
    
demo.launch(share=True)
```

Fixes: https://github.com/gradio-app/gradio/issues/7531
Fixes: https://github.com/gradio-app/gradio/pull/7566
