### PR TITLE
Fix server_messages.py to use the patched BaseModel class for Wasm env

### DIFF
--- a/.changeset/silver-hairs-roll.md
+++ b/.changeset/silver-hairs-roll.md
@@ -3,4 +3,4 @@
 "gradio_client": minor
 ---
 
-feat:Support simplified event api for event only updates
+feat:Fix server_messages.py to use the patched BaseModel class for Wasm env

--- a/gradio/server_messages.py
+++ b/gradio/server_messages.py
@@ -1,7 +1,12 @@
 from typing import List, Literal, Optional, Union
 
 from gradio_client.utils import ServerMessage
-from pydantic import BaseModel
+
+# In the data_classes.py file, the BaseModel class is patched
+# so that it can be used in both Pyodide and non-Pyodide environments.
+# So we import it from the data_classes.py file
+# instead of the original Pydantic BaseModel class.
+from gradio.data_classes import BaseModel
 
 
 class BaseMessage(BaseModel):


### PR DESCRIPTION
## Description

Fix on #7407 for Wasm.

`pydantic.BaseModel` (and `RootModel`) is patched in `data_classes.py` for Wasm env (the normal one is used in the normal env), so we should use it instead of directly importing `pydantic.BaseModel`.
https://github.com/gradio-app/gradio/blob/a57e34ef87d24f40f09380b7b71a052f120a19fe/gradio/data_classes.py#L18-L75
