### PR TITLE
Refactor `example_inputs()`, separating its logic into two separate methods: `example_payload()` and `example_value()`

### DIFF
--- a/gradio/_simple_templates/simpledropdown.py
+++ b/gradio/_simple_templates/simpledropdown.py
@@ -73,7 +73,10 @@ class SimpleDropdown(FormComponent):
             "enum": [c[1] for c in self.choices],
         }
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return self.choices[0][1] if self.choices else None
+
+    def example_value(self) -> Any:
         return self.choices[0][1] if self.choices else None
 
     def preprocess(self, payload: str | int | float | None) -> str | int | float | None:

--- a/gradio/_simple_templates/simpleimage.py
+++ b/gradio/_simple_templates/simpleimage.py
@@ -97,5 +97,8 @@ class SimpleImage(Component):
             return None
         return FileData(path=str(value), orig_name=Path(value).name)
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"
+
+    def example_value(self) -> Any:
         return "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"

--- a/gradio/_simple_templates/simpletextbox.py
+++ b/gradio/_simple_templates/simpletextbox.py
@@ -87,5 +87,8 @@ class SimpleTextbox(FormComponent):
     def api_info(self) -> dict[str, Any]:
         return {"type": "string"}
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return "Hello!!"
+
+    def example_value(self) -> Any:
         return "Hello!!"

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1776,6 +1776,9 @@ Received outputs:
 
             if not block.skip_api:
                 block_config["api_info"] = block.api_info()  # type: ignore
+                # .example_inputs() has been renamed .example_payload() but
+                # we use the old name for backwards compatibility with custom components
+                # created on Gradio 4.20.0 or earlier
                 block_config["example_inputs"] = block.example_inputs()  # type: ignore
             config["components"].append(block_config)
         config["dependencies"] = self.dependencies

--- a/gradio/components/annotated_image.py
+++ b/gradio/components/annotated_image.py
@@ -103,7 +103,7 @@ class AnnotatedImage(Component):
     ) -> tuple[str, list[tuple[str, str]]] | None:
         """
         Parameters:
-            payload: Tuple of base image and list of annotations.
+            payload: Dict of base image and list of annotations.
         Returns:
             Passes its value as a `tuple` consisting of a `str` filepath to a base image and `list` of annotations. Each annotation itself is `tuple` of a mask (as a `str` filepath to image) and a `str` label.
         """
@@ -198,5 +198,8 @@ class AnnotatedImage(Component):
             annotations=sections,
         )
 
-    def example_inputs(self) -> Any:
-        return {}
+    def example_payload(self) -> Any:
+        return {"image": "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png", "annotations": []}
+
+    def example_value(self) -> Any:
+        return ("https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png", [([0, 0, 100, 100], "bus")])

--- a/gradio/components/annotated_image.py
+++ b/gradio/components/annotated_image.py
@@ -199,7 +199,13 @@ class AnnotatedImage(Component):
         )
 
     def example_payload(self) -> Any:
-        return {"image": "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png", "annotations": []}
+        return {
+            "image": "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png",
+            "annotations": [],
+        }
 
     def example_value(self) -> Any:
-        return ("https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png", [([0, 0, 100, 100], "bus")])
+        return (
+            "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png",
+            [([0, 0, 100, 100], "bus")],
+        )

--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -181,7 +181,10 @@ class Audio(
             value=value,
         )
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return "https://github.com/gradio-app/gradio/raw/main/test/test_files/audio_sample.wav"
+
+    def example_value(self) -> Any:
         return "https://github.com/gradio-app/gradio/raw/main/test/test_files/audio_sample.wav"
 
     def preprocess(

--- a/gradio/components/bar_plot.py
+++ b/gradio/components/bar_plot.py
@@ -299,5 +299,8 @@ class BarPlot(Plot):
 
         return AltairPlotData(type="altair", plot=chart.to_json(), chart="bar")
 
-    def example_inputs(self) -> dict[str, Any]:
-        return {}
+    def example_payload(self) -> Any:
+        return None
+
+    def example_value(self) -> Any:
+        return {self.x: [1, 2, 3, 4], self.y: [10, 20, 30, 40]}

--- a/gradio/components/base.py
+++ b/gradio/components/base.py
@@ -83,8 +83,23 @@ class ComponentBase(ABC, metaclass=ComponentMeta):
     @abstractmethod
     def example_inputs(self) -> Any:
         """
-        The example inputs for this component as a dictionary whose values are example inputs compatible with this component.
-        Keys of the dictionary are: raw, serialized
+        Deprecated and replaced by `example_payload()`.
+        """
+        pass
+
+    @abstractmethod
+    def example_payload(self) -> Any:
+        """
+        An example input data for this component, e.g. what is passed to this component's preprocess() method.
+        This is used to generate the docs for the View API page for Gradio apps using this component.
+        """
+        pass
+
+    @abstractmethod
+    def example_value(self) -> Any:
+        """
+        An example output data for this component, e.g. what is passed to this component's postprocess() method.
+        This is used to generate an example value if this component is used as a template for a custom component.
         """
         pass
 
@@ -266,6 +281,10 @@ class Component(ComponentBase, Block):
     def as_example(self, value):
         """Deprecated and replaced by `process_example()`."""
         return self.process_example(value)
+    
+    def example_payload(self) -> Any:
+    def example_value(self) -> Any:
+        return self.example_payload()
 
     def api_info(self) -> dict[str, Any]:
         """

--- a/gradio/components/base.py
+++ b/gradio/components/base.py
@@ -281,9 +281,8 @@ class Component(ComponentBase, Block):
     def as_example(self, value):
         """Deprecated and replaced by `process_example()`."""
         return self.process_example(value)
-    
-    def example_payload(self) -> Any:
-    def example_value(self) -> Any:
+
+    def example_inputs(self) -> Any:
         return self.example_payload()
 
     def api_info(self) -> dict[str, Any]:

--- a/gradio/components/button.py
+++ b/gradio/components/button.py
@@ -89,5 +89,8 @@ class Button(Component):
         """
         return value
 
-    def example_inputs(self) -> Any:
-        return None
+    def example_payload(self) -> Any:
+        return "Run"
+
+    def example_value(self) -> Any:
+        return "Run"

--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -226,5 +226,8 @@ class Chatbot(Component):
             )
         return ChatbotData(root=processed_messages)
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return [["Hello!", None]]
+
+    def example_value(self) -> Any:
         return [["Hello!", None]]

--- a/gradio/components/checkboxgroup.py
+++ b/gradio/components/checkboxgroup.py
@@ -85,7 +85,10 @@ class CheckboxGroup(FormComponent):
             value=value,
         )
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return [self.choices[0][1]] if self.choices else None
+
+    def example_value(self) -> Any:
         return [self.choices[0][1]] if self.choices else None
 
     def api_info(self) -> dict[str, Any]:

--- a/gradio/components/clear_button.py
+++ b/gradio/components/clear_button.py
@@ -127,5 +127,8 @@ class ClearButton(Button):
         """
         return value
 
-    def example_inputs(self) -> Any:
-        return None
+    def example_payload(self) -> Any:
+        return "Clear"
+
+    def example_value(self) -> Any:
+        return "Clear"

--- a/gradio/components/code.py
+++ b/gradio/components/code.py
@@ -162,5 +162,8 @@ class Code(Component):
     def api_info(self) -> dict[str, Any]:
         return {"type": "string"}
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return "print('Hello World')"
+
+    def example_value(self) -> Any:
         return "print('Hello World')"

--- a/gradio/components/color_picker.py
+++ b/gradio/components/color_picker.py
@@ -68,7 +68,10 @@ class ColorPicker(Component):
             value=value,
         )
 
-    def example_inputs(self) -> str:
+    def example_payload(self) -> str:
+        return "#000000"
+
+    def example_value(self) -> str:
         return "#000000"
 
     def api_info(self) -> dict[str, Any]:

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -371,5 +371,8 @@ class Dataframe(Component):
         value_df = pd.DataFrame(value_df_data.data, columns=value_df_data.headers)
         return value_df.head(n=5).to_dict(orient="split")["data"]
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return {"headers": ["a", "b"], "data": [["foo", "bar"]]}
+
+    def example_value(self) -> Any:
         return {"headers": ["a", "b"], "data": [["foo", "bar"]]}

--- a/gradio/components/dataset.py
+++ b/gradio/components/dataset.py
@@ -152,5 +152,8 @@ class Dataset(Component):
             "__type__": "update",
         }
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
         return 0
+
+    def example_value(self) -> Any:
+        return []

--- a/gradio/components/download_button.py
+++ b/gradio/components/download_button.py
@@ -99,7 +99,10 @@ class DownloadButton(Component):
             return None
         return FileData(path=str(value))
 
-    def example_inputs(self) -> str:
+    def example_payload(self) -> str:
+        return "https://github.com/gradio-app/gradio/raw/main/test/test_files/sample_file.pdf"
+
+    def example_value(self) -> str:
         return "https://github.com/gradio-app/gradio/raw/main/test/test_files/sample_file.pdf"
 
     @property

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -130,7 +130,13 @@ class Dropdown(FormComponent):
             }
         return json_type
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        if self.multiselect:
+            return [self.choices[0][1]] if self.choices else []
+        else:
+            return self.choices[0][1] if self.choices else None
+
+    def example_value(self) -> Any:
         if self.multiselect:
             return [self.choices[0][1]] if self.choices else []
         else:

--- a/gradio/components/fallback.py
+++ b/gradio/components/fallback.py
@@ -22,7 +22,10 @@ class Fallback(Component):
         """
         return value
 
-    def example_inputs(self):
+    def example_payload(self):
+        return {"foo": "bar"}
+
+    def example_value(self):
         return {"foo": "bar"}
 
     def api_info(self):

--- a/gradio/components/file.py
+++ b/gradio/components/file.py
@@ -174,7 +174,15 @@ class File(Component):
         else:
             return Path(input_data).name
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        if self.file_count == "single":
+            return "https://github.com/gradio-app/gradio/raw/main/test/test_files/sample_file.pdf"
+        else:
+            return [
+                "https://github.com/gradio-app/gradio/raw/main/test/test_files/sample_file.pdf"
+            ]
+
+    def example_value(self) -> Any:
         if self.file_count == "single":
             return "https://github.com/gradio-app/gradio/raw/main/test/test_files/sample_file.pdf"
         else:

--- a/gradio/components/file_explorer.py
+++ b/gradio/components/file_explorer.py
@@ -104,7 +104,10 @@ class FileExplorer(Component):
             value=value,
         )
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return [["Users", "gradio", "app.py"]]
+
+    def example_value(self) -> Any:
         return ["Users", "gradio", "app.py"]
 
     def preprocess(self, payload: FileExplorerData | None) -> list[str] | str | None:

--- a/gradio/components/gallery.py
+++ b/gradio/components/gallery.py
@@ -220,7 +220,12 @@ class Gallery(Component):
                 converted_image = np.array(converted_image)
             return converted_image
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return [
+            {"image": "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"},
+        ]
+
+    def example_value(self) -> Any:
         return [
             "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"
         ]

--- a/gradio/components/gallery.py
+++ b/gradio/components/gallery.py
@@ -222,7 +222,9 @@ class Gallery(Component):
 
     def example_payload(self) -> Any:
         return [
-            {"image": "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"},
+            {
+                "image": "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"
+            },
         ]
 
     def example_value(self) -> Any:

--- a/gradio/components/highlighted_text.py
+++ b/gradio/components/highlighted_text.py
@@ -91,8 +91,11 @@ class HighlightedText(Component):
             interactive=interactive,
         )
 
-    def example_inputs(self) -> Any:
-        return {"value": [{"token": "Hello", "class_or_confidence": "1"}]}
+    def example_payload(self) -> Any:
+        return [{"token": "The", "class_or_confidence": None}, {"token": "quick", "class_or_confidence": "adj"}]
+
+    def example_value(self) -> Any:
+        return [("The", None), ("quick", "adj"), ("brown", "adj"), ("fox", "noun")]
 
     def preprocess(
         self, payload: HighlightedTextData | None

--- a/gradio/components/highlighted_text.py
+++ b/gradio/components/highlighted_text.py
@@ -92,7 +92,10 @@ class HighlightedText(Component):
         )
 
     def example_payload(self) -> Any:
-        return [{"token": "The", "class_or_confidence": None}, {"token": "quick", "class_or_confidence": "adj"}]
+        return [
+            {"token": "The", "class_or_confidence": None},
+            {"token": "quick", "class_or_confidence": "adj"},
+        ]
 
     def example_value(self) -> Any:
         return [("The", None), ("quick", "adj"), ("brown", "adj"), ("fox", "noun")]

--- a/gradio/components/html.py
+++ b/gradio/components/html.py
@@ -55,7 +55,10 @@ class HTML(Component):
             value=value,
         )
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return "<p>Hello</p>"
+
+    def example_value(self) -> Any:
         return "<p>Hello</p>"
 
     def preprocess(self, payload: str | None) -> str | None:

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -209,7 +209,7 @@ class Image(StreamingInput, Component):
             )
 
     def example_payload(self) -> Any:
-         return "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"
+        return "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"
 
     def example_value(self) -> Any:
         return "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -208,5 +208,8 @@ class Image(StreamingInput, Component):
                 "Image streaming only available if sources is ['webcam']. Streaming not supported with multiple sources."
             )
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+         return "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"
+
+    def example_value(self) -> Any:
         return "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"

--- a/gradio/components/image_editor.py
+++ b/gradio/components/image_editor.py
@@ -315,7 +315,14 @@ class ImageEditor(Component):
             else None,
         )
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return {
+            "background": "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png",
+            "layers": [],
+            "composite": None,
+        }
+
+    def example_value(self) -> Any:
         return {
             "background": "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png",
             "layers": [],

--- a/gradio/components/json_component.py
+++ b/gradio/components/json_component.py
@@ -88,7 +88,10 @@ class JSON(Component):
         else:
             return value
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return {"foo": "bar"}
+
+    def example_value(self) -> Any:
         return {"foo": "bar"}
 
     def flag(

--- a/gradio/components/label.py
+++ b/gradio/components/label.py
@@ -141,7 +141,7 @@ class Label(Component):
             f"Instead, got a {type(value)}"
         )
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
         return {
             "label": "Cat",
             "confidences": [
@@ -149,3 +149,6 @@ class Label(Component):
                 {"label": "dog", "confidence": 0.1},
             ],
         }
+
+    def example_value(self) -> Any:
+        return {"cat": 0.9, "dog": 0.1}

--- a/gradio/components/line_plot.py
+++ b/gradio/components/line_plot.py
@@ -331,5 +331,8 @@ class LinePlot(Plot):
 
         return AltairPlotData(type="altair", plot=chart.to_json(), chart="line")
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
         return None
+
+    def example_value(self) -> Any:
+        return {self.x: [1, 2, 3, 4, 5], self.y: [1, 2, 3, 4, 5]}

--- a/gradio/components/markdown.py
+++ b/gradio/components/markdown.py
@@ -96,7 +96,10 @@ class Markdown(Component):
         unindented_y = inspect.cleandoc(value)
         return unindented_y
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return "# Hello!"
+
+    def example_value(self) -> Any:
         return "# Hello!"
 
     def api_info(self) -> dict[str, Any]:

--- a/gradio/components/model3d.py
+++ b/gradio/components/model3d.py
@@ -117,6 +117,8 @@ class Model3D(Component):
     def process_example(self, input_data: str | Path | None) -> str:
         return Path(input_data).name if input_data else ""
 
-    def example_inputs(self):
-        # TODO: Use permanent link
+    def example_payload(self):
+        return "https://raw.githubusercontent.com/gradio-app/gradio/main/demo/model3D/files/Fox.gltf"
+
+    def example_value(self):
         return "https://raw.githubusercontent.com/gradio-app/gradio/main/demo/model3D/files/Fox.gltf"

--- a/gradio/components/number.py
+++ b/gradio/components/number.py
@@ -134,5 +134,8 @@ class Number(FormComponent):
     def api_info(self) -> dict[str, str]:
         return {"type": "number"}
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return 3
+
+    def example_value(self) -> Any:
         return 3

--- a/gradio/components/paramviewer.py
+++ b/gradio/components/paramviewer.py
@@ -71,7 +71,16 @@ class ParamViewer(Component):
         """
         return value
 
-    def example_inputs(self):
+    def example_payload(self):
+        return {
+            "array": {
+                "type": "numpy",
+                "description": "any valid json",
+                "default": "None",
+            }
+        }
+
+    def example_value(self):
         return {
             "array": {
                 "type": "numpy",

--- a/gradio/components/plot.py
+++ b/gradio/components/plot.py
@@ -102,7 +102,10 @@ class Plot(Component):
         """
         return payload
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return None
+
+    def example_value(self) -> Any:
         return None
 
     def postprocess(self, value: Any) -> PlotData | None:

--- a/gradio/components/radio.py
+++ b/gradio/components/radio.py
@@ -86,7 +86,10 @@ class Radio(FormComponent):
             value=value,
         )
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return self.choices[0][1] if self.choices else None
+
+    def example_value(self) -> Any:
         return self.choices[0][1] if self.choices else None
 
     def preprocess(self, payload: str | int | float | None) -> str | int | float | None:

--- a/gradio/components/scatter_plot.py
+++ b/gradio/components/scatter_plot.py
@@ -356,5 +356,8 @@ class ScatterPlot(Plot):
 
         return AltairPlotData(type="altair", plot=chart.to_json(), chart="scatter")
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
         return None
+
+    def example_value(self) -> Any:
+        return {self.x: [1, 2, 3], self.y: [4, 5, 6]}

--- a/gradio/components/slider.py
+++ b/gradio/components/slider.py
@@ -96,7 +96,10 @@ class Slider(FormComponent):
             "description": f"numeric value between {self.minimum} and {self.maximum}",
         }
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return self.minimum
+
+    def example_value(self) -> Any:
         return self.minimum
 
     def get_random_value(self):

--- a/gradio/components/state.py
+++ b/gradio/components/state.py
@@ -63,7 +63,10 @@ class State(Component):
     def api_info(self) -> dict[str, Any]:
         return {"type": {}, "description": "any valid json"}
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return None
+
+    def example_value(self) -> Any:
         return None
 
     @property

--- a/gradio/components/textbox.py
+++ b/gradio/components/textbox.py
@@ -131,5 +131,8 @@ class Textbox(FormComponent):
     def api_info(self) -> dict[str, Any]:
         return {"type": "string"}
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        return "Hello!!"
+
+    def example_value(self) -> Any:
         return "Hello!!"

--- a/gradio/components/upload_button.py
+++ b/gradio/components/upload_button.py
@@ -110,7 +110,15 @@ class UploadButton(Component):
         else:
             return ListFiles.model_json_schema()
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
+        if self.file_count == "single":
+            return "https://github.com/gradio-app/gradio/raw/main/test/test_files/sample_file.pdf"
+        else:
+            return [
+                "https://github.com/gradio-app/gradio/raw/main/test/test_files/sample_file.pdf"
+            ]
+
+    def example_value(self) -> Any:
         if self.file_count == "single":
             return "https://github.com/gradio-app/gradio/raw/main/test/test_files/sample_file.pdf"
         else:

--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -351,8 +351,10 @@ class Video(Component):
 
         return FileData(path=str(subtitle))
 
-    def example_inputs(self) -> Any:
+    def example_payload(self) -> Any:
         return {
             "video": "https://github.com/gradio-app/gradio/raw/main/demo/video_component/files/world.mp4",
-            "subtitles": None,
         }
+
+    def example_value(self) -> Any:
+        return "https://github.com/gradio-app/gradio/raw/main/demo/video_component/files/world.mp4"


### PR DESCRIPTION
As discussed [internally](https://huggingface.slack.com/archives/C02SPHC1KD1/p1709683107328489), our implementation of `example_inputs()` was faulty, because we were relying on it to do two separate things:

1. Generating the docs on the view API page --> i.e. the input to .preprocess()
1. As an example value when generating the placeholder app for custom component --> i.e. the input to .postprocess()

The reason we've gotten away with this so far is that most components can accept the same format for the input and output (e.g. Textbox, Dropdown, etc.). For file-based components, we were previously doing some preprocessing in the client to convert string paths to FileData dictionaries, so this was effectively true for them as well.

But this is NOT true generally. For example, Video expects a dict for .preprocess() and a str/tuple for .postprocess(). Similarly for Label, etc. In some cases, we were implementing the logic for `example_payload()` and in other cases for `example_value()`

This PR fixes that by refactoring `example_inputs()`, separating its logic into two separate methods: `example_payload()` and `example_value()`

Repro of issue: `gradio cc create --template video video2`, uncommenting the example line and running the demo. It will crash

Still need to:

- [ ]  Add tests -- I'm thinking of automatically testing all components to ensure that `component.preprocess(component.example_payload()` and `component.postprocess(component.example_value()` are valid
- [ ] Update the custom components docs to mention these two methods

But should be otherwise ready for review