### PR TITLE
Fixes: gr.Markdown is not updated properly when it has an image tag

### DIFF
--- a/.changeset/plenty-paths-sing.md
+++ b/.changeset/plenty-paths-sing.md
@@ -1,0 +1,6 @@
+---
+"@gradio/markdown": patch
+"gradio": patch
+---
+
+fix:Fixes: gr.Markdown is not updated properly when it has an image tag

--- a/js/markdown/shared/MarkdownCode.svelte
+++ b/js/markdown/shared/MarkdownCode.svelte
@@ -61,10 +61,16 @@
 	}
 	async function render_html(value: string): Promise<void> {
 		if (latex_delimiters.length > 0 && value) {
-			render_math_in_element(el, {
-				delimiters: latex_delimiters,
-				throwOnError: false
-			});
+			const containsDelimiter = latex_delimiters.some(
+				(delimiter) =>
+					value.includes(delimiter.left) && value.includes(delimiter.right)
+			);
+			if (containsDelimiter) {
+				render_math_in_element(el, {
+					delimiters: latex_delimiters,
+					throwOnError: false
+				});
+			}
 		}
 	}
 	afterUpdate(() => render_html(message));


### PR DESCRIPTION
## Description

Trying to `render_math_in_element` was causing errors, because the kaTex seemed to be trying to access elements in the DOM that weren't loaded yet. Added a check that only runs the `render_math_in_element` when `latex_delimiters` are found in the markdown `value`.

Closes: #7569

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
