### PR TITLE
Add --python-path, --pip-path, --gradio-path CLI arguments to let custom component developers control which executable is used

### DIFF
--- a/.changeset/fast-heads-visit.md
+++ b/.changeset/fast-heads-visit.md
@@ -1,0 +1,6 @@
+---
+"@gradio/preview": patch
+"gradio": patch
+---
+
+fix:Add --python-path, --pip-path, --gradio-path CLI arguments to let custom component developers control which executable is used

--- a/gradio/cli/commands/components/build.py
+++ b/gradio/cli/commands/components/build.py
@@ -2,6 +2,7 @@ import importlib
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Optional
 
 import semantic_version
 import typer
@@ -13,6 +14,7 @@ from gradio.cli.commands.components._docs_utils import (
     get_deep,
 )
 from gradio.cli.commands.components.docs import run_command
+from gradio.cli.commands.components.install_component import _get_executable_path
 from gradio.cli.commands.display import LivePanelDisplay
 
 gradio_template_path = Path(gradio.__file__).parent / "templates" / "frontend"
@@ -32,6 +34,12 @@ def _build(
     generate_docs: Annotated[
         bool, typer.Option(help="Whether to generate the documentation as well.")
     ] = True,
+    python_path: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Path to the python executable. If None, will use the default path found by `shutil.which`."
+        ),
+    ] = None,
 ):
     name = Path(path).resolve()
     if not (name / "pyproject.toml").exists():
@@ -43,6 +51,8 @@ def _build(
         )
         pyproject_toml = parse((path / "pyproject.toml").read_text())
         package_name = get_deep(pyproject_toml, ["project", "name"])
+
+        python_path = _get_executable_path("python", None, "--python-path")
 
         if not isinstance(package_name, str):
             raise ValueError(
@@ -115,6 +125,8 @@ def _build(
                 gradio_template_path,
                 "--mode",
                 "build",
+                "--python-path",
+                python_path,
             ]
             pipe = subprocess.run(
                 node_cmds, capture_output=True, text=True, check=False
@@ -127,7 +139,7 @@ def _build(
             else:
                 live.update(":white_check_mark: Build succeeded!")
 
-        cmds = [shutil.which("python"), "-m", "build", str(name)]
+        cmds = [python_path, "-m", "build", str(name)]
         live.update(f":construction_worker: Building... [grey37]({' '.join(cmds)})[/]")
         pipe = subprocess.run(cmds, capture_output=True, text=True, check=False)
         if pipe.returncode != 0:

--- a/gradio/cli/commands/components/build.py
+++ b/gradio/cli/commands/components/build.py
@@ -52,7 +52,9 @@ def _build(
         pyproject_toml = parse((path / "pyproject.toml").read_text())
         package_name = get_deep(pyproject_toml, ["project", "name"])
 
-        python_path = _get_executable_path("python", None, "--python-path")
+        python_path = _get_executable_path(
+            "python", None, "--python-path", check_3=True
+        )
 
         if not isinstance(package_name, str):
             raise ValueError(

--- a/gradio/cli/commands/components/build.py
+++ b/gradio/cli/commands/components/build.py
@@ -37,7 +37,7 @@ def _build(
     python_path: Annotated[
         Optional[str],
         typer.Option(
-            help="Path to the python executable. If None, will use the default path found by `shutil.which`."
+            help="Path to python executable. If None, will use the default path found by `which python3`. If python3 is not found, `which python` will be tried. If both fail an error will be raised."
         ),
     ] = None,
 ):

--- a/gradio/cli/commands/components/create.py
+++ b/gradio/cli/commands/components/create.py
@@ -51,7 +51,7 @@ def _create(
     pip_path: Annotated[
         Optional[str],
         typer.Option(
-            help="Path to pip executable. If None, will use the default path found by `shutil.which`."
+            help="Path to pip executable. If None, will use the default path found by `which pip3`. If pip3 is not found, `which pip` will be tried. If both fail an error will be raised."
         ),
     ] = None,
     overwrite: Annotated[

--- a/gradio/cli/commands/components/create.py
+++ b/gradio/cli/commands/components/create.py
@@ -48,6 +48,12 @@ def _create(
         str,
         typer.Option(help="NPM install command to use. Default is 'npm install'."),
     ] = "npm install",
+    pip_path: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Path to pip executable. If None, will use the default path found by `shutil.which`."
+        ),
+    ] = None,
     overwrite: Annotated[
         bool,
         typer.Option(help="Whether to overwrite the existing component if it exists."),
@@ -101,7 +107,7 @@ def _create(
         live.update(":art: Created frontend code", add_sleep=0.2)
 
         if install:
-            _install_command(directory, live, npm_install)
+            _install_command(directory, live, npm_install, pip_path)
 
         live._panel.stop()
 

--- a/gradio/cli/commands/components/dev.py
+++ b/gradio/cli/commands/components/dev.py
@@ -1,12 +1,14 @@
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Optional
 
 import typer
 from rich import print
 from typing_extensions import Annotated
 
 import gradio
+from gradio.cli.commands.components.install_component import _get_executable_path
 
 gradio_template_path = Path(gradio.__file__).parent / "templates" / "frontend"
 gradio_node_path = Path(gradio.__file__).parent / "node" / "dev" / "files" / "index.js"
@@ -31,6 +33,18 @@ def _dev(
             help="The host to run the front end server on. Defaults to localhost.",
         ),
     ] = "localhost",
+    python_path: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Path to the python executable. If None, will use the default path found by `shutil.which`."
+        ),
+    ] = None,
+    gradio_path: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Path to gradio executable. If None, will use the default path found by `shutil.which`."
+        ),
+    ] = None,
 ):
     component_directory = component_directory.resolve()
 
@@ -39,6 +53,13 @@ def _dev(
     node = shutil.which("node")
     if not node:
         raise ValueError("node must be installed in order to run dev mode.")
+
+    python_path = _get_executable_path(
+        "python", python_path, cli_arg_name="--python-path"
+    )
+    gradio_path = _get_executable_path(
+        "gradio", gradio_path, cli_arg_name="--gradio-path"
+    )
 
     proc = subprocess.Popen(
         [
@@ -54,6 +75,10 @@ def _dev(
             "dev",
             "--host",
             host,
+            "--python-path",
+            python_path,
+            "--gradio-path",
+            gradio_path,
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/gradio/cli/commands/components/dev.py
+++ b/gradio/cli/commands/components/dev.py
@@ -55,7 +55,7 @@ def _dev(
         raise ValueError("node must be installed in order to run dev mode.")
 
     python_path = _get_executable_path(
-        "python", python_path, cli_arg_name="--python-path"
+        "python", python_path, cli_arg_name="--python-path", check_3=True
     )
     gradio_path = _get_executable_path(
         "gradio", gradio_path, cli_arg_name="--gradio-path"

--- a/gradio/cli/commands/components/dev.py
+++ b/gradio/cli/commands/components/dev.py
@@ -36,7 +36,7 @@ def _dev(
     python_path: Annotated[
         Optional[str],
         typer.Option(
-            help="Path to the python executable. If None, will use the default path found by `shutil.which`."
+            help="Path to python executable. If None, will use the default path found by `which python3`. If python3 is not found, `which python` will be tried. If both fail an error will be raised."
         ),
     ] = None,
     gradio_path: Annotated[

--- a/gradio/cli/commands/components/install_component.py
+++ b/gradio/cli/commands/components/install_component.py
@@ -24,8 +24,31 @@ def _get_npm(npm_install: str):
     return npm_install
 
 
-def _install_command(directory: Path, live: LivePanelDisplay, npm_install: str):
-    cmds = [shutil.which("pip"), "install", "-e", f"{str(directory)}[dev]"]
+def _get_executable_path(
+    executable: str, executable_path: str | None, cli_arg_name: str
+) -> str:
+    """Get the path to an executable, either from the provided path or from the PATH environment variable.
+
+    The value of executable_path takes precedence in case the value in PATH is incorrect.
+    This should give more control to the developer in case their envrinment is not set up correctly.
+    """
+    if executable_path:
+        return executable_path
+    path = shutil.which(executable)
+    if not path:
+        raise ValueError(
+            f"Could not find {executable}. Please ensure it is installed and in your PATH or pass the {cli_arg_name} parameter."
+        )
+    return path
+
+
+def _install_command(
+    directory: Path, live: LivePanelDisplay, npm_install: str, pip_path: str | None
+):
+    pip_executable_path = _get_executable_path(
+        "pip", executable_path=pip_path, cli_arg_name="--pip-path"
+    )
+    cmds = [pip_executable_path, "install", "-e", f"{str(directory)}[dev]"]
     live.update(
         f":construction_worker: Installing python... [grey37]({escape(' '.join(cmds))})[/]"
     )

--- a/gradio/cli/commands/components/install_component.py
+++ b/gradio/cli/commands/components/install_component.py
@@ -93,7 +93,7 @@ def _install(
     pip_path: Annotated[
         Optional[str],
         Option(
-            help="Path to pip executable. If None, will use the default path found by `shutil.which`."
+            help="Path to pip executable. If None, will use the default path found by `which pip3`. If pip3 is not found, `which pip` will be tried. If both fail an error will be raised."
         ),
     ] = None,
 ):

--- a/gradio/cli/commands/components/install_component.py
+++ b/gradio/cli/commands/components/install_component.py
@@ -39,6 +39,10 @@ def _get_executable_path(
     If check_3 is True, we append 3 to the executable name to give python3 priority over python (same for pip).
     """
     if executable_path:
+        if not Path(executable_path).exists() or not Path(executable_path).is_file():
+            raise ValueError(
+                f"The provided {executable} path ({executable_path}) does not exist or is not a file."
+            )
         return executable_path
     path = shutil.which(executable)
     if check_3:

--- a/gradio/cli/commands/components/install_component.py
+++ b/gradio/cli/commands/components/install_component.py
@@ -1,6 +1,7 @@
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Optional
 
 from rich.markup import escape
 from typer import Argument, Option
@@ -82,7 +83,13 @@ def _install(
     npm_install: Annotated[
         str, Option(help="NPM install command to use. Default is 'npm install'.")
     ] = "npm install",
+    pip_path: Annotated[
+        Optional[str],
+        Option(
+            help="Path to pip executable. If None, will use the default path found by `shutil.which`."
+        ),
+    ] = None,
 ):
     npm_install = _get_npm(npm_install)
     with LivePanelDisplay() as live:
-        _install_command(directory, live, npm_install)
+        _install_command(directory, live, npm_install, pip_path)

--- a/gradio/cli/commands/components/install_component.py
+++ b/gradio/cli/commands/components/install_component.py
@@ -26,16 +26,23 @@ def _get_npm(npm_install: str):
 
 
 def _get_executable_path(
-    executable: str, executable_path: str | None, cli_arg_name: str
+    executable: str,
+    executable_path: str | None,
+    cli_arg_name: str,
+    check_3: bool = False,
 ) -> str:
     """Get the path to an executable, either from the provided path or from the PATH environment variable.
 
     The value of executable_path takes precedence in case the value in PATH is incorrect.
     This should give more control to the developer in case their envrinment is not set up correctly.
+
+    If check_3 is True, we append 3 to the executable name to give python3 priority over python (same for pip).
     """
     if executable_path:
         return executable_path
     path = shutil.which(executable)
+    if check_3:
+        path = shutil.which(f"{executable}3") or path
     if not path:
         raise ValueError(
             f"Could not find {executable}. Please ensure it is installed and in your PATH or pass the {cli_arg_name} parameter."
@@ -47,7 +54,7 @@ def _install_command(
     directory: Path, live: LivePanelDisplay, npm_install: str, pip_path: str | None
 ):
     pip_executable_path = _get_executable_path(
-        "pip", executable_path=pip_path, cli_arg_name="--pip-path"
+        "pip", executable_path=pip_path, cli_arg_name="--pip-path", check_3=True
     )
     cmds = [pip_executable_path, "install", "-e", f"{str(directory)}[dev]"]
     live.update(

--- a/guides/05_custom-components/06_frequently-asked-questions.md
+++ b/guides/05_custom-components/06_frequently-asked-questions.md
@@ -15,6 +15,8 @@ This is like when you run `python <app-file>.py`, however the `gradio` command w
 ## The development server didn't work for me 
 Make sure you have your package installed along with any dependencies you have added by running `gradio cc install`.
 Make sure there aren't any syntax or import errors in the Python or JavaScript code.
+If the development server is still not working for you, please use the `--python-path` and `gradio-path` CLI arguments to specify the path of the python and gradio executables for the environment your component is installed in.
+It is likely that the wrong envrironment is being used. For example, if you are using a virtualenv located at `/Users/mary/venv`, pass in `/Users/mary/bin/python` and `/Users/mary/bin/gradio` respectively.
 
 ## Do I need to host my custom component on HuggingFace Spaces?
 You can develop and build your custom component without hosting or connecting to HuggingFace.

--- a/js/preview/src/build.ts
+++ b/js/preview/src/build.ts
@@ -8,16 +8,23 @@ import { examine_module } from "./index";
 interface BuildOptions {
 	component_dir: string;
 	root_dir: string;
+	python_path: string;
 }
 
 export async function make_build({
 	component_dir,
-	root_dir
+	root_dir,
+	python_path
 }: BuildOptions): Promise<void> {
 	process.env.gradio_mode = "dev";
 	const svelte_dir = join(root_dir, "assets", "svelte");
 
-	const module_meta = examine_module(component_dir, root_dir, "build");
+	const module_meta = examine_module(
+		component_dir,
+		root_dir,
+		python_path,
+		"build"
+	);
 	try {
 		for (const comp of module_meta) {
 			const template_dir = comp.template_dir;

--- a/js/preview/src/dev.ts
+++ b/js/preview/src/dev.ts
@@ -23,6 +23,7 @@ interface ServerOptions {
 	frontend_port: number;
 	backend_port: number;
 	host: string;
+	python_path: string;
 }
 
 export async function create_server({
@@ -30,10 +31,11 @@ export async function create_server({
 	root_dir,
 	frontend_port,
 	backend_port,
-	host
+	host,
+	python_path
 }: ServerOptions): Promise<void> {
 	process.env.gradio_mode = "dev";
-	const imports = generate_imports(component_dir, root_dir);
+	const imports = generate_imports(component_dir, root_dir, python_path);
 
 	const NODE_DIR = join(root_dir, "..", "..", "node", "dev");
 	const svelte_dir = join(root_dir, "assets", "svelte");
@@ -109,12 +111,21 @@ function to_posix(_path: string): string {
 	return _path.replace(/\\/g, "/");
 }
 
-function generate_imports(component_dir: string, root: string): string {
+function generate_imports(
+	component_dir: string,
+	root: string,
+	python_path: string
+): string {
 	const components = find_frontend_folders(component_dir);
 
 	const component_entries = components.flatMap((component) => {
-		return examine_module(component, root, "dev");
+		return examine_module(component, root, python_path, "dev");
 	});
+	if (component_entries.length === 0) {
+		console.log(
+			`No custom components were found in ${component_dir}. It is likely that dev mode does not work properly. Please pass the --gradio-path and --python-path CLI arguments so that gradio uses the right executables.`
+		);
+	}
 
 	const imports = component_entries.reduce((acc, component) => {
 		const pkg = JSON.parse(

--- a/js/preview/src/dev.ts
+++ b/js/preview/src/dev.ts
@@ -122,7 +122,7 @@ function generate_imports(
 		return examine_module(component, root, python_path, "dev");
 	});
 	if (component_entries.length === 0) {
-		console.log(
+		console.info(
 			`No custom components were found in ${component_dir}. It is likely that dev mode does not work properly. Please pass the --gradio-path and --python-path CLI arguments so that gradio uses the right executables.`
 		);
 	}

--- a/js/preview/src/examine.py
+++ b/js/preview/src/examine.py
@@ -3,6 +3,7 @@ import importlib
 import inspect
 import os
 from pathlib import Path
+import sys
 
 from tomlkit import dumps, parse
 
@@ -14,58 +15,62 @@ if __name__ == "__main__":
     parser.add_argument("-m", "--mode", help="Build mode or dev mode")
     args = parser.parse_args()
 
-    with open("../pyproject.toml") as f:
-        pyproject_source = f.read()
+    try:
+        with open("../pyproject.toml") as f:
+            pyproject_source = f.read()
 
-    pyproject_toml = parse(pyproject_source)
-    keywords = pyproject_toml["project"]["keywords"]
-    custom_component = ("gradio-custom-component" in  keywords or
-                           "gradio custom component" in keywords)
-    if not custom_component:
-        sys.exit(0)
+        pyproject_toml = parse(pyproject_source)
+        keywords = pyproject_toml["project"]["keywords"]
+        custom_component = ("gradio-custom-component" in  keywords or
+                            "gradio custom component" in keywords)
+        if not custom_component:
+            sys.exit(0)
 
-    module_name = pyproject_toml["project"]["name"]
-    module = importlib.import_module(module_name)
+        module_name = pyproject_toml["project"]["name"]
+        module = importlib.import_module(module_name)
 
-    artifacts: list[str] = pyproject_toml["tool"]["hatch"]["build"]["artifacts"]
+        artifacts: list[str] = pyproject_toml["tool"]["hatch"]["build"]["artifacts"]
 
-    def get_relative_path(path):
-        return (
-            os.path.abspath(Path(__file__).parent / path)
-            .replace(os.path.abspath(os.getcwd()), "")
-            .lstrip("/")
-        )
-
-    for name in dir(module):
-        value = getattr(module, name)
-        if name.startswith("__"):
-            continue
-
-        if inspect.isclass(value) and (
-            issubclass(value, BlockContext) or issubclass(value, Component)
-        ):
-            file_location = Path(inspect.getfile(value)).parent
-
-            found = [
-                x
-                for x in artifacts
-                if get_relative_path(Path("..") / x)
-                == get_relative_path(file_location / value.TEMPLATE_DIR)
-            ]
-            if len(found) == 0:
-                artifacts.append(
-                    os.path.abspath(file_location / value.TEMPLATE_DIR)
-                    .replace(os.path.abspath(Path("..")), "")
-                    .lstrip("/")
-                )
-
-            print(
-                f"{name}~|~|~|~{os.path.abspath(file_location  / value.TEMPLATE_DIR)}~|~|~|~{os.path.abspath(file_location / value.FRONTEND_DIR)}~|~|~|~{value.get_component_class_id()}"
+        def get_relative_path(path):
+            return (
+                os.path.abspath(Path(__file__).parent / path)
+                .replace(os.path.abspath(os.getcwd()), "")
+                .lstrip("/")
             )
-            continue
 
-    if args.mode == "build":
-        pyproject_toml["tool"]["hatch"]["build"]["artifacts"] = artifacts
+        for name in dir(module):
+            value = getattr(module, name)
+            if name.startswith("__"):
+                continue
 
-        with open("../pyproject.toml", "w") as f:
-            f.write(dumps(pyproject_toml))
+            if inspect.isclass(value) and (
+                issubclass(value, BlockContext) or issubclass(value, Component)
+            ):
+                file_location = Path(inspect.getfile(value)).parent
+
+                found = [
+                    x
+                    for x in artifacts
+                    if get_relative_path(Path("..") / x)
+                    == get_relative_path(file_location / value.TEMPLATE_DIR)
+                ]
+                if len(found) == 0:
+                    artifacts.append(
+                        os.path.abspath(file_location / value.TEMPLATE_DIR)
+                        .replace(os.path.abspath(Path("..")), "")
+                        .lstrip("/")
+                    )
+
+                print(
+                    f"{name}~|~|~|~{os.path.abspath(file_location  / value.TEMPLATE_DIR)}~|~|~|~{os.path.abspath(file_location / value.FRONTEND_DIR)}~|~|~|~{value.get_component_class_id()}"
+                )
+                continue
+
+        if args.mode == "build":
+            pyproject_toml["tool"]["hatch"]["build"]["artifacts"] = artifacts
+
+            with open("../pyproject.toml", "w") as f:
+                f.write(dumps(pyproject_toml))
+    except Exception as e:
+        _, _, exc_tb = sys.exc_info()
+        print(f"|EXCEPTION|:{str(e)}, examine.py line {exc_tb.tb_lineno}")

--- a/js/preview/src/index.ts
+++ b/js/preview/src/index.ts
@@ -36,7 +36,8 @@ async function run(): Promise<void> {
 	if (parsed_args.mode === "build") {
 		await make_build({
 			component_dir: parsed_args["component-directory"],
-			root_dir: parsed_args.root
+			root_dir: parsed_args.root,
+			python_path: parsed_args["python-path"]
 		});
 	} else {
 		const [backend_port, frontend_port] = await find_free_ports(7860, 8860);
@@ -51,7 +52,7 @@ async function run(): Promise<void> {
 		process.env.GRADIO_BACKEND_PORT = backend_port.toString();
 
 		const _process = spawn(
-			which.sync("gradio"),
+			parsed_args["gradio-path"],
 			[parsed_args.app, "--watch-dirs", options.component_dir],
 			{
 				shell: true,
@@ -78,7 +79,8 @@ async function run(): Promise<void> {
 						root_dir: options.root_dir,
 						frontend_port,
 						backend_port,
-						host: options.host
+						host: options.host,
+						python_path: parsed_args["python-path"]
 					});
 				}
 
@@ -148,22 +150,27 @@ function is_truthy<T>(value: T | null | undefined | false): value is T {
 export function examine_module(
 	component_dir: string,
 	root: string,
+	python_path: string,
 	mode: "build" | "dev"
 ): ComponentMeta[] {
 	const _process = spawnSync(
-		which.sync("python"),
+		python_path,
 		[join(root, "..", "..", "node", "examine.py"), "-m", mode],
 		{
 			cwd: join(component_dir, "backend"),
 			stdio: "pipe"
 		}
 	);
+	const exceptions: string[] = [];
 
-	return _process.stdout
+	const components = _process.stdout
 		.toString()
 		.trim()
 		.split("\n")
 		.map((line) => {
+			if (line.startsWith("|EXCEPTION|")) {
+				exceptions.push(line.slice("|EXCEPTION|:".length));
+			}
 			const [name, template_dir, frontend_dir, component_class_id] =
 				line.split("~|~|~|~");
 			if (name && template_dir && frontend_dir && component_class_id) {
@@ -177,4 +184,12 @@ export function examine_module(
 			return false;
 		})
 		.filter(is_truthy);
+	if (exceptions.length > 0) {
+		console.log(
+			`While searching for gradio custom component source directories in ${component_dir}, the following exceptions were raised. If dev mode does not work properly please pass the --gradio-path and --python-path CLI arguments so that gradio uses the right executables: ${exceptions.join(
+				"\n"
+			)}`
+		);
+	}
+	return components;
 }

--- a/js/preview/src/index.ts
+++ b/js/preview/src/index.ts
@@ -185,7 +185,7 @@ export function examine_module(
 		})
 		.filter(is_truthy);
 	if (exceptions.length > 0) {
-		console.log(
+		console.info(
 			`While searching for gradio custom component source directories in ${component_dir}, the following exceptions were raised. If dev mode does not work properly please pass the --gradio-path and --python-path CLI arguments so that gradio uses the right executables: ${exceptions.join(
 				"\n"
 			)}`

--- a/test/test_gradio_component_cli.py
+++ b/test/test_gradio_component_cli.py
@@ -66,8 +66,14 @@ if __name__ == "__main__":
 
 
 def test_get_executable_path():
+    assert _get_executable_path(
+        "pip", None, "--pip-path", check_3=True
+    ) == shutil.which("pip3")
     assert _get_executable_path("pip", None, "--pip-path") == shutil.which("pip")
     assert _get_executable_path("pip", "/usr/bin/pip", "--pip-path") == "/usr/bin/pip"
+    assert _get_executable_path(
+        "gradio", None, "--pip-path", check_3=True
+    ) == shutil.which("gradio")
     with pytest.raises(
         ValueError,
         match=r"Could not find foo. Please ensure it is installed and in your PATH or pass the --foo-path parameter.",

--- a/test/test_gradio_component_cli.py
+++ b/test/test_gradio_component_cli.py
@@ -70,7 +70,9 @@ def test_get_executable_path():
         "pip", None, "--pip-path", check_3=True
     ) == shutil.which("pip3")
     assert _get_executable_path("pip", None, "--pip-path") == shutil.which("pip")
-    assert _get_executable_path("pip", "/usr/bin/pip", "--pip-path") == "/usr/bin/pip"
+    assert _get_executable_path(
+        "pip", shutil.which("pip"), "--pip-path"
+    ) == shutil.which("pip")
     assert _get_executable_path(
         "gradio", None, "--pip-path", check_3=True
     ) == shutil.which("gradio")
@@ -79,6 +81,11 @@ def test_get_executable_path():
         match=r"Could not find foo. Please ensure it is installed and in your PATH or pass the --foo-path parameter.",
     ):
         _get_executable_path("foo", None, "--foo-path")
+    with pytest.raises(
+        ValueError,
+        match=r"The provided foo path \(/foo/bar/fum\) does not exist or is not a file.",
+    ):
+        _get_executable_path("foo", "/foo/bar/fum", "--foo-path")
 
 
 def test_raise_error_component_template_does_not_exist(tmp_path):

--- a/test/test_gradio_component_cli.py
+++ b/test/test_gradio_component_cli.py
@@ -7,6 +7,7 @@ import pytest
 from gradio.cli.commands.components._create_utils import OVERRIDES
 from gradio.cli.commands.components.build import _build
 from gradio.cli.commands.components.create import _create
+from gradio.cli.commands.components.install_component import _get_executable_path
 from gradio.cli.commands.components.publish import _get_version_from_file
 from gradio.cli.commands.components.show import _show
 
@@ -62,6 +63,16 @@ if __name__ == "__main__":
         tmp_path / "backend" / "gradio_mycomponent" / "mycomponent.py"
     ).read_text()
     assert "@document()" not in source_code
+
+
+def test_get_executable_path():
+    assert _get_executable_path("pip", None, "--pip-path") == shutil.which("pip")
+    assert _get_executable_path("pip", "/usr/bin/pip", "--pip-path") == "/usr/bin/pip"
+    with pytest.raises(
+        ValueError,
+        match=r"Could not find foo. Please ensure it is installed and in your PATH or pass the --foo-path parameter.",
+    ):
+        _get_executable_path("foo", None, "--foo-path")
 
 
 def test_raise_error_component_template_does_not_exist(tmp_path):


### PR DESCRIPTION
## Description

Closes: #7621 

Adds CLI arguments to let developers control the path of the python executables used in create, dev, and build commands.

Also adds some debugging information to dev mode in case no custom components are found. I suspect this will help debug issues like #6821 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
