### PR TITLE
fix formatting error in gradio/lite package.json

### DIFF
--- a/.changeset/fix_changelogs.cjs
+++ b/.changeset/fix_changelogs.cjs
@@ -68,7 +68,7 @@ function run() {
 
 			writeFileSync(
 				join(all_packages[pkg_name].dir, "package.json"),
-				JSON.stringify(all_packages[pkg_name].packageJson, null, "\t")
+				JSON.stringify(all_packages[pkg_name].packageJson, null, "\t") + "\n"
 			);
 		}
 


### PR DESCRIPTION
We need a new line at the end of the `@gradio/lite` `package.json` file to make the formatter happy.