### PR TITLE
Fix session id not found

### DIFF
--- a/.changeset/good-shirts-melt.md
+++ b/.changeset/good-shirts-melt.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Fix session id not found
+fix:Fix session id not found

--- a/.changeset/good-shirts-melt.md
+++ b/.changeset/good-shirts-melt.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix session id not found


### PR DESCRIPTION
I believe this issue is related to trying to close the connection from both the backend and the frontend, which is causing race conditions. Now we are making the frontend solely responsible for closing the connection when there are no more messages to receive. 
My initial concern had been that if the backend did not recieve the connection close message, the thread might run forever, but since we send heartbeats, the connection should break if the connection is gone while trying to send a heartbeat.

Potentially fixes: #7576