### PR TITLE
Fix OAuth + fix OAuth documentation + undocument logout button

### DIFF
--- a/.changeset/plain-guests-attend.md
+++ b/.changeset/plain-guests-attend.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix OAuth + fix OAuth documentation + undocument logout button

--- a/gradio/oauth.py
+++ b/gradio/oauth.py
@@ -196,7 +196,6 @@ class OAuthProfile(typing.Dict):  # inherit from Dict for backward compatibility
 
         with gr.Blocks() as demo:
             gr.LoginButton()
-            gr.LogoutButton()
             gr.Markdown().attach_load_event(hello, None)
     """
 
@@ -242,7 +241,6 @@ class OAuthToken:
 
         with gr.Blocks() as demo:
             gr.LoginButton()
-            gr.LogoutButton()
             gr.Markdown().attach_load_event(list_organizations, None)
     """
 

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -82,6 +82,11 @@ class Obj:
                 return True
         return False
 
+    def get(self, item, default=None):
+        if item in self:
+            return self.__dict__[item]
+        return default
+
     def keys(self):
         return self.__dict__.keys()
 

--- a/guides/01_getting-started/03_sharing-your-app.md
+++ b/guides/01_getting-started/03_sharing-your-app.md
@@ -274,7 +274,7 @@ Here is a short example:
 
 ```py
 import gradio as gr
-
+from huggingface_hub import whoami
 
 def hello(profile: gr.OAuthProfile | None) -> str:
     if profile is None:
@@ -293,6 +293,8 @@ with gr.Blocks() as demo:
     m2 = gr.Markdown()
     demo.load(hello, inputs=None, outputs=m1)
     demo.load(list_organizations, inputs=None, outputs=m2)
+
+demo.launch()
 ```
 
 When the user clicks on the login button, they get redirected in a new page to authorize your Space.

--- a/guides/01_getting-started/03_sharing-your-app.md
+++ b/guides/01_getting-started/03_sharing-your-app.md
@@ -263,7 +263,7 @@ Note: Gradio's built-in authentication provides a straightforward and basic laye
 Gradio natively supports OAuth login via Hugging Face. In other words, you can easily add a _"Sign in with Hugging Face"_ button to your demo, which allows you to get a user's HF username as well as other information from their HF profile. Check out [this Space](https://huggingface.co/spaces/Wauplin/gradio-oauth-demo) for a live demo.
 
 To enable OAuth, you must set `hf_oauth: true` as a Space metadata in your README.md file. This will register your Space
-as an OAuth application on Hugging Face. Next, you can use `gr.LoginButton` and `gr.LogoutButton` to add login and logout buttons to
+as an OAuth application on Hugging Face. Next, you can use `gr.LoginButton` to add a login button to
 your Gradio app. Once a user is logged in with their HF account, you can retrieve their profile by adding a parameter of type
 `gr.OAuthProfile` to any Gradio function. The user profile will be automatically injected as a parameter value. If you want
 to perform actions on behalf of the user (e.g. list user's private repos, create repo, etc.), you can retrieve the user
@@ -289,7 +289,6 @@ def list_organizations(oauth_token: gr.OAuthToken | None) -> str:
 
 with gr.Blocks() as demo:
     gr.LoginButton()
-    gr.LogoutButton()
     m1 = gr.Markdown()
     m2 = gr.Markdown()
     demo.load(hello, inputs=None, outputs=m1)


### PR DESCRIPTION
2 things in this PR:

1. Fix https://github.com/gradio-app/gradio/issues/7695. The snippet example in the OAuth docs is not complete, resulting in a runtime error when running it. I forgot `from huggingface_hub import whoami` and `demo.launch()`. This is now fixed and I've been able to run it both locally and in a Space. I also took the opportunity to remove mentions to `gr.LogoutButton` from the docs (deprecated in https://github.com/gradio-app/gradio/pull/7063).
2. There seem to be a major bug that broke all OAuth apps on the latest version of gradio. For some reason, now `request.session` is not a dictionary anymore but a `Obj` object that mimics it. The `Obj` class has been added 6 months ago but the bug is for sure much more recent. Can it be related to  https://github.com/gradio-app/gradio/pull/7557 cc @abidlabs? In any case,  I've added a `get` method to `Obj` which solved the issue. 

I think that once this PR is merged, we should make a follow-up release given that it affects all oauth apps running on the latest version of Gradio :confused: 

cc @pngwn who pinged me on this.