### PR TITLE
Run Linux CI on Python 3.8

### DIFF
--- a/.github/actions/install-all-deps/action.yml
+++ b/.github/actions/install-all-deps/action.yml
@@ -22,7 +22,7 @@ inputs:
     default: 'false'
   python_version:
     description: 'Python version'
-    default: '3.10'
+    default: '3.8'
   os:
     description: 'OS'
     default: 'ubuntu-latest'


### PR DESCRIPTION
Our Linux CI was running Python 3.10. This sets it to Python 3.8, which is the minimum supported version by `gradio`. Note that our Windows CI was always running on 3.8.

I've confirmed that once the cache is deleted, this change is sufficient to run the CI on 3.8 in this fork: https://github.com/abidlabs/gradio/actions/runs/8283404782/job/22666866280