### PR TITLE
Fix httpx timeout issues

### DIFF
--- a/.changeset/wise-bikes-hear.md
+++ b/.changeset/wise-bikes-hear.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix httpx timeout issues

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2118,7 +2118,9 @@ Received outputs:
             if not wasm_utils.IS_WASM:
                 # Cannot run async functions in background other than app's scope.
                 # Workaround by triggering the app endpoint
-                httpx.get(f"{self.local_url}startup-events", verify=ssl_verify)
+                httpx.get(
+                    f"{self.local_url}startup-events", verify=ssl_verify, timeout=None
+                )
             else:
                 # NOTE: One benefit of the code above dispatching `startup_events()` via a self HTTP request is
                 # that `self._queue.start()` is called in another thread which is managed by the HTTP server, `uvicorn`

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -253,6 +253,6 @@ def url_ok(url: str) -> bool:
             if r.status_code in (200, 401, 302):  # 401 or 302 if auth is set
                 return True
             time.sleep(0.500)
-    except (ConnectionError, httpx.ConnectError):
+    except (ConnectionError, httpx.ConnectError, httpx.TimeoutException):
         return False
     return False

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -304,7 +304,7 @@ def download_if_url(article: str) -> str:
         response = httpx.get(article, timeout=3)
         if response.status_code == httpx.codes.OK:  # pylint: disable=no-member
             article = response.text
-    except (httpx.InvalidURL, httpx.RequestError):
+    except (httpx.InvalidURL, httpx.RequestError, httpx.TimeoutException):
         pass
 
     return article


### PR DESCRIPTION
## Description

Closes: #5143 

I actually can't repro #5143 at all. But this PR looks at the exceptions raised in #7644 and #7673 and I modified the code so that httpx does not timeout anymore in those cases. 

For #7644, the issue is that by default `httpx` has a 5 second timeout. requests does not. So when we switched from requests to httpx, we simply changed `requests.get( f"{self.local_url}startup-events",...)` to `httpx.get(f"{self.local_url}startup-events, ...)", ...)`. We need to add `timeout=None` to the httpx get function to get the same behavior.

For #7673, the issue is that we're not catching httpx's timeout exception. If we catch it, `url_ok` can try to connect the local URL again. This mirrors the implementation in 3.50.2. 

I don't think we need to add an API to let developers control the httpx timeout. Gradio's use of httpx is an implementation detail and we didn't hear a lot of problems about timeout issues with 3.x so I think this is a matter of modifying our code to be more mindful of some differences between requests and httpx.


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
