### PR TITLE
Add support for object-detection models in `gr.load()`

### DIFF
--- a/.changeset/curly-ends-feel.md
+++ b/.changeset/curly-ends-feel.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Add support for object-detection models in `gr.load()`

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -343,6 +343,11 @@ def from_model(model_name: str, hf_token: str | None, alias: str | None, **kwarg
             label="Predictions", type="array", headers=["prediction"]
         )
         fn = external_utils.tabular_wrapper
+    # example model: microsoft/table-transformer-detection
+    elif p == "object-detection":
+        inputs = components.Image(type="filepath", label="Input Image")
+        outputs = components.AnnotatedImage(label="Annotations")
+        fn = external_utils.object_detection_wrapper(client)
     else:
         raise ValueError(f"Unsupported pipeline type: {p}")
 

--- a/gradio/external_utils.py
+++ b/gradio/external_utils.py
@@ -169,6 +169,26 @@ def token_classification_wrapper(client: InferenceClient):
     return token_classification_inner
 
 
+def object_detection_wrapper(client: InferenceClient):
+    def object_detection_inner(input: str):
+        annotations = client.object_detection(input)
+        formatted_annotations = [
+            (
+                (
+                    a["box"]["xmin"],
+                    a["box"]["ymin"],
+                    a["box"]["xmax"],
+                    a["box"]["ymax"],
+                ),
+                a["label"],
+            )
+            for a in annotations
+        ]
+        return (input, formatted_annotations)
+
+    return object_detection_inner
+
+
 def chatbot_preprocess(text, state):
     if not state:
         return text, [], []


### PR DESCRIPTION
Fixes: https://github.com/gradio-app/gradio/issues/7583

Test with:

```py
import gradio as gr

demo = gr.load(name="microsoft/table-transformer-detection", src="models", examples=["https://nielsr-tatr-demo.hf.space/--replicas/8duds/file=/tmp/gradio/7f043c2497be0235345dcfc1e2d111b46782cbe7/image.png"])

demo.launch()
```