### PR TITLE
Add support for python client connecting to gradio apps running with self-signed SSL certificates

### DIFF
--- a/.changeset/kind-eyes-shake.md
+++ b/.changeset/kind-eyes-shake.md
@@ -1,6 +1,6 @@
 ---
-"gradio": minor
-"gradio_client": minor
+"gradio": patch
+"gradio_client": patch
 ---
 
-feat:Add support for python client connecting to gradio apps running with self-signed SSL certificates
+fix:Add support for python client connecting to gradio apps running with self-signed SSL certificates

--- a/.changeset/kind-eyes-shake.md
+++ b/.changeset/kind-eyes-shake.md
@@ -1,0 +1,6 @@
+---
+"gradio": minor
+"gradio_client": minor
+---
+
+feat:Add support for python client connecting to gradio apps running with self-signed SSL certificates

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -747,6 +747,7 @@ class Client:
         resp = httpx.post(
             urllib.parse.urljoin(self.src, utils.LOGIN_URL),
             data={"username": auth[0], "password": auth[1]},
+            ssl=self.ssl_verify,
         )
         if not resp.is_success:
             if resp.status_code == 401:
@@ -1209,6 +1210,7 @@ class Endpoint:
                 self.client.sse_data_url,
                 self.client.headers,
                 self.client.cookies,
+                self.client.ssl_verify,
             )
 
     async def _sse_fn_v1_v2(
@@ -1224,6 +1226,7 @@ class Endpoint:
             self.client.pending_messages_per_event,
             event_id,
             protocol,
+            self.client.ssl_verify,
         )
 
 

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import concurrent.futures
+import hashlib
 import json
 import os
 import re
 import secrets
+import shutil
 import tempfile
 import threading
 import time
@@ -81,6 +83,7 @@ class Client:
         upload_files: bool = True,  # TODO: remove and hardcode to False in 1.0
         download_files: bool = True,  # TODO: consider setting to False in 1.0
         _skip_components: bool = True,  # internal parameter to skip values certain components (e.g. State) that do not need to be displayed to users.
+        ssl_verify: bool = True,
     ):
         """
         Parameters:
@@ -93,6 +96,7 @@ class Client:
             headers: Additional headers to send to the remote Gradio app on every request. By default only the HF authorization and user-agent headers are sent. These headers will override the default headers if they have the same keys.
             upload_files: Whether the client should treat input string filepath as files and upload them to the remote server. If False, the client will treat input string filepaths as strings always and not modify them, and files should be passed in explicitly using `gradio_client.file("path/to/file/or/url")` instead. This parameter will be deleted and False will become the default in a future version.
             download_files: Whether the client should download output files from the remote API and return them as string filepaths on the local machine. If False, the client will return a FileData dataclass object with the filepath on the remote machine instead.
+            ssl_verify: If False, skips certificate validation which allows self-signed certificates to be used.
         """
         self.verbose = verbose
         self.hf_token = hf_token
@@ -111,6 +115,7 @@ class Client:
         )
         if headers:
             self.headers.update(headers)
+        self.ssl_verify = ssl_verify
         self.space_id = None
         self.cookies: dict[str, str] = {}
         self.output_dir = (
@@ -187,7 +192,9 @@ class Client:
 
     async def stream_messages(self) -> None:
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(timeout=None)) as client:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(timeout=None), verify=self.ssl_verify
+            ) as client:
                 async with client.stream(
                     "GET",
                     self.sse_url,
@@ -227,7 +234,7 @@ class Client:
             raise e
 
     async def send_data(self, data, hash_data):
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=self.ssl_verify) as client:
             req = await client.post(
                 self.sse_data_url,
                 json={**data, **hash_data},
@@ -484,7 +491,12 @@ class Client:
         else:
             api_info_url = urllib.parse.urljoin(self.src, utils.RAW_API_INFO_URL)
         if self.app_version > version.Version("3.36.1"):
-            r = httpx.get(api_info_url, headers=self.headers, cookies=self.cookies)
+            r = httpx.get(
+                api_info_url,
+                headers=self.headers,
+                cookies=self.cookies,
+                verify=self.ssl_verify,
+            )
             if r.is_success:
                 info = r.json()
             else:
@@ -752,6 +764,7 @@ class Client:
             urllib.parse.urljoin(self.src, utils.CONFIG_URL),
             headers=self.headers,
             cookies=self.cookies,
+            verify=self.ssl_verify,
         )
         if r.is_success:
             return r.json()
@@ -760,7 +773,12 @@ class Client:
                 f"Could not load {self.src} as credentials were not provided. Please login."
             )
         else:  # to support older versions of Gradio
-            r = httpx.get(self.src, headers=self.headers, cookies=self.cookies)
+            r = httpx.get(
+                self.src,
+                headers=self.headers,
+                cookies=self.cookies,
+                verify=self.ssl_verify,
+            )
             if not r.is_success:
                 raise ValueError(f"Could not fetch config for {self.src}")
             # some basic regex to extract the config
@@ -1137,21 +1155,48 @@ class Endpoint:
         else:
             file_path = f["path"]
         if not utils.is_http_url_like(file_path):
-            file_path = utils.upload_file(
-                file_path=file_path,
-                upload_url=self.client.upload_url,
-                headers=self.client.headers,
-                cookies=self.client.cookies,
-            )
+            with open(file_path, "rb") as f:
+                files = [("files", (Path(file_path).name, f))]
+                r = httpx.post(
+                    self.client.upload_url,
+                    headers=self.client.headers,
+                    cookies=self.client.cookies,
+                    verify=self.client.ssl_verify,
+                    files=files,
+                )
+            r.raise_for_status()
+            result = r.json()
+            file_path = result[0]
         return {"path": file_path}
 
     def _download_file(self, x: dict) -> str | None:
-        return utils.download_file(
-            self.root_url + "file=" + x["path"],
-            save_dir=self.client.output_dir,
+        url_path = self.root_url + "file=" + x["path"]
+        if self.client.output_dir is not None:
+            os.makedirs(self.client.output_dir, exist_ok=True)
+
+        sha1 = hashlib.sha1()
+        temp_dir = Path(tempfile.gettempdir()) / secrets.token_hex(20)
+        temp_dir.mkdir(exist_ok=True, parents=True)
+
+        with httpx.stream(
+            "GET",
+            url_path,
             headers=self.client.headers,
             cookies=self.client.cookies,
-        )
+            verify=self.client.ssl_verify,
+            follow_redirects=True,
+        ) as response:
+            response.raise_for_status()
+            with open(temp_dir / Path(url_path).name, "wb") as f:
+                for chunk in response.iter_bytes(chunk_size=128 * sha1.block_size):
+                    sha1.update(chunk)
+                    f.write(chunk)
+
+        directory = Path(self.client.output_dir) / sha1.hexdigest()
+        directory.mkdir(exist_ok=True, parents=True)
+        dest = directory / Path(url_path).name
+        shutil.move(temp_dir / Path(url_path).name, dest)
+        return str(dest.resolve())
 
     async def _sse_fn_v0(self, data: dict, hash_data: dict, helper: Communicator):
         async with httpx.AsyncClient(timeout=httpx.Timeout(timeout=None)) as client:

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -747,7 +747,7 @@ class Client:
         resp = httpx.post(
             urllib.parse.urljoin(self.src, utils.LOGIN_URL),
             data={"username": auth[0], "password": auth[1]},
-            ssl=self.ssl_verify,
+            verify=self.ssl_verify,
         )
         if not resp.is_success:
             if resp.status_code == 401:
@@ -1200,7 +1200,7 @@ class Endpoint:
         return str(dest.resolve())
 
     async def _sse_fn_v0(self, data: dict, hash_data: dict, helper: Communicator):
-        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout=None)) as client:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout=None), verify=self.client.ssl_verify) as client:
             return await utils.get_pred_from_sse_v0(
                 client,
                 data,

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -1144,7 +1144,7 @@ class Endpoint:
         else:
             return data
 
-    def _upload_file(self, f: str | dict):
+    def _upload_file(self, f: str | dict) -> dict[str, str]:
         if isinstance(f, str):
             warnings.warn(
                 f'The Client is treating: "{f}" as a file path. In future versions, this behavior will not happen automatically. '
@@ -1169,7 +1169,7 @@ class Endpoint:
             file_path = result[0]
         return {"path": file_path}
 
-    def _download_file(self, x: dict) -> str | None:
+    def _download_file(self, x: dict) -> str:
         url_path = self.root_url + "file=" + x["path"]
         if self.client.output_dir is not None:
             os.makedirs(self.client.output_dir, exist_ok=True)

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -1200,7 +1200,9 @@ class Endpoint:
         return str(dest.resolve())
 
     async def _sse_fn_v0(self, data: dict, hash_data: dict, helper: Communicator):
-        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout=None), verify=self.client.ssl_verify) as client:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout=None), verify=self.client.ssl_verify
+        ) as client:
             return await utils.get_pred_from_sse_v0(
                 client,
                 data,

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -96,7 +96,7 @@ class Client:
             headers: Additional headers to send to the remote Gradio app on every request. By default only the HF authorization and user-agent headers are sent. These headers will override the default headers if they have the same keys.
             upload_files: Whether the client should treat input string filepath as files and upload them to the remote server. If False, the client will treat input string filepaths as strings always and not modify them, and files should be passed in explicitly using `gradio_client.file("path/to/file/or/url")` instead. This parameter will be deleted and False will become the default in a future version.
             download_files: Whether the client should download output files from the remote API and return them as string filepaths on the local machine. If False, the client will return a FileData dataclass object with the filepath on the remote machine instead.
-            ssl_verify: If False, skips certificate validation which allows self-signed certificates to be used.
+            ssl_verify: If False, skips certificate validation which allows the client to connect to Gradio apps that are using self-signed certificates.
         """
         self.verbose = verbose
         self.hf_token = hf_token

--- a/client/python/gradio_client/compatibility.py
+++ b/client/python/gradio_client/compatibility.py
@@ -95,7 +95,10 @@ class EndpointV3Compatibility:
                     raise ValueError(result["error"])
             else:
                 response = httpx.post(
-                    self.client.api_url, headers=self.client.headers, json=data
+                    self.client.api_url,
+                    headers=self.client.headers,
+                    json=data,
+                    verify=self.client.ssl_verify,
                 )
                 result = json.loads(response.content.decode("utf-8"))
             try:
@@ -144,7 +147,12 @@ class EndpointV3Compatibility:
             for f in fs:
                 files.append(("files", (Path(f).name, open(f, "rb"))))  # noqa: SIM115
                 indices.append(i)
-        r = httpx.post(self.client.upload_url, headers=self.client.headers, files=files)
+        r = httpx.post(
+            self.client.upload_url,
+            headers=self.client.headers,
+            files=files,
+            verify=self.client.ssl_verify,
+        )
         if r.status_code != 200:
             uploaded = file_paths
         else:

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -367,7 +367,6 @@ async def get_pred_from_sse_v0(
                     sse_data_url,
                     headers,
                     cookies,
-                    ssl_verify,
                 )
             ),
         ],

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import copy
-import hashlib
 import json
 import mimetypes
 import os
@@ -623,49 +622,6 @@ def apply_diff(obj, diff):
 ########################
 # Data processing utils
 ########################
-
-
-def upload_file(
-    file_path: str,
-    upload_url: str,
-    headers: dict[str, str] | None = None,
-    cookies: dict[str, str] | None = None,
-):
-    with open(file_path, "rb") as f:
-        files = [("files", (Path(file_path).name, f))]
-        r = httpx.post(upload_url, headers=headers, cookies=cookies, files=files)
-    r.raise_for_status()
-    result = r.json()
-    return result[0]
-
-
-def download_file(
-    url_path: str,
-    save_dir: str,
-    headers: dict[str, str] | None = None,
-    cookies: dict[str, str] | None = None,
-) -> str:
-    if save_dir is not None:
-        os.makedirs(save_dir, exist_ok=True)
-
-    sha1 = hashlib.sha1()
-    temp_dir = Path(tempfile.gettempdir()) / secrets.token_hex(20)
-    temp_dir.mkdir(exist_ok=True, parents=True)
-
-    with httpx.stream(
-        "GET", url_path, headers=headers, cookies=cookies, follow_redirects=True
-    ) as response:
-        response.raise_for_status()
-        with open(temp_dir / Path(url_path).name, "wb") as f:
-            for chunk in response.iter_bytes(chunk_size=128 * sha1.block_size):
-                sha1.update(chunk)
-                f.write(chunk)
-
-    directory = Path(save_dir) / sha1.hexdigest()
-    directory.mkdir(exist_ok=True, parents=True)
-    dest = directory / Path(url_path).name
-    shutil.move(temp_dir / Path(url_path).name, dest)
-    return str(dest.resolve())
 
 
 def create_tmp_copy_of_file(file_path: str, dir: str | None = None) -> str:

--- a/client/python/test/test_utils.py
+++ b/client/python/test/test_utils.py
@@ -71,26 +71,6 @@ def test_decode_base64_to_file():
     assert isinstance(temp_file, tempfile._TemporaryFileWrapper)
 
 
-@pytest.mark.flaky
-def test_download_private_file(gradio_temp_dir):
-    url_path = (
-        "https://gradio-tests-not-actually-private-spacev4-sse.hf.space/file=lion.jpg"
-    )
-    file = utils.download_file(
-        url_path=url_path,
-        headers={"Authorization": f"Bearer {HF_TOKEN}"},
-        save_dir=str(gradio_temp_dir),
-    )
-    assert Path(file).name.endswith(".jpg")
-
-
-def test_download_tmp_copy_of_file_does_not_save_errors(monkeypatch, gradio_temp_dir):
-    error_response = httpx.Response(status_code=404)
-    monkeypatch.setattr(httpx, "get", lambda *args, **kwargs: error_response)
-    with pytest.raises(httpx.HTTPStatusError):
-        utils.download_file("https://example.com/foo", save_dir=str(gradio_temp_dir))
-
-
 @pytest.mark.parametrize(
     "orig_filename, new_filename",
     [


### PR DESCRIPTION
This PR adds an `ssl_verify` parameter to `gradio_client.Client` to match the corresponding parameter in `launch()`

Not easy to write a unit test for this but you can run the following to confirm:

1. `openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -nodes` in terminal
2. In the same directory, launch a gradio app:

```py
import gradio as gr

demo = gr.Interface(lambda x:x, "image", "image")

_, url, _ = demo.launch(
    ssl_certfile="cert.pem",
    ssl_keyfile="key.pem",
    ssl_verify=False
)
```

3. Connect with the client:

```py
from gradio_client import Client, file

client = Client(url, ssl_verify=False)

client.predict(file("cheetah.jpg"))
```

Fixes: https://github.com/gradio-app/gradio/issues/5497