### PR TITLE
Replace httpx with requests library in save_url_to_cache to make it work in wasm mode

### DIFF
--- a/.changeset/spotty-parents-wink.md
+++ b/.changeset/spotty-parents-wink.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Replace httpx with requests library in save_url_to_cache to make it work in wasm mode

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -13,8 +13,8 @@ from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-import httpx
 import numpy as np
+import requests
 from gradio_client import utils as client_utils
 from PIL import Image, ImageOps, PngImagePlugin
 
@@ -190,10 +190,9 @@ def save_url_to_cache(url: str, cache_dir: str) -> str:
     full_temp_file_path = str(abspath(temp_dir / name))
 
     if not Path(full_temp_file_path).exists():
-        with httpx.stream("GET", url, follow_redirects=True) as r, open(
-            full_temp_file_path, "wb"
-        ) as f:
-            for chunk in r.iter_raw():
+        response = requests.get(url, stream=True)
+        with open(full_temp_file_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=256):
                 f.write(chunk)
 
     return full_temp_file_path


### PR DESCRIPTION
## Description

Replaced httpx with requests library in `save_url_to_cache` of `processing_utils.py`  to load example urls in wasm mode for gradio lite.


Closes: #6837 


## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`: Ran it on my files.
