### PR TITLE
Explicit urllib3 requirement

### DIFF
--- a/.changeset/eleven-clubs-peel.md
+++ b/.changeset/eleven-clubs-peel.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Explicit urllib3 requirement

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
-import requests
+import urllib3
 from gradio_client import utils as client_utils
 from PIL import Image, ImageOps, PngImagePlugin
 
@@ -190,9 +190,10 @@ def save_url_to_cache(url: str, cache_dir: str) -> str:
     full_temp_file_path = str(abspath(temp_dir / name))
 
     if not Path(full_temp_file_path).exists():
-        response = requests.get(url, stream=True)
+        # NOTE: We use urllib3 instead of httpx because it works in the Wasm environment. See https://github.com/gradio-app/gradio/issues/6837.
+        response = urllib3.request("GET", url, preload_content=False)
         with open(full_temp_file_path, "wb") as f:
-            for chunk in response.iter_content(chunk_size=256):
+            for chunk in response.stream():
                 f.write(chunk)
 
     return full_temp_file_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ pyyaml>=5.0,<7.0
 semantic_version~=2.0
 typing_extensions~=4.0
 uvicorn>=0.14.0
+urllib3>=2.2.0  # urllib3 supports Pyodide since 2.2.0, which is needed for Gradio-Lite.
 typer[all]>=0.9,<1.0
 tomlkit==0.12.0
 ruff>=0.2.2


### PR DESCRIPTION
## Description

Improvements of #7725
* Add `urllib3` to `requirements.txt` as an explicit dependency.
* Use `urllib3` instead of `requests` because it's a more 'primitive' dependency in that `requests` depends on it too, and it's explicitly declared as a required package in `requirements.txt`.

For future readers: `urllib3` is already shipped with Gradio as a dependency of the `huggingface_hub` pacakge, so this change doesn't introduce additional package installations.