### PR TITLE
Cast button value as string in postprocess

### DIFF
--- a/.changeset/tasty-donkeys-warn.md
+++ b/.changeset/tasty-donkeys-warn.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Cast button value as string in postprocess

--- a/gradio/components/button.py
+++ b/gradio/components/button.py
@@ -87,7 +87,7 @@ class Button(Component):
         Returns:
             Expects a `str` value that is set as the button label
         """
-        return value
+        return str(value)
 
     def example_payload(self) -> Any:
         return "Run"

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -2939,6 +2939,12 @@ class TestFileExplorer:
         assert tree == answer
 
 
+class TestButton:
+    def test_postprocess(self):
+        assert gr.Button().postprocess("5") == "5"
+        assert gr.Button().postprocess(5) == "5"
+
+
 def test_component_class_ids():
     button_id = gr.Button().component_class_id
     textbox_id = gr.Textbox().component_class_id


### PR DESCRIPTION
Gradio launch succeeds but gets stuck on loading screen if you use integers instead of strings for the "value" field on gr.Button().

## Description

Add forced casting to string of button value in postprocess function of gradio Button component (`return str(value)`)

Closes: #7690
(https://github.com/gradio-app/gradio/issues/7690#issuecomment-1997718185)

## 🎯 PRs Should Target Issues

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
