### PR TITLE
Trigger input event for Radio even when radio is output component

### DIFF
--- a/.changeset/mighty-bags-begin.md
+++ b/.changeset/mighty-bags-begin.md
@@ -1,0 +1,6 @@
+---
+"@gradio/radio": patch
+"gradio": patch
+---
+
+fix:Trigger input event for Radio even when radio is output component

--- a/js/radio/Index.svelte
+++ b/js/radio/Index.svelte
@@ -23,7 +23,6 @@
 	export let elem_classes: string[] = [];
 	export let visible = true;
 	export let value: string | null = null;
-	export let value_is_output = false;
 	export let choices: [string, string | number][] = [];
 	export let show_label = true;
 	export let container = false;
@@ -34,14 +33,8 @@
 
 	function handle_change(): void {
 		gradio.dispatch("change");
-		if (!value_is_output) {
-			gradio.dispatch("input");
-		}
 	}
 
-	afterUpdate(() => {
-		value_is_output = false;
-	});
 	$: value, handle_change();
 
 	$: disabled = !interactive;
@@ -71,8 +64,10 @@
 				{internal_value}
 				bind:selected={value}
 				{disabled}
-				on:input={() =>
-					gradio.dispatch("select", { value: internal_value, index: i })}
+				on:input={() => {
+					gradio.dispatch("select", { value: internal_value, index: i });
+					gradio.dispatch("input");
+				}}
 			/>
 		{/each}
 	</div>


### PR DESCRIPTION
## Description

Closes: #7757

The `input` event was not triggered if the Radio was output by an event. But based on the docstring for `input`, it should be triggered for all user input, which makes it equivalent to `select` event.

Based on the discussion in the issue, it seems like this was working in a previous version. Not sure what could have changed (didn't look into it), but I think this refactor makes sense anyways.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
