### PR TITLE
Add diff threshold to image editor story

### DIFF
--- a/js/imageeditor/ImageEditor.stories.svelte
+++ b/js/imageeditor/ImageEditor.stories.svelte
@@ -11,6 +11,7 @@
 		component: ImageEditor,
 		parameters: {
 			chromatic: {
+				diffThreshold: 0.4,
 				modes: {
 					desktop: allModes["desktop"],
 					mobile: allModes["mobile"]


### PR DESCRIPTION
## Description

I did this a while ago but the Delta of interaction changes was too high for `diffThreshold` to take any effect due to the pixels moving slightly during the drawing interaction. I adjusted the interaction story such that it landed back to the fixed default Image Editor state but there is still a tiny pixel change that Storybook is picking up upon occasion for some reason. 

I think this threshold should fix that flakiness. If not then I'll reach out to the Chromatic team. 

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
