### PR TITLE
Configure playwright to automatically retry failing tests up to 3 times

### DIFF
--- a/.config/playwright.config.js
+++ b/.config/playwright.config.js
@@ -19,7 +19,8 @@ const base = defineConfig({
 	timeout: 30000,
 	testMatch: /.*.spec.ts/,
 	testDir: "..",
-	workers: process.env.CI ? 1 : undefined
+	workers: process.env.CI ? 1 : undefined,
+	retries: 3,
 });
 
 const normal = defineConfig(base, {
@@ -40,7 +41,8 @@ const lite = defineConfig(base, {
 		// "**/kitchen_sink.spec.ts",
 		"**/gallery_component_events.spec.ts"
 	],
-	workers: 1
+	workers: 1,
+	retries: 3
 });
 
 lite.projects = undefined; // Explicitly unset this field due to https://github.com/microsoft/playwright/issues/28795

--- a/.config/playwright.config.js
+++ b/.config/playwright.config.js
@@ -20,7 +20,7 @@ const base = defineConfig({
 	testMatch: /.*.spec.ts/,
 	testDir: "..",
 	workers: process.env.CI ? 1 : undefined,
-	retries: 3,
+	retries: 3
 });
 
 const normal = defineConfig(base, {

--- a/js/app/test/chatbot_multimodal.spec.ts
+++ b/js/app/test/chatbot_multimodal.spec.ts
@@ -23,6 +23,7 @@ test("text input by a user should be shown in the chatbot as a paragraph", async
 test("images uploaded by a user should be shown in the chat", async ({
 	page
 }) => {
+	expect(false);
 	const fileChooserPromise = page.waitForEvent("filechooser");
 	await page.getByRole("button", { name: "+", exact: true }).click();
 	const fileChooser = await fileChooserPromise;

--- a/js/app/test/chatbot_multimodal.spec.ts
+++ b/js/app/test/chatbot_multimodal.spec.ts
@@ -23,7 +23,6 @@ test("text input by a user should be shown in the chatbot as a paragraph", async
 test("images uploaded by a user should be shown in the chat", async ({
 	page
 }) => {
-	expect(false);
 	const fileChooserPromise = page.waitForEvent("filechooser");
 	await page.getByRole("button", { name: "+", exact: true }).click();
 	const fileChooser = await fileChooserPromise;


### PR DESCRIPTION
## Description

Tests that pass when they are retried are reported as flaky by playwright

<img width="821" alt="image" src="https://github.com/gradio-app/gradio/assets/41651716/2a49d7fc-7008-4116-afc9-15f8f2c44d4f">

So the idea here is to notice the flakes but not slow down development velocity. 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
