### PR TITLE
Fix input event for Number, Slider, Checkbox

### DIFF
--- a/.changeset/evil-nights-wear.md
+++ b/.changeset/evil-nights-wear.md
@@ -1,8 +1,8 @@
 ---
-"@gradio/checkbox": minor
-"@gradio/number": minor
-"@gradio/slider": minor
-"gradio": minor
+"@gradio/checkbox": patch
+"@gradio/number": patch
+"@gradio/slider": patch
+"gradio": patch
 ---
 
-feat:Fix input events for some components
+feat:Fix input event for Number, Slider, Checkbox

--- a/.changeset/evil-nights-wear.md
+++ b/.changeset/evil-nights-wear.md
@@ -1,0 +1,8 @@
+---
+"@gradio/checkbox": minor
+"@gradio/number": minor
+"@gradio/slider": minor
+"gradio": minor
+---
+
+feat:Fix input events for some components

--- a/js/checkbox/Index.svelte
+++ b/js/checkbox/Index.svelte
@@ -15,7 +15,6 @@
 	export let elem_classes: string[] = [];
 	export let visible = true;
 	export let value = false;
-	export let value_is_output = false;
 	export let label = "Checkbox";
 	export let info: string | undefined = undefined;
 	export let container = true;
@@ -28,16 +27,6 @@
 		input: never;
 	}>;
 	export let interactive: boolean;
-
-	function handle_change(): void {
-		gradio.dispatch("change");
-		if (!value_is_output) {
-			gradio.dispatch("input");
-		}
-	}
-	afterUpdate(() => {
-		value_is_output = false;
-	});
 
 	// When the value changes, dispatch the change event via handle_change()
 	// See the docs for an explanation: https://svelte.dev/docs/svelte-components#script-3-$-marks-a-statement-as-reactive
@@ -58,7 +47,10 @@
 		bind:value
 		{label}
 		{interactive}
-		on:change={handle_change}
-		on:select={(e) => gradio.dispatch("select", e.detail)}
+		on:change={() => gradio.dispatch("change")}
+		on:select={(e) => {
+			gradio.dispatch("select", e.detail);
+			gradio.dispatch("input")
+		}}
 	/>
 </Block>

--- a/js/checkbox/Index.svelte
+++ b/js/checkbox/Index.svelte
@@ -50,7 +50,7 @@
 		on:change={() => gradio.dispatch("change")}
 		on:select={(e) => {
 			gradio.dispatch("select", e.detail);
-			gradio.dispatch("input")
+			gradio.dispatch("input");
 		}}
 	/>
 </Block>

--- a/js/number/Index.svelte
+++ b/js/number/Index.svelte
@@ -3,7 +3,7 @@
 	import { Block, BlockTitle } from "@gradio/atoms";
 	import { StatusTracker } from "@gradio/statustracker";
 	import type { LoadingStatus } from "@gradio/statustracker";
-	import { afterUpdate, tick } from "svelte";
+	import { tick } from "svelte";
 
 	export let gradio: Gradio<{
 		change: never;
@@ -25,21 +25,14 @@
 	export let minimum: number | undefined = undefined;
 	export let maximum: number | undefined = undefined;
 	export let loading_status: LoadingStatus;
-	export let value_is_output = false;
 	export let step: number | null = null;
 	export let interactive: boolean;
 
 	function handle_change(): void {
 		if (!isNaN(value) && value !== null) {
 			gradio.dispatch("change");
-			if (!value_is_output) {
-				gradio.dispatch("input");
-			}
 		}
 	}
-	afterUpdate(() => {
-		value_is_output = false;
-	});
 
 	async function handle_keypress(e: KeyboardEvent): Promise<void> {
 		await tick();
@@ -79,6 +72,7 @@
 			on:keypress={handle_keypress}
 			on:blur={() => gradio.dispatch("blur")}
 			on:focus={() => gradio.dispatch("focus")}
+			on:input={() => gradio.dispatch("input")}
 			{disabled}
 		/>
 	</label>

--- a/js/slider/Index.svelte
+++ b/js/slider/Index.svelte
@@ -29,7 +29,7 @@
 	export let show_label: boolean;
 	export let interactive: boolean;
 	export let loading_status: LoadingStatus;
-	export let value_is_output = false;
+	let old_value = value;
 
 	let rangeInput: HTMLInputElement;
 	let numberInput: HTMLInputElement;
@@ -38,12 +38,8 @@
 
 	function handle_change(): void {
 		gradio.dispatch("change");
-		if (!value_is_output) {
-			gradio.dispatch("input");
-		}
 	}
 	afterUpdate(() => {
-		value_is_output = false;
 		setSlider();
 	});
 
@@ -99,6 +95,7 @@
 				on:blur={clamp}
 				{step}
 				{disabled}
+				on:input={() => gradio.dispatch("input")}
 				on:pointerup={handle_release}
 			/>
 		</div>
@@ -110,6 +107,7 @@
 		name="cowbell"
 		bind:value
 		bind:this={rangeInput}
+		on:input={() => gradio.dispatch("input")}
 		min={minimum}
 		max={maximum}
 		{step}

--- a/js/slider/Index.svelte
+++ b/js/slider/Index.svelte
@@ -29,7 +29,6 @@
 	export let show_label: boolean;
 	export let interactive: boolean;
 	export let loading_status: LoadingStatus;
-	let old_value = value;
 
 	let rangeInput: HTMLInputElement;
 	let numberInput: HTMLInputElement;


### PR DESCRIPTION
## Description

Follow-up from #7762 

The input event for some components does not work if they are returned by an event.
Fixing that in this PR.

To test, you can use the repro from #7762 but change out the component. The input event should trigger after the update button is clicked. Example of `Slider`

```python
def select_llm(llm_name):
    gr.Info(f"Selected {llm_name}")

def update_llm_select():
    return gr.Slider(value=14, label="Code code code")


with gr.Blocks() as demo:
    radio = gr.Slider()
    update_radio_btn = gr.Button("Update")

    radio.input(select_llm, radio, [])
    update_radio_btn.click(update_llm_select, [], [radio])

demo.queue().launch()
```

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
