### PR TITLE
Adds trigger_mode to gr.on. Use it to set trigger_model="always_last" for live interfaces.

### DIFF
--- a/.changeset/two-suns-trade.md
+++ b/.changeset/two-suns-trade.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Adds trigger_mode to gr.on. Use it to set trigger_model="always_last" for live interfaces.

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -342,6 +342,7 @@ def on(
     preprocess: bool = True,
     postprocess: bool = True,
     cancels: dict[str, Any] | list[dict[str, Any]] | None = None,
+    trigger_mode: Literal["once", "multiple", "always_last"] | None = None,
     every: float | None = None,
     js: str | None = None,
     concurrency_limit: int | None | Literal["default"] = "default",
@@ -363,6 +364,7 @@ def on(
         preprocess: If False, will not run preprocessing of component data before running 'fn' (e.g. leaving it as a base64 string if this method is called with the `Image` component).
         postprocess: If False, will not run postprocessing of component data before returning 'fn' output to the browser.
         cancels: A list of other events to cancel when this listener is triggered. For example, setting cancels=[click_event] will cancel the click_event, where click_event is the return value of another components .click method. Functions that have not yet run (or generators that are iterating) will be cancelled, but functions that are currently running will be allowed to finish.
+        trigger_mode: If "once" (default for all events except `.change()`) would not allow any submissions while an event is pending. If set to "multiple", unlimited submissions are allowed while pending, and "always_last" (default for `.change()` and `.key_up()` events) would allow a second submission after the pending event is complete.
         every: Run this event 'every' number of seconds while the client connection is open. Interpreted in seconds.
         js: Optional frontend js method to run before running 'fn'. Input arguments for js method are values of 'inputs', return should be a list of values for output components.
         concurrency_limit: If set, this is the maximum number of this event that can be running simultaneously. Can be set to None to mean no concurrency_limit (any number of this event can be running simultaneously). Set to "default" to use the default concurrency limit (defined by the `default_concurrency_limit` parameter in `Blocks.queue()`, which itself is 1 by default).
@@ -398,6 +400,7 @@ def on(
                 concurrency_limit=concurrency_limit,
                 concurrency_id=concurrency_id,
                 show_api=show_api,
+                trigger_mode=trigger_mode,
             )
 
             @wraps(func)
@@ -439,6 +442,7 @@ def on(
         max_batch_size=max_batch_size,
         every=every,
         show_api=show_api,
+        trigger_mode=trigger_mode,
     )
     set_cancel_events(triggers, cancels)
     return Dependency(None, dep, dep_index, fn)

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -684,6 +684,7 @@ class Interface(Blocks):
                     preprocess=not (self.api_mode),
                     postprocess=not (self.api_mode),
                     show_progress="hidden" if streaming_event else "full",
+                    trigger_mode="always_last",
                 )
         else:
             if _submit_btn is None:

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -248,3 +248,18 @@ def test_interface_adds_stop_button(interface_type, live, use_generator):
         assert has_stop
     else:
         assert not has_stop
+
+
+def test_live_interface_sets_always_last():
+    iface = gradio.Interface(
+        fn=lambda s: s,
+        inputs=gradio.Textbox(lines=2, placeholder="Hello 👋", label="Input Sentence"),
+        outputs=gradio.Markdown(),
+        live=True,  # Set live to True for real-time feedback
+    )
+    config = iface.get_config_file()
+    for dep in config["dependencies"]:
+        if dep["targets"][0][1] == "change":
+            assert dep["trigger_mode"] == "always_last"
+            return
+    raise AssertionError("No change dependency found")


### PR DESCRIPTION
## Description

Closes: #7752 

You can test it here: https://huggingface.co/spaces/freddyaboulton/fast-typing-live-bug

Should not drop any text like the video in the original issue

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
