### PR TITLE
This fixes issue #7497 on Chromium based browsers

### DIFF
--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -281,7 +281,7 @@ class Audio(
         if value is None:
             return None, output_file
         if isinstance(value, bytes):
-            output_file["url"]=f"stream/{output_id}"
+            output_file["url"] = f"stream/{output_id}"
             return value, output_file
         if client_utils.is_http_url_like(value["path"]):
             response = httpx.get(value["path"])
@@ -303,7 +303,7 @@ class Audio(
                     )
                 else:
                     binary_data = binary_data[44:]
-            output_file["url"]=f"stream/{output_id}"
+            output_file["url"] = f"stream/{output_id}"
         return binary_data, output_file
 
     def process_example(


### PR DESCRIPTION
This fixes issue #7497 on Chromium based browsers. For Safari, the http response needs more work to make it working.

## Description

This PR is trying to address issue #7497. 

Closes: #7497 (Only "partially", as it still is not working for Safari)

I think the issues was introduced by commit 68a54a7a310 which was attempting to provide differential streaming for chatbot. After that, the audio element in HTML missed the URL attribute which was generated automatically. In the current main branch, the machinery to add URL from audio data request seems to be missing. The patch passes the URL through. 

## Tests

the PR can run this test script properly https://gist.github.com/cschin/a28f97b95823a35aff47cda761589673 on Edge and Chromo. 
  
