### PR TITLE
Small fix to client.view_api() in the case of default file values

### DIFF
--- a/.changeset/clever-masks-melt.md
+++ b/.changeset/clever-masks-melt.md
@@ -1,0 +1,6 @@
+---
+"gradio": minor
+"gradio_client": minor
+---
+
+feat:Small fix to client.view_api() in the case of default values

--- a/.changeset/clever-masks-melt.md
+++ b/.changeset/clever-masks-melt.md
@@ -3,4 +3,4 @@
 "gradio_client": patch
 ---
 
-feat:Small fix to client.view_api() in the case of default values
+feat:Small fix to client.view_api() in the case of default file values

--- a/.changeset/clever-masks-melt.md
+++ b/.changeset/clever-masks-melt.md
@@ -1,6 +1,6 @@
 ---
-"gradio": minor
-"gradio_client": minor
+"gradio": patch
+"gradio_client": patch
 ---
 
 feat:Small fix to client.view_api() in the case of default values

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -679,10 +679,11 @@ class Client:
                     else ""
                 )
                 default_value = info.get("parameter_default")
+                default_value = utils.traverse(default_value, lambda x: f"file(\"{x['url']}\")", utils.is_file_obj_with_meta)
                 default_info = (
                     "(required)"
                     if not info.get("parameter_has_default", False)
-                    else f"(not required, defaults to {default_value})"
+                    else f"(not required, defaults to:   {default_value})"
                 )
                 type_ = info["python_type"]["type"]
                 if info.get("parameter_has_default", False) and default_value is None:

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -679,7 +679,11 @@ class Client:
                     else ""
                 )
                 default_value = info.get("parameter_default")
-                default_value = utils.traverse(default_value, lambda x: f"file(\"{x['url']}\")", utils.is_file_obj_with_meta)
+                default_value = utils.traverse(
+                    default_value,
+                    lambda x: f"file(\"{x['url']}\")",
+                    utils.is_file_obj_with_meta,
+                )
                 default_info = (
                     "(required)"
                     if not info.get("parameter_has_default", False)


### PR DESCRIPTION
I forgot to address this comment by @freddyaboulton: https://github.com/gradio-app/gradio/pull/7732#discussion_r1534706772. This PR fixes it. 

Test with:

```py
import gradio as gr

demo = gr.Interface(
    lambda x,y:x,
    [gr.Audio("test.mp3"), gr.Number()],
    "audio"
)

_, url, _ = demo.launch(inline=False)

from gradio_client import Client

client = Client(url)

client.view_api()
```