### PR TITLE
Stop importing gradio.ipython_ext in Wasm mode

### DIFF
--- a/.changeset/neat-numbers-matter.md
+++ b/.changeset/neat-numbers-matter.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:Stop importing gradio.ipython_ext in Wasm mode

--- a/gradio/__init__.py
+++ b/gradio/__init__.py
@@ -80,7 +80,6 @@ from gradio.helpers import (
 )
 from gradio.helpers import create_examples as Examples  # noqa: N812
 from gradio.interface import Interface, TabbedInterface, close_all
-from gradio.ipython_ext import load_ipython_extension
 from gradio.layouts import Accordion, Column, Group, Row, Tab, TabItem, Tabs
 from gradio.oauth import OAuthProfile, OAuthToken
 from gradio.routes import Request, mount_gradio_app
@@ -99,5 +98,10 @@ from gradio.templates import (
 )
 from gradio.themes import Base as Theme
 from gradio.utils import NO_RELOAD, get_package_version, set_static_paths
+from gradio.wasm_utils import IS_WASM
+
+if not IS_WASM:
+    from gradio.ipython_ext import load_ipython_extension
+
 
 __version__ = get_package_version()


### PR DESCRIPTION
## Description

Related to #7791 

`gradio.ipython_ext` is one major part taking the import time which is also an unnecessary part for Wasm, so it shouldn't be imported in the Wasm env.

### Performance measurement with normal Python
#### `main` (ff6bf3e):
![image](https://github.com/gradio-app/gradio/assets/3135397/0a601c3a-511f-49f4-ac1e-a14dc57fdad1)

#### This PR (56c7a61):
To make the change effective, set `IS_WASM = True` manually during the measurement.
![image](https://github.com/gradio-app/gradio/assets/3135397/67742ba1-9cda-44e3-9a23-32918ec73b6c)
