### PR TITLE
fix: The meaning of fill_height is reversed at ChatInterface

### DIFF
--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -184,7 +184,7 @@ class ChatInterface(Blocks):
                 self.chatbot = chatbot.render()
             else:
                 self.chatbot = Chatbot(
-                    label="Chatbot", scale=1, height=200 if fill_height else None
+                    label="Chatbot", scale=1, height=None if fill_height else 200
                 )
 
             with Row():


### PR DESCRIPTION
## Description

It says fill_height extends to the height of the window when True

But it actually extends to the height of the window when fill_height is False

Therefore, if fill_height is True, it should be None, and if it is False, it should be 200

Thanks!
