### PR TITLE
Exclude `typer` from the requirements list for Wasm env and fix `gradio.cli` not to be imported

### DIFF
--- a/.changeset/silly-spies-cross.md
+++ b/.changeset/silly-spies-cross.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Exclude `typer` from the requirements list for Wasm env and fix `gradio.cli` not to be imported

--- a/.changeset/silly-spies-cross.md
+++ b/.changeset/silly-spies-cross.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Exclude `typer` from the requirements list for Wasm env and fix `gradio.cli` not to be imported

--- a/gradio/__init__.py
+++ b/gradio/__init__.py
@@ -7,7 +7,6 @@ import gradio.templates
 from gradio import components, layouts, themes
 from gradio.blocks import Blocks
 from gradio.chat_interface import ChatInterface
-from gradio.cli import deploy
 from gradio.components import (
     HTML,
     JSON,
@@ -99,5 +98,9 @@ from gradio.templates import (
 )
 from gradio.themes import Base as Theme
 from gradio.utils import NO_RELOAD, get_package_version, set_static_paths
+from gradio.wasm_utils import IS_WASM
+
+if not IS_WASM:
+    from gradio.cli import deploy
 
 __version__ = get_package_version()

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -680,6 +680,11 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
 
     @property
     def _is_running_in_reload_thread(self):
+        if wasm_utils.IS_WASM:
+            # Wasm (Pyodide) doesn't support threading,
+            # so the return value is always False.
+            return False
+
         from gradio.cli.commands.reload import reload_thread
 
         return getattr(reload_thread, "running_reload", False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ pyyaml>=5.0,<7.0
 semantic_version~=2.0
 typing_extensions~=4.0
 uvicorn>=0.14.0; sys.platform != 'emscripten'
-typer[all]>=0.9,<1.0
+typer[all]>=0.9,<1.0; sys.platform != 'emscripten'
 tomlkit==0.12.0
 ruff>=0.2.2; sys.platform != 'emscripten'


### PR DESCRIPTION
## Description

Related to #7791 

|  | This PR (`f86fea0`) | `main` (ff6bf3e) |
|---|---|---|
| 1 | 9.861 | 10.090 |
| 2 | 8.722 | 9.548 |
| 3 | 8.511 | 8.099 |
| Avg | 9.031 | 9.246 |

Also, the initial payload size is reduced from 110MB to 105MB because `typer` and its deps such as `click` and `rich` are not downloaded.