### PR TITLE
Fix gradio/components/dataframe.py not to import `pandas.io`

### DIFF
--- a/.changeset/solid-cars-spend.md
+++ b/.changeset/solid-cars-spend.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix gradio/components/dataframe.py not to import `pandas.io`

--- a/.changeset/solid-cars-spend.md
+++ b/.changeset/solid-cars-spend.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Fix gradio/components/dataframe.py not to import `pandas.io`

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -236,6 +236,8 @@ class Dataframe(Component):
         Returns:
             the uploaded spreadsheet data as an object with `headers` and `data` attributes
         """
+        from pandas.io.formats.style import Styler
+
         if value is None:
             return self.postprocess(self.empty_input)
         if isinstance(value, dict):

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -19,7 +19,6 @@ import numpy as np
 import pandas as pd
 import semantic_version
 from gradio_client.documentation import document
-from pandas.io.formats.style import Styler
 
 from gradio.components import Component
 from gradio.data_classes import GradioModel
@@ -27,6 +26,7 @@ from gradio.events import Events
 
 if TYPE_CHECKING:
     import polars as pl  # type: ignore
+    from pandas.io.formats.style import Styler
 
 
 def _is_polars_available():


### PR DESCRIPTION
## Description

Related to #7791 

`pandas.io` imports `matplotlib` internally. It takes a long time and makes #7157 less effective.
This PR fixes it.

### Performance assessment on Lite

|  | This PR (8194bfd) | `main` (1a7c8d3) |
| --- | --- | --- |
| 1 | 7.369 | 9.023 |
| 2 | 6.909 | 8.798 |
| 3 | 6.991 | 9.556 |
| Average | 7.090 | 9.126 |
