### PR TITLE
Revert the minify setting in vite.config.js which was mistakingly introduced in #6261

### DIFF
--- a/.changeset/eleven-states-tan.md
+++ b/.changeset/eleven-states-tan.md
@@ -1,0 +1,6 @@
+---
+"@gradio/app": minor
+"gradio": minor
+---
+
+feat:Revert the minify setting in vite.config.js which was mistakingly introduced in #6261

--- a/js/app/vite.config.ts
+++ b/js/app/vite.config.ts
@@ -61,8 +61,7 @@ export default defineConfig(({ mode }) => {
 		build: {
 			sourcemap: true,
 			target: "esnext",
-			// minify: production,
-			minify: false,
+			minify: production,
 			outDir: is_lite ? resolve(__dirname, "../lite/dist") : targets[mode],
 			// To build Gradio-lite as a library, we can't use the library mode
 			// like `lib: is_lite && {}`


### PR DESCRIPTION
## Description

Ref: https://huggingface.slack.com/archives/C055NMB0S87/p1711525308205149?thread_ts=1711089573.553429&cid=C055NMB0S87


Confirmed that `pnpm --filter @gradio/app build:lite` generated a minified `lite.js`.