### PR TITLE
Lighter wheel for gradio lite

### DIFF
--- a/.config/lite-builder/pyproject.toml
+++ b/.config/lite-builder/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["hatchling",]
+build-backend = "hatchling.build"
+
+[project]
+name = "lite-builder"
+description = "Python library for easily interacting with trained machine learning models"
+license = "Apache-2.0"
+version = "0.0.2"
+requires-python = ">=3.8"
+authors = [
+  { name = "Abubakar Abid", email = "gradio-team@huggingface.co" },
+  { name = "Ali Abid", email = "gradio-team@huggingface.co" },
+  { name = "Ali Abdalla", email = "gradio-team@huggingface.co" },
+  { name = "Dawood Khan", email = "gradio-team@huggingface.co" },
+  { name = "Ahsen Khaliq", email = "gradio-team@huggingface.co" },
+  { name = "Pete Allen", email = "gradio-team@huggingface.co" },
+  { name = "Ömer Faruk Özdemir", email = "gradio-team@huggingface.co" },
+  { name = "Freddy A Boulton", email = "gradio-team@huggingface.co" },
+  { name = "Hannah Blair", email = "gradio-team@huggingface.co" },
+]
+keywords = ["machine learning", "reproducibility", "visualization"]
+
+classifiers = [
+  'Development Status :: 5 - Production/Stable',
+]
+
+[tool.hatch.build]
+sources = ["src"]
+only-packages = true
+
+[project.entry-points.hatch]
+aws = "lite_builder.hooks"

--- a/.config/lite-builder/src/lite_builder/builder.py
+++ b/.config/lite-builder/src/lite_builder/builder.py
@@ -1,0 +1,5 @@
+from hatchling.builders.wheel import WheelBuilder
+
+
+class LiteBuilder(WheelBuilder):
+    PLUGIN_NAME = 'lite'

--- a/.config/lite-builder/src/lite_builder/hooks.py
+++ b/.config/lite-builder/src/lite_builder/hooks.py
@@ -1,0 +1,6 @@
+from hatchling.plugin import hookimpl
+from .builder import LiteBuilder
+
+@hookimpl
+def hatch_register_builder():
+    return LiteBuilder

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .eggs/
 gradio.egg-info
 dist/
+dist-lite/
 *.pyc
 __pycache__/
 *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,12 @@ artifacts = [
   "py.typed",
 ]
 
+[tool.hatch.build.targets.lite]
+artifacts = ["gradio/templates", "*.pyi", "!/gradio/test_data", "!/gradio/_frontend_code", "!/gradio/node"]
+path = ".config/lite_builder.py"
+directory = "dist-lite"
+dependencies = ["lite-builder @ {root:uri}/../.config/lite-builder"]
+
 [tool.hatch.build.targets.wheel.hooks.custom]
 path = ".config/copy_frontend.py"
 


### PR DESCRIPTION
## Description

Adds a custom build target for hatch called `lite`. It exclude `_frontend_code`,  `node`, and `test_data` but should be identical otherwise. You can build this with `hatch build -t lite`. The output is placed in `dist-lite`. Locally I see that `dist-lite` is 11mb compared to 35mb for the normal build.

<img width="738" alt="image" src="https://github.com/gradio-app/gradio/assets/41651716/97139ca3-6b81-4370-8b33-e1e304669f20">


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
