### PR TITLE
Make buttons in `gr.ChatInterface` more mobile-friendly

### DIFF
--- a/.changeset/shaggy-symbols-tie.md
+++ b/.changeset/shaggy-symbols-tie.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Make buttons in `gr.ChatInterface` more mobile-friendly

--- a/.changeset/shaggy-symbols-tie.md
+++ b/.changeset/shaggy-symbols-tie.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Make buttons in `gr.ChatInterface` more mobile-friendly

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -193,7 +193,9 @@ class ChatInterface(Blocks):
                         if isinstance(btn, Button):
                             btn.render()
                         elif isinstance(btn, str):
-                            btn = Button(btn, variant="secondary", size="sm", min_width=60)
+                            btn = Button(
+                                btn, variant="secondary", size="sm", min_width=60
+                            )
                         else:
                             raise ValueError(
                                 f"All the _btn parameters must be a gr.Button, string, or None, not {type(btn)}"

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -193,7 +193,7 @@ class ChatInterface(Blocks):
                         if isinstance(btn, Button):
                             btn.render()
                         elif isinstance(btn, str):
-                            btn = Button(btn, variant="secondary", size="sm")
+                            btn = Button(btn, variant="secondary", size="sm", min_width=60)
                         else:
                             raise ValueError(
                                 f"All the _btn parameters must be a gr.Button, string, or None, not {type(btn)}"


### PR DESCRIPTION
Reduces the default min width of the buttons in `gr.ChatInterface` to make it more mobile-friendly.

Before:

![image](https://github.com/gradio-app/gradio/assets/1778297/c6c3bc8f-aa31-4043-8426-cd708cfd378c)


After:

![image](https://github.com/gradio-app/gradio/assets/1778297/bdf6ff4b-bebc-4a48-b8a8-ce6d9c3ca0ea)

