### PR TITLE
[ZeroGPU] postMessage `zerogpu-headers`

### DIFF
--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -187,12 +187,12 @@ export function api_factory(
 		url: string,
 		body: unknown,
 		token?: `hf_${string}`,
-		headers?: Record<string, string>,
+		additional_headers?: Record<string, string>,
 	): Promise<[PostResponse, number]> {
 		const headers: {
 			Authorization?: string;
 			"Content-Type": "application/json";
-		} = { "Content-Type": "application/json", ...headers};
+		} = { "Content-Type": "application/json"};
 		if (token) {
 			headers.Authorization = `Bearer ${token}`;
 		}
@@ -201,7 +201,7 @@ export function api_factory(
 			var response = await fetch_implementation(url, {
 				method: "POST",
 				body: JSON.stringify(body),
-				headers
+				headers: {...headers, ...additional_headers},
 			});
 		} catch (e) {
 			return [{ error: BROKEN_CONNECTION_MSG }, 500];

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -783,7 +783,7 @@ export function api_factory(
 								? `https://moon-${hostname.split(".")[1]}.${hfhubdev}`
 								: `https://huggingface.co`;
 							const zerogpu_auth_promise =
-								dependency.zerogpu && window.parent != window
+								dependency.zerogpu && window.parent != window && config.space_id
 									? postMessage<Headers>("zerogpu-headers", origin)
 									: Promise.resolve(null);
 							const post_data_promise = zerogpu_auth_promise.then((headers) => {

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -782,9 +782,10 @@ export function api_factory(
 							const origin = hostname.includes(".dev.")
 								? `https://moon-${hostname.split(".")[1]}.${hfhubdev}`
 								: `https://huggingface.co`;
-							const zerogpu_auth_promise = dependency.zerogpu
-								? postMessage<Headers>("zerogpu-headers", origin)
-								: Promise.resolve(null);
+							const zerogpu_auth_promise =
+								dependency.zerogpu && window.parent != window
+									? postMessage<Headers>("zerogpu-headers", origin)
+									: Promise.resolve(null);
 							const post_data_promise = zerogpu_auth_promise.then((headers) => {
 								return post_data(
 									`${config.root}/queue/join?${url_params}`,

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -777,8 +777,11 @@ export function api_factory(
 								fn_index,
 								time: new Date()
 							});
+							const origin = window.location.hostname.includes('.dev.')
+								? `moon-${window.location.hostname.split('.')[1]}.dev.spaces.huggingface.tech`
+								: `https://huggingface.co`;
 							const zerogpu_auth_promise = dependency.zerogpu
-								? postMessage<string>("whoami", "https://moon-sp-zerogpu-login-b6.dev.spaces.huggingface.tech")
+								? postMessage<Headers>("whoami", origin)
 								: Promise.resolve(null);
 							zerogpu_auth_promise.then((zerogpu_auth) => {
 								return post_data(

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -778,7 +778,7 @@ export function api_factory(
 								time: new Date()
 							});
 							const origin = window.location.hostname.includes('.dev.')
-								? `moon-${window.location.hostname.split('.')[1]}.dev.spaces.huggingface.tech`
+								? `https://moon-${window.location.hostname.split('.')[1]}.dev.spaces.huggingface.tech`
 								: `https://huggingface.co`;
 							const zerogpu_auth_promise = dependency.zerogpu
 								? postMessage<Headers>("zerogpu-headers", origin)

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -781,9 +781,9 @@ export function api_factory(
 								? `moon-${window.location.hostname.split('.')[1]}.dev.spaces.huggingface.tech`
 								: `https://huggingface.co`;
 							const zerogpu_auth_promise = dependency.zerogpu
-								? postMessage<Headers>("whoami", origin)
+								? postMessage<Headers>("zerogpu-headers", origin)
 								: Promise.resolve(null);
-							zerogpu_auth_promise.then((zerogpu_auth) => {
+							zerogpu_auth_promise.then((zerogpu_headers) => {
 								return post_data(
 									`${config.root}/queue/join?${url_params}`,
 									{
@@ -791,7 +791,7 @@ export function api_factory(
 										session_hash
 									},
 									hf_token,
-									zerogpu_auth ? {'X-Visitor-Token': zerogpu_auth} : null,
+									zerogpu_headers,
 								)
 							}).then(([response, status]) => {
 								if (status === 503) {

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -13,7 +13,7 @@ import {
 	hardware_types,
 	resolve_root,
 	apply_diff,
-	postMessage
+	post_message
 } from "./utils.js";
 
 import type {
@@ -784,7 +784,7 @@ export function api_factory(
 								: `https://huggingface.co`;
 							const zerogpu_auth_promise =
 								dependency.zerogpu && window.parent != window && config.space_id
-									? postMessage<Headers>("zerogpu-headers", origin)
+									? post_message<Headers>("zerogpu-headers", origin)
 									: Promise.resolve(null);
 							const post_data_promise = zerogpu_auth_promise.then((headers) => {
 								return post_data(

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -187,12 +187,12 @@ export function api_factory(
 		url: string,
 		body: unknown,
 		token?: `hf_${string}`,
-		additional_headers?: Record<string, string>,
+		additional_headers?: Record<string, string>
 	): Promise<[PostResponse, number]> {
 		const headers: {
 			Authorization?: string;
 			"Content-Type": "application/json";
-		} = { "Content-Type": "application/json"};
+		} = { "Content-Type": "application/json" };
 		if (token) {
 			headers.Authorization = `Bearer ${token}`;
 		}
@@ -201,7 +201,7 @@ export function api_factory(
 			var response = await fetch_implementation(url, {
 				method: "POST",
 				body: JSON.stringify(body),
-				headers: {...headers, ...additional_headers},
+				headers: { ...headers, ...additional_headers }
 			});
 		} catch (e) {
 			return [{ error: BROKEN_CONNECTION_MSG }, 500];
@@ -777,13 +777,15 @@ export function api_factory(
 								fn_index,
 								time: new Date()
 							});
-							const origin = window.location.hostname.includes('.dev.')
-								? `https://moon-${window.location.hostname.split('.')[1]}.dev.spaces.huggingface.tech`
+							let hostname = window.location.hostname;
+							let hfhubdev = "dev.spaces.huggingface.tech";
+							const origin = hostname.includes(".dev.")
+								? `https://moon-${hostname.split(".")[1]}.${hfhubdev}`
 								: `https://huggingface.co`;
 							const zerogpu_auth_promise = dependency.zerogpu
 								? postMessage<Headers>("zerogpu-headers", origin)
 								: Promise.resolve(null);
-							zerogpu_auth_promise.then((zerogpu_headers) => {
+							const post_data_promise = zerogpu_auth_promise.then((headers) => {
 								return post_data(
 									`${config.root}/queue/join?${url_params}`,
 									{
@@ -791,9 +793,10 @@ export function api_factory(
 										session_hash
 									},
 									hf_token,
-									zerogpu_headers,
-								)
-							}).then(([response, status]) => {
+									headers
+								);
+							});
+							post_data_promise.then(([response, status]) => {
 								if (status === 503) {
 									fire_event({
 										type: "status",

--- a/client/js/src/utils.ts
+++ b/client/js/src/utils.ts
@@ -299,7 +299,7 @@ export function apply_diff(
 	return obj;
 }
 
-export function postMessage<Res = any>(
+export function post_message<Res = any>(
 	message: any,
 	origin: string
 ): Promise<Res> {

--- a/client/js/src/utils.ts
+++ b/client/js/src/utils.ts
@@ -298,3 +298,14 @@ export function apply_diff(
 
 	return obj;
 }
+
+export function postMessage<Res = any>(message: any, origin: string): Promise<Res> {
+	return new Promise((res, _rej) => {
+		const channel = new MessageChannel();
+		channel.port1.onmessage = (({data}) => {
+			channel.port1.close();
+			res(data);
+		}) as (ev: MessageEvent<Res>) => void;
+		window.parent.postMessage(message, origin, [channel.port2]);
+	});
+}

--- a/client/js/src/utils.ts
+++ b/client/js/src/utils.ts
@@ -299,10 +299,13 @@ export function apply_diff(
 	return obj;
 }
 
-export function postMessage<Res = any>(message: any, origin: string): Promise<Res> {
+export function postMessage<Res = any>(
+	message: any,
+	origin: string
+): Promise<Res> {
 	return new Promise((res, _rej) => {
 		const channel = new MessageChannel();
-		channel.port1.onmessage = (({data}) => {
+		channel.port1.onmessage = (({ data }) => {
 			channel.port1.close();
 			res(data);
 		}) as (ev: MessageEvent<Res>) => void;

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1060,6 +1060,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
             "trigger_only_on_success": trigger_only_on_success,
             "trigger_mode": trigger_mode,
             "show_api": show_api,
+            "zerogpu": hasattr(fn, 'zerogpu'),
         }
         self.dependencies.append(dependency)
         return dependency, len(self.dependencies) - 1

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1060,7 +1060,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
             "trigger_only_on_success": trigger_only_on_success,
             "trigger_mode": trigger_mode,
             "show_api": show_api,
-            "zerogpu": hasattr(fn, 'zerogpu'),
+            "zerogpu": hasattr(fn, "zerogpu"),
         }
         self.dependencies.append(dependency)
         return dependency, len(self.dependencies) - 1

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -799,6 +799,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
                     original_mapping[o] for o in dependency["outputs"]
                 ]
                 dependency.pop("status_tracker", None)
+                dependency.pop("zerogpu")
                 dependency["preprocess"] = False
                 dependency["postprocess"] = False
                 if is_then_event:


### PR DESCRIPTION
Provide a logged-in experience for ZeroGPU (regarding GPU quotas)

ZeroGPU functions are marked with a `zerogpu` attribute by the `@spaces.GPU` decorator
When this attribute is detected, `"zerogpu"` is set to `True` in the dependency config

On JS client side, when `dependency.zerogpu` is `true` we ask parent frame (HF hub) for headers to be included in the API request (through the postMessage API)