### PR TITLE
logout route deleting cookie fix

### DIFF
--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -331,6 +331,7 @@ class App(FastAPI):
 
             @app.get("/logout")
             def logout(response: Response, user: str = Depends(get_current_user)):
+                response = RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
                 response.delete_cookie(key=f"access-token-{app.cookie_id}", path="/")
                 response.delete_cookie(
                     key=f"access-token-unsecure-{app.cookie_id}", path="/"
@@ -339,7 +340,7 @@ class App(FastAPI):
                 for token in list(app.tokens.keys()):
                     if app.tokens[token] == user:
                         del app.tokens[token]
-                return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
+                return response
 
         ###############
         # Main Routes


### PR DESCRIPTION
Closes #7885 

now deleting cookies properly by calling 
RedirectResponse(url="/", status_code=status.HTTP_302_FOUND) 
earlier in the logout route 