### PR TITLE
Make internal event handlers of gr.Interface and gr.ChatInterface async

### DIFF
--- a/.changeset/strong-hornets-push.md
+++ b/.changeset/strong-hornets-push.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:Make internal event handlers of gr.Interface and gr.ChatInterface async

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -29,7 +29,7 @@ from gradio.helpers import special_args
 from gradio.layouts import Accordion, Group, Row
 from gradio.routes import Request
 from gradio.themes import ThemeClass as Theme
-from gradio.utils import SyncToAsyncIterator, async_iteration
+from gradio.utils import SyncToAsyncIterator, async_iteration, async_lambda
 
 
 @document()
@@ -378,7 +378,7 @@ class ChatInterface(Blocks):
                 show_api=False,
                 queue=False,
             ).then(
-                lambda x: x,
+                async_lambda(lambda x: x),
                 [self.saved_input],
                 [self.textbox],
                 show_api=False,
@@ -387,7 +387,7 @@ class ChatInterface(Blocks):
 
         if self.clear_btn:
             self.clear_btn.click(
-                lambda: ([], [], None),
+                async_lambda(lambda: ([], [], None)),
                 None,
                 [self.chatbot, self.chatbot_state, self.saved_input],
                 queue=False,
@@ -401,9 +401,11 @@ class ChatInterface(Blocks):
             if self.submit_btn:
                 for event_trigger in event_triggers:
                     event_trigger(
-                        lambda: (
-                            Button(visible=False),
-                            Button(visible=True),
+                        async_lambda(
+                            lambda: (
+                                Button(visible=False),
+                                Button(visible=True),
+                            )
                         ),
                         None,
                         [self.submit_btn, self.stop_btn],
@@ -411,7 +413,7 @@ class ChatInterface(Blocks):
                         queue=False,
                     )
                 event_to_cancel.then(
-                    lambda: (Button(visible=True), Button(visible=False)),
+                    async_lambda(lambda: (Button(visible=True), Button(visible=False))),
                     None,
                     [self.submit_btn, self.stop_btn],
                     show_api=False,
@@ -420,14 +422,14 @@ class ChatInterface(Blocks):
             else:
                 for event_trigger in event_triggers:
                     event_trigger(
-                        lambda: Button(visible=True),
+                        async_lambda(lambda: Button(visible=True)),
                         None,
                         [self.stop_btn],
                         show_api=False,
                         queue=False,
                     )
                 event_to_cancel.then(
-                    lambda: Button(visible=False),
+                    async_lambda(lambda: Button(visible=False)),
                     None,
                     [self.stop_btn],
                     show_api=False,
@@ -471,7 +473,7 @@ class ChatInterface(Blocks):
         if message["text"] is not None and isinstance(message["text"], str):
             history.append([message["text"], response])
 
-    def _display_input(
+    async def _display_input(
         self, message: str | dict[str, list], history: list[list[str | tuple | None]]
     ) -> tuple[list[list[str | tuple | None]], list[list[str | tuple | None]]]:
         if self.multimodal and isinstance(message, dict):
@@ -631,7 +633,7 @@ class ChatInterface(Blocks):
         async for response in generator:
             yield [[message, response]]
 
-    def _delete_prev_fn(
+    async def _delete_prev_fn(
         self,
         message: str | dict[str, list],
         history: list[list[str | tuple | None]],

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -701,14 +701,16 @@ class Interface(Blocks):
             if _stop_btn:
                 extra_output = [_submit_btn, _stop_btn]
 
-                def cleanup():
+                async def cleanup():
                     return [Button(visible=True), Button(visible=False)]
 
                 predict_event = on(
                     triggers,
-                    lambda: (
-                        Button(visible=False),
-                        Button(visible=True),
+                    utils.async_lambda(
+                        lambda: (
+                            Button(visible=False),
+                            Button(visible=True),
+                        )
                     ),
                     inputs=None,
                     outputs=[_submit_btn, _stop_btn],
@@ -827,7 +829,9 @@ class Interface(Blocks):
                 )
             flag_method = FlagMethod(self.flagging_callback, label, value)
             flag_btn.click(
-                lambda: Button(value="Saving...", interactive=False),
+                utils.async_lambda(
+                    lambda: Button(value="Saving...", interactive=False)
+                ),
                 None,
                 flag_btn,
                 queue=False,
@@ -842,7 +846,11 @@ class Interface(Blocks):
                 show_api=False,
             )
             _clear_btn.click(
-                flag_method.reset, None, flag_btn, queue=False, show_api=False
+                utils.async_lambda(flag_method.reset),
+                None,
+                flag_btn,
+                queue=False,
+                show_api=False,
             )
 
     def render_examples(self):

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -26,6 +26,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from contextlib import contextmanager
+from functools import wraps
 from io import BytesIO
 from numbers import Number
 from pathlib import Path
@@ -1245,3 +1246,15 @@ def simplify_file_data_in_str(s):
     if isinstance(payload, str):
         return payload
     return json.dumps(payload)
+
+
+def async_lambda(f: Callable) -> Callable:
+    """Turn a function into an async function.
+    Useful for internal event handlers defined as lambda functions used in the codebase
+    """
+
+    @wraps(f)
+    async def function_wrapper(*args, **kwargs):
+        return f(*args, **kwargs)
+
+    return function_wrapper


### PR DESCRIPTION
## Description

As discussed [earlier](https://huggingface.slack.com/archives/C02QNREU24S/p1711549951697389?thread_ts=1711493071.830579&cid=C02QNREU24S), most of the event handlers for manipulating the UI in gr.Interface and gr.ChatInterface can be made async. This should lead to better performance as new threads would not be spun up to handle these quick updates.


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
