### PR TITLE
Update multiselect styling

### DIFF
--- a/js/dropdown/shared/Multiselect.svelte
+++ b/js/dropdown/shared/Multiselect.svelte
@@ -306,8 +306,8 @@
 <style>
 	.icon-wrap {
 		color: var(--body-text-color);
-		margin-right: var(--size-2);
-		width: var(--size-5);
+		margin-right: var(--spacing-sm);
+		width: var(--size-2-5);
 	}
 	label:not(.container),
 	label:not(.container) .wrap,

--- a/js/icons/src/DropdownArrow.svelte
+++ b/js/icons/src/DropdownArrow.svelte
@@ -3,15 +3,13 @@
 	xmlns="http://www.w3.org/2000/svg"
 	width="100%"
 	height="100%"
-	viewBox="0 0 18 18"
+	viewBox="0 0 2 1"
 >
-	<path d="M5 8l4 4 4-4z" />
+	<path d="m0 0 1 1 1-1z" />
 </svg>
 
 <style>
 	.dropdown-arrow {
 		fill: currentColor;
-		/* margin-right: var(--size-2); */
-		/* width: var(--size-5); */
 	}
 </style>


### PR DESCRIPTION
## Description

For the multiselect:
1. Removes the empty space that is built into the dropdown arrow SVG. This allows the padding/border/margin to be completely controlled in CSS, allowing for easy override from downstream applications/plugins.
2. Makes the dropdown arrow's right margin consistent in size with the text (`var(--spacing-sm)`)
3. Slightly increases the arrow's size (`var(--size-2-5)`)
4. Removes 2 old commented-out styles

Before:
![before](https://github.com/gradio-app/gradio/assets/16239365/953c57a7-4ae1-4071-b9d7-79cdab8a11da)
After:
![after](https://github.com/gradio-app/gradio/assets/16239365/432c6508-a8bd-4147-aeea-e8c6b80dd1e0)