### PR TITLE
Allow displaying gr.Code examples by their filename if value is a tuple

### DIFF
--- a/.changeset/fast-walls-drop.md
+++ b/.changeset/fast-walls-drop.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Add code

--- a/.changeset/fast-walls-drop.md
+++ b/.changeset/fast-walls-drop.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Add code
+feat:Allow displaying gr.Code examples by their filename if value is a tuple

--- a/gradio/components/code.py
+++ b/gradio/components/code.py
@@ -163,3 +163,8 @@ class Code(Component):
 
     def example_value(self) -> Any:
         return "print('Hello World')"
+
+    def process_example(self, value: str | tuple[str] | None) -> str | None:
+        if isinstance(value, tuple):
+            return value[0]
+        return super().process_example(value)

--- a/gradio/components/code.py
+++ b/gradio/components/code.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Callable, Literal
 
 from gradio_client.documentation import document
@@ -166,5 +167,5 @@ class Code(Component):
 
     def process_example(self, value: str | tuple[str] | None) -> str | None:
         if isinstance(value, tuple):
-            return value[0]
+            return Path(value[0]).name
         return super().process_example(value)

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -2943,7 +2943,6 @@ class TestCode:
         assert code.process_example(None) is None
         filename = str(Path("test/test_files/test_label_json.json"))
         assert code.process_example((filename,)) == "test_label_json.json"
-        assert code.process_example(Path(filename)) == "test_label_json.json"
 
 
 class TestFileExplorer:

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -2935,6 +2935,15 @@ class TestCode:
             "_selectable": False,
         }
 
+    def test_process_example(self):
+        code = gr.Code()
+        assert (
+            code.process_example("def fn(a):\n  return a") == "def fn(a):\n  return a"
+        )
+        assert code.process_example(None) is None
+        filename = str(Path("test/test_files/test_label_json.json"))
+        assert code.process_example((filename,)) == filename
+
 
 class TestFileExplorer:
     def test_component_functions(self):

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -2942,7 +2942,8 @@ class TestCode:
         )
         assert code.process_example(None) is None
         filename = str(Path("test/test_files/test_label_json.json"))
-        assert code.process_example((filename,)) == filename
+        assert code.process_example((filename,)) == "test_label_json.json"
+        assert code.process_example(Path(filename)) == "test_label_json.json"
 
 
 class TestFileExplorer:


### PR DESCRIPTION
## Description

You can display a filename for the code component example as opposed to the whole contents of the file. Just need to pass in a tuple to denote it's a file (same as postprocess)

Test with

```python
import gradio as gr

demo = gr.Interface(
    lambda x: x,
    gr.Code(),
    gr.Code(),
    examples=[[("/Users/freddy/sources/gradio/demo/code_component/run.py",)], ]
)


if __name__ == "__main__":
    demo.launch()
```

Don't think we need #4268 for this

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
