### PR TITLE
Audio upload performance improvement for filepath output

### DIFF
--- a/.changeset/spicy-turkeys-repair.md
+++ b/.changeset/spicy-turkeys-repair.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Audio upload performance improvement for filepath output

--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -212,6 +212,15 @@ class Audio(
             temp_file_path.with_name(f"{temp_file_path.stem}{temp_file_path.suffix}")
         )
 
+        # skip all processing if the file is already in the correct format and user asks for filepath
+        if (
+            self.type == "filepath"
+            and temp_file_path.suffix == f".{self.format}"
+            and self.min_length is None
+            and self.max_length is None
+        ):
+            return payload.path
+            
         sample_rate, data = processing_utils.audio_from_file(temp_file_path)
 
         duration = len(data) / sample_rate


### PR DESCRIPTION
Basically, if there's no changes needed to be made to the audio file and the user requests a file, we can save performance time by skipping loading into numpy and saving back as a file.

May fix: #7681