### PR TITLE
Handle the case of multiple headers when constructing root url

### DIFF
--- a/.changeset/little-breads-allow.md
+++ b/.changeset/little-breads-allow.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Handle the case of multiple headers when constructing root url

--- a/.changeset/little-breads-allow.md
+++ b/.changeset/little-breads-allow.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Handle the case of multiple headers when constructing root url

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -312,9 +312,7 @@ def get_root_url(
     def get_first_header_value(header_name: str):
         header_value = request.headers.get(header_name)
         if header_value:
-            return header_value.split(",")[
-                0
-            ].strip()
+            return header_value.split(",")[0].strip()
         return None
 
     if root_path and client_utils.is_http_url_like(root_path):

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -308,10 +308,13 @@ def get_root_url(
     In cases (2) and (3), We also check to see if the x-forwarded-proto header is present, and if so, convert the root url to https.
     And if there are multiple hosts in the x-forwarded-host or multiple protocols in the x-forwarded-proto, the first one is used.
     """
+
     def get_first_header_value(header_name: str):
         header_value = request.headers.get(header_name)
         if header_value:
-            return header_value.split(',')[0].strip()  # Splits the value and returns the first element
+            return header_value.split(",")[
+                0
+            ].strip()  # Splits the value and returns the first element
         return None
 
     if root_path and client_utils.is_http_url_like(root_path):

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -306,16 +306,23 @@ def get_root_url(
     And if a relative `root_path` is provided, and it is not already the subpath of the URL, it is appended to the root url.
 
     In cases (2) and (3), We also check to see if the x-forwarded-proto header is present, and if so, convert the root url to https.
+    And if there are multiple hosts in the x-forwarded-host or multiple protocols in the x-forwarded-proto, the first one is used.
     """
+    def get_first_header_value(header_name: str):
+        header_value = request.headers.get(header_name)
+        if header_value:
+            return header_value.split(',')[0].strip()  # Splits the value and returns the first element
+        return None
+
     if root_path and client_utils.is_http_url_like(root_path):
         return root_path.rstrip("/")
 
-    x_forwarded_host = request.headers.get("x-forwarded-host")
+    x_forwarded_host = get_first_header_value("x-forwarded-host")
     root_url = f"http://{x_forwarded_host}" if x_forwarded_host else str(request.url)
     root_url = httpx.URL(root_url)
     root_url = root_url.copy_with(query=None)
     root_url = str(root_url).rstrip("/")
-    if request.headers.get("x-forwarded-proto") == "https":
+    if get_first_header_value("x-forwarded-proto") == "https":
         root_url = root_url.replace("http://", "https://")
 
     route_path = route_path.rstrip("/")

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -314,7 +314,7 @@ def get_root_url(
         if header_value:
             return header_value.split(",")[
                 0
-            ].strip()  # Splits the value and returns the first element
+            ].strip()
         return None
 
     if root_path and client_utils.is_http_url_like(root_path):

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1096,6 +1096,12 @@ def test_get_root_url(
             "https://gradio.dev",
         ),
         (
+            {"x-forwarded-host": "gradio.dev,internal.gradio.dev", "x-forwarded-proto": "https,http"},
+            "/",
+            "/",
+            "https://gradio.dev",
+        ),
+        (
             {"x-forwarded-host": "gradio.dev", "x-forwarded-proto": "https"},
             "http://google.com",
             "/",

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1096,7 +1096,10 @@ def test_get_root_url(
             "https://gradio.dev",
         ),
         (
-            {"x-forwarded-host": "gradio.dev,internal.gradio.dev", "x-forwarded-proto": "https,http"},
+            {
+                "x-forwarded-host": "gradio.dev,internal.gradio.dev",
+                "x-forwarded-proto": "https,http",
+            },
             "/",
             "/",
             "https://gradio.dev",


### PR DESCRIPTION
While investigating https://github.com/gradio-app/gradio/issues/7934, I learned that the x-forwarded-host and x-forwarded-proto headers can contain multiple values if the request has passed through several proxies. 

E.g. see https://gitlab.com/gitlab-org/gitlab-pages/-/merge_requests/386

This PR modifies the `get_root_url()` method to handle these cases