### PR TITLE
Fix task bug in python 3.9

### DIFF
--- a/.changeset/twenty-paws-poke.md
+++ b/.changeset/twenty-paws-poke.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Fix task bug in python 3.9

--- a/.changeset/twenty-paws-poke.md
+++ b/.changeset/twenty-paws-poke.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix task bug in python 3.9

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -795,7 +795,7 @@ async def _delete_state_handler(app: App):
     """When the server launches, regularly delete expired state."""
     # The stop event needs to get the current event loop for python 3.8
     # but the loop parameter is deprecated for 3.8+
-    if sys.version_info < (3, 9):
+    if sys.version_info < (3, 10):
         loop = asyncio.get_running_loop()
         app.stop_event = asyncio.Event(loop=loop)
     asyncio.create_task(_delete_state(app))


### PR DESCRIPTION
## Description

Closes a task bug found by @aliabd in python 3.9. Python 3.10 and 3.11 are good.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
