### PR TITLE
Adding hint `list[list]` for example parameter

### DIFF
--- a/.changeset/honest-spiders-visit.md
+++ b/.changeset/honest-spiders-visit.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Adding hint `list[list]` for example parameter

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -61,7 +61,7 @@ class ChatInterface(Blocks):
         additional_inputs: str | Component | list[str | Component] | None = None,
         additional_inputs_accordion_name: str | None = None,
         additional_inputs_accordion: str | Accordion | None = None,
-        examples: list[str] | list[dict[str, str | list]] | None = None,
+        examples: list[str] | list[dict[str, str | list]] | list[list] | None = None,
         cache_examples: bool | Literal["lazy"] | None = None,
         title: str | None = None,
         description: str | None = None,


### PR DESCRIPTION
## Description

This PR add the hint type `list[list]` in the example parameter of the `gr.ChatInterface()` object, to resolve the "Expected parameter" message when a single or multiple additionnal_inputs are provided to the instance.

Closes: #7931 (closed)

  