### PR TITLE
Fix heartbeat in the js client to be Lite compatible

### DIFF
--- a/.changeset/eighty-rockets-march.md
+++ b/.changeset/eighty-rockets-march.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": minor
+"gradio": minor
+---
+
+feat:Fix heartbeat in the js client to be Lite compatible

--- a/.changeset/eighty-rockets-march.md
+++ b/.changeset/eighty-rockets-march.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/client": minor
-"gradio": minor
+"@gradio/client": patch
+"gradio": patch
 ---
 
-feat:Fix heartbeat in the js client to be Lite compatible
+fix:Fix heartbeat in the js client to be Lite compatible

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -361,7 +361,7 @@ export function api_factory(
 				const heartbeat_url = new URL(
 					`${config.root}/heartbeat/${session_hash}`
 				);
-				const heartbeat = EventSource_factory(heartbeat_url);
+				EventSource_factory(heartbeat_url); // Just connect to the endpoint without parsing the response. Ref: https://github.com/gradio-app/gradio/pull/7974#discussion_r1557717540
 				res(_config);
 			} catch (e) {
 				console.error(e);

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -358,9 +358,10 @@ export function api_factory(
 
 				const _config = await config_success(config);
 				// connect to the heartbeat endpoint via GET request
-				const heartbeat = new EventSource(
+				const heartbeat_url = new URL(
 					`${config.root}/heartbeat/${session_hash}`
 				);
+				const heartbeat = EventSource_factory(heartbeat_url);
 				res(_config);
 			} catch (e) {
 				console.error(e);


### PR DESCRIPTION
## Description

Fixes this error
> GET http://localhost:7860/heartbeat/0gcss84krmc5 net::ERR_CONNECTION_REFUSED
![CleanShot 2024-04-09 at 16 08 56@2x](https://github.com/gradio-app/gradio/assets/3135397/341c7a66-f027-48d5-9ff2-48b8b3ce51a8)
