### PR TITLE
Update the Lite custom element parser

### DIFF
--- a/.changeset/strong-colts-take.md
+++ b/.changeset/strong-colts-take.md
@@ -1,0 +1,6 @@
+---
+"@gradio/app": minor
+"gradio": minor
+---
+
+feat:Update the Lite custom element parser

--- a/js/app/src/lite/custom-element/index.ts
+++ b/js/app/src/lite/custom-element/index.ts
@@ -115,11 +115,6 @@ export function bootstrap_custom_element(
 		}
 
 		parseGradioLiteAppOptions(): GradioLiteAppOptions {
-			// When gradioLiteAppElement only contains text content, it is treated as the Python code.
-			if (this.childElementCount === 0) {
-				return { code: this.textContent ?? "" };
-			}
-
 			// When it contains child elements, parse them as options. Available child elements are:
 			// * <gradio-file />
 			//   Represents a file to be mounted in the virtual file system of the Wasm worker.
@@ -157,13 +152,24 @@ export function bootstrap_custom_element(
 			}
 
 			const codeElements = this.getElementsByTagName("gradio-code");
-			if (codeElements.length > 1) {
-				console.warn(
-					"Multiple <gradio-code> elements are found. Only the first one will be used."
-				);
+			if (codeElements.length === 0) {
+				// If there is no <gradio-code> element, try to parse the content of the custom element as code.
+				let code = "";
+				this.childNodes.forEach((node) => {
+					if (node.nodeType === Node.TEXT_NODE) {
+						code += node.textContent;
+					}
+				});
+				options.code = code.trim() || undefined;
+			} else {
+				if (codeElements.length > 1) {
+					console.warn(
+						"Multiple <gradio-code> elements are found. Only the first one will be used."
+					);
+				}
+				const firstCodeElement = codeElements[0];
+				options.code = firstCodeElement?.textContent ?? undefined;
 			}
-			const firstCodeElement = codeElements[0];
-			options.code = firstCodeElement?.textContent ?? undefined;
 
 			const requirementsElements = this.getElementsByTagName(
 				"gradio-requirements"

--- a/js/app/src/lite/custom-element/index.ts
+++ b/js/app/src/lite/custom-element/index.ts
@@ -160,7 +160,7 @@ export function bootstrap_custom_element(
 						code += node.textContent;
 					}
 				});
-				options.code = code.trim() || undefined;
+				options.code = code || undefined;
 			} else {
 				if (codeElements.length > 1) {
 					console.warn(


### PR DESCRIPTION
## Description

With this PR, using the custom component like below becomes possible where the child elements such as `<gradio-requirements>` are used with the text literal directly inside the top-level `<gradio-lite>`.
```html
<gradio-lite>
import gradio as gr

gr.Interface(
	fn=lambda x: x,
	inputs=gr.Textbox(),
	outputs=gr.Textbox()
).launch()

<gradio-requirements>
matplotlib
</gradio-requirements>
</gradio-lite>
```

Before this PR, the `<gradio-code>` element is needed to declare the source code with using `<gradio-requirements>`.