### PR TITLE
GRADIO_SHARE Environment Variable

### DIFF
--- a/.changeset/free-things-wink.md
+++ b/.changeset/free-things-wink.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:GRADIO_SHARE Environment Variable

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2246,9 +2246,10 @@ Received outputs:
         else:
             self.share = share
 
-        # GRADIO_SHARE environment variable for forcing 'share=True'
-        if bool(os.getenv("GRADIO_SHARE")):
-            self.share = True
+        # GRADIO_SHARE environment variable for forcing 'share=True' or 'share=False'
+        share_env = os.getenv("GRADIO_SHARE")
+        if share_env is not None:
+            self.share = bool(share_env)
 
         # If running in a colab or not able to access localhost,
         # a shareable link must be created.

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2247,6 +2247,8 @@ Received outputs:
             self.share = share
 
         # GRADIO_SHARE environment variable for forcing 'share=True' or 'share=False'
+        # GRADIO_SHARE=0 => share=False
+        # GRADIO_SHARE=1 => share=True
         share_env = os.getenv("GRADIO_SHARE")
         if share_env is not None:
             self.share = bool(int(share_env))

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2249,7 +2249,7 @@ Received outputs:
         # GRADIO_SHARE environment variable for forcing 'share=True' or 'share=False'
         share_env = os.getenv("GRADIO_SHARE")
         if share_env is not None:
-            self.share = bool(share_env)
+            self.share = bool(int(share_env))
 
         # If running in a colab or not able to access localhost,
         # a shareable link must be created.

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2243,15 +2243,15 @@ Received outputs:
                 self.share = True
             else:
                 self.share = False
+
+                # GRADIO_SHARE environment variable for forcing 'share=True'
+                # GRADIO_SHARE=True => share=True
+                share_env = os.getenv("GRADIO_SHARE")
+                if share_env is not None:
+                    if share_env.lower() == "true":
+                        self.share = True
         else:
             self.share = share
-
-        # GRADIO_SHARE environment variable for forcing 'share=True' or 'share=False'
-        # GRADIO_SHARE=0 => share=False
-        # GRADIO_SHARE=1 => share=True
-        share_env = os.getenv("GRADIO_SHARE")
-        if share_env is not None:
-            self.share = bool(int(share_env))
 
         # If running in a colab or not able to access localhost,
         # a shareable link must be created.

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2247,9 +2247,8 @@ Received outputs:
                 # GRADIO_SHARE environment variable for forcing 'share=True'
                 # GRADIO_SHARE=True => share=True
                 share_env = os.getenv("GRADIO_SHARE")
-                if share_env is not None:
-                    if share_env.lower() == "true":
-                        self.share = True
+                if share_env is not None and share_env.lower() == "true":
+                    self.share = True
         else:
             self.share = share
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2246,6 +2246,10 @@ Received outputs:
         else:
             self.share = share
 
+        # GRADIO_SHARE environment variable for forcing 'share=True'
+        if bool(os.getenv("GRADIO_SHARE")):
+            self.share = True
+
         # If running in a colab or not able to access localhost,
         # a shareable link must be created.
         if (

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2040,7 +2040,7 @@ Received outputs:
         Parameters:
             inline: whether to display in the gradio app inline in an iframe. Defaults to True in python notebooks; False otherwise.
             inbrowser: whether to automatically launch the gradio app in a new tab on the default browser.
-            share: whether to create a publicly shareable link for the gradio app. Creates an SSH tunnel to make your UI accessible from anywhere. If not provided, it is set to False by default every time, except when running in Google Colab. When localhost is not accessible (e.g. Google Colab), setting share=False is not supported.
+            share: whether to create a publicly shareable link for the gradio app. Creates an SSH tunnel to make your UI accessible from anywhere. If not provided, it is set to False by default every time, except when running in Google Colab. When localhost is not accessible (e.g. Google Colab), setting share=False is not supported. Can be set by environment variable GRADIO_SHARE=True.
             debug: if True, blocks the main thread from running. If running in Google Colab, this is needed to print the errors in the cell output.
             auth: If provided, username and password (or list of username-password tuples) required to access app. Can also provide function that takes username and password and returns True if valid login.
             auth_message: If provided, HTML message provided on login page.

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2243,7 +2243,6 @@ Received outputs:
                 self.share = True
             else:
                 self.share = False
-
                 # GRADIO_SHARE environment variable for forcing 'share=True'
                 # GRADIO_SHARE=True => share=True
                 share_env = os.getenv("GRADIO_SHARE")


### PR DESCRIPTION
## Description

This feature lets you override the `share` argument passed into the `launch()` method.

There are many gradio apps, and some apps have the `share=True` hardcoded and some don't. But sometimes we want to just take ANY gradio app and make them shareable via the gradio.live URL, even if the original source code does not specify `app.launch(share=True)`.

How it works:

1. `GRADIO_SHARE=1 python app.py`: will launch the gradio.live share link even if the `app.py` launched the server with `app.launch()`.
2. `GRADIO_SHARE=0 python app.py`: will launch WITHOUT the gradio.live share link even if the `app.py` launched with the server with `app.launch(share=True)`


## 🎯 PRs Should Target Issues

I've searched and couldn't find any similar issue. So just created one here: https://github.com/gradio-app/gradio/issues/7985

## Tests

I tested this locally by monkey patching my `site-packages` directly and confirm it's working as explained, but could not test by pulling from my PR fork (since the `share=True` option can only run on the versions released through PyPi).

Happy to do whatever is needed.