### PR TITLE
Fix gr.Examples in reload mode

### DIFF
--- a/.changeset/true-teeth-add.md
+++ b/.changeset/true-teeth-add.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataset": patch
+"gradio": patch
+---
+
+fix:Fix gr.Examples in reload mode

--- a/js/dataset/Index.svelte
+++ b/js/dataset/Index.svelte
@@ -32,7 +32,6 @@
 	$: console.log("component_map", component_map);
 	$: console.log("_component_map", _component_map);
 
-
 	// Although the `samples_dir` prop is not used in any of the core Gradio component, it is kept for backward compatibility
 	// with any custom components created with gradio<=4.20.0
 	let samples_dir: string = proxy_url

--- a/js/dataset/Index.svelte
+++ b/js/dataset/Index.svelte
@@ -27,6 +27,12 @@
 		select: SelectData;
 	}>;
 
+	let _component_map = component_map;
+
+	$: console.log("component_map", component_map);
+	$: console.log("_component_map", _component_map);
+
+
 	// Although the `samples_dir` prop is not used in any of the core Gradio component, it is kept for backward compatibility
 	// with any custom components created with gradio<=4.20.0
 	let samples_dir: string = proxy_url
@@ -91,7 +97,7 @@
 							sample_row.map(async (sample_cell, j) => {
 								return {
 									value: sample_cell,
-									component: (await component_map.get(components[j]))
+									component: (await _component_map.get(components[j]))
 										?.default as ComponentType<SvelteComponent>
 								};
 							})
@@ -145,7 +151,7 @@
 						on:mouseenter={() => handle_mouseenter(i)}
 						on:mouseleave={() => handle_mouseleave()}
 					>
-						{#if component_meta.length && component_map.get(components[0])}
+						{#if component_meta.length && _component_map.get(components[0])}
 							<svelte:component
 								this={component_meta[0][0].component}
 								{...component_props[0]}
@@ -185,7 +191,7 @@
 						>
 							{#each sample_row as { value, component }, j}
 								{@const component_name = components[j]}
-								{#if component_name !== undefined && component_map.get(component_name) !== undefined}
+								{#if component_name !== undefined && _component_map.get(component_name) !== undefined}
 									<td
 										style="max-width: {component_name === 'textbox'
 											? '35ch'


### PR DESCRIPTION
## Description

Noticed that if you ran a demo with gr.Examples in reload mode, the app would crash after reloading. The UI would update though. You can test this with `calculator_blocks` demo.

The issue is that the `component_map` in `Dataset` would be empty after reloading. It is a bit strange because I verified that the `Dataset` gets a non-empty map in `init.ts`, but then the size of the map would decrease to 0 and then the error would happen. So I fixed this by storing the initial component map in a new variable.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
