### PR TITLE
round [x, y, w, h] before cropping to avoid unexpected interpolation on pixel values

### DIFF
--- a/.changeset/green-keys-invite.md
+++ b/.changeset/green-keys-invite.md
@@ -1,0 +1,6 @@
+---
+"@gradio/imageeditor": patch
+"gradio": patch
+---
+
+fix:round [x, y, w, h] before cropping to avoid unexpected interpolation on pixel values

--- a/js/imageeditor/shared/ImageEditor.svelte
+++ b/js/imageeditor/shared/ImageEditor.svelte
@@ -241,10 +241,10 @@
 		return $pixi?.get_blobs(
 			$pixi.get_layers(),
 			new Rectangle(
-				l * $dimensions[0],
-				t * $dimensions[1],
-				w * $dimensions[0],
-				h * $dimensions[1]
+				Math.round(l * $dimensions[0]),
+				Math.round(t * $dimensions[1]),
+				Math.round(w * $dimensions[0]),
+				Math.round(h * $dimensions[1])
 			),
 			$dimensions
 		);


### PR DESCRIPTION
## Description

**round [x, y, w, h] before cropping to avoid unexpected interpolation on pixel values**
  
I'm working on some demo of image watermarking. Cropping the test image using `ImageEditor` ruins the watermark while my watermark should have the ability to withstand cropping.

After some investigation into both front-end and back-end, I figured the problem is that the current implementation of cropping using `CanvasRenderingContext2D: drawImage()` in front-end would produce undesired interpolation on pixel values **if the canvas dimensions are not integers**.

Therefore, a simple fix is to round the cropping parameters before calling `$pixi.get_layers()`