### PR TITLE
Update `typer` to drop `[all]` as it is no longer needed

### DIFF
--- a/.changeset/sour-queens-count.md
+++ b/.changeset/sour-queens-count.md
@@ -2,4 +2,4 @@
 "gradio": patch
 ---
 
-feat:Update `typer` to drop `[all]` as it is no longer needed
+fix:Update `typer` to drop `[all]` as it is no longer needed

--- a/.changeset/sour-queens-count.md
+++ b/.changeset/sour-queens-count.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:Update `typer` to drop `[all]` as it is no longer needed

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,6 @@ semantic_version~=2.0
 typing_extensions~=4.0
 urllib3~=2.0  # urllib3 is used for Lite support. Version spec can be omitted because urllib3==2.1.0 is prebuilt for Pyodide and urllib>=2.2.0 supports Pyodide as well.
 uvicorn>=0.14.0; sys.platform != 'emscripten'
-typer[all]>=0.9,<1.0; sys.platform != 'emscripten'
+typer>=0.12,<1.0; sys.platform != 'emscripten'
 tomlkit==0.12.0
 ruff>=0.2.2; sys.platform != 'emscripten'


### PR DESCRIPTION
## Description

Source: https://typer.tiangolo.com/release-notes/#0121



  
