### PR TITLE
Fix Label component's value change detection to avoid infinite loop dispatching the change event

### DIFF
--- a/.changeset/silly-drinks-glow.md
+++ b/.changeset/silly-drinks-glow.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/label": minor
-"gradio": minor
+"@gradio/label": patch
+"gradio": patch
 ---
 
 feat:Fix Label component's value change detection to avoid infinite loop dispatching the change event

--- a/.changeset/silly-drinks-glow.md
+++ b/.changeset/silly-drinks-glow.md
@@ -1,0 +1,6 @@
+---
+"@gradio/label": minor
+"gradio": minor
+---
+
+feat:Fix Label component's value change detection to avoid infinite loop dispatching the change event

--- a/js/label/Index.svelte
+++ b/js/label/Index.svelte
@@ -22,6 +22,7 @@
 		label?: string;
 		confidences?: { label: string; confidence: number }[];
 	} = {};
+	let old_value: typeof value | null = null;
 	export let label = gradio.i18n("label.label");
 	export let container = true;
 	export let scale: number | null = null;
@@ -30,8 +31,14 @@
 	export let show_label = true;
 	export let _selectable = false;
 
-	$: ({ confidences, label: _label } = value);
-	$: _label, confidences, gradio.dispatch("change");
+	$: {
+		if (JSON.stringify(value) !== JSON.stringify(old_value)) {
+			old_value = value;
+			gradio.dispatch("change");
+		}
+	}
+
+	$: _label = value.label;
 </script>
 
 <Block


### PR DESCRIPTION
## Description

Happened to find the `<Label />` component continues to dispatch the `change` event once it gets some `value`.

For example, if you add `console.log("gradio event.", e.detail);` in this event listener↓
https://github.com/gradio-app/gradio/blob/0424c759d8a790529406229c52f47cb469e78d3e/js/app/src/Blocks.svelte#L423-L442
and run the following app,
```python
import gradio as gr


def fn(_):
    return {"foo": 0.9, "bar": 0.8}


demo = gr.Interface(
    fn=fn,
    inputs=None,
    outputs=gr.Label()
)

demo.launch()
```
you can find the event is dispatched infinitely after clicking the submit button as below.
![CleanShot 2024-04-17 at 15 27 58@2x](https://github.com/gradio-app/gradio/assets/3135397/ec7c5bc9-6fa3-4bcd-8a4a-7cbff96257bf)


I modified `<Label />`'s code detecting the changes of `value` to be like other component such as 
https://github.com/gradio-app/gradio/blob/0424c759d8a790529406229c52f47cb469e78d3e/js/json/Index.svelte#L29-L34
