### PR TITLE
Using keys to preserve values between reloads

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -121,6 +121,7 @@ class Block:
         self.state_session_capacity = 10000
         self.temp_files: set[str] = set()
         self.GRADIO_CACHE = get_upload_folder()
+        self.key: int | str | None = None
         # Keep tracks of files that should not be deleted when the delete_cache parmaeter is set
         # These files are the default value of the component and files that are used in examples
         self.keep_in_cache = set()
@@ -1892,6 +1893,7 @@ Received outputs:
             block_config["component_class_id"] = getattr(
                 block, "component_class_id", None
             )
+            block_config["key"] = block.key
 
             if not block.skip_api:
                 block_config["api_info"] = block.api_info()  # type: ignore
@@ -2128,6 +2130,11 @@ Received outputs:
             raise ValueError("`blocked_paths` must be a list of directories.")
 
         self.validate_queue_settings()
+
+        if self.dev_mode:
+            for block in self.blocks.values():
+                if block.key is None:
+                    block.key = f"__{block._id}__"
 
         self.config = self.get_config_file()
         self.max_threads = max_threads

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -288,11 +288,11 @@ class App(FastAPI):
 
                     if app.change_event and app.change_event.is_set():
                         app.change_event.clear()
-                        yield """data: CHANGE\n\n"""
+                        yield """event: reload\ndata: {}\n\n"""
 
                     await asyncio.sleep(check_rate)
                     if time.perf_counter() - last_heartbeat > heartbeat_rate:
-                        yield """data: HEARTBEAT\n\n"""
+                        yield """event: heartbeat\ndata: {}\n\n"""
                         last_heartbeat = time.time()
 
             return StreamingResponse(

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -23,6 +23,7 @@
 
 	export let root: string;
 	export let components: ComponentMeta[];
+	let old_components: ComponentMeta[] = components;
 	export let layout: LayoutNode;
 	export let dependencies: Dependency[];
 	export let title = "Gradio";
@@ -51,6 +52,24 @@
 		create_layout
 	} = create_components();
 
+	const restore_keyed_values = () => {
+		let component_values_by_key: Record<string | number, ComponentMeta> = {};
+		old_components.forEach((component) => {
+			if (component.key) {
+				component_values_by_key[component.key] = component;
+			}
+		});
+		components.forEach((component) => {
+			if (component.key) {
+				const old_component = component_values_by_key[component.key];
+				if (old_component) {
+					console.log("set old value", old_component.props.value);
+					component.props.value = old_component.props.value;
+				}
+			}
+		});
+	};
+
 	$: create_layout({
 		components,
 		layout,
@@ -59,7 +78,8 @@
 		app,
 		options: {
 			fill_height
-		}
+		},
+		callback: restore_keyed_values
 	});
 
 	$: {

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -302,17 +302,13 @@
 				const { host } = new URL(api_url);
 				let url = new URL(`http://${host}/dev/reload`);
 				eventSource = new EventSource(url);
-				eventSource.onmessage = async function (event) {
-					if (event.data === "CHANGE") {
-						app = await client(api_url, {
-							status_callback: handle_status
-						});
-
-						config = app.config;
-						window.__gradio_space__ = config.space_id;
-						await mount_custom_css(config.css);
-					}
-				};
+				eventSource.addEventListener("reload", async (event) => {
+					app = await client(api_url, {
+						status_callback: handle_status
+					});
+					config = app.config;
+					await mount_custom_css(config.css);
+				});
 			}, 200);
 		}
 	});

--- a/js/app/src/init.ts
+++ b/js/app/src/init.ts
@@ -38,6 +38,7 @@ export function create_components(): {
 		options: {
 			fill_height: boolean;
 		};
+		callback?: () => void;
 	}) => void;
 } {
 	let _component_map: Map<number, ComponentMeta>;
@@ -61,7 +62,8 @@ export function create_components(): {
 		layout,
 		dependencies,
 		root,
-		options
+		options,
+		callback
 	}: {
 		app: client_return;
 		components: ComponentMeta[];
@@ -71,6 +73,7 @@ export function create_components(): {
 		options: {
 			fill_height: boolean;
 		};
+		callback?: () => void;
 	}): void {
 		app = _app;
 		_components = components;
@@ -120,6 +123,7 @@ export function create_components(): {
 
 		walk_layout(layout, root).then(() => {
 			layout_store.set(_rootNode);
+			callback();
 		});
 	}
 

--- a/js/app/src/types.ts
+++ b/js/app/src/types.ts
@@ -26,6 +26,7 @@ export interface ComponentMeta {
 	children?: ComponentMeta[];
 	value?: any;
 	component_class_id: string;
+	key: string | number | null;
 }
 
 /** Dictates whether a dependency is continous and/or a generator */

--- a/js/textbox/Index.svelte
+++ b/js/textbox/Index.svelte
@@ -42,6 +42,7 @@
 	export let autofocus = false;
 	export let autoscroll = true;
 	export let interactive: boolean;
+	console.log("interactive", interactive);
 </script>
 
 <Block


### PR DESCRIPTION
Added the concept of a key to a Block, such that any Block that has the same key between re-renders has its value preserved between renders. Will be needed specifically for render PR.

Implemented in dev mode by automatically assigning every Block a generated key and giving similarly positioned blocks have the same key across renders. See below how re-renders do not change the value of the components. 

BEFORE:
![Recording 2024-04-17 at 18 14 02](https://github.com/gradio-app/gradio/assets/7870876/1de15736-fb32-400c-adab-4c8f7f58672c)


AFTER:
![Recording 2024-04-17 at 18 10 29](https://github.com/gradio-app/gradio/assets/7870876/4671d373-2412-4dae-9b85-93c51a8c7679)

