### PR TITLE
fix: break words in dropdown + multiselect

### DIFF
--- a/js/dropdown/shared/DropdownOptions.svelte
+++ b/js/dropdown/shared/DropdownOptions.svelte
@@ -92,6 +92,7 @@
 				class:active={index === active_index}
 				class:bg-gray-100={index === active_index}
 				class:dark:bg-gray-600={index === active_index}
+				style:width={input_width + "px"}
 				data-index={index}
 				aria-label={choices[index][0]}
 				data-testid="dropdown-option"
@@ -127,6 +128,7 @@
 		display: flex;
 		cursor: pointer;
 		padding: var(--size-2);
+		word-break: break-word;
 	}
 
 	.item:hover,

--- a/js/dropdown/shared/Multiselect.svelte
+++ b/js/dropdown/shared/Multiselect.svelte
@@ -357,6 +357,7 @@
 		font-weight: var(--checkbox-label-text-weight);
 		font-size: var(--checkbox-label-text-size);
 		line-height: var(--line-md);
+		word-break: break-word;
 	}
 
 	.token > * + * {

--- a/js/dropdown/shared/Multiselect.svelte
+++ b/js/dropdown/shared/Multiselect.svelte
@@ -376,6 +376,7 @@
 		padding: var(--size-0-5);
 		width: 16px;
 		height: 16px;
+		flex-shrink: 0;
 	}
 
 	.secondary-wrap {


### PR DESCRIPTION
## Description

As seen in the issue below, the dropdown options and multiselect have text that trails off the screen if the text is too long. I included `word-break` in the styling and adjusted the sizing of the dropdown option to resolve the issue. For example in this demo,

```python
import gradio as gr

with gr.Blocks() as demo:
    d = gr.Dropdown(value=None, choices=["too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long too long ", "b"], multiselect=True)
demo.launch()
```

the menus look like this now.

<img width="1265" alt="Screenshot 2024-04-17 at 6 30 07 PM" src="https://github.com/gradio-app/gradio/assets/91300605/ca21f9fd-a109-4416-8420-96ff51a4d996">

Closes: #7467 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
