### PR TITLE
Hide the scroll bar in WaveformControls when it's not necessary

### DIFF
--- a/.changeset/loud-ears-grab.md
+++ b/.changeset/loud-ears-grab.md
@@ -1,0 +1,6 @@
+---
+"@gradio/audio": minor
+"gradio": minor
+---
+
+feat:Hide the scroll bar in WaveformControls when it's not necessary

--- a/.changeset/loud-ears-grab.md
+++ b/.changeset/loud-ears-grab.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/audio": minor
-"gradio": minor
+"@gradio/audio": patch
+"gradio": patch
 ---
 
 feat:Hide the scroll bar in WaveformControls when it's not necessary

--- a/js/audio/shared/WaveformControls.svelte
+++ b/js/audio/shared/WaveformControls.svelte
@@ -318,7 +318,12 @@
 			grid-template-areas:
 				"playback playback"
 				"controls editing";
-			overflow: scroll;
+		}
+	}
+
+	@media (max-width: 319px) {
+		.controls {
+			overflow-x: scroll;
 		}
 	}
 


### PR DESCRIPTION
## Description

The scrollable styling in the `WaveformControls` component was introduced in #6991 which is great,
but in some environments the scroll bars are displayed in any time which can be visually annoying.
For example, on Mac, when the "Show scroll bars" setting is not "When scrolling",

![CleanShot 2024-04-18 at 15 01 52@2x](https://github.com/gradio-app/gradio/assets/3135397/42804be1-fe73-4e61-bfc0-fcb75d352b64)

the scroll bars are always shown like this even when scrolling is not necessary.
![CleanShot 2024-04-18 at 15 01 13@2x](https://github.com/gradio-app/gradio/assets/3135397/cb4aefc3-d1d2-4b9e-aec5-dcea01056015)

So in this PR,
* Disable the vertical scroll bar which is always not necessary.
* Set narrower width as a break point to show the horizontal scroll bar. I set the breakpoint as 319px, assuming the narrowest width of popular smartphones are 320px and there is an enough margin between it and the max width with which the scroll bar becomes necessary.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
