### PR TITLE
Fix the Lite custom element parser so it doesn't add the .code option when the entrypoint file is already specified

### DIFF
--- a/.changeset/cuddly-snakes-swim.md
+++ b/.changeset/cuddly-snakes-swim.md
@@ -1,0 +1,6 @@
+---
+"@gradio/app": minor
+"gradio": minor
+---
+
+feat:Fix the Lite custom element parser so it doesn't add the .code option when the entrypoint file is already specified

--- a/js/app/src/lite/custom-element/index.ts
+++ b/js/app/src/lite/custom-element/index.ts
@@ -151,24 +151,29 @@ export function bootstrap_custom_element(
 				}
 			}
 
-			const codeElements = this.getElementsByTagName("gradio-code");
-			if (codeElements.length === 0) {
-				// If there is no <gradio-code> element, try to parse the content of the custom element as code.
-				let code = "";
-				this.childNodes.forEach((node) => {
-					if (node.nodeType === Node.TEXT_NODE) {
-						code += node.textContent;
+			if (options.entrypoint == null) {
+				// If no entrypoint file is specified,
+				// try to find the source code to be passed to the .code option instead.
+
+				const codeElements = this.getElementsByTagName("gradio-code");
+				if (codeElements.length === 0) {
+					// If there is no <gradio-code> element, try to parse the content of the custom element as code.
+					let code = "";
+					this.childNodes.forEach((node) => {
+						if (node.nodeType === Node.TEXT_NODE) {
+							code += node.textContent;
+						}
+					});
+					options.code = code || undefined;
+				} else {
+					if (codeElements.length > 1) {
+						console.warn(
+							"Multiple <gradio-code> elements are found. Only the first one will be used."
+						);
 					}
-				});
-				options.code = code || undefined;
-			} else {
-				if (codeElements.length > 1) {
-					console.warn(
-						"Multiple <gradio-code> elements are found. Only the first one will be used."
-					);
+					const firstCodeElement = codeElements[0];
+					options.code = firstCodeElement?.textContent ?? undefined;
 				}
-				const firstCodeElement = codeElements[0];
-				options.code = firstCodeElement?.textContent ?? undefined;
 			}
 
 			const requirementsElements = this.getElementsByTagName(


### PR DESCRIPTION
## Description

With #7975, the Lite custom component app like below started to fail because the user intends to execute `app.py` but the parser tries to get the source code directly from the text content of most-outer `<gradio-lite>` tag.
```html
		<gradio-lite>
			<gradio-file name="app.py" entrypoint>
import gradio as gr
demo = gr.Interface(
	fn=lambda x: x,
	inputs="text",
	outputs="text"
)

demo.launch()
			</gradio-file>
		</gradio-lite>
```

This PR fixes it.