### PR TITLE
fix typos in README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 The `ImageEditor` component has been refreshed to make it more user-friendly and reliable.
 
-This release contains a host of improvements to the `ImageEditor` component, that will be of particular interest to those builing real-time image editing applications or complex image processing pipelines:
+This release contains a host of improvements to the `ImageEditor` component, that will be of particular interest to those building real-time image editing applications or complex image processing pipelines:
 
 - Cleaner and more compact interface.
 - New option to hide the layer controls for a more minimal UI.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ You can build very custom and complex applications using `gr.Blocks()`. For exam
 
 #### The Gradio Python & JavaScript Ecosystem
 
-That's the gist of the core `gradio` Python library, but Gradio is actually so much more! Its an entire ecosystem of Python and JavaScript libraries that let you build machine learning applications, or query them programmatically, in Python or JavaScript. Here are other related parts of the Gradio ecosystem:
+That's the gist of the core `gradio` Python library, but Gradio is actually so much more! It's an entire ecosystem of Python and JavaScript libraries that let you build machine learning applications, or query them programmatically, in Python or JavaScript. Here are other related parts of the Gradio ecosystem:
 
 * [Gradio Python Client](https://www.gradio.app/guides/getting-started-with-the-python-client) (`gradio_client`): query any Gradio app programmatically in Python.
 * [Gradio JavaScript Client](https://www.gradio.app/guides/getting-started-with-the-js-client) (`@gradio/client`): query any Gradio app programmatically in JavaScript.


### PR DESCRIPTION
## Description

Fixed two small typos in text files:
Its -> It's in README
builing -> building in CHANGELOG