### PR TITLE
Fix causing Hot Reload (#8070)

### DIFF
--- a/.changeset/easy-symbols-pick.md
+++ b/.changeset/easy-symbols-pick.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix causing Hot Reload (#8070)

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -169,7 +169,7 @@ def _remove_no_reload_codeblocks(file_path: str):
         file_path (str): The path to the file to remove the no_reload code blocks from.
     """
 
-    with open(file_path) as file:
+    with open(file_path, encoding="utf-8") as file:
         code = file.read()
 
     tree = ast.parse(code)


### PR DESCRIPTION
## Description

Fixes bug causing Hot Reload failure in code with non-English languages due to missing encoding specification.

I hardcoded UTF-8 because I couldn't figure out how to specify the encoding, similar to the fix in `gradio\cli\commands\reload.py`.

Closes: #8070