### PR TITLE
Fix an enconding issue in gradio/components/code.py

### DIFF
--- a/gradio/components/code.py
+++ b/gradio/components/code.py
@@ -151,7 +151,7 @@ class Code(Component):
         if value is None:
             return None
         elif isinstance(value, tuple):
-            with open(value[0]) as file_data:
+            with open(value[0], encoding="utf-8") as file_data:
                 return file_data.read()
         else:
             return value.strip()


### PR DESCRIPTION
## Description

Modified the postprocess function in gradio/components/code.py to handle file encoding properly. Added encoding="utf-8" parameter to the open function when reading code files. I hardcoded UTF-8 because I couldn't figure out how to specify the encoding, similar to the fix in [gradio-app#8075](https://github.com/gradio-app/gradio/pull/8075).

Closes: #(8076)
  
