### PR TITLE
Fix the visual test on the Label component

### DIFF
--- a/js/label/Label.stories.svelte
+++ b/js/label/Label.stories.svelte
@@ -1,10 +1,19 @@
 <script context="module">
 	import { Template, Story } from "@storybook/addon-svelte-csf";
+	import { allModes } from "../storybook/modes";
 	import Label from "./Index.svelte";
 
 	export const meta = {
 		title: "Components/Label",
-		component: Label
+		component: Label,
+		parameters: {
+			chromatic: {
+				modes: {
+					desktop: allModes["desktop"],
+					mobile: allModes["mobile"]
+				}
+			}
+		}
 	};
 </script>
 

--- a/js/label/Label.stories.svelte
+++ b/js/label/Label.stories.svelte
@@ -28,8 +28,7 @@
 			label: "Label",
 			confidences: [
 				{
-					label:
-						"Long space separated label text, long space separated label text, long space separated label text",
+					label: "Long space separated label text, ".repeat(10),
 					confidence: 0.8
 				}
 			]


### PR DESCRIPTION
## Description

Rel: #8063

Found that the visual CI is not testing what #8063 fixed properly as there is no line-break in the stories.
This PR fixes it.

Before:
![CleanShot 2024-04-19 at 13 34 38@2x](https://github.com/gradio-app/gradio/assets/3135397/256a0105-80b0-4baf-a030-7549ee3b5e60)

This PR:
![CleanShot 2024-04-19 at 13 36 00@2x](https://github.com/gradio-app/gradio/assets/3135397/54c2db43-1078-4614-a15c-3e04c9e65405)
