### PR TITLE
[HF OAuth] Logout user if oauth token has expired

### DIFF
--- a/.changeset/purple-radios-marry.md
+++ b/.changeset/purple-radios-marry.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:[HF OAuth] Logout user if oauth token has expired

--- a/gradio/components/login_button.py
+++ b/gradio/components/login_button.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import time
 import warnings
 from typing import Literal
 
@@ -87,12 +88,21 @@ class LoginButton(Button):
         session = getattr(request, "session", None) or getattr(
             request.request, "session", None
         )
+
         if session is None or "oauth_info" not in session:
-            return LoginButton(value=self.value, interactive=True)  # type: ignore
-        else:
-            username = session["oauth_info"]["userinfo"]["preferred_username"]
-            logout_text = self.logout_value.format(username)
-            return LoginButton(logout_text, interactive=True)
+            # Cookie set but user not logged in
+            return LoginButton(self.value, interactive=True)  # type: ignore[arg-type]
+
+        oauth_info = session["oauth_info"]
+        expires_at = oauth_info.get("expires_at")
+        if expires_at is not None and expires_at < time.time():
+            # User is logged in but token has expired => logout
+            session.pop("oauth_info", None)
+            return LoginButton(self.value, interactive=True)  # type: ignore[arg-type]
+
+        # User is correctly logged in
+        username = oauth_info["userinfo"]["preferred_username"]
+        return LoginButton(self.logout_value.format(username), interactive=True)
 
 
 # JS code to redirects to /login/huggingface if user is not logged in.

--- a/gradio/components/login_button.py
+++ b/gradio/components/login_button.py
@@ -1,4 +1,5 @@
 """Predefined button to sign in with Hugging Face in a Gradio Space."""
+
 from __future__ import annotations
 
 import json
@@ -91,14 +92,14 @@ class LoginButton(Button):
 
         if session is None or "oauth_info" not in session:
             # Cookie set but user not logged in
-            return LoginButton(self.value, interactive=True)  # type: ignore[arg-type]
+            return LoginButton(self.value, interactive=True)
 
         oauth_info = session["oauth_info"]
         expires_at = oauth_info.get("expires_at")
         if expires_at is not None and expires_at < time.time():
             # User is logged in but token has expired => logout
             session.pop("oauth_info", None)
-            return LoginButton(self.value, interactive=True)  # type: ignore[arg-type]
+            return LoginButton(self.value, interactive=True)
 
         # User is correctly logged in
         username = oauth_info["userinfo"]["preferred_username"]

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -347,7 +347,7 @@ def move_files_to_cache(
     postprocess: bool = False,
     check_in_upload_folder=False,
     keep_in_cache=False,
-) -> dict:
+):
     """Move any files in `data` to cache and (optionally), adds URL prefixes (/file=...) needed to access the cached file.
     Also handles the case where the file is on an external Gradio app (/proxy=...).
 

--- a/test/test_pipelines.py
+++ b/test/test_pipelines.py
@@ -67,6 +67,7 @@ def test_interface_in_blocks():
     demo.close()
 
 
+@pytest.mark.flaky
 def test_transformers_load_from_pipeline():
     from transformers import pipeline
 


### PR DESCRIPTION
When using "Sign in with HF", the server returns an OAuth token that is limited in time. Currently we pass the `expires_at` value to the gradio functions but it's useless as it means Space authors have to deal with it (which is undocumented anyway). The problem with expired tokens been passed to functions is that it leads to HTTP errors when making calls to the Hub. These errors are annoying both for Space authors and users as they can't do much about them. The current solution is for the user to logout + login again.

This PR changes this workflow. Now on every page load/refresh (i.e. with `LoginButton.attach_load_event(..., None)`) we check if the user has an outdated session (based on `expires_at` attribute). If yes, then we delete the session cookie and display a `"Sign in with HF"` button instead of a `"Logout"` one.

Alternatives:
- redirects user to `/login/huggingface` which should refresh the token with just a redirect. Problem: if Space was in a certain state, that's lost for the user. Also if user revoked the Space, they would be automatically redirected to an authorization page when landing on the Space, even though they haven't clicked on "Sign in with HF".
- automatically refresh the token. Requires [moon-landing/#8412](https://github.com/huggingface/moon-landing/issues/8412) (private link) to be implemented first.

Given the alternatives, I prefer to implement this logic now and add the correct auto-refresh logic once it's ready. 


cc @apolinario who mentioned this on [slack](https://huggingface.slack.com/archives/C02136Y252P/p1713776994399539?thread_ts=1713775401.042389&cid=C02136Y252P) (private link)