### PR TITLE
Remove deprecated 'shape' parameter from tutorial

### DIFF
--- a/readme_files/zh-cn/README.md
+++ b/readme_files/zh-cn/README.md
@@ -150,7 +150,7 @@ def sepia(input_img):
     sepia_img /= sepia_img.max()
     return sepia_img
 
-demo = gr.Interface(sepia, gr.Image(shape=(200, 200)), "image")
+demo = gr.Interface(sepia, gr.Image(), "image")
 demo.launch()
 ```
 

--- a/readme_files/zh-cn/README.md
+++ b/readme_files/zh-cn/README.md
@@ -161,7 +161,7 @@ demo.launch()
 你也可以用 `type=` 关键字参数设置组件使用的数据类型。例如，如果你想让你的函数获取一个图像的文件路径，而不是一个NumPy数组时，输入 `Image` 组件可以写成：
 
 ```python
-gr.Image(type="filepath", shape=...)
+gr.Image(type="filepath")
 ```
 
 还要注意，我们的输入 `Image` 组件带有一个编辑按钮 🖉，它允许裁剪和放大图像。以这种方式操作图像可以帮助揭示机器学习模型中的偏见或隐藏的缺陷！


### PR DESCRIPTION
## Description

Closes: [#(7619)](https://github.com/gradio-app/gradio/issues/7619)

Remove deprecated `shape` parameter of `gradio.Image.__init__` from tutorial.