### PR TITLE
Pass Error status in /dev/reload stream

### DIFF
--- a/.changeset/slow-bats-sniff.md
+++ b/.changeset/slow-bats-sniff.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/app": minor
-"gradio": minor
+"@gradio/app": patch
+"gradio": patch
 ---
 
 feat:Pass Error status in /dev/reload stream

--- a/.changeset/slow-bats-sniff.md
+++ b/.changeset/slow-bats-sniff.md
@@ -1,0 +1,6 @@
+---
+"@gradio/app": minor
+"gradio": minor
+---
+
+feat:Pass Error status in /dev/reload stream

--- a/.changeset/slow-bats-sniff.md
+++ b/.changeset/slow-bats-sniff.md
@@ -1,5 +1,4 @@
 ---
-"@gradio/app": patch
 "gradio": patch
 ---
 

--- a/.changeset/slow-bats-sniff.md
+++ b/.changeset/slow-bats-sniff.md
@@ -1,4 +1,5 @@
 ---
+"@gradio/app": patch
 "gradio": patch
 ---
 

--- a/gradio/http_server.py
+++ b/gradio/http_server.py
@@ -5,7 +5,6 @@ import socket
 import threading
 import time
 from functools import partial
-from queue import Queue as ThreadQueue
 from typing import TYPE_CHECKING
 
 import uvicorn
@@ -138,15 +137,12 @@ def start_server(
             )
             reloader = None
             if GRADIO_WATCH_DIRS:
-                queue = ThreadQueue()
-                app.reload_queue = queue
                 reloader = SourceFileReloader(
                     app=app,
                     watch_dirs=GRADIO_WATCH_DIRS,
                     watch_module_name=GRADIO_WATCH_MODULE_NAME,
                     demo_name=GRADIO_WATCH_DEMO_NAME,
                     stop_event=threading.Event(),
-                    reload_queue=queue,
                     demo_file=GRADIO_WATCH_DEMO_PATH,
                 )
             server = Server(config=config, reloader=reloader)

--- a/gradio/http_server.py
+++ b/gradio/http_server.py
@@ -5,6 +5,7 @@ import socket
 import threading
 import time
 from functools import partial
+from queue import Queue as ThreadQueue
 from typing import TYPE_CHECKING
 
 import uvicorn
@@ -137,15 +138,15 @@ def start_server(
             )
             reloader = None
             if GRADIO_WATCH_DIRS:
-                change_event = threading.Event()
-                app.change_event = change_event
+                queue = ThreadQueue()
+                app.reload_queue = queue
                 reloader = SourceFileReloader(
                     app=app,
                     watch_dirs=GRADIO_WATCH_DIRS,
                     watch_module_name=GRADIO_WATCH_MODULE_NAME,
                     demo_name=GRADIO_WATCH_DEMO_NAME,
                     stop_event=threading.Event(),
-                    change_event=change_event,
+                    reload_queue=queue,
                     demo_file=GRADIO_WATCH_DEMO_PATH,
                 )
             server = Server(config=config, reloader=reloader)

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -175,6 +175,7 @@ class App(FastAPI):
         self.uploaded_file_dir = get_upload_folder()
         self.change_count: int = 0
         self.change_type: Literal["reload", "error"] | None = None
+        self.reload_error_message: str | None = None
         self._asyncio_tasks: list[asyncio.Task] = []
         self.auth_dependency = auth_dependency
         self.api_info = None
@@ -293,7 +294,12 @@ class App(FastAPI):
 
                     if app.change_count != current_count:
                         current_count = app.change_count
-                        yield f"""event: {app.change_type}\ndata: {{}}\n\n"""
+                        msg = (
+                            json.dumps(f"{app.reload_error_message}")
+                            if app.change_type == "error"
+                            else "{}"
+                        )
+                        yield f"""event: {app.change_type}\ndata: {msg}\n\n"""
 
                     await asyncio.sleep(check_rate)
                     if time.perf_counter() - last_heartbeat > heartbeat_rate:

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -297,7 +297,7 @@ class App(FastAPI):
 
                     await asyncio.sleep(check_rate)
                     if time.perf_counter() - last_heartbeat > heartbeat_rate:
-                        yield """event: heartbeat\ndata: {}\n\n\n\n"""
+                        yield """event: heartbeat\ndata: {}\n\n"""
                         last_heartbeat = time.time()
 
             return StreamingResponse(

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -30,7 +30,6 @@ from functools import wraps
 from io import BytesIO
 from numbers import Number
 from pathlib import Path
-from queue import Queue as ThreadQueue
 from types import AsyncGeneratorType, GeneratorType, ModuleType
 from typing import (
     TYPE_CHECKING,
@@ -125,7 +124,6 @@ class SourceFileReloader(BaseReloader):
         watch_module_name: str,
         demo_file: str,
         stop_event: threading.Event,
-        reload_queue: ThreadQueue,
         demo_name: str = "demo",
     ) -> None:
         super().__init__()
@@ -133,7 +131,6 @@ class SourceFileReloader(BaseReloader):
         self.watch_dirs = watch_dirs
         self.watch_module_name = watch_module_name
         self.stop_event = stop_event
-        self.reload_queue = reload_queue
         self.demo_name = demo_name
         self.demo_file = Path(demo_file)
 
@@ -147,8 +144,9 @@ class SourceFileReloader(BaseReloader):
     def stop(self) -> None:
         self.stop_event.set()
 
-    def alert_change(self, change_type: Literal["change", "error"] = "change"):
-        self.reload_queue.put(change_type)
+    def alert_change(self, change_type: Literal["reload", "error"] = "reload"):
+        self.app.change_type = change_type
+        self.app.change_count += 1
 
     def swap_blocks(self, demo: Blocks):
         old_blocks = self.running_app.blocks
@@ -156,7 +154,7 @@ class SourceFileReloader(BaseReloader):
         if old_blocks:
             reassign_keys(old_blocks, demo)
         demo.config = demo.get_config_file()
-        self.alert_change()
+        self.alert_change("reload")
 
 
 NO_RELOAD = True

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -282,6 +282,7 @@ def watchfn(reloader: SourceFileReloader):
                 traceback.print_exc()
                 mtimes = {}
                 reloader.alert_change("error")
+                reloader.app.reload_error_message = traceback.format_exc()
                 continue
             demo = getattr(module, reloader.demo_name)
             reloader.swap_blocks(demo)

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -155,6 +155,10 @@
 		};
 	}
 
+	export function add_new_message(message: string, type: ToastMessage["type"]) {
+		messages = [new_message(message, -1, type), ...messages];
+	}
+
 	let _error_id = -1;
 
 	let user_left_page = false;

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -155,7 +155,10 @@
 		};
 	}
 
-	export function add_new_message(message: string, type: ToastMessage["type"]) {
+	export function add_new_message(
+		message: string,
+		type: ToastMessage["type"]
+	): void {
 		messages = [new_message(message, -1, type), ...messages];
 	}
 

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -307,8 +307,9 @@
 				const { host } = new URL(api_url);
 				let url = new URL(`http://${host}/dev/reload`);
 				eventSource = new EventSource(url);
-				eventSource.addEventListener("error", async () => {
+				eventSource.addEventListener("error", async (e) => {
 					new_message_fn("Error reloading app", "error");
+					console.error(JSON.parse(e.data));
 				});
 				eventSource.addEventListener("reload", async (event) => {
 					app.close();

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -309,6 +309,7 @@
 				eventSource = new EventSource(url);
 				eventSource.addEventListener("error", async (e) => {
 					new_message_fn("Error reloading app", "error");
+					// @ts-ignore
 					console.error(JSON.parse(e.data));
 				});
 				eventSource.addEventListener("reload", async (event) => {

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -307,6 +307,9 @@
 				const { host } = new URL(api_url);
 				let url = new URL(`http://${host}/dev/reload`);
 				eventSource = new EventSource(url);
+				eventSource.addEventListener("error", async () => {
+					new_message_fn("Error reloading app", "error");
+				});
 				eventSource.addEventListener("reload", async (event) => {
 					app.close();
 					app = await Client.connect(api_url, {
@@ -376,6 +379,8 @@
 			);
 		}
 	};
+
+	let new_message_fn: (message: string, type: string) => void;
 
 	onMount(async () => {
 		intersecting.register(_id, wrapper);
@@ -454,6 +459,7 @@
 			{autoscroll}
 			bind:ready
 			bind:render_complete
+			bind:add_new_message={new_message_fn}
 			show_footer={!is_embed}
 			{app_mode}
 			{version}


### PR DESCRIPTION
## Description

Let clients know when an error happened during reload. Also refactored the route to support more than one client connecting simultaneously.

Logic is here and should not conflict with #8056 but will wait for #8056

There are two message types in the thread `reload` and `error`.

![reload_status_stream](https://github.com/gradio-app/gradio/assets/41651716/d61fca9c-106e-44f2-a7c0-619af88327f5)

Edit: also errors are shown in the UI now

<img width="1330" alt="image" src="https://github.com/gradio-app/gradio/assets/41651716/c76536b7-53c5-497d-a14a-9cd3d84d0309">




## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
