### PR TITLE
Cache an error from app.submit() and show it on frontend

### DIFF
--- a/.changeset/rich-bikes-crash.md
+++ b/.changeset/rich-bikes-crash.md
@@ -1,0 +1,6 @@
+---
+"@gradio/app": patch
+"gradio": patch
+---
+
+feat:Cache an error from app.submit() and show it on frontend

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -19,7 +19,6 @@
 	import logo from "./images/logo.svg";
 	import api_logo from "./api_docs/img/api-logo.svg";
 	import { create_components, AsyncFunction } from "./init";
-	import type { SubmitReturn } from "client/js/src/types";
 
 	setupi18n();
 
@@ -260,7 +259,7 @@
 				api_calls = [...api_calls, payload];
 			}
 
-			let submission: SubmitReturn;
+			let submission: ReturnType<typeof app.submit>;
 			try {
 				submission = app.submit(
 					payload.fn_index,

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -19,6 +19,7 @@
 	import logo from "./images/logo.svg";
 	import api_logo from "./api_docs/img/api-logo.svg";
 	import { create_components, AsyncFunction } from "./init";
+	import type { SubmitReturn } from "client/js/src/types";
 
 	setupi18n();
 
@@ -258,13 +259,30 @@
 			if (api_recorder_visible) {
 				api_calls = [...api_calls, payload];
 			}
-			const submission = app
-				.submit(
+
+			let submission: SubmitReturn;
+			try {
+				submission = app.submit(
 					payload.fn_index,
 					payload.data as unknown[],
 					payload.event_data,
 					payload.trigger_id
-				)
+				);
+			} catch (e) {
+				const fn_index = 0; // Mock value for fn_index
+				messages = [new_message(String(e), fn_index, "error"), ...messages];
+				loading_status.update({
+					status: "error",
+					fn_index,
+					eta: 0,
+					queue: false,
+					queue_position: null
+				});
+				set_status($loading_status);
+				return;
+			}
+
+			submission
 				.on("data", ({ data, fn_index }) => {
 					if (dep.pending_request && dep.final_event) {
 						dep.pending_request = false;


### PR DESCRIPTION
### ## Description

Background: https://github.com/gradio-app/gradio/pull/8041#issuecomment-2059945536

When an error occurs for example at the `/info` endpoint, the frontend app silently crashes which is confusing,
because [an error from `Client.submit`](https://github.com/gradio-app/gradio/blob/487db7b5d57e1a1350494efdf37c121cbf627780/client/js/src/utils/submit.ts#L48-L49) is not caught to show the message toast.

![CleanShot 2024-04-24 at 23 24 56](https://github.com/gradio-app/gradio/assets/3135397/b80348fb-a009-4982-86df-9d91ec571822)

Sample code:
```python
import gradio as gr
import numpy as np

with gr.Blocks() as demo:
    inp = gr.JSON(
        value=np.array([1, 2, 3])
    )
    out = gr.JSON()
    btn = gr.Button("Submit")
    btn.click(lambda x: x, inp, out)

demo.launch()
```

While the exact error occurring in the examle above will be fixed in #8041 on the server side, these should be such an error handler on the frontend for potential similar problems.


With this PR, the error message toast and error status are shown in the app.

![CleanShot 2024-04-24 at 23 32 04@2x](https://github.com/gradio-app/gradio/assets/3135397/7cee54ea-08b9-4421-b5ed-b5175ce1ffd8)

