### PR TITLE
Add session hash to gr request

### DIFF
--- a/.changeset/great-plants-deny.md
+++ b/.changeset/great-plants-deny.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Add session hash to gr request

--- a/.changeset/great-plants-deny.md
+++ b/.changeset/great-plants-deny.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Add session hash to gr request

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 __tmp/*
 *.pyi
 py.typed
+.ipynb_checkpoints/
 
 # JS build
 gradio/templates/*

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -112,7 +112,7 @@ class Request:
     A Gradio request object that can be used to access the request headers, cookies,
     query parameters and other information about the request from within the prediction
     function. The class is a thin wrapper around the fastapi.Request class. Attributes
-    of this class include: `headers`, `client`, `query_params`, and `path_params`. If
+    of this class include: `headers`, `client`, `query_params`, `session_hash`, and `path_params`. If
     auth is enabled, the `username` attribute can be used to get the logged in user.
     Example:
         import gradio as gr
@@ -121,6 +121,7 @@ class Request:
                 print("Request headers dictionary:", request.headers)
                 print("IP address:", request.client.host)
                 print("Query parameters:", dict(request.query_params))
+                print("Session hash:", request.session_hash)
             return text
         io = gr.Interface(echo, "textbox", "textbox").launch()
     Demos: request_ip_headers
@@ -138,6 +139,8 @@ class Request:
         attributes (needed for queueing).
         Parameters:
             request: A fastapi.Request
+            username: The username of the logged in user (if auth is enabled)
+            session_hash: The session hash of the current session. It is unique for each page load.
         """
         self.request = request
         self.username = username

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -130,6 +130,7 @@ class Request:
         self,
         request: fastapi.Request | None = None,
         username: str | None = None,
+        session_hash: str | None = None,
         **kwargs,
     ):
         """
@@ -140,6 +141,7 @@ class Request:
         """
         self.request = request
         self.username = username
+        self.session_hash = session_hash
         self.kwargs: dict = kwargs
 
     def dict_to_obj(self, d):
@@ -191,11 +193,15 @@ def compile_gr_request(
         if body.batched:
             gr_request = [Request(username=username, request=request)]
         else:
-            gr_request = Request(username=username, request=body.request)
+            gr_request = Request(
+                username=username, request=body.request, session_hash=body.session_hash
+            )
     else:
         if request is None:
             raise ValueError("request must be provided if body.request is None")
-        gr_request = Request(username=username, request=request)
+        gr_request = Request(
+            username=username, request=request, session_hash=body.session_hash
+        )
 
     return gr_request
 

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -637,7 +637,7 @@ class App(FastAPI):
                         if "stop" in done:
                             raise asyncio.CancelledError()
                     except asyncio.CancelledError:
-                        req = Request(request, username)
+                        req = Request(request, username, session_hash=session_hash)
                         root_path = route_utils.get_root_url(
                             request=request,
                             route_path=f"/hearbeat/{session_hash}",


### PR DESCRIPTION
## Description

Being able to pull the session_hash has come up twice recently: the command+R demo and I personally wanted build a demo where I use the session hash to save some files to disk and then clean them up with `unload`. To get the session hash, you have to use `await request.body()` which is not ideal since you'd have to make your handler async and it's also not clear you have to parse the body to get the session hash.

I think this should make it easier in the future for others.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
