### PR TITLE
Be able to link to a custom component in the gallery directly

### DIFF
--- a/.changeset/puny-queens-clean.md
+++ b/.changeset/puny-queens-clean.md
@@ -1,0 +1,5 @@
+---
+"website": minor
+---
+
+feat:Be able to link to a custom component in the gallery directly

--- a/js/_website/src/routes/custom-components/gallery/+page.svelte
+++ b/js/_website/src/routes/custom-components/gallery/+page.svelte
@@ -11,6 +11,7 @@
 
 	let components: ComponentData[] = [];
 	let selection: string = "";
+	let link_copied = false;
 
 	let selected_component: ComponentData | null = null;
 	let components_length: number = 0;
@@ -57,8 +58,9 @@
 			components_length = components.length;
 		}
 		components = components.sort((a, b) => b["likes"] - a["likes"]);
-		const id  = $page.url.searchParams.get("id")
-		selected_component = components.find((component) => component.id === id) ?? null;
+		const id = $page.url.searchParams.get("id");
+		selected_component =
+			components.find((component) => component.id === id) ?? null;
 	}
 
 	onMount(fetch_components);
@@ -67,6 +69,17 @@
 		await tick();
 		e.preventDefault();
 		fetch_components(selection.split(","));
+	}
+
+	function copy_link(id: string) {
+		const url = $page.url;
+		url.searchParams.set("id", id);
+		const link = url.toString();
+		navigator.clipboard.writeText(link).then(() => {
+			window.setTimeout(() => {
+				link_copied = false;
+			}, 1000);
+		});
 	}
 </script>
 
@@ -174,17 +187,32 @@
 			selected_component = null;
 		}}
 	>
-		<button>
-			<a>Share</a>
-		</button>
-		<a
-			href={`https://huggingface.co/spaces/${component.id}`}
-			target="_blank"
-			class="flex-none self-end mr-8 rounded-md w-fit px-3.5 py-1 text-sm font-semibold text-white bg-orange-300 hover:drop-shadow-sm"
-		>
-			Go to Space <span aria-hidden="true">→</span></a
-		>
-
+		<div class="self-end mr-8 flex">
+			{#if !link_copied}
+				<button
+					on:click={(e) => {
+						link_copied = true;
+						copy_link(component.id);
+					}}
+					class="rounded-md w-fit px-3.5 py-1 text-sm font-semibold text-white bg-orange-300 hover:drop-shadow-sm mr-4"
+				>
+					Share
+				</button>
+			{:else}
+				<span
+					class="rounded-md w-fit px-3.5 py-1 text-sm font-semibold text-white bg-orange-300 hover:drop-shadow-sm mr-4"
+				>
+					Link copied to clipboard!
+				</span>
+			{/if}
+			<a
+				href={`https://huggingface.co/spaces/${component.id}`}
+				target="_blank"
+				class="rounded-md w-fit px-3.5 py-1 text-sm font-semibold text-white bg-orange-300 hover:drop-shadow-sm"
+			>
+				Go to Space <span aria-hidden="true">→</span>
+			</a>
+		</div>
 		<iframe
 			src={`https://${component.subdomain}.hf.space?__theme=light`}
 			height="100%"

--- a/js/_website/src/routes/custom-components/gallery/+page.svelte
+++ b/js/_website/src/routes/custom-components/gallery/+page.svelte
@@ -57,6 +57,8 @@
 			components_length = components.length;
 		}
 		components = components.sort((a, b) => b["likes"] - a["likes"]);
+		const id  = $page.url.searchParams.get("id")
+		selected_component = components.find((component) => component.id === id) ?? null;
 	}
 
 	onMount(fetch_components);
@@ -172,6 +174,9 @@
 			selected_component = null;
 		}}
 	>
+		<button>
+			<a>Share</a>
+		</button>
 		<a
 			href={`https://huggingface.co/spaces/${component.id}`}
 			target="_blank"

--- a/js/_website/src/routes/custom-components/gallery/utils.ts
+++ b/js/_website/src/routes/custom-components/gallery/utils.ts
@@ -37,9 +37,12 @@ export const classToEmojiMapping: { [key: string]: string } = {
 	Video: "🎥"
 };
 
-export function clickOutside(element: any, callbackFunction: any) {
+export function clickOutside(element: HTMLDivElement, callbackFunction: any) {
 	function onClick(event: any) {
-		if (!element.contains(event.target)) {
+		if (
+			!element.contains(event.target) &&
+			!(event.target.textContent && event.target.textContent === "Share")
+		) {
 			callbackFunction();
 		}
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1478,25 +1478,6 @@ importers:
         specifier: ^3.28.0
         version: 3.28.0
 
-  js/preview/test/newcomponent/frontend:
-    dependencies:
-      '@gradio/atoms':
-        specifier: workspace:^
-        version: link:../../../../atoms
-      '@gradio/statustracker':
-        specifier: workspace:^
-        version: link:../../../../statustracker
-      '@gradio/utils':
-        specifier: workspace:^
-        version: link:../../../../utils
-      '@zerodevx/svelte-json-view':
-        specifier: ^1.0.7
-        version: 1.0.7(svelte@4.2.12)
-    devDependencies:
-      '@gradio/preview':
-        specifier: workspace:^
-        version: link:../../..
-
   js/preview/test/test/frontend:
     dependencies:
       '@gradio/atoms':
@@ -1511,25 +1492,6 @@ importers:
       '@zerodevx/svelte-json-view':
         specifier: ^1.0.7
         version: 1.0.7(svelte@4.2.12)
-    devDependencies:
-      '@gradio/preview':
-        specifier: workspace:^
-        version: link:../../..
-
-  js/preview/test/testdemo/frontend:
-    dependencies:
-      '@gradio/atoms':
-        specifier: workspace:^
-        version: link:../../../../atoms
-      '@gradio/icons':
-        specifier: workspace:^
-        version: link:../../../../icons
-      '@gradio/statustracker':
-        specifier: workspace:^
-        version: link:../../../../statustracker
-      '@gradio/utils':
-        specifier: workspace:^
-        version: link:../../../../utils
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1478,6 +1478,25 @@ importers:
         specifier: ^3.28.0
         version: 3.28.0
 
+  js/preview/test/newcomponent/frontend:
+    dependencies:
+      '@gradio/atoms':
+        specifier: workspace:^
+        version: link:../../../../atoms
+      '@gradio/statustracker':
+        specifier: workspace:^
+        version: link:../../../../statustracker
+      '@gradio/utils':
+        specifier: workspace:^
+        version: link:../../../../utils
+      '@zerodevx/svelte-json-view':
+        specifier: ^1.0.7
+        version: 1.0.7(svelte@4.2.12)
+    devDependencies:
+      '@gradio/preview':
+        specifier: workspace:^
+        version: link:../../..
+
   js/preview/test/test/frontend:
     dependencies:
       '@gradio/atoms':
@@ -1492,6 +1511,25 @@ importers:
       '@zerodevx/svelte-json-view':
         specifier: ^1.0.7
         version: 1.0.7(svelte@4.2.12)
+    devDependencies:
+      '@gradio/preview':
+        specifier: workspace:^
+        version: link:../../..
+
+  js/preview/test/testdemo/frontend:
+    dependencies:
+      '@gradio/atoms':
+        specifier: workspace:^
+        version: link:../../../../atoms
+      '@gradio/icons':
+        specifier: workspace:^
+        version: link:../../../../icons
+      '@gradio/statustracker':
+        specifier: workspace:^
+        version: link:../../../../statustracker
+      '@gradio/utils':
+        specifier: workspace:^
+        version: link:../../../../utils
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^


### PR DESCRIPTION
## Description

Added a `Share` button to the custom component card that copies a link to your clipboard that you can use to open the gallery to that component. 

![share_custom_components](https://github.com/gradio-app/gradio/assets/41651716/b0e6b1be-a11b-4c57-a50f-0553862684ea)


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
