### PR TITLE
Allow users to template the `ImageEditor` when using custom components

### DIFF
--- a/.changeset/metal-doodles-grow.md
+++ b/.changeset/metal-doodles-grow.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Allow users to template the `ImageEditor` when using custom components

--- a/gradio/cli/commands/components/_create_utils.py
+++ b/gradio/cli/commands/components/_create_utils.py
@@ -199,6 +199,11 @@ OVERRIDES = {
         """
         ),
     ),
+    "ImageEditor": ComponentFiles(
+        template="ImageEditor",
+        python_file_name="image_editor.py",
+        js_dir="imageeditor",
+    ),
 }
 
 


### PR DESCRIPTION
## Description

Closes #6746

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
