### PR TITLE
ensure @gradio/preview dist files are published

### DIFF
--- a/.changeset/slick-buses-bake.md
+++ b/.changeset/slick-buses-bake.md
@@ -1,0 +1,6 @@
+---
+"@gradio/preview": patch
+"gradio": patch
+---
+
+fix:ensure @gradio/preview dist files are published

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         run: | 
           . venv/bin/activate
           pip install build
-          pnpm --filter @gradio/client --filter @gradio/lite build
+          pnpm --filter @gradio/client --filter @gradio/lite --filter @gradio/preview build
       - name: create and publish versions
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## Description

We have a slight issue with the build caching, we only cache the frontend dir in the templates but the build also build multiple packages that we need to publish. Ideally we would have more granular caching. For now I've just added the preview build in a different step because it is very fast anyway.

Closes: #8138 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
