### PR TITLE
fix: handling SIGINT correctly in reload.py, single entrance of block_thread in blocks.py

### DIFF
--- a/.changeset/cold-spies-fail.md
+++ b/.changeset/cold-spies-fail.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:fix: handling SIGINT correctly in reload.py, single entrance of block_thread in blocks.py

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2427,18 +2427,21 @@ Received outputs:
             }
             analytics.launched_analytics(self, data)
 
-        # Block main thread if debug==True
-        if debug or int(os.getenv("GRADIO_DEBUG", "0")) == 1 and not wasm_utils.IS_WASM:
-            self.block_thread()
-        # Block main thread if running in a script to stop script from exiting
         is_in_interactive_mode = bool(getattr(sys, "ps1", sys.flags.interactive))
 
+        # Block main thread if debug==True
         if (
-            not prevent_thread_lock
-            and not is_in_interactive_mode
-            # In the Wasm env, we don't have to block the main thread because the server won't be shut down after the execution finishes.
-            # Moreover, we MUST NOT do it because there is only one thread in the Wasm env and blocking it will stop the subsequent code from running.
+            debug
+            or int(os.getenv("GRADIO_DEBUG", "0")) == 1
             and not wasm_utils.IS_WASM
+            or (
+                # Block main thread if running in a script to stop script from exiting
+                not prevent_thread_lock
+                and not is_in_interactive_mode
+                # In the Wasm env, we don't have to block the main thread because the server won't be shut down after the execution finishes.
+                # Moreover, we MUST NOT do it because there is only one thread in the Wasm env and blocking it will stop the subsequent code from running.
+                and not wasm_utils.IS_WASM
+            )
         ):
             self.block_thread()
 

--- a/gradio/cli/commands/reload.py
+++ b/gradio/cli/commands/reload.py
@@ -130,7 +130,7 @@ def main(
         try:
             popen.wait()
         except (KeyboardInterrupt, OSError):
-            print("gradio-cli: Waiting gradio main thread cleaning.")
+            pass
 
 
 if __name__ == "__main__":

--- a/gradio/cli/commands/reload.py
+++ b/gradio/cli/commands/reload.py
@@ -126,7 +126,11 @@ def main(
             GRADIO_WATCH_DEMO_PATH=str(path),
         ),
     )
-    popen.wait()
+    if popen.poll() is None:
+        try:
+            popen.wait()
+        except (KeyboardInterrupt, OSError):
+            print("gradio-cli: Waiting gradio main thread cleaning.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

* Handle SIGINT correctly in reload.py, to prevent gradio-cli exit when subprocess running 
* Make sure there is only a single entrance of block_thread in blocks.py

Closes: #8157 