### PR TITLE
Only connect to heartbeat if needed

### DIFF
--- a/.changeset/polite-lamps-burn.md
+++ b/.changeset/polite-lamps-burn.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": patch
+"gradio": patch
+---
+
+fix:Only connect to heartbeat if needed

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -135,7 +135,7 @@ export class Client {
 			await this._resolve_config().then(async ({ config }) => {
 				if (config) {
 					this.config = config;
-					if (this.config) {
+					if (this.config && this.config.connect_heartbeat) {
 						// connect to the heartbeat endpoint via GET request
 						const heartbeat_url = new URL(
 							`${this.config.root}/heartbeat/${this.session_hash}`

--- a/client/js/src/helpers/init_helpers.ts
+++ b/client/js/src/helpers/init_helpers.ts
@@ -73,7 +73,7 @@ export async function resolve_config(
 		const config = window.gradio_config;
 		let config_root = resolve_root(endpoint, config.root, false);
 		config.root = config_root;
-		return { ...config, path };
+		return { ...config, path } as Config;
 	} else if (endpoint) {
 		const response = await this.fetch_implementation(
 			`${endpoint}/${CONFIG_URL}`,

--- a/client/js/src/types.ts
+++ b/client/js/src/types.ts
@@ -116,6 +116,7 @@ export type SpaceStatusCallback = (a: SpaceStatus) => void;
 export interface Config {
 	auth_required: boolean;
 	analytics_enabled: boolean;
+	connect_heartbeat: boolean;
 	auth_message: string;
 	components: any[];
 	css: string | null;

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1904,6 +1904,7 @@ Received outputs:
             "analytics_enabled": self.analytics_enabled,
             "components": [],
             "css": self.css,
+            "connect_heartbeat": False,
             "js": self.js,
             "head": self.head,
             "title": self.title or "Gradio",
@@ -1931,6 +1932,17 @@ Received outputs:
             "fill_height": self.fill_height,
         }
         config.update(self.default_config.get_config())
+        any_state = any(
+            isinstance(block, components.State) for block in self.blocks.values()
+        )
+        any_unload = False
+        for dep in config["dependencies"]:
+            for target in dep["targets"]:
+                if isinstance(target, (list, tuple)) and len(target) == 2:
+                    any_unload = target[1] == "unload"
+                    if any_unload:
+                        break
+        config["connect_heartbeat"] = any_state or any_unload
 
         return config
 


### PR DESCRIPTION
## Description

Closes: #8022 

Rather than always connecting to the heartbeat route, we should do so only when gr.State variables are used (to clean up state) or when the `unload` event is set. Users may still run into the browser limit, however. 

EDIT: I originally wanted to raise an error or message when the page locked up due to the connection limit. But the browser will block all requests after the limit is reached so we won't be able to fetch the config and progressively load the app.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
