### PR TITLE
Add ETag to `/custom_component` route to control browser caching

### DIFF
--- a/.changeset/icy-otters-stand.md
+++ b/.changeset/icy-otters-stand.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Add ETag to `/custom_component` route to control browser caching

--- a/.changeset/icy-otters-stand.md
+++ b/.changeset/icy-otters-stand.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Add ETag to `/custom_component` route to control browser caching
+fix:Add ETag to `/custom_component` route to control browser caching


### PR DESCRIPTION
## Description

Setting an ETag in the response of `/custom_component` that's equal to the hash of the requested file. I think this is preferable than setting a `max-age` because it should minimize the chance of a stale cache. During development, it's possible to build frequently to see if latest changes work outside the development server ( I do that atleast) so the `max-age` would be hard to set in this case.

Closes: #8168 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
