### PR TITLE
run python reload only if python file changed

### DIFF
--- a/.changeset/major-zoos-read.md
+++ b/.changeset/major-zoos-read.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:run python reload only if python file changed

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -261,15 +261,16 @@ def watchfn(reloader: SourceFileReloader):
                 # This is because the main demo file may import the changed file and we need the
                 # changes to be reflected in the main demo file.
 
-                changed_in_copy = _remove_no_reload_codeblocks(str(changed))
-                if changed != reloader.demo_file:
-                    changed_module = _find_module(changed)
-                    exec(changed_in_copy, changed_module.__dict__)
-                    top_level_parent = sys.modules[
-                        changed_module.__name__.split(".")[0]
-                    ]
-                    if top_level_parent != changed_module:
-                        importlib.reload(top_level_parent)
+                if changed.suffix == ".py":
+                    changed_in_copy = _remove_no_reload_codeblocks(str(changed))
+                    if changed != reloader.demo_file:
+                        changed_module = _find_module(changed)
+                        exec(changed_in_copy, changed_module.__dict__)
+                        top_level_parent = sys.modules[
+                            changed_module.__name__.split(".")[0]
+                        ]
+                        if top_level_parent != changed_module:
+                            importlib.reload(top_level_parent)
 
                 changed_demo_file = _remove_no_reload_codeblocks(
                     str(reloader.demo_file)


### PR DESCRIPTION
## Description

Add a conditional to run reload only on python files.

Closes: #8192

## 🎯 PRs Should Target Issues

Targets issue #8192

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`