### PR TITLE
Set the show_api flag on Lite

### DIFF
--- a/.changeset/cruel-cars-think.md
+++ b/.changeset/cruel-cars-think.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Set the show_api flag on Lite

--- a/.changeset/cruel-cars-think.md
+++ b/.changeset/cruel-cars-think.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Set the show_api flag on Lite

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2052,7 +2052,7 @@ Received outputs:
         ssl_keyfile_password: str | None = None,
         ssl_verify: bool = True,
         quiet: bool = False,
-        show_api: bool = True,
+        show_api: bool = not wasm_utils.IS_WASM,
         allowed_paths: list[str] | None = None,
         blocked_paths: list[str] | None = None,
         root_path: str | None = None,


### PR DESCRIPTION
## Description

Hide the "Use via API" link on Lite, which doesn't make sense in Lite env.

<table>
<tr>
<th> <code>main</code> </th>
<th>this PR</th>
</tr>
<tr>
<td>
<img src="https://github.com/gradio-app/gradio/assets/3135397/4d657fb0-1a01-4bd2-a832-6bad08b807d2" />

</td>
<td>

<img src="https://github.com/gradio-app/gradio/assets/3135397/c49e3e30-778e-4ad0-9518-64d4761f70ff" />

</td>
</tr>
</table>