### PR TITLE
remove redundant event source logic

### DIFF
--- a/.changeset/gold-frogs-sniff.md
+++ b/.changeset/gold-frogs-sniff.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": minor
+"gradio": minor
+---
+
+feat:remove redundant event source logic

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -36,16 +36,6 @@ export class NodeBlob extends Blob {
 	}
 }
 
-if (typeof window === "undefined") {
-	import("eventsource")
-		.then((EventSourceModule) => {
-			global.EventSource = EventSourceModule.default as any;
-		})
-		.catch((error) =>
-			console.error("Failed to load EventSource module:", error)
-		);
-}
-
 export class Client {
 	app_reference: string;
 	options: ClientOptions;


### PR DESCRIPTION
## Description

The old event source logic was mistakenly added back in in #8181. This removes that.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
