### PR TITLE
Allow Spaces with `.success()` to be `gr.load`-ed

### DIFF
--- a/.changeset/social-tigers-lie.md
+++ b/.changeset/social-tigers-lie.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Allow Spaces with `.success()` to be `gr.load`-ed

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -990,7 +990,10 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
                 # This assumes that you cannot combine multiple .then() events in a single
                 # gr.on() event, which is true for now. If this changes, we will need to
                 # update this code.
-                if not isinstance(_targets[0], int) and _targets[0][1] == "then":
+                if not isinstance(_targets[0], int) and _targets[0][1] in [
+                    "then",
+                    "success",
+                ]:
                     if len(_targets) != 1:
                         raise ValueError(
                             "This logic assumes that .then() events are not combined with other events in a single gr.on() event"

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -82,13 +82,26 @@ class TestBlocksMethods:
             gr.Image(height=54, width=240)
 
         config1 = demo1.get_config_file()
-        demo2 = gr.Blocks.from_config(config1, [update], "https://fake.hf.space")
+        demo2 = gr.Blocks.from_config(config1, [update], fake_url)
 
         for component in config1["components"]:
             component["props"]["proxy_url"] = f"{fake_url}/"
         config2 = demo2.get_config_file()
 
         assert assert_configs_are_equivalent_besides_ids(config1, config2)
+
+    def test_load_config_with_sucess(self):
+        fake_url = "https://fake.hf.space"
+        with gr.Blocks() as demo1:
+            t1 = gr.Textbox()
+            t2 = gr.Textbox()
+            t3 = gr.Textbox()
+            t4 = gr.Textbox()
+            t1.change(lambda x: x, t1, t2).then(lambda x: x, t2, t3).success(
+                lambda x: x, t3, t4
+            )
+        config1 = demo1.get_config_file()
+        gr.Blocks.from_config(config1, [lambda x: x] * 3, fake_url)
 
     def test_partial_fn_in_config(self):
         def greet(name, formatter):


### PR DESCRIPTION
Small PR that fixes: https://github.com/gradio-app/gradio/issues/8164