### PR TITLE
Adds `examples_per_page` to `gr.ChatInterface` and allows `clear_btn` in `gr.Interface` to be hidden

### DIFF
--- a/.changeset/fruity-books-win.md
+++ b/.changeset/fruity-books-win.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Adds `examples_per_page` to `gr.ChatInterface` and allows `clear_btn` in `gr.Interface` to be hidden

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -62,6 +62,7 @@ class ChatInterface(Blocks):
         additional_inputs_accordion: str | Accordion | None = None,
         examples: list[str] | list[dict[str, str | list]] | list[list] | None = None,
         cache_examples: bool | Literal["lazy"] | None = None,
+        examples_per_page: int = 10,
         title: str | None = None,
         description: str | None = None,
         theme: Theme | str | None = None,
@@ -88,8 +89,9 @@ class ChatInterface(Blocks):
             additional_inputs: An instance or list of instances of gradio components (or their string shortcuts) to use as additional inputs to the chatbot. If components are not already rendered in a surrounding Blocks, then the components will be displayed under the chatbot, in an accordion.
             additional_inputs_accordion_name: Deprecated. Will be removed in a future version of Gradio. Use the `additional_inputs_accordion` parameter instead.
             additional_inputs_accordion: If a string is provided, this is the label of the `gr.Accordion` to use to contain additional inputs. A `gr.Accordion` object can be provided as well to configure other properties of the container holding the additional inputs. Defaults to a `gr.Accordion(label="Additional Inputs", open=False)`. This parameter is only used if `additional_inputs` is provided.
-            examples: Sample inputs for the function; if provided, appear below the chatbot and can be clicked to populate the chatbot input.
+            examples: Sample inputs for the function; if provided, appear below the chatbot and can be clicked to populate the chatbot input. Should be a list of strings if `multimodal` is False, and a list of dictionaries (with keys `text` and `files`) if `multimodal` is True.
             cache_examples: If True, caches examples in the server for fast runtime in examples. The default option in HuggingFace Spaces is True. The default option elsewhere is False.
+            examples_per_page: If examples are provided, how many to display per page.
             title: a title for the interface; if provided, appears above chatbot in large font. Also used as the tab title when opened in a browser window.
             description: a description for the interface; if provided, appears above the chatbot and beneath the title in regular font. Accepts Markdown and HTML content.
             theme: Theme to use, loaded from gradio.themes.
@@ -285,6 +287,7 @@ class ChatInterface(Blocks):
                     fn=examples_fn,
                     cache_examples=self.cache_examples,
                     _defer_caching=True,
+                    examples_per_page=examples_per_page,
                 )
 
             any_unrendered_inputs = any(

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -129,7 +129,7 @@ class Interface(Blocks):
         *,
         submit_btn: str | Button = "Submit",
         stop_btn: str | Button = "Stop",
-        clear_btn: str | Button = "Clear",
+        clear_btn: str | Button | None = "Clear",
         delete_cache: tuple[int, int] | None = None,
         **kwargs,
     ):
@@ -145,7 +145,7 @@ class Interface(Blocks):
             title: A title for the interface; if provided, appears above the input and output components in large font. Also used as the tab title when opened in a browser window.
             description: A description for the interface; if provided, appears above the input and output components and beneath the title in regular font. Accepts Markdown and HTML content.
             article: An expanded article explaining the interface; if provided, appears below the input and output components in regular font. Accepts Markdown and HTML content. If it is an HTTP(S) link to a downloadable remote file, the content of this file is displayed.
-            thumbnail: String path or url to image to use as display image when the web demo is shared on social media.
+            thumbnail: This parameter has been deprecated and has no effect.
             theme: A Theme object or a string representing a theme. If a string, will look for a built-in theme with that name (e.g. "soft" or "default"), or will attempt to load a theme from the Hugging Face Hub (e.g. "gradio/monochrome"). If None, will use the Default theme.
             css: Custom css as a string or path to a css file. This css will be included in the demo webpage.
             allow_flagging: One of "never", "auto", or "manual". If "never" or "auto", users will not see a button to flag an input and output. If "manual", users will see a button to flag. If "auto", every input the user submits will be automatically flagged, along with the generated output. If "manual", both the input and outputs are flagged when the user clicks flag button. This parameter can be set with environmental variable GRADIO_ALLOW_FLAGGING; otherwise defaults to "manual".
@@ -164,7 +164,7 @@ class Interface(Blocks):
             additional_inputs_accordion: If a string is provided, this is the label of the `gr.Accordion` to use to contain additional inputs. A `gr.Accordion` object can be provided as well to configure other properties of the container holding the additional inputs. Defaults to a `gr.Accordion(label="Additional Inputs", open=False)`. This parameter is only used if `additional_inputs` is provided.
             submit_btn: The button to use for submitting inputs. Defaults to a `gr.Button("Submit", variant="primary")`. This parameter does not apply if the Interface is output-only, in which case the submit button always displays "Generate". Can be set to a string (which becomes the button label) or a `gr.Button` object (which allows for more customization).
             stop_btn: The button to use for stopping the interface. Defaults to a `gr.Button("Stop", variant="stop", visible=False)`. Can be set to a string (which becomes the button label) or a `gr.Button` object (which allows for more customization).
-            clear_btn: The button to use for clearing the inputs. Defaults to a `gr.Button("Clear", variant="secondary")`. Can be set to a string (which becomes the button label) or a `gr.Button` object (which allows for more customization).
+            clear_btn: The button to use for clearing the inputs. Defaults to a `gr.Button("Clear", variant="secondary")`. Can be set to a string (which becomes the button label) or a `gr.Button` object (which allows for more customization). Can be set to None, which hides the button.
             delete_cache: A tuple corresponding [frequency, age] both expressed in number of seconds. Every `frequency` seconds, the temporary files created by this Blocks instance will be deleted if more than `age` seconds have passed since the file was created. For example, setting this to (86400, 86400) will delete temporary files every day. The cache will be deleted entirely when the server restarts. If None, no cache deletion will occur.
         """
         super().__init__(
@@ -346,7 +346,12 @@ class Interface(Blocks):
                 f"The stop_btn parameter must be a gr.Button or string, not {type(stop_btn)}"
             )
 
-        if isinstance(clear_btn, Button):
+        if clear_btn is None:
+            self.clear_btn_params = {
+                "visible": False,
+                "variant": "secondary",
+            }
+        elif isinstance(clear_btn, Button):
             self.clear_btn_params = clear_btn.recover_kwargs(clear_btn.get_config())
         elif isinstance(clear_btn, str):
             self.clear_btn_params = {
@@ -355,7 +360,7 @@ class Interface(Blocks):
             }
         else:
             raise ValueError(
-                f"The clear_btn parameter must be a gr.Button or string, not {type(clear_btn)}"
+                f"The clear_btn parameter must be a gr.Button, a string, or None, not {type(clear_btn)}"
             )
 
         self.simple_server = None

--- a/guides/04_chatbots/01_creating-a-chatbot-fast.md
+++ b/guides/04_chatbots/01_creating-a-chatbot-fast.md
@@ -125,6 +125,17 @@ gr.ChatInterface(
 ).launch()
 ```
 
+In particular, if you'd like to add a "placeholder" for your chat interface, which appears before the user has started chatting, you can do so using the `placeholder` argument of `gr.Chatbot`, which accepts Markdown or HTML. 
+
+```python
+gr.ChatInterface(
+    yes_man,
+    chatbot=gr.Chatbot(placeholder="<strong>Your Personal Yes-Man</strong><br>Ask Me Anything"),
+...
+```
+
+The placeholder appears vertically and horizontally centered in the chatbot.
+
 ## Add Multimodal Capability to your chatbot
 
 You may want to add multimodal capability to your chatbot. For example, you may want users to be able to easily upload images or files to your chatbot and ask questions about it. You can make your chatbot "multimodal" by passing in a single parameter (`multimodal=True`) to the `gr.ChatInterface` class.
@@ -143,8 +154,7 @@ demo = gr.ChatInterface(fn=count_files, examples=[{"text": "Hello", "files": []}
 demo.launch()
 ```
 
-When `multimodal=True`, the first parameter of your function should receives a dictionary consisting of the submitted text and uploaded files that looks like this: `{"text": "user input", "file": ["file_path1", "file_path2", ...]}`.
-
+When `multimodal=True`, the signature of `fn` changes slightly. The first parameter of your function should accept a dictionary consisting of the submitted text and uploaded files that looks like this: `{"text": "user input", "file": ["file_path1", "file_path2", ...]}`. Similarly, any examples you provide should be in a dictionary of this form. Your function should still return a single `str` message. 
 
 Tip: If you'd like to customize the UI/UX of the textbox for your multimodal chatbot, you should pass in an instance of `gr.MultimodalTextbox` to the `textbox` argument of `ChatInterface` instead of an instance of `gr.Textbox`.
 


### PR DESCRIPTION
A few small changes in this PR:

1. First, adds `examples_per_page` to `gr.ChatInterface`, closes: https://github.com/gradio-app/gradio/issues/8233. My original plan had been to add support for providing an instance of `gr.Examples` but this does not really make sense since a user can't provide the correct `fn` to `examples` since the example function is redefined internally. We also have the same `examples_per_page` argument in `gr.Interface`
2. I went through the arguments of `gr.Interface` to make sure that we have equivalent arguments in `gr.ChatInterface` and made a few other small tweaks, such as allowing `clear_btn` in `gr.Interface` to be set to `None` hiding it, similar to how the buttons in `gr.ChatInterface`. I believe there was an issue about this that we closed
3. Adds some docs to `gr.ChatInterface` guide