### PR TITLE
Send ProcessCompleted message when job is cancelled

### DIFF
--- a/.changeset/red-bottles-brake.md
+++ b/.changeset/red-bottles-brake.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Send ProcessCompleted message when job is cancelled
+fix:Send ProcessCompleted message when job is cancelled

--- a/.changeset/red-bottles-brake.md
+++ b/.changeset/red-bottles-brake.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Send ProcessCompleted message when job is cancelled

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -490,6 +490,7 @@ class BlockFunction:
         scroll_to_output: bool = False,
         show_api: bool = True,
         renderable: Renderable | None = None,
+        is_cancel_function: bool = False,
     ):
         self.fn = fn
         self.inputs = inputs
@@ -526,6 +527,15 @@ class BlockFunction:
             or bool(self.every)
         )
         self.renderable = renderable
+
+        # We need to keep track of which events are cancel events
+        # in two places:
+        # 1. So that we can skip postprocessing for cancel events.
+        #   They return event_ids that have been cancelled but there
+        #   are no output components
+        # 2. So that we can place the ProcessCompletedMessage in the
+        #   event stream so that clients can close the stream when necessary
+        self.is_cancel_function = is_cancel_function
 
         self.spaces_auto_wrap()
 
@@ -1143,6 +1153,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
         concurrency_id: str | None = None,
         show_api: bool = True,
         renderable: Renderable | None = None,
+        is_cancel_function: bool = False,
     ) -> tuple[BlockFunction, int]:
         """
         Adds an event to the component's dependencies.
@@ -1170,6 +1181,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
             concurrency_limit: If set, this is the maximum number of this event that can be running simultaneously. Can be set to None to mean no concurrency_limit (any number of this event can be running simultaneously). Set to "default" to use the default concurrency limit (defined by the `default_concurrency_limit` parameter in `queue()`, which itself is 1 by default).
             concurrency_id: If set, this is the id of the concurrency group. Events with the same concurrency_id will be limited by the lowest set concurrency_limit.
             show_api: whether to show this event in the "view API" page of the Gradio app, or in the ".view_api()" method of the Gradio clients. Unlike setting api_name to False, setting show_api to False will still allow downstream apps to use this event. If fn is None, show_api will automatically be set to False.
+            is_cancel_function: whether this event cancels another running event.
         Returns: dependency information, dependency index
         """
         # Support for singular parameter
@@ -1292,6 +1304,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
             scroll_to_output=scroll_to_output,
             show_api=show_api,
             renderable=renderable,
+            is_cancel_function=is_cancel_function,
         )
 
         self.fns.append(block_fn)
@@ -1656,9 +1669,17 @@ Received outputs:
 
     async def postprocess_data(
         self, fn_index: int, predictions: list | dict, state: SessionState | None
-    ):
+    ) -> Any:
         state = state or SessionState(self)
         block_fn = self.fns[fn_index]
+
+        # If the function is a cancel function, 'predictions' are the ids of
+        # the event in the queue that has been cancelled. We need these
+        # so that the server can put the ProcessCompleted message in the event stream
+        # Cancel events have no output components, so we need to return early otherise the output
+        # be None.
+        if block_fn.is_cancel_function:
+            return predictions
 
         if isinstance(predictions, dict) and len(predictions) > 0:
             predictions = convert_component_dict_to_list(

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -38,6 +38,7 @@ def set_cancel_events(
             preprocess=False,
             show_api=False,
             cancels=fn_indices_to_cancel,
+            is_cancel_function=True,
         )
 
 

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -302,6 +302,7 @@ class Queue:
                         process_event_task,
                         events[0].session_hash,
                         events[0].fn_index,
+                        events[0]._id,
                         batch,
                     )
 

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1282,7 +1282,7 @@ class TestCancel:
 
         cancel_fun = demo.fns[-1].fn
         task = asyncio.create_task(long_job())
-        task.set_name("foo_0")
+        task.set_name("foo_0<gradio-sep>event")
         # If cancel_fun didn't cancel long_job the message would be printed to the console
         # The test would also take 10 seconds
         await asyncio.gather(task, cancel_fun("foo"), return_exceptions=True)
@@ -1314,7 +1314,7 @@ class TestCancel:
         cancel_fun = demo.fns[-1].fn
 
         task = asyncio.create_task(long_job())
-        task.set_name("foo_1")
+        task.set_name("foo_1<gradio-sep>event")
         await asyncio.gather(task, cancel_fun("foo"), return_exceptions=True)
         captured = capsys.readouterr()
         assert "HELLO FROM LONG JOB" not in captured.out


### PR DESCRIPTION
## Description

If a job is cancelled, the server and the client will keep the `/queue/data` stream open forever.

Notice that in the first image, the multiple heartbeats gets sent after the job is cancelled (indicating the channel was kept open for at least 45 seconds post cancellation) while in the second message the process_completed and close_stream messages are sent after cancellation. This was tested on the `fake_diffusion` demo.

### Main
<img width="597" alt="Screenshot 2024-05-10 at 3 36 47 PM" src="https://github.com/gradio-app/gradio/assets/41651716/b14d68d3-6ff1-4435-8dcb-e08b423c059a">

### This PR
<img width="545" alt="Screenshot 2024-05-10 at 3 35 08 PM" src="https://github.com/gradio-app/gradio/assets/41651716/b4c917c0-9afa-47c2-b9dc-b67ae50d7e82">


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
