### PR TITLE
Fix bug where status tracker was the target of pointer events

### DIFF
--- a/.changeset/tidy-groups-lose.md
+++ b/.changeset/tidy-groups-lose.md
@@ -1,0 +1,6 @@
+---
+"@gradio/statustracker": patch
+"gradio": patch
+---
+
+fix:Fix bug where status tracker was the target of pointer events

--- a/js/statustracker/static/index.svelte
+++ b/js/statustracker/static/index.svelte
@@ -330,6 +330,7 @@
 		border: 2px solid var(--color-accent);
 		background: transparent;
 		z-index: var(--layer-1);
+		pointer-events: none;
 	}
 
 	.translucent {


### PR DESCRIPTION
## Description

Closes: #8250 

I removed the `pointer-events: none` in #7909 so that users can close the error modal but this caused #8250. 

My fix was to apply `pointer-events: none` when the component is generating.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
