### PR TITLE
Link to troubleshooting guide in the custom component loading status

### DIFF
--- a/.changeset/strong-cases-study.md
+++ b/.changeset/strong-cases-study.md
@@ -1,0 +1,7 @@
+---
+"@gradio/app": minor
+"@gradio/statustracker": minor
+"gradio": minor
+---
+
+feat:Link to troubleshooting guide in the custom component loading status

--- a/.changeset/strong-cases-study.md
+++ b/.changeset/strong-cases-study.md
@@ -1,7 +1,7 @@
 ---
-"@gradio/app": minor
-"@gradio/statustracker": minor
-"gradio": minor
+"@gradio/app": patch
+"@gradio/statustracker": patch
+"gradio": patch
 ---
 
 feat:Link to troubleshooting guide in the custom component loading status

--- a/guides/06_custom-components/06_frequently-asked-questions.md
+++ b/guides/06_custom-components/06_frequently-asked-questions.md
@@ -34,11 +34,6 @@ If the `window.__GRADIO__CC` variable is not empty (see below for an example), t
 **4. Make sure you are using a virtual environment**
 It is highly recommended you use a virtual environment to prevent conflicts with other python dependencies installed in your system.
 
-**5. Add code**
-
-
-
-
 
 ## Do I need to host my custom component on HuggingFace Spaces?
 You can develop and build your custom component without hosting or connecting to HuggingFace.

--- a/guides/06_custom-components/06_frequently-asked-questions.md
+++ b/guides/06_custom-components/06_frequently-asked-questions.md
@@ -13,10 +13,32 @@ When you run `gradio cc dev`, a development server will load and run a Gradio ap
 This is like when you run `python <app-file>.py`, however the `gradio` command will hot reload so you can instantly see your changes. 
 
 ## The development server didn't work for me 
-Make sure you have your package installed along with any dependencies you have added by running `gradio cc install`.
-Make sure there aren't any syntax or import errors in the Python or JavaScript code.
-If the development server is still not working for you, please use the `--python-path` and `gradio-path` CLI arguments to specify the path of the python and gradio executables for the environment your component is installed in.
-It is likely that the wrong envrironment is being used. For example, if you are using a virtualenv located at `/Users/mary/venv`, pass in `/Users/mary/bin/python` and `/Users/mary/bin/gradio` respectively.
+
+**1. Check your terminal and browser console**
+
+Make sure there are no syntax errors or other obvious problems in your code. Exceptions triggered from python will be displayed in the terminal. Exceptions from javascript will be displayed in the browser console and/or the terminal.
+
+**2. Are you developing on Windows?**
+
+Chrome on Windows will block the local compiled svelte files for security reasons. We recommend developing your custom component in the windows subsystem for linux (WSL) while we the teams looks at this issue.
+
+**3. Inspect the window.__GRADIO_CC__ variable**
+
+In the browser console, print the `window.__GRADIO__CC` varible (just type it into the console). If it is an empty object, that means
+that the CLI could not find your custom component source code. Typically, this happens when the custom component is installed in a different virtual environment than the one used to run the dev command. Please use the `--python-path` and `gradio-path` CLI arguments to specify the path of the python and gradio executables for the environment your component is installed in. For example, if you are using a virtualenv located at `/Users/mary/venv`, pass in `/Users/mary/bin/python` and `/Users/mary/bin/gradio` respectively.
+
+If the `window.__GRADIO__CC` variable is not empty (see below for an example), then the dev server should be working correctly. 
+
+![](https://gradio-builds.s3.amazonaws.com/demo-files/gradio_CC_DEV.png)
+
+**4. Make sure you are using a virtual environment**
+It is highly recommended you use a virtual environment to prevent conflicts with other python dependencies installed in your system.
+
+**5. Add code**
+
+
+
+
 
 ## Do I need to host my custom component on HuggingFace Spaces?
 You can develop and build your custom component without hosting or connecting to HuggingFace.

--- a/guides/06_custom-components/06_frequently-asked-questions.md
+++ b/guides/06_custom-components/06_frequently-asked-questions.md
@@ -24,7 +24,7 @@ Chrome on Windows will block the local compiled svelte files for security reason
 
 **3. Inspect the window.__GRADIO_CC__ variable**
 
-In the browser console, print the `window.__GRADIO__CC` varible (just type it into the console). If it is an empty object, that means
+In the browser console, print the `window.__GRADIO__CC` variable (just type it into the console). If it is an empty object, that means
 that the CLI could not find your custom component source code. Typically, this happens when the custom component is installed in a different virtual environment than the one used to run the dev command. Please use the `--python-path` and `gradio-path` CLI arguments to specify the path of the python and gradio executables for the environment your component is installed in. For example, if you are using a virtualenv located at `/Users/mary/venv`, pass in `/Users/mary/bin/python` and `/Users/mary/bin/gradio` respectively.
 
 If the `window.__GRADIO__CC` variable is not empty (see below for an example), then the dev server should be working correctly. 

--- a/guides/06_custom-components/06_frequently-asked-questions.md
+++ b/guides/06_custom-components/06_frequently-asked-questions.md
@@ -20,7 +20,7 @@ Make sure there are no syntax errors or other obvious problems in your code. Exc
 
 **2. Are you developing on Windows?**
 
-Chrome on Windows will block the local compiled svelte files for security reasons. We recommend developing your custom component in the windows subsystem for linux (WSL) while we the teams looks at this issue.
+Chrome on Windows will block the local compiled svelte files for security reasons. We recommend developing your custom component in the windows subsystem for linux (WSL) while the team looks at this issue.
 
 **3. Inspect the window.__GRADIO_CC__ variable**
 

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -417,13 +417,17 @@
 			i18n={$_}
 			{autoscroll}
 		>
-		<div class="load-text" slot="additional-loading-text">
-			{#if gradio_dev_mode === "dev"}
-				<p>
-					If your custom component never loads, consult the trouble shooting <a style='color: blue;'href='https://www.gradio.app/guides/frequently-asked-questions#the-development-server-didnt-work-for-me'>guide</a>.
-				</p>
-			{/if}
-		</div>
+			<div class="load-text" slot="additional-loading-text">
+				{#if gradio_dev_mode === "dev"}
+					<p>
+						If your custom component never loads, consult the trouble shooting <a
+							style="color: blue;"
+							href="https://www.gradio.app/guides/frequently-asked-questions#the-development-server-didnt-work-for-me"
+							>guide</a
+						>.
+					</p>
+				{/if}
+			</div>
 			<!-- todo: translate message text -->
 			<div class="error" slot="error">
 				<p><strong>{status?.message || ""}</strong></p>
@@ -473,7 +477,6 @@
 </Embed>
 
 <style>
-
 	.load-text {
 		z-index: var(--layer-2);
 		color: var(--body-text-color);

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -257,11 +257,12 @@
 	function handle_status(_status: SpaceStatus): void {
 		status = _status;
 	}
+	//@ts-ignore
+	const gradio_dev_mode = window.__GRADIO_DEV__;
+
 	onMount(async () => {
 		active_theme_mode = handle_theme_mode(wrapper);
 
-		//@ts-ignore
-		const gradio_dev_mode = window.__GRADIO_DEV__;
 		//@ts-ignore
 		const server_port = window.__GRADIO__SERVER_PORT__;
 
@@ -416,6 +417,13 @@
 			i18n={$_}
 			{autoscroll}
 		>
+		<div class="load-text" slot="additional-loading-text">
+			{#if gradio_dev_mode === "dev"}
+				<p>
+					If your custom component never loads, consult the trouble shooting <a style='color: blue;'href='https://www.gradio.app/guides/frequently-asked-questions#the-development-server-didnt-work-for-me'>guide</a>.
+				</p>
+			{/if}
+		</div>
 			<!-- todo: translate message text -->
 			<div class="error" slot="error">
 				<p><strong>{status?.message || ""}</strong></p>
@@ -465,6 +473,11 @@
 </Embed>
 
 <style>
+
+	.load-text {
+		z-index: var(--layer-2);
+		color: var(--body-text-color);
+	}
 	.error {
 		position: relative;
 		padding: var(--size-4);

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -477,10 +477,6 @@
 </Embed>
 
 <style>
-	.load-text {
-		z-index: var(--layer-2);
-		color: var(--body-text-color);
-	}
 	.error {
 		position: relative;
 		padding: var(--size-4);

--- a/js/app/src/Index.svelte
+++ b/js/app/src/Index.svelte
@@ -420,7 +420,7 @@
 			<div class="load-text" slot="additional-loading-text">
 				{#if gradio_dev_mode === "dev"}
 					<p>
-						If your custom component never loads, consult the trouble shooting <a
+						If your custom component never loads, consult the troubleshooting <a
 							style="color: blue;"
 							href="https://www.gradio.app/guides/frequently-asked-questions#the-development-server-didnt-work-for-me"
 							>guide</a

--- a/js/statustracker/static/index.svelte
+++ b/js/statustracker/static/index.svelte
@@ -275,7 +275,7 @@
 
 		{#if !timer}
 			<p class="loading">{loading_text}</p>
-			<slot name="additional-loading-text"/>
+			<slot name="additional-loading-text" />
 		{/if}
 	{:else if status === "error"}
 		<div class="clear-status">

--- a/js/statustracker/static/index.svelte
+++ b/js/statustracker/static/index.svelte
@@ -275,6 +275,7 @@
 
 		{#if !timer}
 			<p class="loading">{loading_text}</p>
+			<slot name="additional-loading-text"/>
 		{/if}
 	{:else if status === "error"}
 		<div class="clear-status">


### PR DESCRIPTION
## Description

Adds a link to the troubleshooting guide in the loading text of the custom component index page. That way, if something goes wrong during the dev command, developers can get to the troubleshooting tips from their app.

<img width="692" alt="Screenshot 2024-05-13 at 3 35 46 PM" src="https://github.com/gradio-app/gradio/assets/41651716/f1cda98a-ee98-4599-9415-7c069b1b1eb5">


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
