### PR TITLE
Update custom component installation requirements

### DIFF
--- a/guides/06_custom-components/01_custom-components-in-five-minutes.md
+++ b/guides/06_custom-components/01_custom-components-in-five-minutes.md
@@ -10,6 +10,7 @@ This guide will cover how to get started making custom components.
 You will need to have:
 
 * Python 3.8+ (<a href="https://www.python.org/downloads/" target="_blank">install here</a>)
+* pip 21.3+ (`python -m pip install --upgrade pip`)
 * Node.js v16.14+ (<a href="https://nodejs.dev/en/download/package-manager/" target="_blank">install here</a>)
 * npm 9+ (<a href="https://docs.npmjs.com/downloading-and-installing-node-js-and-npm/" target="_blank">install here</a>)
 * Gradio 4.0+ (`pip install --upgrade gradio`)


### PR DESCRIPTION
## Description

- Added pip 21.3+ requirement to be able to build from pyproject.toml otherwise get errors of this type:
```
 👷 Installing python... (/my/path/.venv/bin/pip3 install -e testcomponent[dev])                                                                           │
│ 🟥 Python installation failed                                                                                                                                                                                  │
│ ERROR: File "setup.py" or "setup.cfg" not found. Directory cannot be installed in editable mode: /my/path/gradio-components/testcomponent              │
│ (A "pyproject.toml" file was found, but editable mode currently requires a setuptools-based build.) 
```
  
