### PR TITLE
ensure the client correctly handles all binary data

### DIFF
--- a/.changeset/sixty-horses-tell.md
+++ b/.changeset/sixty-horses-tell.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": patch
+"gradio": patch
+---
+
+fix:Walk blobs ignoring blobs in arrays directly

--- a/.changeset/sixty-horses-tell.md
+++ b/.changeset/sixty-horses-tell.md
@@ -3,4 +3,4 @@
 "gradio": patch
 ---
 
-fix:Walk blobs ignoring blobs in arrays directly
+fix:ensure the client correctly handles all binary data

--- a/client/js/src/helpers/data.ts
+++ b/client/js/src/helpers/data.ts
@@ -41,13 +41,15 @@ export async function walk_and_store_blobs(
 		let blob_refs: BlobRef[] = [];
 
 		await Promise.all(
-			data.map(async (_, item) => {
+			data.map(async (_, index) => {
 				let new_path = path.slice();
-				new_path.push(String(item));
+				new_path.push(String(index));
 
 				const array_refs = await walk_and_store_blobs(
-					data[item],
-					root ? endpoint_info?.parameters[item]?.component || undefined : type,
+					data[index],
+					root
+						? endpoint_info?.parameters[index]?.component || undefined
+						: type,
 					new_path,
 					false,
 					endpoint_info

--- a/client/js/src/helpers/data.ts
+++ b/client/js/src/helpers/data.ts
@@ -41,9 +41,9 @@ export async function walk_and_store_blobs(
 		let blob_refs: BlobRef[] = [];
 
 		await Promise.all(
-			data.map(async (item) => {
+			data.map(async (_, item) => {
 				let new_path = path.slice();
-				new_path.push(item);
+				new_path.push(String(item));
 
 				const array_refs = await walk_and_store_blobs(
 					data[item],

--- a/client/js/src/helpers/data.ts
+++ b/client/js/src/helpers/data.ts
@@ -87,22 +87,6 @@ export async function walk_and_store_blobs(
 			);
 		}
 
-		if (
-			!blob_refs.length &&
-			!(
-				data instanceof Blob ||
-				data instanceof ArrayBuffer ||
-				data instanceof Uint8Array
-			)
-		) {
-			return [
-				{
-					path: path,
-					blob: new NodeBlob([JSON.stringify(data)]),
-					type: typeof data
-				}
-			];
-		}
 		return blob_refs;
 	}
 

--- a/client/js/src/test/data.test.ts
+++ b/client/js/src/test/data.test.ts
@@ -43,6 +43,15 @@ describe("walk_and_store_blobs", () => {
 		expect(parts[0].blob).toBe(false);
 	});
 
+	it("should handle arrays", async () => {
+		const image = new Blob([]);
+		const parts = await walk_and_store_blobs([image]);
+
+		expect(parts).toHaveLength(1);
+		expect(parts[0].blob).toBeInstanceOf(NodeBlob);
+		expect(parts[0].path).toEqual(["0"]);
+	});
+
 	it("should handle deep structures", async () => {
 		const image = new Blob([]);
 		const parts = await walk_and_store_blobs({ a: { b: { data: { image } } } });

--- a/client/js/src/test/data.test.ts
+++ b/client/js/src/test/data.test.ts
@@ -151,18 +151,6 @@ describe("walk_and_store_blobs", () => {
 		expect(parts[0].path).toEqual(["a", "b", "data", "image"]);
 		expect(parts[0].blob).toBeInstanceOf(NodeBlob);
 	});
-
-	it("should convert an object with primitive values to BlobRefs", async () => {
-		const param = {
-			test: "test"
-		};
-		const parts = await walk_and_store_blobs(param);
-
-		expect(parts).toHaveLength(1);
-		expect(parts[0].path).toEqual([]);
-		expect(parts[0].blob).toBeInstanceOf(NodeBlob);
-		expect(parts[0].type).toEqual("object");
-	});
 });
 describe("update_object", () => {
 	it("should update the value of a nested property", () => {


### PR DESCRIPTION
## Description

The `walk_and_store_blobs` function was ignoring blobs that were directly inside of arrays such as `[blob]` due to the `map` using the blob value as the key, rather than the index.

Closes: #7778
