### PR TITLE
Fix zero gpu auth ignoring hf_token

### DIFF
--- a/client/js/src/utils/submit.ts
+++ b/client/js/src/utils/submit.ts
@@ -496,8 +496,12 @@ export function submit(
 					const origin = hostname.includes(".dev.")
 						? `https://moon-${hostname.split(".")[1]}.${hfhubdev}`
 						: `https://huggingface.co`;
+
+					const is_iframe =
+						typeof window !== "undefined" && window.parent != window;
+					const is_zerogpu_space = dependency.zerogpu && config.space_id;
 					const zerogpu_auth_promise =
-						dependency.zerogpu && window.parent != window && config.space_id
+						is_iframe && is_zerogpu_space
 							? post_message<Headers>("zerogpu-headers", origin)
 							: Promise.resolve(null);
 					const post_data_promise = zerogpu_auth_promise.then((headers) => {


### PR DESCRIPTION
## Description

When sending requests to a ZeroGPU endpoint via the JS client on node, the client would attempt to index `window` while getting credentials, causing an error. The logic has been changed to prefer the `hf_token`, falling back to the `post_message` if the `window` is available, and finally falling back to `null`.

I have not included an issue due to the size of the PR, as per the PR template, but will add if needed!
  
