### PR TITLE
fix: prevent triggering gr.File.select on delete

### DIFF
--- a/.changeset/light-rats-exist.md
+++ b/.changeset/light-rats-exist.md
@@ -1,0 +1,6 @@
+---
+"@gradio/file": patch
+"gradio": patch
+---
+
+fix:fix: prevent triggering gr.File.select on delete

--- a/js/file/shared/FilePreview.svelte
+++ b/js/file/shared/FilePreview.svelte
@@ -45,15 +45,20 @@
 >
 	<table class="file-preview">
 		<tbody>
-			{#each normalized_files as file, i}
+			{#each normalized_files as file, i (file)}
 				<tr
 					class="file"
 					class:selectable
-					on:click={() =>
-						dispatch("select", {
-							value: file.orig_name,
-							index: i
-						})}
+					on:click={(event) => {
+						const tr = event.currentTarget;
+						const should_select =
+							event.target === tr || // Only select if the click is on the row itself
+							event.composedPath().includes(tr.firstElementChild); // Or if the click is on the name column
+
+						if (should_select) {
+							dispatch("select", { value: file, index: i });
+						}
+					}}
 				>
 					<td class="filename" aria-label={file.orig_name}>
 						<span class="stem">{file.filename_stem}</span>
@@ -74,12 +79,15 @@
 							{i18n("file.uploading")}
 						{/if}
 					</td>
+
 					{#if normalized_files.length > 1}
 						<td>
 							<button
 								class="label-clear-button"
 								aria-label="Remove this file"
-								on:click={() => remove_file(i)}
+								on:click={() => {
+									remove_file(i);
+								}}
 								on:keydown={(event) => {
 									if (event.key === "Enter") {
 										remove_file(i);

--- a/js/file/shared/FilePreview.svelte
+++ b/js/file/shared/FilePreview.svelte
@@ -31,6 +31,20 @@
 		};
 	});
 
+	function handle_row_click(
+		event: MouseEvent & { currentTarget: HTMLTableRowElement },
+		index: number
+	) {
+		const tr = event.currentTarget;
+		const should_select =
+			event.target === tr || // Only select if the click is on the row itself
+			event.composedPath().includes(tr.firstElementChild); // Or if the click is on the name column
+
+		if (should_select) {
+			dispatch("select", { value: normalized_files[index], index });
+		}
+	}
+
 	function remove_file(index: number): void {
 		normalized_files.splice(index, 1);
 		normalized_files = [...normalized_files];
@@ -50,14 +64,7 @@
 					class="file"
 					class:selectable
 					on:click={(event) => {
-						const tr = event.currentTarget;
-						const should_select =
-							event.target === tr || // Only select if the click is on the row itself
-							event.composedPath().includes(tr.firstElementChild); // Or if the click is on the name column
-
-						if (should_select) {
-							dispatch("select", { value: file, index: i });
-						}
+						handle_row_click(event, i);
 					}}
 				>
 					<td class="filename" aria-label={file.orig_name}>

--- a/js/file/shared/FilePreview.svelte
+++ b/js/file/shared/FilePreview.svelte
@@ -34,7 +34,7 @@
 	function handle_row_click(
 		event: MouseEvent & { currentTarget: HTMLTableRowElement },
 		index: number
-	) {
+	): void {
 		const tr = event.currentTarget;
 		const should_select =
 			event.target === tr || // Only select if the click is on the row itself


### PR DESCRIPTION
## Description
the select event shouldn't be triggering on any of the files, but it did because of some dom-bubbling and svelte lifecycle

just adding the key to the each fixes that issue by ensuring the element is removed,
added additional checks just to be sure and so that e.g. clicking the download like doesn't trigger select

Closes: #8268

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
