### PR TITLE
Use Any if JsonValue cannot be imported

### DIFF
--- a/gradio/data_classes.py
+++ b/gradio/data_classes.py
@@ -16,7 +16,12 @@ from gradio_client.utils import traverse
 from . import wasm_utils
 
 if not wasm_utils.IS_WASM or TYPE_CHECKING:
-    from pydantic import BaseModel, JsonValue, RootModel, ValidationError
+    from pydantic import BaseModel, RootModel, ValidationError
+
+    try:
+        from pydantic import JsonValue
+    except ImportError:
+        JsonValue = Any
 else:
     # XXX: Currently Pyodide V2 is not available on Pyodide,
     # so we install V1 for the Wasm version.


### PR DESCRIPTION
## Description

JsonValue was introduced in version 2.5.0 so we should use a fallback type `Any` if it cannot be imported.




## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
