### PR TITLE
Fix Chatbot, Dataframe, Markdown custom components

### DIFF
--- a/.changeset/tall-suits-train.md
+++ b/.changeset/tall-suits-train.md
@@ -1,0 +1,6 @@
+---
+"@gradio/markdown": patch
+"gradio": patch
+---
+
+fix:Fix Chatbot, Dataframe, Markdown custom components

--- a/js/markdown/shared/MarkdownCode.svelte
+++ b/js/markdown/shared/MarkdownCode.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { afterUpdate, createEventDispatcher } from "svelte";
 	import DOMPurify from "dompurify";
-	import * as render_math_in_element from "katex/contrib/auto-render";
+	import render_math_in_element from "katex/contrib/auto-render";
 	import "katex/dist/katex.min.css";
 	import { create_marked } from "./utils";
 
@@ -66,7 +66,6 @@
 					value.includes(delimiter.left) && value.includes(delimiter.right)
 			);
 			if (containsDelimiter) {
-				//@ts-ignore
 				render_math_in_element(el, {
 					delimiters: latex_delimiters,
 					throwOnError: false

--- a/js/markdown/shared/MarkdownCode.svelte
+++ b/js/markdown/shared/MarkdownCode.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { afterUpdate, createEventDispatcher } from "svelte";
 	import DOMPurify from "dompurify";
-	import render_math_in_element from "katex/dist/contrib/auto-render.js";
+	import * as render_math_in_element from "katex/contrib/auto-render";
 	import "katex/dist/katex.min.css";
 	import { create_marked } from "./utils";
 

--- a/js/markdown/shared/MarkdownCode.svelte
+++ b/js/markdown/shared/MarkdownCode.svelte
@@ -66,6 +66,7 @@
 					value.includes(delimiter.left) && value.includes(delimiter.right)
 			);
 			if (containsDelimiter) {
+				//@ts-ignore
 				render_math_in_element(el, {
 					delimiters: latex_delimiters,
 					throwOnError: false

--- a/js/markdown/shared/utils.ts
+++ b/js/markdown/shared/utils.ts
@@ -1,7 +1,7 @@
 import { type Renderer, Marked } from "marked";
 import { markedHighlight } from "marked-highlight";
 import { gfmHeadingId } from "marked-gfm-heading-id";
-import Prism from "prismjs";
+import * as Prism from "prismjs";
 import "prismjs/components/prism-python";
 import "prismjs/components/prism-latex";
 import "prismjs/components/prism-bash";


### PR DESCRIPTION
## Description

Closes: #8309

You can verify this works by templating off of DataFrame or Chatbot and making the following modifications to `@gradio/markdown` in node_modules.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
