### PR TITLE
Enable hidding inline_category in HighlightedText

### DIFF
--- a/gradio/components/highlighted_text.py
+++ b/gradio/components/highlighted_text.py
@@ -39,6 +39,7 @@ class HighlightedText(Component):
         color_map: dict[str, str]
         | None = None,  # Parameter moved to HighlightedText.style()
         show_legend: bool = False,
+        show_inline_category: bool = True,
         combine_adjacent: bool = False,
         adjacent_separator: str = "",
         label: str | None = None,
@@ -59,6 +60,7 @@ class HighlightedText(Component):
             value: Default value to show. If callable, the function will be called whenever the app loads to set the initial value of the component.
             color_map: A dictionary mapping labels to colors. The colors may be specified as hex codes or by their names. For example: {"person": "red", "location": "#FFEE22"}
             show_legend: whether to show span categories in a separate legend or inline.
+            show_inline_category: If False, will not display span category label. Only works if show_legend=False and interactive=False.
             combine_adjacent: If True, will merge the labels of adjacent tokens belonging to the same category.
             adjacent_separator: Specifies the separator to be used between tokens if combine_adjacent is True.
             label: The label for this component. Appears above the component and is also used as the header if there are a table of examples for this component. If None and used in a `gr.Interface`, the label will be the name of the parameter this component is assigned to.
@@ -76,6 +78,7 @@ class HighlightedText(Component):
         """
         self.color_map = color_map
         self.show_legend = show_legend
+        self.show_inline_category = show_inline_category
         self.combine_adjacent = combine_adjacent
         self.adjacent_separator = adjacent_separator
         super().__init__(

--- a/js/highlightedtext/Index.svelte
+++ b/js/highlightedtext/Index.svelte
@@ -27,6 +27,7 @@
 	}[];
 	let old_value: typeof value;
 	export let show_legend: boolean;
+	export let show_inline_category: boolean;
 	export let color_map: Record<string, string> = {};
 	export let label = gradio.i18n("highlighted_text.highlighted_text");
 	export let container = true;
@@ -87,6 +88,7 @@
 				selectable={_selectable}
 				{value}
 				{show_legend}
+				{show_inline_category}
 				{color_map}
 			/>
 		{:else}

--- a/js/highlightedtext/README.md
+++ b/js/highlightedtext/README.md
@@ -14,6 +14,7 @@ BaseStaticHighlightedText
 		class_or_confidence: string | number | null;
 	}[] = [];
 	export let show_legend = false;
+	export let show_inline_category = true;
 	export let color_map: Record<string, string> = {};
 	export let selectable = false;
 ```

--- a/js/highlightedtext/shared/StaticHighlightedtext.svelte
+++ b/js/highlightedtext/shared/StaticHighlightedtext.svelte
@@ -10,6 +10,7 @@
 		class_or_confidence: string | number | null;
 	}[] = [];
 	export let show_legend = false;
+	export let show_inline_category = true;
 	export let color_map: Record<string, string> = {};
 	export let selectable = false;
 
@@ -122,7 +123,7 @@
 									!_color_map[v.class_or_confidence]}
 								class="text">{line}</span
 							>
-							{#if !show_legend && v.class_or_confidence !== null}
+							{#if !show_legend && show_inline_category && v.class_or_confidence !== null}
 								&nbsp;
 								<span
 									class="label"


### PR DESCRIPTION
## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
