### PR TITLE
Include JS Client package in CI for PR testing

### DIFF
--- a/.github/workflows/deploy-spaces.yml
+++ b/.github/workflows/deploy-spaces.yml
@@ -1,11 +1,6 @@
 name: "deploy / spaces"
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
-    branches:
-      - js-client-test-tgz
-
   workflow_dispatch:
   workflow_run:
     workflows: ["trigger"]


### PR DESCRIPTION
## Description

To make testing the JS Client easier, this PR amends our workflow to package the JS client and upload it as a .tgz to S3 so we can `npm install` it and test it as an external dependency. 

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
