### PR TITLE
Add allow-credentials to preflight header

### DIFF
--- a/.changeset/dark-streets-visit.md
+++ b/.changeset/dark-streets-visit.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Add allow-credentials to preflight header

--- a/.changeset/dark-streets-visit.md
+++ b/.changeset/dark-streets-visit.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Add allow-credentials to preflight header

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -696,6 +696,7 @@ class CustomCORSMiddleware:
         self.preflight_headers = {
             "Access-Control-Allow-Methods": ", ".join(self.all_methods),
             "Access-Control-Max-Age": str(600),
+            "Access-Control-Allow-Credentials": "true",
         }
         self.simple_headers = {"Access-Control-Allow-Credentials": "true"}
         # Any of these hosts suggests that the Gradio app is running locally.


### PR DESCRIPTION
I've tested and this fixes the issue that @hannahblair I identified. I don't think this introduces any security risk based on my mental model (as long as the origins are trusted, we do indeed want to pass on cookies and authorization headers).