### PR TITLE
Fix bug in reload mode equality check. Better equality conversion for state variables

### DIFF
--- a/.changeset/ripe-tools-jam.md
+++ b/.changeset/ripe-tools-jam.md
@@ -1,0 +1,6 @@
+---
+"gradio": patch
+"gradio_client": patch
+---
+
+fix:Fix bug in reload mode equality check. Better equality conversion for state variables

--- a/.changeset/ripe-tools-jam.md
+++ b/.changeset/ripe-tools-jam.md
@@ -1,6 +1,5 @@
 ---
 "gradio": patch
-"gradio_client": patch
 ---
 
 fix:Fix bug in reload mode equality check. Better equality conversion for state variables

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -1356,6 +1356,7 @@ class Endpoint:
                     f"File {file_path} exceeds the maximum file size of {max_file_size} bytes "
                     f"set in {component_config.get('label', '') + ''} component."
                 )
+            orig_name = Path(file_path).name
             with open(file_path, "rb") as f:
                 files = [("files", (orig_name.name, f))]
                 r = httpx.post(

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -1356,7 +1356,6 @@ class Endpoint:
                     f"File {file_path} exceeds the maximum file size of {max_file_size} bytes "
                     f"set in {component_config.get('label', '') + ''} component."
                 )
-            orig_name = Path(file_path).name
             with open(file_path, "rb") as f:
                 files = [("files", (orig_name.name, f))]
                 r = httpx.post(

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1726,7 +1726,9 @@ Received outputs:
 
             if block.stateful:
                 if not utils.is_update(predictions[i]):
-                    if block._id not in state or state[block._id] != predictions[i]:
+                    if block._id not in state or not utils.gradio_deep_equal(
+                        state[block._id], predictions[i]
+                    ):
                         changed_state_ids.append(block._id)
                     state[block._id] = predictions[i]
                 output.append(None)

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1728,7 +1728,7 @@ Received outputs:
                 if not utils.is_update(predictions[i]):
                     has_change_event = False
                     for dep in state.blocks_config.fns.values():
-                        if block._id in [t[0] for t in dep.targets]:
+                        if block._id in [t[0] for t in dep.targets if t[1] == "change"]:
                             has_change_event = True
                             break
                     if has_change_event and (

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1726,7 +1726,7 @@ Received outputs:
 
             if block.stateful:
                 if not utils.is_update(predictions[i]):
-                    if block._id not in state or not utils.gradio_deep_equal(
+                    if block._id not in state or not utils.deep_equal(
                         state[block._id], predictions[i]
                     ):
                         changed_state_ids.append(block._id)

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1726,8 +1726,14 @@ Received outputs:
 
             if block.stateful:
                 if not utils.is_update(predictions[i]):
-                    if block._id not in state or not utils.deep_equal(
-                        state[block._id], predictions[i]
+                    has_change_event = False
+                    for dep in state.blocks_config.fns.values():
+                        if block._id in [t[0] for t in dep.targets]:
+                            has_change_event = True
+                            break
+                    if has_change_event and (
+                        block._id not in state
+                        or not utils.deep_equal(state[block._id], predictions[i])
                     ):
                         changed_state_ids.append(block._id)
                     state[block._id] = predictions[i]

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -291,7 +291,7 @@ def watchfn(reloader: SourceFileReloader):
         time.sleep(0.05)
 
 
-def gradio_deep_equal(a: Any, b: Any) -> bool:
+def deep_equal(a: Any, b: Any) -> bool:
     """
     Deep equality check for component values.
 

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -46,6 +46,7 @@ from typing import (
 import anyio
 import gradio_client.utils as client_utils
 import httpx
+import orjson
 from gradio_client.documentation import document
 from typing_extensions import ParamSpec
 
@@ -290,6 +291,29 @@ def watchfn(reloader: SourceFileReloader):
         time.sleep(0.05)
 
 
+def gradio_deep_equal(a: Any, b: Any) -> bool:
+    """
+    Deep equality check for component values.
+
+    Prefer orjson for performance and compatibility with numpy arrays/dataframes/torch tensors.
+    If objects are not serializable by orjson, fall back to regular equality check.
+    """
+
+    def _serialize(a: Any) -> bytes:
+        return orjson.dumps(
+            a,
+            option=orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_PASSTHROUGH_DATETIME,
+        )
+
+    try:
+        return _serialize(a) == _serialize(b)
+    except TypeError:
+        try:
+            return a == b
+        except Exception:
+            return False
+
+
 def reassign_keys(old_blocks: Blocks, new_blocks: Blocks):
     from gradio.blocks import BlockContext
 
@@ -310,8 +334,10 @@ def reassign_keys(old_blocks: Blocks, new_blocks: Blocks):
                     old_block.__class__ == new_block.__class__
                     and old_block is not None
                     and old_block.key not in assigned_keys
-                    and json.dumps(getattr(old_block, "value", None))
-                    == json.dumps(getattr(new_block, "value", None))
+                    and gradio_deep_equal(
+                        getattr(old_block, "value", None),
+                        getattr(new_block, "value", None),
+                    )
                 ):
                     new_block.key = old_block.key
                 else:

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -334,7 +334,7 @@ def reassign_keys(old_blocks: Blocks, new_blocks: Blocks):
                     old_block.__class__ == new_block.__class__
                     and old_block is not None
                     and old_block.key not in assigned_keys
-                    and gradio_deep_equal(
+                    and deep_equal(
                         getattr(old_block, "value", None),
                         getattr(new_block, "value", None),
                     )


### PR DESCRIPTION
## Description

Closes #8384 

Fixes the linked issue specific reload mode. But the equality check for state, basically `current_state != old_state` would throw an error for some types like numpy/dataframe. So proposing a function to handle that case.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
