### PR TITLE
Connect heartbeat if state created in render. Also fix config cleanup bug #8407

### DIFF
--- a/.changeset/easy-trains-obey.md
+++ b/.changeset/easy-trains-obey.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/client": minor
-"gradio": minor
+"@gradio/client": patch
+"gradio": patch
 ---
 
-feat:Connect heartbeat if state created in render. Also fix config cleanup bug #8407
+fix:Connect heartbeat if state created in render. Also fix config cleanup bug #8407

--- a/.changeset/easy-trains-obey.md
+++ b/.changeset/easy-trains-obey.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": minor
+"gradio": minor
+---
+
+feat:Connect heartbeat if state created in render. Also fix config cleanup bug #8407

--- a/client/js/src/utils/submit.ts
+++ b/client/js/src/utils/submit.ts
@@ -165,7 +165,7 @@ export function submit(
 		const resolve_heartbeat = async (config: Config): Promise<void> => {
 			await this._resolve_hearbeat(config);
 		};
-	
+
 		async function handle_render_config(render_config: any): Promise<void> {
 			if (!config) return;
 			let render_id: number = render_config.render_id;
@@ -177,9 +177,7 @@ export function submit(
 				...config.dependencies.filter((d) => d.rendered_in !== render_id),
 				...render_config.dependencies
 			];
-			const any_state = config.components.some(
-				(c) => c.type === "state"
-			);
+			const any_state = config.components.some((c) => c.type === "state");
 			const any_unload = config.dependencies.some((d) =>
 				d.targets.some((t) => t[1] === "unload")
 			);

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -903,7 +903,6 @@ class BlocksConfig:
             if renderable is None or fn.rendered_in == renderable:
                 dependencies.append(fn.get_config())
         config["dependencies"] = dependencies
-
         return config
 
     def __copy__(self):
@@ -2043,18 +2042,9 @@ Received outputs:
             "fill_height": self.fill_height,
         }
         config.update(self.default_config.get_config())
-        any_state = any(
-            isinstance(block, components.State) for block in self.blocks.values()
+        config["connect_heartbeat"] = utils.connect_heartbeat(
+            config, self.blocks.values()
         )
-        any_unload = False
-        for dep in config["dependencies"]:
-            for target in dep["targets"]:
-                if isinstance(target, (list, tuple)) and len(target) == 2:
-                    any_unload = target[1] == "unload"
-                    if any_unload:
-                        break
-        config["connect_heartbeat"] = any_state or any_unload
-
         return config
 
     def __enter__(self):

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -1381,3 +1381,17 @@ def _parse_file_size(size: str | int | None) -> int | None:
     if not multiple:
         raise ValueError(f"Invalid file size unit: {unit}")
     return multiple * size_int
+
+
+def connect_heartbeat(config: dict[str, Any], blocks) -> bool:
+    from gradio.components import State
+
+    any_state = any(isinstance(block, State) for block in blocks)
+    any_unload = False
+    for dep in config["dependencies"]:
+        for target in dep["targets"]:
+            if isinstance(target, (list, tuple)) and len(target) == 2:
+                any_unload = target[1] == "unload"
+                if any_unload:
+                    break
+    return any_state or any_unload


### PR DESCRIPTION
## Description

Noticed a bug where the heartbeat was not established if a state variable was created in a render.
In the process of fixing that, I noticed that components were not being removed from the old config. The rendered_in key is in props, not the top level component config.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
