### PR TITLE
Fix flaky render test

### DIFF
--- a/js/app/test/render_merge.spec.ts
+++ b/js/app/test/render_merge.spec.ts
@@ -22,14 +22,14 @@ test("Test re-renders reattach components and listeners", async ({ page }) => {
 	await expect(page.getByLabel("Box 2")).toBeEmpty();
 
 	await page.getByLabel("range slider for Textbox Count").fill("4");
-	await page.getByLabel("Box 0").click();
-	await page.getByLabel("Box 0").fill("t");
-	await page.getByLabel("Box 1").click();
-	await page.getByLabel("Box 1").fill("e");
-	await page.getByLabel("Box 2").click();
-	await page.getByLabel("Box 2").fill("s");
 	await page.getByLabel("Box 3").click();
 	await page.getByLabel("Box 3").fill("t");
+	await page.getByLabel("Box 2").click();
+	await page.getByLabel("Box 2").fill("s");
+	await page.getByLabel("Box 1").click();
+	await page.getByLabel("Box 1").fill("e");
+	await page.getByLabel("Box 0").click();
+	await page.getByLabel("Box 0").fill("t");
 	await page.getByRole("button", { name: "Merge" }).click();
 
 	await expect(output).toHaveValue("t e s t");


### PR DESCRIPTION
Render test was flaky because sometimes it would start editing a component while it was being re-rendered. Edited the test to start editing the last component in a render first, which ensures the render is complete before starting to edit.