### PR TITLE
Fix type hints for render and on

### DIFF
--- a/.changeset/breezy-bottles-hide.md
+++ b/.changeset/breezy-bottles-hide.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix type hints for render and on

--- a/.changeset/breezy-bottles-hide.md
+++ b/.changeset/breezy-bottles-hide.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Fix type hints for render and on

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -5,7 +5,17 @@ from __future__ import annotations
 
 import dataclasses
 from functools import partial, wraps
-from typing import TYPE_CHECKING, Any, Callable, List, Literal, Sequence, Union, cast, Dict
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Sequence,
+    Union,
+    cast,
+)
 
 from gradio_client.documentation import document
 from jinja2 import Template

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import dataclasses
 from functools import partial, wraps
-from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, Union, cast
 
 from gradio_client.documentation import document
 from jinja2 import Template
@@ -148,23 +148,23 @@ class EventListenerMethod:
 if TYPE_CHECKING:
     EventListenerCallable = Callable[
         [
-            Callable | None,
-            Component | list[Component] | set[Component] | None,
-            Block | list[Block] | list[Component] | Component | None,
-            str | None | Literal[False],
+            Union[Callable, None],
+            Union[Component, Sequence[Component], None],
+            Union[Block, Sequence[Block], Sequence[Component], Component, None],
+            Union[str, None, Literal[False]],
             bool,
             Literal["full", "minimal", "hidden"],
-            bool | None,
+            Union[bool, None],
             bool,
             int,
             bool,
             bool,
-            dict[str, Any] | list[dict[str, Any]] | None,
-            float | None,
-            Literal["once", "multiple", "always_last"] | None,
-            str | None,
-            int | None | Literal["default"],
-            str | None,
+            Union[dict[str, Any], list[dict[str, Any]], None],
+            Union[float, None],
+            Union[Literal["once", "multiple", "always_last"], None],
+            Union[str, None],
+            Union[int, None, Literal["default"]],
+            Union[str, None],
             bool,
         ],
         Dependency,

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import dataclasses
 from functools import partial, wraps
-from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, List, Literal, Sequence, Union, cast, Dict
 
 from gradio_client.documentation import document
 from jinja2 import Template
@@ -159,7 +159,7 @@ if TYPE_CHECKING:
             int,
             bool,
             bool,
-            Union[dict[str, Any], list[dict[str, Any]], None],
+            Union[Dict[str, Any], List[Dict[str, Any]], None],
             Union[float, None],
             Union[Literal["once", "multiple", "always_last"], None],
             Union[str, None],

--- a/gradio/renderable.py
+++ b/gradio/renderable.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, List, Literal, Union, cast
+from typing import TYPE_CHECKING, Callable, List, Literal, Sequence, Union, cast
 
 from gradio_client.documentation import document
 
@@ -80,7 +80,7 @@ class Renderable:
 @document()
 def render(
     inputs: list[Component] | Component | None = None,
-    triggers: list[EventListenerCallable] | EventListenerCallable | None = None,
+    triggers: Sequence[EventListenerCallable] | EventListenerCallable | None = None,
     *,
     queue: bool = True,
     trigger_mode: Literal["once", "multiple", "always_last"] | None = "always_last",

--- a/gradio/renderable.py
+++ b/gradio/renderable.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Literal
+from typing import TYPE_CHECKING, Callable, List, Literal, Union, cast
 
 from gradio_client.documentation import document
 
@@ -9,6 +9,9 @@ from gradio.components import Component
 from gradio.context import Context, LocalContext
 from gradio.events import EventListener, EventListenerMethod
 from gradio.layouts import Column, Row
+
+if TYPE_CHECKING:
+    from gradio.events import EventListenerCallable
 
 
 class Renderable:
@@ -76,8 +79,8 @@ class Renderable:
 
 @document()
 def render(
-    inputs: list[Component] | None = None,
-    triggers: list[EventListener] | EventListener | None = None,
+    inputs: list[Component] | Component | None = None,
+    triggers: list[EventListenerCallable] | EventListenerCallable | None = None,
     *,
     queue: bool = True,
     trigger_mode: Literal["once", "multiple", "always_last"] | None = "always_last",
@@ -116,6 +119,8 @@ def render(
                             btn = gr.Button("Clear")
                             btn.click(lambda: gr.Textbox(value=""), None, text)
     """
+    new_triggers = cast(Union[List[EventListener], EventListener, None], triggers)
+
     if Context.root_block is None:
         raise ValueError("Reactive render must be inside a Blocks context.")
 
@@ -123,16 +128,18 @@ def render(
         [inputs] if isinstance(inputs, Component) else [] if inputs is None else inputs
     )
     _triggers: list[tuple[Block | None, str]] = []
-    if triggers is None:
+    if new_triggers is None:
         _triggers = [(Context.root_block, "load")]
         for input in inputs:
             if hasattr(input, "change"):
                 _triggers.append((input, "change"))
     else:
-        triggers = [triggers] if isinstance(triggers, EventListener) else triggers
+        new_triggers = (
+            [new_triggers] if isinstance(new_triggers, EventListener) else new_triggers
+        )
         _triggers = [
             (getattr(t, "__self__", None) if t.has_trigger else None, t.event_name)
-            for t in triggers
+            for t in new_triggers
         ]
 
     def wrapper_function(fn):


### PR DESCRIPTION
## Description

I noticed two things that were off about the type hints for on and render
- We were using `Any` for the triggers of `gr.on`. Which was too broad.
- In `render`, the triggers were not typed correctly so passing a valid trigger, e.g. `slider.change` would be flagged in vs code. 
- In `render`, the type hint did not allow for a single component to be passed as input, but it is allowed.

**Main**
<img width="658" alt="Screenshot 2024-05-31 at 2 09 04 PM" src="https://github.com/gradio-app/gradio/assets/41651716/b279931e-0426-4d38-84b9-796099fbbf72">
<img width="572" alt="Screenshot 2024-05-31 at 2 03 46 PM" src="https://github.com/gradio-app/gradio/assets/41651716/aeb308a7-547e-42bf-9000-098f81eeeef0">

**PR**
Invalid value for `triggers` of `gr.on` is flagged
<img width="779" alt="image" src="https://github.com/gradio-app/gradio/assets/41651716/d9b8ca08-a0b4-4aa1-9a52-258a02d51ad1">

Passing an event listener method for `render` is not flagged
<img width="701" alt="image" src="https://github.com/gradio-app/gradio/assets/41651716/e9c6bde0-ad81-40a7-a1d0-d739304612a6">


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
