### PR TITLE
Fix encoding error in gradio/routes.py

### DIFF
--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -470,7 +470,7 @@ class App(FastAPI):
 
             if key not in app.custom_component_hashes:
                 app.custom_component_hashes[key] = hashlib.md5(
-                    Path(path).read_text().encode()
+                    Path(path).read_text(encoding="utf-8").encode()
                 ).hexdigest()
 
             version = app.custom_component_hashes.get(key)


### PR DESCRIPTION
## Description

`gradio/routes.py`
```python
  if key not in app.custom_component_hashes:
      app.custom_component_hashes[key] = hashlib.md5(
          Path(path).read_text().encode()
      ).hexdigest()
```
Change `Path(path).read_text().encode()` to `Path(path).read_text(encoding="utf-8").encode()` to support custom components with i18n code.

Closes: #8426

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
