### PR TITLE
Tweak meta titles and descriptions for clients

### DIFF
--- a/.changeset/early-files-allow.md
+++ b/.changeset/early-files-allow.md
@@ -1,5 +1,5 @@
 ---
-"website": minor
+"website": patch
 ---
 
 feat:Tweak meta titles and descriptions for clients

--- a/.changeset/early-files-allow.md
+++ b/.changeset/early-files-allow.md
@@ -1,0 +1,5 @@
+---
+"website": minor
+---
+
+feat:Tweak meta titles and descriptions for clients

--- a/js/_website/src/lib/templates/python-client/gradio_client/01_introduction.svx
+++ b/js/_website/src/lib/templates/python-client/gradio_client/01_introduction.svx
@@ -2,7 +2,7 @@
     import CopyButton from "$lib/components/CopyButton.svelte";
 </script>
 
-# Python Client
+# Introduction
 
 ## The lightweight Gradio client libraries make it easy to use any Gradio app as an API. We currently support both a Python client library as well as a JavaScript client library.
 

--- a/js/_website/src/routes/[[version]]/docs/js-client/+page.svelte
+++ b/js/_website/src/routes/[[version]]/docs/js-client/+page.svelte
@@ -20,10 +20,10 @@
 </script>
 
 <MetaTags
-	title={"Gradio Python Client Docs"}
+	title={"Gradio Javascript Client Docs"}
 	url={$page.url.pathname}
 	canonical={$page.url.pathname}
-	description={"The lightweight Gradio client library that makes it easy to use any Gradio app as an API"}
+	description={"Make programmatic requests to Gradio applications in JavaScript (TypeScript) from the browser or server-side."}
 />
 
 <main class="container mx-auto px-4 flex gap-4">

--- a/js/_website/src/routes/[[version]]/docs/python-client/[doc]/+page.svelte
+++ b/js/_website/src/routes/[[version]]/docs/python-client/[doc]/+page.svelte
@@ -92,13 +92,17 @@
 	$: if (dynamic_component) {
 		all_headers = get_headers();
 	}
+	let title: string;
+	let description: string;
+	$: title = all_headers.page_title.title === "Introduction" ? "Gradio Python Client - " + all_headers.page_title.title + " Docs" : "Gradio Python Client - " + all_headers.page_title.title + " Class Docs";
+	$: description = all_headers.page_title.title === "Introduction" ? "Introduction to the Gradio Python Client." : "Using the " + all_headers.page_title.title + " class in the Gradio Python Client.";
 </script>
 
 <MetaTags
-	title={"Gradio Client " + all_headers.page_title.title + " Docs"}
+	title={title}
 	url={$page.url.pathname}
 	canonical={$page.url.pathname}
-	description={"Gradio Client docs for using " + all_headers.page_title.title}
+	description={description}
 />
 
 <svelte:window bind:scrollY={y} />

--- a/js/_website/src/routes/[[version]]/docs/python-client/[doc]/+page.svelte
+++ b/js/_website/src/routes/[[version]]/docs/python-client/[doc]/+page.svelte
@@ -95,7 +95,7 @@
 	let title: string;
 	let description: string;
 	$: title = all_headers.page_title.title === "Introduction" ? "Gradio Python Client - " + all_headers.page_title.title + " Docs" : "Gradio Python Client - " + all_headers.page_title.title + " Class Docs";
-	$: description = all_headers.page_title.title === "Introduction" ? "Introduction to the Gradio Python Client." : "Using the " + all_headers.page_title.title + " class in the Gradio Python Client.";
+	$: description = all_headers.page_title.title === "Introduction" ? "Make programmatic requests to Gradio applications from Python environments." : "Using the " + all_headers.page_title.title + " class in the Gradio Python Client.";
 </script>
 
 <MetaTags

--- a/js/_website/src/routes/[[version]]/docs/python-client/[doc]/+page.svelte
+++ b/js/_website/src/routes/[[version]]/docs/python-client/[doc]/+page.svelte
@@ -94,15 +94,25 @@
 	}
 	let title: string;
 	let description: string;
-	$: title = all_headers.page_title.title === "Introduction" ? "Gradio Python Client - " + all_headers.page_title.title + " Docs" : "Gradio Python Client - " + all_headers.page_title.title + " Class Docs";
-	$: description = all_headers.page_title.title === "Introduction" ? "Make programmatic requests to Gradio applications from Python environments." : "Using the " + all_headers.page_title.title + " class in the Gradio Python Client.";
+	$: title =
+		all_headers.page_title.title === "Introduction"
+			? "Gradio Python Client - " + all_headers.page_title.title + " Docs"
+			: "Gradio Python Client - " +
+				all_headers.page_title.title +
+				" Class Docs";
+	$: description =
+		all_headers.page_title.title === "Introduction"
+			? "Make programmatic requests to Gradio applications from Python environments."
+			: "Using the " +
+				all_headers.page_title.title +
+				" class in the Gradio Python Client.";
 </script>
 
 <MetaTags
-	title={title}
+	{title}
 	url={$page.url.pathname}
 	canonical={$page.url.pathname}
-	description={description}
+	{description}
 />
 
 <svelte:window bind:scrollY={y} />


### PR DESCRIPTION
Now the pages are: 

title: Gradio Python Client -  Introduction Docs 
description: Make programmatic requests to Gradio applications from Python environments.

title: Gradio Python Client -  Client Class Docs 
description: Using the Client Class in the Gradio Python Client
