### PR TITLE
fix client flaky tests

### DIFF
--- a/.changeset/crazy-turtles-sing.md
+++ b/.changeset/crazy-turtles-sing.md
@@ -1,0 +1,6 @@
+---
+"gradio": minor
+"gradio_client": minor
+---
+
+feat:fix client flaky tests

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -1308,7 +1308,7 @@ class Endpoint:
         else:
             return data
 
-    def _upload_file(self, f: str | dict, data_index: int) -> dict[str, str]:
+    def _upload_file(self, f: dict, data_index: int) -> dict[str, str]:
         file_path = f["path"]
         orig_name = Path(file_path)
         if not utils.is_http_url_like(file_path):

--- a/client/python/test/test_client.py
+++ b/client/python/test/test_client.py
@@ -159,12 +159,18 @@ class TestClientPredictions:
         space_id = "gradio-tests/space_with_files_v4_sse_v2"
         client = Client(space_id)
         payload = (
-            handle_file("https://audio-samples.github.io/samples/mp3/blizzard_unconditional/sample-0.mp3"),
+            handle_file(
+                "https://audio-samples.github.io/samples/mp3/blizzard_unconditional/sample-0.mp3"
+            ),
             {
-                "video": handle_file("https://github.com/gradio-app/gradio/raw/main/demo/video_component/files/world.mp4"),
+                "video": handle_file(
+                    "https://github.com/gradio-app/gradio/raw/main/demo/video_component/files/world.mp4"
+                ),
                 "subtitle": None,
             },
-            handle_file("https://audio-samples.github.io/samples/mp3/blizzard_unconditional/sample-0.mp3"),
+            handle_file(
+                "https://audio-samples.github.io/samples/mp3/blizzard_unconditional/sample-0.mp3"
+            ),
         )
         output = client.predict(*payload, api_name="/predict")
         assert output[0].endswith(".wav")  # Audio files are converted to wav
@@ -853,7 +859,131 @@ class TestAPIInfo:
     @pytest.mark.flaky
     def test_numerical_to_label_space(self):
         client = Client("gradio-tests/titanic-survival")
-        assert client.view_api(return_format="dict") == {'named_endpoints': {'/predict': {'parameters': [{'label': 'Sex', 'type': {'type': 'string'}, 'python_type': {'type': 'str', 'description': ''}, 'component': 'Radio', 'example_input': 'Howdy!', 'serializer': 'StringSerializable'}, {'label': 'Age', 'type': {'type': 'number'}, 'python_type': {'type': 'int | float', 'description': ''}, 'component': 'Slider', 'example_input': 5, 'serializer': 'NumberSerializable'}, {'label': 'Fare (british pounds)', 'type': {'type': 'number'}, 'python_type': {'type': 'int | float', 'description': ''}, 'component': 'Slider', 'example_input': 5, 'serializer': 'NumberSerializable'}], 'returns': [{'label': 'output', 'type': {'type': {}, 'description': 'any valid json'}, 'python_type': {'type': 'Dict[Any, Any]', 'description': 'any valid json'}, 'component': 'Label', 'serializer': 'JSONSerializable'}]}, '/predict_1': {'parameters': [{'label': 'Sex', 'type': {'type': 'string'}, 'python_type': {'type': 'str', 'description': ''}, 'component': 'Radio', 'example_input': 'Howdy!', 'serializer': 'StringSerializable'}, {'label': 'Age', 'type': {'type': 'number'}, 'python_type': {'type': 'int | float', 'description': ''}, 'component': 'Slider', 'example_input': 5, 'serializer': 'NumberSerializable'}, {'label': 'Fare (british pounds)', 'type': {'type': 'number'}, 'python_type': {'type': 'int | float', 'description': ''}, 'component': 'Slider', 'example_input': 5, 'serializer': 'NumberSerializable'}], 'returns': [{'label': 'output', 'type': {'type': {}, 'description': 'any valid json'}, 'python_type': {'type': 'Dict[Any, Any]', 'description': 'any valid json'}, 'component': 'Label', 'serializer': 'JSONSerializable'}]}, '/predict_2': {'parameters': [{'label': 'Sex', 'type': {'type': 'string'}, 'python_type': {'type': 'str', 'description': ''}, 'component': 'Radio', 'example_input': 'Howdy!', 'serializer': 'StringSerializable'}, {'label': 'Age', 'type': {'type': 'number'}, 'python_type': {'type': 'int | float', 'description': ''}, 'component': 'Slider', 'example_input': 5, 'serializer': 'NumberSerializable'}, {'label': 'Fare (british pounds)', 'type': {'type': 'number'}, 'python_type': {'type': 'int | float', 'description': ''}, 'component': 'Slider', 'example_input': 5, 'serializer': 'NumberSerializable'}], 'returns': [{'label': 'output', 'type': {'type': {}, 'description': 'any valid json'}, 'python_type': {'type': 'Dict[Any, Any]', 'description': 'any valid json'}, 'component': 'Label', 'serializer': 'JSONSerializable'}]}}, 'unnamed_endpoints': {}}
+        assert client.view_api(return_format="dict") == {
+            "named_endpoints": {
+                "/predict": {
+                    "parameters": [
+                        {
+                            "label": "Sex",
+                            "type": {"type": "string"},
+                            "python_type": {"type": "str", "description": ""},
+                            "component": "Radio",
+                            "example_input": "Howdy!",
+                            "serializer": "StringSerializable",
+                        },
+                        {
+                            "label": "Age",
+                            "type": {"type": "number"},
+                            "python_type": {"type": "int | float", "description": ""},
+                            "component": "Slider",
+                            "example_input": 5,
+                            "serializer": "NumberSerializable",
+                        },
+                        {
+                            "label": "Fare (british pounds)",
+                            "type": {"type": "number"},
+                            "python_type": {"type": "int | float", "description": ""},
+                            "component": "Slider",
+                            "example_input": 5,
+                            "serializer": "NumberSerializable",
+                        },
+                    ],
+                    "returns": [
+                        {
+                            "label": "output",
+                            "type": {"type": {}, "description": "any valid json"},
+                            "python_type": {
+                                "type": "Dict[Any, Any]",
+                                "description": "any valid json",
+                            },
+                            "component": "Label",
+                            "serializer": "JSONSerializable",
+                        }
+                    ],
+                },
+                "/predict_1": {
+                    "parameters": [
+                        {
+                            "label": "Sex",
+                            "type": {"type": "string"},
+                            "python_type": {"type": "str", "description": ""},
+                            "component": "Radio",
+                            "example_input": "Howdy!",
+                            "serializer": "StringSerializable",
+                        },
+                        {
+                            "label": "Age",
+                            "type": {"type": "number"},
+                            "python_type": {"type": "int | float", "description": ""},
+                            "component": "Slider",
+                            "example_input": 5,
+                            "serializer": "NumberSerializable",
+                        },
+                        {
+                            "label": "Fare (british pounds)",
+                            "type": {"type": "number"},
+                            "python_type": {"type": "int | float", "description": ""},
+                            "component": "Slider",
+                            "example_input": 5,
+                            "serializer": "NumberSerializable",
+                        },
+                    ],
+                    "returns": [
+                        {
+                            "label": "output",
+                            "type": {"type": {}, "description": "any valid json"},
+                            "python_type": {
+                                "type": "Dict[Any, Any]",
+                                "description": "any valid json",
+                            },
+                            "component": "Label",
+                            "serializer": "JSONSerializable",
+                        }
+                    ],
+                },
+                "/predict_2": {
+                    "parameters": [
+                        {
+                            "label": "Sex",
+                            "type": {"type": "string"},
+                            "python_type": {"type": "str", "description": ""},
+                            "component": "Radio",
+                            "example_input": "Howdy!",
+                            "serializer": "StringSerializable",
+                        },
+                        {
+                            "label": "Age",
+                            "type": {"type": "number"},
+                            "python_type": {"type": "int | float", "description": ""},
+                            "component": "Slider",
+                            "example_input": 5,
+                            "serializer": "NumberSerializable",
+                        },
+                        {
+                            "label": "Fare (british pounds)",
+                            "type": {"type": "number"},
+                            "python_type": {"type": "int | float", "description": ""},
+                            "component": "Slider",
+                            "example_input": 5,
+                            "serializer": "NumberSerializable",
+                        },
+                    ],
+                    "returns": [
+                        {
+                            "label": "output",
+                            "type": {"type": {}, "description": "any valid json"},
+                            "python_type": {
+                                "type": "Dict[Any, Any]",
+                                "description": "any valid json",
+                            },
+                            "component": "Label",
+                            "serializer": "JSONSerializable",
+                        }
+                    ],
+                },
+            },
+            "unnamed_endpoints": {},
+        }
 
     def test_state_does_not_appear(self, state_demo):
         with connect(state_demo) as client:
@@ -1139,7 +1269,9 @@ class TestEndpoints:
         client = Client(
             src="gradio/zip_files",
         )
-        url_path = handle_file("https://gradio-tests-not-actually-private-spacev4-sse.hf.space/file=lion.jpg")
+        url_path = handle_file(
+            "https://gradio-tests-not-actually-private-spacev4-sse.hf.space/file=lion.jpg"
+        )
         file = client.endpoints[0]._upload_file(url_path, 0)  # type: ignore
         assert file["path"].endswith(".jpg")
 

--- a/client/python/test/test_client.py
+++ b/client/python/test/test_client.py
@@ -159,22 +159,19 @@ class TestClientPredictions:
         space_id = "gradio-tests/space_with_files_v4_sse_v2"
         client = Client(space_id)
         payload = (
-            "https://audio-samples.github.io/samples/mp3/blizzard_unconditional/sample-0.mp3",
+            handle_file("https://audio-samples.github.io/samples/mp3/blizzard_unconditional/sample-0.mp3"),
             {
-                "video": "https://github.com/gradio-app/gradio/raw/main/demo/video_component/files/world.mp4",
+                "video": handle_file("https://github.com/gradio-app/gradio/raw/main/demo/video_component/files/world.mp4"),
                 "subtitle": None,
             },
-            "https://audio-samples.github.io/samples/mp3/blizzard_unconditional/sample-0.mp3",
+            handle_file("https://audio-samples.github.io/samples/mp3/blizzard_unconditional/sample-0.mp3"),
         )
         output = client.predict(*payload, api_name="/predict")
         assert output[0].endswith(".wav")  # Audio files are converted to wav
         assert output[1]["video"].endswith(
             "world.mp4"
         )  # Video files are not converted by default
-        assert (
-            output[2]
-            == "https://audio-samples.github.io/samples/mp3/blizzard_unconditional/sample-0.mp3"
-        )  # textbox string should remain exactly the same
+        assert "sample-0.mp3" in output[2]
 
     def test_state(self, increment_demo):
         with connect(increment_demo) as client:
@@ -856,131 +853,7 @@ class TestAPIInfo:
     @pytest.mark.flaky
     def test_numerical_to_label_space(self):
         client = Client("gradio-tests/titanic-survival")
-        assert client.view_api(return_format="dict") == {
-            "named_endpoints": {
-                "/predict": {
-                    "parameters": [
-                        {
-                            "label": "Sex",
-                            "type": {"type": "string"},
-                            "python_type": {"type": "str", "description": ""},
-                            "component": "Radio",
-                            "example_input": "Howdy!",
-                            "serializer": "StringSerializable",
-                        },
-                        {
-                            "label": "Age",
-                            "type": {"type": "number"},
-                            "python_type": {"type": "int | float", "description": ""},
-                            "component": "Slider",
-                            "example_input": 5,
-                            "serializer": "NumberSerializable",
-                        },
-                        {
-                            "label": "Fare (british pounds)",
-                            "type": {"type": "number"},
-                            "python_type": {"type": "int | float", "description": ""},
-                            "component": "Slider",
-                            "example_input": 5,
-                            "serializer": "NumberSerializable",
-                        },
-                    ],
-                    "returns": [
-                        {
-                            "label": "output",
-                            "type": {"type": {}, "description": "any valid json"},
-                            "python_type": {
-                                "type": "str",
-                                "description": "filepath to JSON file",
-                            },
-                            "component": "Label",
-                            "serializer": "JSONSerializable",
-                        }
-                    ],
-                },
-                "/predict_1": {
-                    "parameters": [
-                        {
-                            "label": "Sex",
-                            "type": {"type": "string"},
-                            "python_type": {"type": "str", "description": ""},
-                            "component": "Radio",
-                            "example_input": "Howdy!",
-                            "serializer": "StringSerializable",
-                        },
-                        {
-                            "label": "Age",
-                            "type": {"type": "number"},
-                            "python_type": {"type": "int | float", "description": ""},
-                            "component": "Slider",
-                            "example_input": 5,
-                            "serializer": "NumberSerializable",
-                        },
-                        {
-                            "label": "Fare (british pounds)",
-                            "type": {"type": "number"},
-                            "python_type": {"type": "int | float", "description": ""},
-                            "component": "Slider",
-                            "example_input": 5,
-                            "serializer": "NumberSerializable",
-                        },
-                    ],
-                    "returns": [
-                        {
-                            "label": "output",
-                            "type": {"type": {}, "description": "any valid json"},
-                            "python_type": {
-                                "type": "str",
-                                "description": "filepath to JSON file",
-                            },
-                            "component": "Label",
-                            "serializer": "JSONSerializable",
-                        }
-                    ],
-                },
-                "/predict_2": {
-                    "parameters": [
-                        {
-                            "label": "Sex",
-                            "type": {"type": "string"},
-                            "python_type": {"type": "str", "description": ""},
-                            "component": "Radio",
-                            "example_input": "Howdy!",
-                            "serializer": "StringSerializable",
-                        },
-                        {
-                            "label": "Age",
-                            "type": {"type": "number"},
-                            "python_type": {"type": "int | float", "description": ""},
-                            "component": "Slider",
-                            "example_input": 5,
-                            "serializer": "NumberSerializable",
-                        },
-                        {
-                            "label": "Fare (british pounds)",
-                            "type": {"type": "number"},
-                            "python_type": {"type": "int | float", "description": ""},
-                            "component": "Slider",
-                            "example_input": 5,
-                            "serializer": "NumberSerializable",
-                        },
-                    ],
-                    "returns": [
-                        {
-                            "label": "output",
-                            "type": {"type": {}, "description": "any valid json"},
-                            "python_type": {
-                                "type": "str",
-                                "description": "filepath to JSON file",
-                            },
-                            "component": "Label",
-                            "serializer": "JSONSerializable",
-                        }
-                    ],
-                },
-            },
-            "unnamed_endpoints": {},
-        }
+        assert client.view_api(return_format="dict") == {'named_endpoints': {'/predict': {'parameters': [{'label': 'Sex', 'type': {'type': 'string'}, 'python_type': {'type': 'str', 'description': ''}, 'component': 'Radio', 'example_input': 'Howdy!', 'serializer': 'StringSerializable'}, {'label': 'Age', 'type': {'type': 'number'}, 'python_type': {'type': 'int | float', 'description': ''}, 'component': 'Slider', 'example_input': 5, 'serializer': 'NumberSerializable'}, {'label': 'Fare (british pounds)', 'type': {'type': 'number'}, 'python_type': {'type': 'int | float', 'description': ''}, 'component': 'Slider', 'example_input': 5, 'serializer': 'NumberSerializable'}], 'returns': [{'label': 'output', 'type': {'type': {}, 'description': 'any valid json'}, 'python_type': {'type': 'Dict[Any, Any]', 'description': 'any valid json'}, 'component': 'Label', 'serializer': 'JSONSerializable'}]}, '/predict_1': {'parameters': [{'label': 'Sex', 'type': {'type': 'string'}, 'python_type': {'type': 'str', 'description': ''}, 'component': 'Radio', 'example_input': 'Howdy!', 'serializer': 'StringSerializable'}, {'label': 'Age', 'type': {'type': 'number'}, 'python_type': {'type': 'int | float', 'description': ''}, 'component': 'Slider', 'example_input': 5, 'serializer': 'NumberSerializable'}, {'label': 'Fare (british pounds)', 'type': {'type': 'number'}, 'python_type': {'type': 'int | float', 'description': ''}, 'component': 'Slider', 'example_input': 5, 'serializer': 'NumberSerializable'}], 'returns': [{'label': 'output', 'type': {'type': {}, 'description': 'any valid json'}, 'python_type': {'type': 'Dict[Any, Any]', 'description': 'any valid json'}, 'component': 'Label', 'serializer': 'JSONSerializable'}]}, '/predict_2': {'parameters': [{'label': 'Sex', 'type': {'type': 'string'}, 'python_type': {'type': 'str', 'description': ''}, 'component': 'Radio', 'example_input': 'Howdy!', 'serializer': 'StringSerializable'}, {'label': 'Age', 'type': {'type': 'number'}, 'python_type': {'type': 'int | float', 'description': ''}, 'component': 'Slider', 'example_input': 5, 'serializer': 'NumberSerializable'}, {'label': 'Fare (british pounds)', 'type': {'type': 'number'}, 'python_type': {'type': 'int | float', 'description': ''}, 'component': 'Slider', 'example_input': 5, 'serializer': 'NumberSerializable'}], 'returns': [{'label': 'output', 'type': {'type': {}, 'description': 'any valid json'}, 'python_type': {'type': 'Dict[Any, Any]', 'description': 'any valid json'}, 'component': 'Label', 'serializer': 'JSONSerializable'}]}}, 'unnamed_endpoints': {}}
 
     def test_state_does_not_appear(self, state_demo):
         with connect(state_demo) as client:
@@ -1266,7 +1139,7 @@ class TestEndpoints:
         client = Client(
             src="gradio/zip_files",
         )
-        url_path = "https://gradio-tests-not-actually-private-spacev4-sse.hf.space/file=lion.jpg"
+        url_path = handle_file("https://gradio-tests-not-actually-private-spacev4-sse.hf.space/file=lion.jpg")
         file = client.endpoints[0]._upload_file(url_path, 0)  # type: ignore
         assert file["path"].endswith(".jpg")
 

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -176,15 +176,6 @@ class TestLoadInterface:
         assert isinstance(interface.input_components[0], gr.Textbox)
         assert isinstance(interface.output_components[0], gr.Audio)
 
-    def test_text_to_image(self):
-        model_type = "text-to-image"
-        interface = gr.load(
-            "models/osanseviero/BigGAN-deep-128", hf_token=None, alias=model_type
-        )
-        assert interface.__name__ == model_type
-        assert isinstance(interface.input_components[0], gr.Textbox)
-        assert isinstance(interface.output_components[0], gr.Image)
-
     def test_english_to_spanish(self):
         with pytest.raises(GradioVersionIncompatibleError):
             gr.load("spaces/gradio-tests/english_to_spanish", title="hi")
@@ -284,14 +275,6 @@ class TestLoadInterface:
                 assert resp.json()["data"] is not None
         finally:
             io.close()
-
-    def test_text_to_image_model(self):
-        io = gr.load("models/osanseviero/BigGAN-deep-128")
-        try:
-            filename = io("chest")
-            assert filename.lower().endswith((".jpg", ".jpeg", ".png"))
-        except TooManyRequestsError:
-            pass
 
     def test_private_space(self):
         io = gr.load(


### PR DESCRIPTION
Some Client tests were failing because we now require `handle_file()`.

And https://huggingface.co/osanseviero/BigGAN-deep-128 no longer has an Inference API for some reason so I've just removed those tests