### PR TITLE
Control Display of Error, Info, Warning

### DIFF
--- a/.changeset/neat-roses-tan.md
+++ b/.changeset/neat-roses-tan.md
@@ -3,6 +3,7 @@
 "@gradio/client": minor
 "@gradio/statustracker": minor
 "gradio": minor
+"website": minor
 ---
 
 feat:Control Display of Error, Info, Warning

--- a/.changeset/neat-roses-tan.md
+++ b/.changeset/neat-roses-tan.md
@@ -1,0 +1,8 @@
+---
+"@gradio/app": minor
+"@gradio/client": minor
+"@gradio/statustracker": minor
+"gradio": minor
+---
+
+feat:Control Display of Error, Info, Warning

--- a/client/js/src/helpers/api_info.ts
+++ b/client/js/src/helpers/api_info.ts
@@ -318,6 +318,8 @@ export function handle_message(
 					status: {
 						queue,
 						message: data.output.error as string,
+						display: data.output.display as boolean,
+						duration: data.output.duration as number,
 						stage: "error",
 						code: data.code,
 						success: data.success

--- a/client/js/src/helpers/api_info.ts
+++ b/client/js/src/helpers/api_info.ts
@@ -318,7 +318,7 @@ export function handle_message(
 					status: {
 						queue,
 						message: data.output.error as string,
-						display: data.output.display as boolean,
+						visible: data.output.visible as boolean,
 						duration: data.output.duration as number,
 						stage: "error",
 						code: data.code,

--- a/client/js/src/types.ts
+++ b/client/js/src/types.ts
@@ -363,6 +363,8 @@ export interface LogMessage extends Log {
 	type: "log";
 	endpoint: string;
 	fn_index: number;
+	display: boolean;
+	duration: number | null;
 }
 
 export interface RenderMessage extends Render {

--- a/client/js/src/types.ts
+++ b/client/js/src/types.ts
@@ -330,7 +330,7 @@ export interface Status {
 	success?: boolean;
 	stage: "pending" | "error" | "complete" | "generating";
 	duration?: number;
-	display?: boolean;
+	visible?: boolean;
 	broken?: boolean;
 	size?: number;
 	position?: number;
@@ -364,6 +364,7 @@ export interface LogMessage extends Log {
 	endpoint: string;
 	fn_index: number;
 	duration: number | null;
+	visible: boolean;
 }
 
 export interface RenderMessage extends Render {

--- a/client/js/src/types.ts
+++ b/client/js/src/types.ts
@@ -329,6 +329,8 @@ export interface Status {
 	code?: string;
 	success?: boolean;
 	stage: "pending" | "error" | "complete" | "generating";
+	duration?: number;
+	display?: boolean;
 	broken?: boolean;
 	size?: number;
 	position?: number;

--- a/client/js/src/types.ts
+++ b/client/js/src/types.ts
@@ -363,7 +363,6 @@ export interface LogMessage extends Log {
 	type: "log";
 	endpoint: string;
 	fn_index: number;
-	display: boolean;
 	duration: number | null;
 }
 

--- a/client/js/src/utils/submit.ts
+++ b/client/js/src/utils/submit.ts
@@ -343,7 +343,6 @@ export function submit(
 								log: data.log,
 								level: data.level,
 								endpoint: _endpoint,
-								display: data.display,
 								duration: data.duration,
 								fn_index
 							});
@@ -476,7 +475,6 @@ export function submit(
 								log: data.log,
 								level: data.level,
 								endpoint: _endpoint,
-								display: data.display,
 								duration: data.duration,
 								fn_index
 							});
@@ -634,7 +632,6 @@ export function submit(
 											log: data.log,
 											level: data.level,
 											endpoint: _endpoint,
-											display: data.display,
 											duration: data.duration,
 											fn_index
 										});

--- a/client/js/src/utils/submit.ts
+++ b/client/js/src/utils/submit.ts
@@ -343,6 +343,8 @@ export function submit(
 								log: data.log,
 								level: data.level,
 								endpoint: _endpoint,
+								display: data.display,
+								duration: data.duration,
 								fn_index
 							});
 						} else if (type === "generating") {
@@ -474,6 +476,8 @@ export function submit(
 								log: data.log,
 								level: data.level,
 								endpoint: _endpoint,
+								display: data.display,
+								duration: data.duration,
 								fn_index
 							});
 						} else if (type === "generating") {
@@ -630,6 +634,8 @@ export function submit(
 											log: data.log,
 											level: data.level,
 											endpoint: _endpoint,
+											display: data.display,
+											duration: data.duration,
 											fn_index
 										});
 										return;

--- a/client/js/src/utils/submit.ts
+++ b/client/js/src/utils/submit.ts
@@ -344,6 +344,7 @@ export function submit(
 								level: data.level,
 								endpoint: _endpoint,
 								duration: data.duration,
+								visible: data.visible,
 								fn_index
 							});
 						} else if (type === "generating") {
@@ -476,6 +477,7 @@ export function submit(
 								level: data.level,
 								endpoint: _endpoint,
 								duration: data.duration,
+								visible: data.visible,
 								fn_index
 							});
 						} else if (type === "generating") {
@@ -633,6 +635,7 @@ export function submit(
 											level: data.level,
 											endpoint: _endpoint,
 											duration: data.duration,
+											visible: data.visible,
 											fn_index
 										});
 										return;

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -76,15 +76,14 @@ class Error(Exception):
     def __init__(
         self,
         message: str = "Error raised.",
-        display: bool = True,
-        duration: int | None = 10000,
+        duration: int | None = 10,
     ):
         """
         Parameters:
             message: The error message to be displayed to the user.
+            duration: The duration in seconds to display the error message. If None, the error message will be displayed until the user closes it. If 0, the error message will not be displayed in the UI but will still be raised as an exception.
         """
         self.message = message
-        self.display = display
         self.duration = duration
         super().__init__(self.message)
 

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -73,12 +73,16 @@ class Error(Exception):
     Demos: calculator, blocks_chained_events
     """
 
-    def __init__(self, message: str = "Error raised."):
+    def __init__(self, message: str = "Error raised.",
+                 display: bool = True,
+                 duration: int | None = 10000):
         """
         Parameters:
             message: The error message to be displayed to the user.
         """
         self.message = message
+        self.display = display
+        self.duration = duration
         super().__init__(self.message)
 
     def __str__(self):

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -73,9 +73,12 @@ class Error(Exception):
     Demos: calculator, blocks_chained_events
     """
 
-    def __init__(self, message: str = "Error raised.",
-                 display: bool = True,
-                 duration: int | None = 10000):
+    def __init__(
+        self,
+        message: str = "Error raised.",
+        display: bool = True,
+        duration: int | None = 10000,
+    ):
         """
         Parameters:
             message: The error message to be displayed to the user.

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gradio_client.documentation import document
 
 

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -78,7 +78,7 @@ class Error(Exception):
     def __init__(
         self,
         message: str = "Error raised.",
-        duration: int | None = 10,
+        duration: float | None = 10,
         visible: bool = True,
     ):
         """

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -79,14 +79,17 @@ class Error(Exception):
         self,
         message: str = "Error raised.",
         duration: int | None = 10,
+        visible: bool = True,
     ):
         """
         Parameters:
             message: The error message to be displayed to the user.
-            duration: The duration in seconds to display the error message. If None, the error message will be displayed until the user closes it. If 0, the error message will not be displayed in the UI but will still be raised as an exception.
+            duration: The duration in seconds to display the error message. If None or 0, the error message will be displayed until the user closes it.
+            visible: Whether the error message should be displayed in the UI.
         """
         self.message = message
         self.duration = duration
+        self.visible = visible
         super().__init__(self.message)
 
     def __str__(self):

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -1229,8 +1229,7 @@ def make_waveform(
 def log_message(
     message: str,
     level: Literal["info", "warning"] = "info",
-    display: bool = True,
-    duration: int | None = 10000,
+    duration: int | None = 10,
 ):
     from gradio.context import LocalContext
 
@@ -1245,19 +1244,20 @@ def log_message(
             warnings.warn(message)
         return
     blocks._queue.log_message(
-        event_id=event_id, log=message, level=level, display=display, duration=duration
+        event_id=event_id, log=message, level=level, duration=duration
     )
 
 
 @document(documentation_group="modals")
 def Warning(  # noqa: N802
-    message: str = "Warning issued.", display: bool = True, duration: int | None = 10000
+    message: str = "Warning issued.", duration: int | None = 10
 ):
     """
     This function allows you to pass custom warning messages to the user. You can do so simply by writing `gr.Warning('message here')` in your function, and when that line is executed the custom message will appear in a modal on the demo. The modal is yellow by default and has the heading: "Warning." Queue must be enabled for this behavior; otherwise, the warning will be printed to the console using the `warnings` library.
     Demos: blocks_chained_events
     Parameters:
         message: The warning message to be displayed to the user.
+        duration: The duration in seconds that the warning message should be displayed for. If None, the message will be displayed indefinitely until the user closes it.  If 0, the error message will not be displayed in the UI but will still be logged to the console.
     Example:
         import gradio as gr
         def hello_world():
@@ -1268,18 +1268,19 @@ def Warning(  # noqa: N802
             demo.load(hello_world, inputs=None, outputs=[md])
         demo.queue().launch()
     """
-    log_message(message, level="warning", display=display, duration=duration)
+    log_message(message, level="warning", duration=duration)
 
 
 @document(documentation_group="modals")
 def Info(  # noqa: N802
-    message: str = "Info issued.", display: bool = True, duration: int | None = 10000
+    message: str = "Info issued.", duration: int | None = 10
 ):
     """
     This function allows you to pass custom info messages to the user. You can do so simply by writing `gr.Info('message here')` in your function, and when that line is executed the custom message will appear in a modal on the demo. The modal is gray by default and has the heading: "Info." Queue must be enabled for this behavior; otherwise, the message will be printed to the console.
     Demos: blocks_chained_events
     Parameters:
         message: The info message to be displayed to the user.
+        duration: The duration in seconds that the info message should be displayed for. If None, the message will be displayed indefinitely until the user closes it. If 0, the error message will not be displayed in the UI but will still be logged to the console.
     Example:
         import gradio as gr
         def hello_world():
@@ -1290,4 +1291,4 @@ def Info(  # noqa: N802
             demo.load(hello_world, inputs=None, outputs=[md])
         demo.queue().launch()
     """
-    log_message(message, level="info", display=display, duration=duration)
+    log_message(message, level="info", duration=duration)

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -1226,7 +1226,12 @@ def make_waveform(
     return output_mp4.name
 
 
-def log_message(message: str, level: Literal["info", "warning"] = "info"):
+def log_message(
+    message: str,
+    level: Literal["info", "warning"] = "info",
+    display: bool = True,
+    duration: int | None = 10000,
+):
     from gradio.context import LocalContext
 
     blocks = LocalContext.blocks.get()
@@ -1239,11 +1244,15 @@ def log_message(message: str, level: Literal["info", "warning"] = "info"):
         elif level == "warning":
             warnings.warn(message)
         return
-    blocks._queue.log_message(event_id=event_id, log=message, level=level)
+    blocks._queue.log_message(
+        event_id=event_id, log=message, level=level, display=display, duration=duration
+    )
 
 
 @document(documentation_group="modals")
-def Warning(message: str = "Warning issued."):  # noqa: N802
+def Warning(  # noqa: N802
+    message: str = "Warning issued.", display: bool = True, duration: int | None = 10000
+):
     """
     This function allows you to pass custom warning messages to the user. You can do so simply by writing `gr.Warning('message here')` in your function, and when that line is executed the custom message will appear in a modal on the demo. The modal is yellow by default and has the heading: "Warning." Queue must be enabled for this behavior; otherwise, the warning will be printed to the console using the `warnings` library.
     Demos: blocks_chained_events
@@ -1259,11 +1268,13 @@ def Warning(message: str = "Warning issued."):  # noqa: N802
             demo.load(hello_world, inputs=None, outputs=[md])
         demo.queue().launch()
     """
-    log_message(message, level="warning")
+    log_message(message, level="warning", display=display, duration=duration)
 
 
 @document(documentation_group="modals")
-def Info(message: str = "Info issued."):  # noqa: N802
+def Info(  # noqa: N802
+    message: str = "Info issued.", display: bool = True, duration: int | None = 10000
+):
     """
     This function allows you to pass custom info messages to the user. You can do so simply by writing `gr.Info('message here')` in your function, and when that line is executed the custom message will appear in a modal on the demo. The modal is gray by default and has the heading: "Info." Queue must be enabled for this behavior; otherwise, the message will be printed to the console.
     Demos: blocks_chained_events
@@ -1279,4 +1290,4 @@ def Info(message: str = "Info issued."):  # noqa: N802
             demo.load(hello_world, inputs=None, outputs=[md])
         demo.queue().launch()
     """
-    log_message(message, level="info")
+    log_message(message, level="info", display=display, duration=duration)

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -1230,6 +1230,7 @@ def log_message(
     message: str,
     level: Literal["info", "warning"] = "info",
     duration: int | None = 10,
+    visible: bool = True,
 ):
     from gradio.context import LocalContext
 
@@ -1244,20 +1245,21 @@ def log_message(
             warnings.warn(message)
         return
     blocks._queue.log_message(
-        event_id=event_id, log=message, level=level, duration=duration
+        event_id=event_id, log=message, level=level, duration=duration, visible=visible
     )
 
 
 @document(documentation_group="modals")
 def Warning(  # noqa: N802
-    message: str = "Warning issued.", duration: int | None = 10
+    message: str = "Warning issued.", duration: int | None = 10, visible: bool = True
 ):
     """
     This function allows you to pass custom warning messages to the user. You can do so simply by writing `gr.Warning('message here')` in your function, and when that line is executed the custom message will appear in a modal on the demo. The modal is yellow by default and has the heading: "Warning." Queue must be enabled for this behavior; otherwise, the warning will be printed to the console using the `warnings` library.
     Demos: blocks_chained_events
     Parameters:
         message: The warning message to be displayed to the user.
-        duration: The duration in seconds that the warning message should be displayed for. If None, the message will be displayed indefinitely until the user closes it.  If 0, the error message will not be displayed in the UI but will still be logged to the console.
+        duration: The duration in seconds that the warning message should be displayed for. If None or 0, the message will be displayed indefinitely until the user closes it.
+        visible: Whether the error message should be displayed in the UI.
     Example:
         import gradio as gr
         def hello_world():
@@ -1268,19 +1270,22 @@ def Warning(  # noqa: N802
             demo.load(hello_world, inputs=None, outputs=[md])
         demo.queue().launch()
     """
-    log_message(message, level="warning", duration=duration)
+    log_message(message, level="warning", duration=duration, visible=visible)
 
 
 @document(documentation_group="modals")
 def Info(  # noqa: N802
-    message: str = "Info issued.", duration: int | None = 10
+    message: str = "Info issued.",
+    duration: int | None = 10,
+    visible: bool = True,
 ):
     """
     This function allows you to pass custom info messages to the user. You can do so simply by writing `gr.Info('message here')` in your function, and when that line is executed the custom message will appear in a modal on the demo. The modal is gray by default and has the heading: "Info." Queue must be enabled for this behavior; otherwise, the message will be printed to the console.
     Demos: blocks_chained_events
     Parameters:
         message: The info message to be displayed to the user.
-        duration: The duration in seconds that the info message should be displayed for. If None, the message will be displayed indefinitely until the user closes it. If 0, the error message will not be displayed in the UI but will still be logged to the console.
+        duration: The duration in seconds that the info message should be displayed for. If None or 0, the message will be displayed indefinitely until the user closes it.
+        visible: Whether the error message should be displayed in the UI.
     Example:
         import gradio as gr
         def hello_world():
@@ -1291,4 +1296,4 @@ def Info(  # noqa: N802
             demo.load(hello_world, inputs=None, outputs=[md])
         demo.queue().launch()
     """
-    log_message(message, level="info", duration=duration)
+    log_message(message, level="info", duration=duration, visible=visible)

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -1229,7 +1229,7 @@ def make_waveform(
 def log_message(
     message: str,
     level: Literal["info", "warning"] = "info",
-    duration: int | None = 10,
+    duration: float | None = 10,
     visible: bool = True,
 ):
     from gradio.context import LocalContext
@@ -1251,7 +1251,7 @@ def log_message(
 
 @document(documentation_group="modals")
 def Warning(  # noqa: N802
-    message: str = "Warning issued.", duration: int | None = 10, visible: bool = True
+    message: str = "Warning issued.", duration: float | None = 10, visible: bool = True
 ):
     """
     This function allows you to pass custom warning messages to the user. You can do so simply by writing `gr.Warning('message here')` in your function, and when that line is executed the custom message will appear in a modal on the demo. The modal is yellow by default and has the heading: "Warning." Queue must be enabled for this behavior; otherwise, the warning will be printed to the console using the `warnings` library.
@@ -1276,7 +1276,7 @@ def Warning(  # noqa: N802
 @document(documentation_group="modals")
 def Info(  # noqa: N802
     message: str = "Info issued.",
-    duration: int | None = 10,
+    duration: float | None = 10,
     visible: bool = True,
 ):
     """

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -18,7 +18,6 @@ from gradio import route_utils, routes
 from gradio.data_classes import (
     PredictBody,
 )
-from gradio.exceptions import Error
 from gradio.helpers import TrackedIterable
 from gradio.server_messages import (
     EstimationMessage,
@@ -30,7 +29,13 @@ from gradio.server_messages import (
     ProgressMessage,
     ProgressUnit,
 )
-from gradio.utils import LRUCache, run_coro_in_background, safe_get_lock, set_task_name, error_payload
+from gradio.utils import (
+    LRUCache,
+    error_payload,
+    run_coro_in_background,
+    safe_get_lock,
+    set_task_name,
+)
 
 if TYPE_CHECKING:
     from gradio.blocks import BlockFunction, Blocks
@@ -376,6 +381,8 @@ class Queue:
         event_id: str,
         log: str,
         level: Literal["info", "warning"],
+        display: bool = True,
+        duration: int | None = 10000,
     ):
         events = [
             evt for job in self.active_jobs if job is not None for evt in job
@@ -385,6 +392,8 @@ class Queue:
                 log_message = LogMessage(
                     log=log,
                     level=level,
+                    display=display,
+                    duration=duration,
                 )
                 self.send_message(event, log_message)
 

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -381,7 +381,6 @@ class Queue:
         event_id: str,
         log: str,
         level: Literal["info", "warning"],
-        display: bool = True,
         duration: int | None = 10000,
     ):
         events = [
@@ -392,7 +391,6 @@ class Queue:
                 log_message = LogMessage(
                     log=log,
                     level=level,
-                    display=display,
                     duration=duration,
                 )
                 self.send_message(event, log_message)

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -381,7 +381,8 @@ class Queue:
         event_id: str,
         log: str,
         level: Literal["info", "warning"],
-        duration: int | None = 10000,
+        duration: int | None = 10,
+        visible: bool = True,
     ):
         events = [
             evt for job in self.active_jobs if job is not None for evt in job
@@ -392,6 +393,7 @@ class Queue:
                     log=log,
                     level=level,
                     duration=duration,
+                    visible=visible,
                 )
                 self.send_message(event, log_message)
 

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -381,7 +381,7 @@ class Queue:
         event_id: str,
         log: str,
         level: Literal["info", "warning"],
-        duration: int | None = 10,
+        duration: float | None = 10,
         visible: bool = True,
     ):
         events = [

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -737,10 +737,10 @@ class App(FastAPI):
                     root_path=root_path,
                 )
             except BaseException as error:
-                show_error = app.get_blocks().show_error or isinstance(error, Error)
+                content = utils.error_payload(error, app.get_blocks().show_error)
                 traceback.print_exc()
                 return JSONResponse(
-                    content={"error": str(error) if show_error else None},
+                    content=content,
                     status_code=500,
                 )
             return output

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -76,7 +76,6 @@ from gradio.data_classes import (
     ResetBody,
     SimplePredictBody,
 )
-from gradio.exceptions import Error
 from gradio.oauth import attach_oauth
 from gradio.route_utils import (  # noqa: F401
     CustomCORSMiddleware,

--- a/gradio/server_messages.py
+++ b/gradio/server_messages.py
@@ -31,6 +31,8 @@ class LogMessage(BaseMessage):
     msg: Literal[ServerMessage.log] = ServerMessage.log
     log: str
     level: Literal["info", "warning"]
+    display: bool = True
+    duration: int | None = 10000
 
 
 class EstimationMessage(BaseMessage):

--- a/gradio/server_messages.py
+++ b/gradio/server_messages.py
@@ -31,7 +31,6 @@ class LogMessage(BaseMessage):
     msg: Literal[ServerMessage.log] = ServerMessage.log
     log: str
     level: Literal["info", "warning"]
-    display: bool = True
     duration: int | None = 10000
 
 

--- a/gradio/server_messages.py
+++ b/gradio/server_messages.py
@@ -31,7 +31,7 @@ class LogMessage(BaseMessage):
     msg: Literal[ServerMessage.log] = ServerMessage.log
     log: str
     level: Literal["info", "warning"]
-    duration: int | None = 10000
+    duration: Optional[int] = 10
 
 
 class EstimationMessage(BaseMessage):

--- a/gradio/server_messages.py
+++ b/gradio/server_messages.py
@@ -32,6 +32,7 @@ class LogMessage(BaseMessage):
     log: str
     level: Literal["info", "warning"]
     duration: Optional[int] = 10
+    visible: bool = True
 
 
 class EstimationMessage(BaseMessage):

--- a/gradio/server_messages.py
+++ b/gradio/server_messages.py
@@ -31,7 +31,7 @@ class LogMessage(BaseMessage):
     msg: Literal[ServerMessage.log] = ServerMessage.log
     log: str
     level: Literal["info", "warning"]
-    duration: Optional[int] = 10
+    duration: Optional[float] = 10
     visible: bool = True
 
 

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -53,8 +53,8 @@ from typing_extensions import ParamSpec
 import gradio
 from gradio.context import get_blocks_context
 from gradio.data_classes import FileData
-from gradio.strings import en
 from gradio.exceptions import Error
+from gradio.strings import en
 
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
     from gradio.blocks import BlockContext, Blocks
@@ -1420,12 +1420,14 @@ def deep_hash(obj):
     return hasher.hexdigest()
 
 
-def error_payload(error: BaseException | None, show_error: bool) -> dict[str, bool | str | int | None]:
+def error_payload(
+    error: BaseException | None, show_error: bool
+) -> dict[str, bool | str | int | None]:
     content: dict[str, bool | str | int | None] = {"error": None}
     show_error = show_error or isinstance(error, Error)
     if show_error:
-        content['error'] = str(error)
+        content["error"] = str(error)
     if isinstance(error, Error):
-        content['display'] = error.display
-        content['duration'] = error.duration
+        content["display"] = error.display
+        content["duration"] = error.duration
     return content

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -54,6 +54,7 @@ import gradio
 from gradio.context import get_blocks_context
 from gradio.data_classes import FileData
 from gradio.strings import en
+from gradio.exceptions import Error
 
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
     from gradio.blocks import BlockContext, Blocks
@@ -1417,3 +1418,14 @@ def deep_hash(obj):
         items = str(id(obj)).encode("utf-8")
     hasher.update(repr(items).encode("utf-8"))
     return hasher.hexdigest()
+
+
+def error_payload(error: BaseException | None, show_error: bool) -> dict[str, bool | str | int | None]:
+    content: dict[str, bool | str | int | None] = {"error": None}
+    show_error = show_error or isinstance(error, Error)
+    if show_error:
+        content['error'] = str(error)
+    if isinstance(error, Error):
+        content['display'] = error.display
+        content['duration'] = error.duration
+    return content

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -1428,6 +1428,5 @@ def error_payload(
     if show_error:
         content["error"] = str(error)
     if isinstance(error, Error):
-        content["display"] = error.display
         content["duration"] = error.duration
     return content

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -1422,8 +1422,8 @@ def deep_hash(obj):
 
 def error_payload(
     error: BaseException | None, show_error: bool
-) -> dict[str, bool | str | int | None]:
-    content: dict[str, bool | str | int | None] = {"error": None}
+) -> dict[str, bool | str | float | None]:
+    content: dict[str, bool | str | float | None] = {"error": None}
     show_error = show_error or isinstance(error, Error)
     if show_error:
         content["error"] = str(error)

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -1429,4 +1429,5 @@ def error_payload(
         content["error"] = str(error)
     if isinstance(error, Error):
         content["duration"] = error.duration
+        content["visible"] = error.visible
     return content

--- a/js/_website/src/lib/assets/style.css
+++ b/js/_website/src/lib/assets/style.css
@@ -278,6 +278,12 @@ strong {
 	font-weight: 600;
 }
 
+.obj a {
+	color: var(--tw-prose-links);
+	text-decoration: underline;
+	font-weight: 500;
+}
+
 .codeblock > pre {
 	font-size: 1em;
 }

--- a/js/_website/src/lib/templates/gradio/05_modals/error.svx
+++ b/js/_website/src/lib/templates/gradio/05_modals/error.svx
@@ -17,12 +17,18 @@
 
 <!--- Usage -->
 ```python
-gradio.Error(···)
+raise gradio.Error("An error occured 💥!", duration=5)
 ```
 
 <!--- Description -->
 ### Description
 ## {@html style_formatted_text(obj.description)}
+
+## You can control for how long the error message is displayed with the `duration` parameter. If it's `None`, the message will be displayed forever until the user closes it. If it's a number, it will be shown for that many seconds. 
+
+## Below is a demo of how different values of duration control the error, info, and warning messages. You can see the code [here](https://huggingface.co/spaces/freddyaboulton/gradio-error-duration/blob/244331cf53f6b5fa2fd406ece3bf55c6ccb9f5f2/app.py#L17).
+
+![modal_control](https://github.com/gradio-app/gradio/assets/41651716/f0977bcd-eaec-4eca-a2fd-ede95fdb8fd2)
 
 <!-- Example Usage --> 
 

--- a/js/_website/src/lib/templates/gradio/05_modals/error.svx
+++ b/js/_website/src/lib/templates/gradio/05_modals/error.svx
@@ -25,7 +25,7 @@ raise gradio.Error("An error occured 💥!", duration=5)
 ## {@html style_formatted_text(obj.description)}
 
 ## You can control for how long the error message is displayed with the `duration` parameter. If it's `None`, the message will be displayed forever until the user closes it. If it's a number, it will be shown for that many seconds. 
-
+## You can also hide the error modal from being shown in the UI by setting `visible=False`.
 ## Below is a demo of how different values of duration control the error, info, and warning messages. You can see the code [here](https://huggingface.co/spaces/freddyaboulton/gradio-error-duration/blob/244331cf53f6b5fa2fd406ece3bf55c6ccb9f5f2/app.py#L17).
 
 ![modal_control](https://github.com/gradio-app/gradio/assets/41651716/f0977bcd-eaec-4eca-a2fd-ede95fdb8fd2)

--- a/js/_website/src/lib/templates/gradio/05_modals/info.svx
+++ b/js/_website/src/lib/templates/gradio/05_modals/info.svx
@@ -17,7 +17,7 @@
 
 <!--- Usage -->
 ```python
-gradio.Info(···)
+gradio.Info("Helpful info message ℹ️", duration=5)
 ```
 
 <!--- Description -->

--- a/js/_website/src/lib/templates/gradio/05_modals/warning.svx
+++ b/js/_website/src/lib/templates/gradio/05_modals/warning.svx
@@ -17,7 +17,7 @@
 
 <!--- Usage -->
 ```python
-gradio.Warning(···)
+gradio.Warning("A warning occured ⛔️!", duration=5)
 ```
 
 <!--- Description -->

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -142,8 +142,8 @@
 		message: string,
 		fn_index: number,
 		type: ToastMessage["type"],
-		display=true,
-		duration=10000,
+		display = true,
+		duration: number | null = 10000
 	): ToastMessage & { fn_index: number } {
 		return {
 			message,
@@ -348,8 +348,11 @@
 			}
 
 			function handle_log(msg: LogMessage): void {
-				const { log, fn_index, level } = msg;
-				messages = [new_message(log, fn_index, level), ...messages];
+				const { log, fn_index, level, display, duration } = msg;
+				messages = [
+					new_message(log, fn_index, level, display, duration),
+					...messages
+				];
 			}
 
 			function handle_status_update(message: StatusMessage): void {
@@ -420,7 +423,16 @@
 							MESSAGE_QUOTE_RE,
 							(_, b) => b
 						);
-						messages = [new_message(_message, fn_index, "error", status.display, status.duration), ...messages];
+						messages = [
+							new_message(
+								_message,
+								fn_index,
+								"error",
+								status.display,
+								status.duration
+							),
+							...messages
+						];
 					}
 					dependencies.map(async (dep) => {
 						if (

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -142,7 +142,7 @@
 		message: string,
 		fn_index: number,
 		type: ToastMessage["type"],
-		duration: number | null = 10000
+		duration: number | null = 10
 	): ToastMessage & { fn_index: number } {
 		return {
 			message,

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -142,7 +142,6 @@
 		message: string,
 		fn_index: number,
 		type: ToastMessage["type"],
-		display = true,
 		duration: number | null = 10000
 	): ToastMessage & { fn_index: number } {
 		return {
@@ -150,7 +149,6 @@
 			fn_index,
 			type,
 			id: ++_error_id,
-			display,
 			duration
 		};
 	}
@@ -348,11 +346,8 @@
 			}
 
 			function handle_log(msg: LogMessage): void {
-				const { log, fn_index, level, display, duration } = msg;
-				messages = [
-					new_message(log, fn_index, level, display, duration),
-					...messages
-				];
+				const { log, fn_index, level, duration } = msg;
+				messages = [new_message(log, fn_index, level, duration), ...messages];
 			}
 
 			function handle_status_update(message: StatusMessage): void {
@@ -424,13 +419,7 @@
 							(_, b) => b
 						);
 						messages = [
-							new_message(
-								_message,
-								fn_index,
-								"error",
-								status.display,
-								status.duration
-							),
+							new_message(_message, fn_index, "error", status.duration),
 							...messages
 						];
 					}

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -141,13 +141,17 @@
 	function new_message(
 		message: string,
 		fn_index: number,
-		type: ToastMessage["type"]
+		type: ToastMessage["type"],
+		display=true,
+		duration=10000,
 	): ToastMessage & { fn_index: number } {
 		return {
 			message,
 			fn_index,
 			type,
-			id: ++_error_id
+			id: ++_error_id,
+			display,
+			duration
 		};
 	}
 
@@ -416,7 +420,7 @@
 							MESSAGE_QUOTE_RE,
 							(_, b) => b
 						);
-						messages = [new_message(_message, fn_index, "error"), ...messages];
+						messages = [new_message(_message, fn_index, "error", status.display, status.duration), ...messages];
 					}
 					dependencies.map(async (dep) => {
 						if (

--- a/js/app/src/Blocks.svelte
+++ b/js/app/src/Blocks.svelte
@@ -142,14 +142,16 @@
 		message: string,
 		fn_index: number,
 		type: ToastMessage["type"],
-		duration: number | null = 10
+		duration: number | null = 10,
+		visible = true
 	): ToastMessage & { fn_index: number } {
 		return {
 			message,
 			fn_index,
 			type,
 			id: ++_error_id,
-			duration
+			duration,
+			visible
 		};
 	}
 
@@ -346,8 +348,11 @@
 			}
 
 			function handle_log(msg: LogMessage): void {
-				const { log, fn_index, level, duration } = msg;
-				messages = [new_message(log, fn_index, level, duration), ...messages];
+				const { log, fn_index, level, duration, visible } = msg;
+				messages = [
+					new_message(log, fn_index, level, duration, visible),
+					...messages
+				];
 			}
 
 			function handle_status_update(message: StatusMessage): void {
@@ -419,7 +424,13 @@
 							(_, b) => b
 						);
 						messages = [
-							new_message(_message, fn_index, "error", status.duration),
+							new_message(
+								_message,
+								fn_index,
+								"error",
+								status.duration,
+								status.visible
+							),
 							...messages
 						];
 					}

--- a/js/statustracker/static/Toast.svelte
+++ b/js/statustracker/static/Toast.svelte
@@ -7,6 +7,8 @@
 
 	$: scroll_to_top(messages);
 
+	$: console.log(messages.map((m) => [m.message, m.duration]));
+
 	function scroll_to_top(_messages: ToastMessage[]): void {
 		if (_messages.length > 0) {
 			if ("parentIFrame" in window) {
@@ -17,9 +19,9 @@
 </script>
 
 <div class="toast-wrap">
-	{#each messages as { type, message, id } (id)}
+	{#each messages as { type, message, id, display, duration } (id)}
 		<div animate:flip={{ duration: 300 }} style:width="100%">
-			<ToastContent {type} {message} on:close {id} />
+			<ToastContent {type} {message} {display} {duration} on:close {id} />
 		</div>
 	{/each}
 </div>

--- a/js/statustracker/static/Toast.svelte
+++ b/js/statustracker/static/Toast.svelte
@@ -7,8 +7,6 @@
 
 	$: scroll_to_top(messages);
 
-	$: console.log(messages.map((m) => [m.message, m.duration]));
-
 	function scroll_to_top(_messages: ToastMessage[]): void {
 		if (_messages.length > 0) {
 			if ("parentIFrame" in window) {

--- a/js/statustracker/static/Toast.svelte
+++ b/js/statustracker/static/Toast.svelte
@@ -17,9 +17,9 @@
 </script>
 
 <div class="toast-wrap">
-	{#each messages as { type, message, id, display, duration } (id)}
+	{#each messages as { type, message, id, duration } (id)}
 		<div animate:flip={{ duration: 300 }} style:width="100%">
-			<ToastContent {type} {message} {display} {duration} on:close {id} />
+			<ToastContent {type} {message} {duration} on:close {id} />
 		</div>
 	{/each}
 </div>

--- a/js/statustracker/static/Toast.svelte
+++ b/js/statustracker/static/Toast.svelte
@@ -17,9 +17,9 @@
 </script>
 
 <div class="toast-wrap">
-	{#each messages as { type, message, id, duration } (id)}
+	{#each messages as { type, message, id, duration, visible } (id)}
 		<div animate:flip={{ duration: 300 }} style:width="100%">
-			<ToastContent {type} {message} {duration} on:close {id} />
+			<ToastContent {type} {message} {duration} {visible} on:close {id} />
 		</div>
 	{/each}
 </div>

--- a/js/statustracker/static/ToastContent.svelte
+++ b/js/statustracker/static/ToastContent.svelte
@@ -24,7 +24,7 @@
 		}
 	});
 
-	$: timer_animation_duration = duration !== null ? `${duration / 1000}s` : null;
+	$: timer_animation_duration = `${(duration || 0) / 1000}s`;
 </script>
 
 <!-- TODO: fix-->
@@ -66,7 +66,7 @@
 		<span aria-hidden="true">&#215;</span>
 	</button>
 
-	<div class="timer {type}" style="{timer_animation_duration !== null ? `animation-duration: ${timer_animation_duration};` : ''}" />
+	<div class="timer {type}" style="{`animation-duration: ${timer_animation_duration};`}" />
 </div>
 
 <style>

--- a/js/statustracker/static/ToastContent.svelte
+++ b/js/statustracker/static/ToastContent.svelte
@@ -7,7 +7,7 @@
 	export let message = "";
 	export let type: ToastMessage["type"];
 	export let id: number;
-	export let duration = 10000;
+	export let duration = 10000; // Add duration prop
 	export let display = true;
 
 	const dispatch = createEventDispatcher();
@@ -17,10 +17,14 @@
 	}
 
 	onMount(() => {
-		setTimeout(() => {
-			close_message();
-		}, duration);
+		if (duration !== null) {
+			setTimeout(() => {
+				close_message();
+			}, duration);
+		}
 	});
+
+	$: timer_animation_duration = duration !== null ? `${duration / 1000}s` : null;
 </script>
 
 <!-- TODO: fix-->
@@ -62,7 +66,7 @@
 		<span aria-hidden="true">&#215;</span>
 	</button>
 
-	<div class="timer {type}"/>
+	<div class="timer {type}" style="{timer_animation_duration !== null ? `animation-duration: ${timer_animation_duration};` : ''}" />
 </div>
 
 <style>
@@ -278,6 +282,7 @@
 	:global(.dark) .timer.info {
 		background: var(--color-grey-500);
 	}
+
 	.hidden {
 		display: none;
 	}

--- a/js/statustracker/static/ToastContent.svelte
+++ b/js/statustracker/static/ToastContent.svelte
@@ -7,6 +7,8 @@
 	export let message = "";
 	export let type: ToastMessage["type"];
 	export let id: number;
+	export let duration = 10000;
+	export let display = true;
 
 	const dispatch = createEventDispatcher();
 
@@ -17,7 +19,7 @@
 	onMount(() => {
 		setTimeout(() => {
 			close_message();
-		}, 10000);
+		}, duration);
 	});
 </script>
 
@@ -27,6 +29,7 @@
 	class="toast-body {type}"
 	role="alert"
 	data-testid="toast-body"
+	class:hidden={!display}
 	on:click|stopPropagation
 	on:keydown|stopPropagation
 	in:fade={{ duration: 200, delay: 100 }}
@@ -59,7 +62,7 @@
 		<span aria-hidden="true">&#215;</span>
 	</button>
 
-	<div class="timer {type}" />
+	<div class="timer {type}"/>
 </div>
 
 <style>
@@ -274,5 +277,8 @@
 
 	:global(.dark) .timer.info {
 		background: var(--color-grey-500);
+	}
+	.hidden {
+		display: none;
 	}
 </style>

--- a/js/statustracker/static/ToastContent.svelte
+++ b/js/statustracker/static/ToastContent.svelte
@@ -7,7 +7,7 @@
 	export let message = "";
 	export let type: ToastMessage["type"];
 	export let id: number;
-	export let duration = 10000; // Add duration prop
+	export let duration: number | null = 10000; // Add duration prop
 	export let display = true;
 
 	const dispatch = createEventDispatcher();
@@ -66,7 +66,10 @@
 		<span aria-hidden="true">&#215;</span>
 	</button>
 
-	<div class="timer {type}" style="{`animation-duration: ${timer_animation_duration};`}" />
+	<div
+		class="timer {type}"
+		style={`animation-duration: ${timer_animation_duration};`}
+	/>
 </div>
 
 <style>

--- a/js/statustracker/static/ToastContent.svelte
+++ b/js/statustracker/static/ToastContent.svelte
@@ -7,8 +7,9 @@
 	export let message = "";
 	export let type: ToastMessage["type"];
 	export let id: number;
-	export let duration: number | null = 10000; // Add duration prop
-	export let display = true;
+	export let duration: number | null = 10; // Add duration prop
+
+	$: display = duration ? duration > 0 : true;
 
 	const dispatch = createEventDispatcher();
 
@@ -20,11 +21,11 @@
 		if (duration !== null) {
 			setTimeout(() => {
 				close_message();
-			}, duration);
+			}, duration * 1000);
 		}
 	});
 
-	$: timer_animation_duration = `${(duration || 0) / 1000}s`;
+	$: timer_animation_duration = `${duration || 0}s`;
 </script>
 
 <!-- TODO: fix-->

--- a/js/statustracker/static/ToastContent.svelte
+++ b/js/statustracker/static/ToastContent.svelte
@@ -7,9 +7,11 @@
 	export let message = "";
 	export let type: ToastMessage["type"];
 	export let id: number;
-	export let duration: number | null = 10; // Add duration prop
+	export let duration: number | null = 10;
+	export let visible = true;
 
-	$: display = duration ? duration > 0 : true;
+	$: display = visible;
+	$: duration = duration || null;
 
 	const dispatch = createEventDispatcher();
 

--- a/js/statustracker/static/types.ts
+++ b/js/statustracker/static/types.ts
@@ -21,6 +21,5 @@ export interface ToastMessage {
 	type: "error" | "warning" | "info";
 	message: string;
 	id: number;
-	display: boolean;
 	duration: number | null;
 }

--- a/js/statustracker/static/types.ts
+++ b/js/statustracker/static/types.ts
@@ -21,4 +21,6 @@ export interface ToastMessage {
 	type: "error" | "warning" | "info";
 	message: string;
 	id: number;
+	display: boolean;
+	duration: number;
 }

--- a/js/statustracker/static/types.ts
+++ b/js/statustracker/static/types.ts
@@ -22,5 +22,5 @@ export interface ToastMessage {
 	message: string;
 	id: number;
 	display: boolean;
-	duration: number;
+	duration: number | null;
 }

--- a/js/statustracker/static/types.ts
+++ b/js/statustracker/static/types.ts
@@ -22,4 +22,5 @@ export interface ToastMessage {
 	message: string;
 	id: number;
 	duration: number | null;
+	visible: boolean;
 }


### PR DESCRIPTION
## Description

Adds `duration` property to `gr.Warning`, `gr.Info`, and `gr.Error`.

Setting `duration` to 0 not display the toast in the UI. This is useful for giving useful error messages for clients. For example, the data validation done in the component classes can now raise `gr.Error` instead of `TypeError` or `ValueError` and clients will see the exact error message.

The `duration` parameter is specified in seconds. If it's `None`, the toast will be displayed indefinitely.

Closes: https://github.com/gradio-app/gradio/issues/6480

![modal_control](https://github.com/gradio-app/gradio/assets/41651716/f0977bcd-eaec-4eca-a2fd-ede95fdb8fd2)



```python
import gradio as gr
from functools import partial

with gr.Blocks() as demo:
    with gr.Row():
        duration = gr.Number(label="Duration", info="Set to -1 for infinite", value=10, minimum=-1)
    with gr.Row():
        error = gr.Button("Error")
        info = gr.Button("Info")
        warning = gr.Button("Warning")

    def display_message(type, msg, duration):
        duration = None if duration < 0 else duration
        if type == "error":
            raise gr.Error(msg, duration=duration)
        elif type == "info":
            gr.Info(msg, duration=duration)
        elif type == "warning":
            gr.Warning(msg,  duration=duration)

    error.click(partial(display_message, "error", "ERROR 💥"),  [duration])
    info.click(partial(display_message, "info", "INFO ℹ️"), [duration])
    warning.click(partial(display_message, "warning", "WARNING ⚠️"), [duration])


demo.launch()
```



## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
