### PR TITLE
Remove broken guide redirect

### DIFF
--- a/.changeset/long-tables-guess.md
+++ b/.changeset/long-tables-guess.md
@@ -1,0 +1,5 @@
+---
+"website": minor
+---
+
+feat:Remove broken guide redirect

--- a/.changeset/long-tables-guess.md
+++ b/.changeset/long-tables-guess.md
@@ -1,7 +1,7 @@
 ---
-"@gradio/upload": minor
-"gradio": minor
-"website": minor
+"@gradio/upload": patch
+"gradio": patch
+"website": patch
 ---
 
 feat:Remove broken guide redirect

--- a/js/_website/src/routes/redirects.js
+++ b/js/_website/src/routes/redirects.js
@@ -104,7 +104,6 @@ export const redirects = {
 	"/gradio-and-llm-agents": "/guides/gradio-and-llm-agents",
 	"/fastapi-app-with-the-gradio-client":
 		"/guides/fastapi-app-with-the-gradio-client",
-	"/guides/key-features": "/guides/queuing",
 	"/docs/client": "/docs/python-client/client",
 	"/docs/job": "/docs/python-client/job",
 	"/docs/set_static_paths": "/docs/gradio/set_static_paths",

--- a/js/upload/package.json
+++ b/js/upload/package.json
@@ -10,7 +10,6 @@
 		"@gradio/atoms": "workspace:^",
 		"@gradio/icons": "workspace:^",
 		"@gradio/client": "workspace:^",
-		"@gradio/upload": "workspace:^",
 		"@gradio/utils": "workspace:^",
 		"@gradio/wasm": "workspace:^"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1714,9 +1714,6 @@ importers:
       '@gradio/icons':
         specifier: workspace:^
         version: link:../icons
-      '@gradio/upload':
-        specifier: workspace:^
-        version: 'link:'
       '@gradio/utils':
         specifier: workspace:^
         version: link:../utils


### PR DESCRIPTION
For some reason key features guide was redirected to queuing guide by mistake. Removes that line

Also fixes dependency loop with @gradio/upload https://github.com/gradio-app/gradio/actions/runs/9410901936/job/25923318456