### PR TITLE
Fixes TabbedInterface bug where only first interface events get triggered

### DIFF
--- a/.changeset/pretty-clowns-fall.md
+++ b/.changeset/pretty-clowns-fall.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fixes TabbedInterface bug where only first interface events get triggered

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1355,6 +1355,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
                 if isinstance(dep.api_name, str)
             ]
             for dependency in self.fns.values():
+                dependency._id += dependency_offset
                 api_name = dependency.api_name
                 if isinstance(api_name, str):
                     api_name_ = utils.append_unique_suffix(

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -263,3 +263,15 @@ def test_live_interface_sets_always_last():
             assert dep["trigger_mode"] == "always_last"
             return
     raise AssertionError("No change dependency found")
+
+
+def test_tabbed_interface_predictions(connect):
+    hello_world = gradio.Interface(lambda name: "Hello " + name, "text", "text")
+    bye_world = gradio.Interface(lambda name: "Bye " + name, "text", "text")
+
+    demo = gradio.TabbedInterface(
+        [hello_world, bye_world], ["Hello World", "Bye World"]
+    )
+    with connect(demo) as client:
+        assert client.predict("Emily", api_name="/predict") == "Hello Emily"
+        assert client.predict("Hannah", api_name="/predict") == "Hello Hannah"


### PR DESCRIPTION
## Description

Closes: #8425

Test with the following demo:

```python
import gradio as gr

hello_world = gr.Interface(lambda name: "Hello " + name, "text", "text")
bye_world = gr.Interface(lambda name: "Bye " + name, "text", "text")

demo = gr.TabbedInterface([hello_world, bye_world], ["Hello World", "Bye World"])

if __name__ == "__main__":
    demo.launch()
```

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
