### PR TITLE
add handle_file docs

### DIFF
--- a/.changeset/tired-dryers-retire.md
+++ b/.changeset/tired-dryers-retire.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": minor
+"gradio": minor
+---
+
+feat:add handle_file docs


### PR DESCRIPTION
## Description

Adds `handle_file` documentation to the client README.



Closes: #8476.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
