### PR TITLE
feat: exception handling about file_count params of File component

### DIFF
--- a/.changeset/tangy-moose-check.md
+++ b/.changeset/tangy-moose-check.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:feat: exception handling about file_count params of File component

--- a/gradio/components/file.py
+++ b/gradio/components/file.py
@@ -69,11 +69,7 @@ class File(Component):
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             key: if assigned, will be used to assume identity across a re-render. Components that have the same key across a re-render will have their value preserved.
         """
-        file_count_valid_types = [
-            "single",
-            "multiple",
-            "directory"
-        ]
+        file_count_valid_types = ["single", "multiple", "directory"]
         self.file_count = file_count
 
         if self.file_count not in file_count_valid_types:

--- a/gradio/components/file.py
+++ b/gradio/components/file.py
@@ -69,8 +69,18 @@ class File(Component):
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             key: if assigned, will be used to assume identity across a re-render. Components that have the same key across a re-render will have their value preserved.
         """
+        file_count_valid_types = [
+            "single",
+            "multiple",
+            "directory"
+        ]
         self.file_count = file_count
-        if self.file_count in ["multiple", "directory"]:
+
+        if self.file_count not in file_count_valid_types:
+            raise ValueError(
+                f"Parameter file_count must be one of them: {file_count_valid_types}"
+            )
+        elif self.file_count in ["multiple", "directory"]:
             self.data_model = ListFiles
         else:
             self.data_model = FileData


### PR DESCRIPTION
## Description

According to docs, Parameter `file_count` of `File` component must be one of them(`single, multiple, directory`). But I put other integer value(ex. `file_count=0`) in the parameter by mistake, below error occurs.
```zsh
Traceback (most recent call last):
  File "/Users/zedd.ai/.pyenv/versions/3.10.12/envs/gradio-pr/lib/python3.10/site-packages/gradio/queueing.py", line 532, in process_events
    response = await route_utils.call_process_api(
  File "/Users/zedd.ai/.pyenv/versions/3.10.12/envs/gradio-pr/lib/python3.10/site-packages/gradio/route_utils.py", line 276, in call_process_api
    output = await app.get_blocks().process_api(
  File "/Users/zedd.ai/.pyenv/versions/3.10.12/envs/gradio-pr/lib/python3.10/site-packages/gradio/blocks.py", line 1924, in process_api
    inputs = await self.preprocess_data(
  File "/Users/zedd.ai/.pyenv/versions/3.10.12/envs/gradio-pr/lib/python3.10/site-packages/gradio/blocks.py", line 1653, in preprocess_data
    inputs_cached = block.data_model(**inputs_cached)  # type: ignore
TypeError: gradio.data_classes.FileData() argument after ** must be a mapping, not list
```
The error confused me because the message of error doesn't tell me the reason why the error occurs. So, I debugged above traceback error and followed the objects of all funcions in the stdout error. Finally, I found my mistake of putting the integer value in `file_count` parameter of `File` component. my error code is below.

```python
import gradio as gr
import pandas as pd

from gradio.themes.base import Base

def preprocess_file(file) -> str:
    df = pd.read_csv(file.name)

    column = df.columns[0]
    print("file:", type(file), type(file.name))
    print("df:", type(df))
    return column


class Seafoam(Base):
    pass


with gr.Blocks(theme=Seafoam(), title="TEST") as demo:
    gr.Markdown("""
    # TEST
    """)
    with gr.Tab("TEST"):
        file_output = gr.File(file_count=1, file_types=["csv"])   # it causes error
        upload_button = gr.Button(value="submit button")

    opt = gr.Textbox()
    upload_button.click(
        fn=preprocess_file,
        inputs=file_output,
        outputs=opt
    )

demo.launch(debug=True)
```

Of course, according to [official docs](https://www.gradio.app/docs/gradio/file#initialization), there is a content about type of the parameter. But, if the validation logic exists in the parameter, I should have found the reason of error earlier. So, for like me, I append validation logic of the parameter in this PR

## 🎯 PRs Should Target Issues

According to [the list of issue](https://github.com/gradio-app/gradio/issues?q=is%3Aissue+is%3Aopen+file_count), I can't find the issue about this parameter of `File` component now

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
