### PR TITLE
Fix request serialization for fastapi `/docs`

### DIFF
--- a/.changeset/dull-lizards-suffer.md
+++ b/.changeset/dull-lizards-suffer.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix request serialization for fastapi `/docs`

--- a/gradio/data_classes.py
+++ b/gradio/data_classes.py
@@ -110,6 +110,24 @@ class PredictBody(BaseModel):
         None  # dictionary of request headers, query parameters, url, etc. (used to to pass in request for queuing)
     )
 
+    def __get_pydantic_json_schema__(self, source_type: Any, handler):
+        return {
+            "title": "PredictBody",
+            "type": "object",
+            "properties": {
+                "session_hash": {"type": "string"},
+                "event_id": {"type": "string"},
+                "data": {"type": "array", "items": {"type": "object"}},
+                "event_data": {"type": "object"},
+                "fn_index": {"type": "integer"},
+                "trigger_id": {"type": "integer"},
+                "simple_format": {"type": "boolean"},
+                "batched": {"type": "boolean"},
+                "request": {"type": "object"},
+            },
+            "required": ["data"],
+        }
+
 
 class ResetBody(BaseModel):
     event_id: str

--- a/gradio/data_classes.py
+++ b/gradio/data_classes.py
@@ -110,7 +110,8 @@ class PredictBody(BaseModel):
         None  # dictionary of request headers, query parameters, url, etc. (used to to pass in request for queuing)
     )
 
-    def __get_pydantic_json_schema__(self, source_type: Any, handler):
+    @classmethod
+    def __get_pydantic_json_schema__(cls, core_schema, handler):
         return {
             "title": "PredictBody",
             "type": "object",

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1320,3 +1320,19 @@ def test_max_file_size_used_in_upload_route(connect):
     with open("test/test_files/alphabet.txt", "rb") as f:
         r = test_client.post("/upload", files={"files": f})
         assert r.status_code == 200
+
+
+def test_docs_url():
+    with gr.Blocks() as demo:
+        num = gr.Number(value=0)
+        button = gr.Button()
+        button.click(lambda n: n + 1, [num], [num])
+
+    app, _, _ = demo.launch(app_kwargs={"docs_url": "/docs"}, prevent_thread_lock=True)
+    try:
+        test_client = TestClient(app)
+        with test_client:
+            r = test_client.get("/docs")
+            assert r.status_code == 200
+    finally:
+        demo.close()


### PR DESCRIPTION
This commit addresses a serialization issue in the `PredictBody` model that has been present since version 4.0. The `request` attribute, being of type `Request`, could not be serialized automatically, affecting FastAPI's auto-generated documentation (/openapi.json).
By adding a custom `__get_pydantic_json_schema__` method, the serialization schema is manually defined, ensuring correct documentation generation.
This is also one of the reasons why applications like "stable-diffusion-webui," which require /docs pages, have not updated to newer versions of Gradio.

Closes: #7287
