### PR TITLE
Fix reload mode by implementing `close` on the client

### DIFF
--- a/.changeset/red-rice-build.md
+++ b/.changeset/red-rice-build.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/client": minor
-"gradio": minor
+"@gradio/client": patch
+"gradio": patch
 ---
 
-feat:Fix reload mode by implementing `close` on the client
+fix:Fix reload mode by implementing `close` on the client

--- a/.changeset/red-rice-build.md
+++ b/.changeset/red-rice-build.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": minor
+"gradio": minor
+---
+
+feat:Fix reload mode by implementing `close` on the client

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -31,7 +31,7 @@ import {
 	parse_and_set_cookies
 } from "./helpers/init_helpers";
 import { check_space_status } from "./helpers/spaces";
-import { open_stream, readable_stream } from "./utils/stream";
+import { open_stream, readable_stream, close_stream } from "./utils/stream";
 import { API_INFO_ERROR_MSG, CONFIG_ERROR_MSG } from "./constants";
 
 export class Client {
@@ -209,7 +209,7 @@ export class Client {
 	}
 
 	close(): void {
-		this.heartbeat_event?.close();
+		close_stream(this.stream_status, this.abort_controller);
 	}
 
 	static async duplicate(

--- a/js/app/test/test_chatinterface.reload.spec.ts
+++ b/js/app/test/test_chatinterface.reload.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "@playwright/test";
+import { spawnSync } from "node:child_process";
+import { launch_app_background, kill_process } from "./utils";
+import { join } from "path";
+
+let _process;
+
+const demo_file = "chat_demo.py";
+
+test.beforeAll(() => {
+	const demo = `
+import gradio as gr
+    
+def greet(msg, history):
+    return "Hello"
+
+demo = gr.ChatInterface(fn=greet)
+
+if __name__ == "__main__":
+    demo.launch()
+`;
+	spawnSync(`echo '${demo}' > ${join(process.cwd(), demo_file)}`, {
+		shell: true,
+		stdio: "pipe",
+		env: {
+			...process.env,
+			PYTHONUNBUFFERED: "true"
+		}
+	});
+});
+
+test.afterAll(() => {
+	if (_process) kill_process(_process);
+	spawnSync(`rm  ${join(process.cwd(), demo_file)}`, {
+		shell: true,
+		stdio: "pipe",
+		env: {
+			...process.env,
+			PYTHONUNBUFFERED: "true"
+		}
+	});
+});
+
+test("gradio dev mode correctly reloads a stateful ChatInterface demo", async ({
+	page
+}) => {
+	test.setTimeout(20 * 1000);
+
+	try {
+		const port = 7890;
+		const { _process: server_process } = await launch_app_background(
+			`GRADIO_SERVER_PORT=${port} gradio ${join(process.cwd(), demo_file)}`,
+			process.cwd()
+		);
+		_process = server_process;
+		console.log("Connected to port", port);
+		const demo = `
+import gradio as gr
+
+def greet(msg, history):
+    return "Hello"
+
+demo = gr.ChatInterface(fn=greet, textbox=gr.Textbox(label="foo"))
+
+if __name__ == "__main__":
+    demo.launch()
+`;
+		await page.goto(`http://localhost:${port}`);
+		spawnSync(`echo '${demo}' > ${join(process.cwd(), demo_file)}`, {
+			shell: true,
+			stdio: "pipe",
+			env: {
+				...process.env,
+				PYTHONUNBUFFERED: "true"
+			}
+		});
+		await expect(page.getByLabel("foo")).toBeVisible();
+	} finally {
+		if (_process) kill_process(_process);
+	}
+});


### PR DESCRIPTION
## Description

Reload mode would break because the heartbeat could not be closed - 

<img width="606" alt="Screenshot 2024-06-13 at 10 53 15 AM" src="https://github.com/gradio-app/gradio/assets/41651716/6ab634d8-8b3d-464d-9d44-294040aeee75">

You can test by with a stateful demo like ChatInterface

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
