### PR TITLE
Fixes the `favicon_path` working error

### DIFF
--- a/.changeset/red-badgers-sip.md
+++ b/.changeset/red-badgers-sip.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fixes the `favicon_path` working error

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -7,6 +7,7 @@ import asyncio
 import contextlib
 import math
 import sys
+import warnings
 
 if sys.version_info >= (3, 9):
     from importlib.resources import files
@@ -1287,6 +1288,12 @@ def mount_gradio_app(
         app = gr.mount_gradio_app(app, io, path="/gradio")
         # Then run `uvicorn run:app` from the terminal and navigate to http://localhost:8000/gradio.
     """
+    if favicon_path is not None and path != "/":
+        warnings.warn(
+            "The 'favicon_path' parameter is set but will be ignored because 'path' is not '/'. "
+            "Please add the favicon directly to your FastAPI app."
+        )
+
     blocks.dev_mode = False
     blocks.max_file_size = utils._parse_file_size(max_file_size)
     blocks.config = blocks.get_config_file()


### PR DESCRIPTION
## Description

Trying to fix the bug related to `favicon_path` which doesn't seem to work when using it as a path for `gradio.mount_gradio_app` and FastAPI.

I've made the appropriate changes as suggested by @freddyaboulton on the issue:

"""
It would be here:

https://github.com/gradio-app/gradio/blob/94a1143686733c7fe16e204764b9a3e7240ccf02/gradio/routes.py#L1222

We want to output a warning if `favicon_path` is not `None` and the `path` is not `/`
"""

Closes: #8137 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
