### PR TITLE
Allow `gr.load` to work inside `gr.Blocks` automatically

### DIFF
--- a/.changeset/quick-dolls-admire.md
+++ b/.changeset/quick-dolls-admire.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Allow `gr.load` to work inside `gr.Blocks` automatically

--- a/.changeset/quick-dolls-admire.md
+++ b/.changeset/quick-dolls-admire.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Allow `gr.load` to work inside `gr.Blocks` automatically
+fix:Allow `gr.load` to work inside `gr.Blocks` automatically

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1181,7 +1181,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
 
         with Blocks(theme=theme) as blocks:
             # ID 0 should be the root Blocks component
-            original_mapping[0] = Context.root_block or blocks
+            original_mapping[0] = root_block = Context.root_block or blocks
 
             iterate_over_children(config["layout"]["children"])
 
@@ -1256,7 +1256,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
                         )
                         for t in targets
                     ]
-                dependency = blocks.default_config.set_event_trigger(
+                dependency = root_block.default_config.set_event_trigger(
                     targets=targets, fn=fn, **dependency
                 )[0]
                 if first_dependency is None:

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -509,7 +509,5 @@ def test_load_custom_component():
 
 def test_load_inside_blocks():
     demo = gr.load("spaces/abidlabs/en2fr")
-    output = demo(
-        "test/test_files/sample_file.pdf", "What does this say?", api_name="predict"
-    )
+    output = demo("Hello")
     assert isinstance(output, str)

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -505,3 +505,11 @@ def test_load_custom_component():
         "test/test_files/sample_file.pdf", "What does this say?", api_name="predict"
     )
     assert isinstance(output, str)
+
+
+def test_load_inside_blocks():
+    demo = gr.load("spaces/abidlabs/en2fr")
+    output = demo(
+        "test/test_files/sample_file.pdf", "What does this say?", api_name="predict"
+    )
+    assert isinstance(output, str)


### PR DESCRIPTION
Closes: https://github.com/gradio-app/gradio/issues/7996. Now both of these work:

```py
import gradio as gr

gr.load("abidlabs/en2fr", src="spaces").launch()
```

and 

```py
import gradio as gr

with gr.Blocks() as demo:
    gr.load("abidlabs/en2fr", src="spaces")
    
demo.launch()
```