### PR TITLE
fix dataset update

### DIFF
--- a/.changeset/soft-worms-remain.md
+++ b/.changeset/soft-worms-remain.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataset": minor
+"gradio": minor
+---
+
+feat:fix dataset update

--- a/.changeset/soft-worms-remain.md
+++ b/.changeset/soft-worms-remain.md
@@ -1,6 +1,7 @@
 ---
 "@gradio/dataset": patch
 "gradio": patch
+"website": patch
 ---
 
 fix:fix dataset update

--- a/.changeset/soft-worms-remain.md
+++ b/.changeset/soft-worms-remain.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/dataset": minor
-"gradio": minor
+"@gradio/dataset": patch
+"gradio": patch
 ---
 
-feat:fix dataset update
+fix:fix dataset update

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -244,7 +244,7 @@ class Block:
             if to_add:
                 config = {**to_add, **config}
         config.pop("render", None)
-        config = {**config,  "name": self.get_block_class()}
+        config = {**config, "proxy_url": self.proxy_url, "name": self.get_block_class()}
         if self.rendered_in is not None:
             config["rendered_in"] = self.rendered_in._id
         if (_selectable := getattr(self, "_selectable", None)) is not None:

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -244,7 +244,7 @@ class Block:
             if to_add:
                 config = {**to_add, **config}
         config.pop("render", None)
-        config = {**config, "proxy_url": self.proxy_url, "name": self.get_block_class()}
+        config = {**config,  "name": self.get_block_class()}
         if self.rendered_in is not None:
             config["rendered_in"] = self.rendered_in._id
         if (_selectable := getattr(self, "_selectable", None)) is not None:
@@ -1723,12 +1723,12 @@ Received outputs:
                 ) from err
 
             if block.stateful:
-                if not utils.is_update(predictions[i]):
+                if not utils.is_prop_update(predictions[i]):
                     state[block._id] = predictions[i]
                 output.append(None)
             else:
                 prediction_value = predictions[i]
-                if utils.is_update(
+                if utils.is_prop_update(
                     prediction_value
                 ):  # if update is passed directly (deprecated), remove Nones
                     prediction_value = utils.delete_none(
@@ -1738,7 +1738,7 @@ Received outputs:
                 if isinstance(prediction_value, Block):
                     prediction_value = prediction_value.constructor_args.copy()
                     prediction_value["__type__"] = "update"
-                if utils.is_update(prediction_value):
+                if utils.is_prop_update(prediction_value):
                     kwargs = state[block._id].constructor_args.copy()
                     kwargs.update(prediction_value)
                     kwargs.pop("value", None)

--- a/gradio/components/dataset.py
+++ b/gradio/components/dataset.py
@@ -150,7 +150,7 @@ class Dataset(Component):
     def postprocess(self, sample: int | list | None) -> int | None:
         """
         Parameters:
-            samples: Expects an `int` index or `list` of sample data. Returns the index of the sample in the dataset or `None` if the sample is not found.
+            sample: Expects an `int` index or `list` of sample data. Returns the index of the sample in the dataset or `None` if the sample is not found.
         Returns:
             Returns the index of the sample in the dataset.
         """

--- a/gradio/components/dataset.py
+++ b/gradio/components/dataset.py
@@ -18,7 +18,8 @@ from gradio.events import Events
 @document()
 class Dataset(Component):
     """
-    Creates a gallery or table to display data samples. This component is designed for internal use to display examples.
+    Creates a gallery or table to display data samples. This component is primarily designed for internal use to display examples.
+    However, it can also be used directly to display a dataset and let users select examples.
     """
 
     EVENTS = [Events.click, Events.select]

--- a/gradio/components/dataset.py
+++ b/gradio/components/dataset.py
@@ -26,7 +26,7 @@ class Dataset(Component):
         self,
         *,
         label: str | None = None,
-        components: list[Component] | list[str],
+        components: list[Component] | list[str] | None = None,
         component_props: list[dict[str, Any]] | None = None,
         samples: list[list[Any]] | None = None,
         headers: list[str] | None = None,
@@ -70,7 +70,7 @@ class Dataset(Component):
         self.container = container
         self.scale = scale
         self.min_width = min_width
-        self._components = [get_component_instance(c) for c in components]
+        self._components = [get_component_instance(c) for c in components or []]
         if component_props is None:
             self.component_props = [
                 component.recover_kwargs(

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -164,7 +164,7 @@ class CSVLogger(FlaggingCallback):
             ) / client_utils.strip_invalid_filename_characters(
                 getattr(component, "label", None) or f"component {idx}"
             )
-            if utils.is_update(sample):
+            if utils.is_prop_update(sample):
                 csv_data.append(str(sample))
             else:
                 data = (

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -544,7 +544,7 @@ class Examples:
                     component, components.File
                 ):
                     value_to_use = value_as_dict
-                if not utils.is_update(value_as_dict):
+                if not utils.is_prop_update(value_as_dict):
                     raise TypeError("value wasn't an update")  # caught below
                 output.append(value_as_dict)
             except (ValueError, TypeError, SyntaxError):

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -737,7 +737,7 @@ def validate_url(possible_url: str) -> bool:
         return False
 
 
-def is_update(val):
+def is_prop_update(val):
     return isinstance(val, dict) and "update" in val.get("__type__", "")
 
 

--- a/js/_website/src/lib/templates/gradio/03_components/dataset.svx
+++ b/js/_website/src/lib/templates/gradio/03_components/dataset.svx
@@ -86,6 +86,40 @@ def predict(···) -> list[list]
 <DemosSection demos={obj.demos} />
 {/if}
 
+### Examples
+
+**Updating a Dataset**
+
+In this example, we display a text dataset using `gr.Dataset` and then update it when the user clicks a button:
+
+```py
+import gradio as gr
+
+philosophy_quotes = [
+    ["I think therefore I am."],
+    ["The unexamined life is not worth living."]
+]
+
+startup_quotes = [
+    ["Ideas are easy. Implementation is hard"],
+    ["Make mistakes faster."]
+]
+
+def show_startup_quotes():
+    return gr.Dataset(samples=startup_quotes)
+
+with gr.Blocks() as demo:
+    textbox = gr.Textbox()
+    dataset = gr.Dataset(components=[textbox], samples=philosophy_quotes)
+    button = gr.Button()
+
+    button.click(show_startup_quotes, None, dataset)
+
+demo.launch()
+```
+
+
+
 {#if obj.fns && obj.fns.length > 0}
 <!--- Event Listeners -->
 ### Event Listeners 
@@ -97,3 +131,4 @@ def predict(···) -> list[list]
 ### Guides
 <GuidesSection guides={obj.guides}/>
 {/if}
+

--- a/js/dataset/Index.svelte
+++ b/js/dataset/Index.svelte
@@ -12,7 +12,7 @@
 	>;
 	export let label = "Examples";
 	export let headers: string[];
-	export let samples: any[][];
+	export let samples: any[][] | null = null;
 	export let elem_id = "";
 	export let elem_classes: string[] = [];
 	export let visible = true;
@@ -34,7 +34,7 @@
 		: `${root}/file=`;
 	let page = 0;
 	$: gallery = components.length < 2;
-	let paginate = samples.length > samples_per_page;
+	let paginate = samples ? samples.length > samples_per_page : false;
 
 	let selected_samples: any[][];
 	let page_count: number;
@@ -51,6 +51,7 @@
 	}
 
 	$: {
+		samples = samples || [];
 		paginate = samples.length > samples_per_page;
 		if (paginate) {
 			visible_pages = [];

--- a/test/components/test_dataset.py
+++ b/test/components/test_dataset.py
@@ -43,27 +43,10 @@ class TestDataset:
         assert dataset.samples == [["value 1"], ["value 2"]]
 
     def test_postprocessing(self):
-        test_file_dir = Path(Path(__file__).parent, "test_files")
-        bus = Path(test_file_dir, "bus.png")
-
         dataset = gr.Dataset(
             components=["number", "textbox", "image", "html", "markdown"], type="index"
         )
-
-        output = dataset.postprocess(
-            samples=[
-                [5, "hello", bus, "<b>Bold</b>", "**Bold**"],
-                [15, "hi", bus, "<i>Italics</i>", "*Italics*"],
-            ],
-        )
-
-        assert output == {
-            "samples": [
-                [5, "hello", bus, "<b>Bold</b>", "**Bold**"],
-                [15, "hi", bus, "<i>Italics</i>", "*Italics*"],
-            ],
-            "__type__": "update",
-        }
+        assert dataset.postprocess(1) == 1
 
 
 @patch(


### PR DESCRIPTION
Allows the samples in a `gr.Dataset` to be updated. Here's a quick example:

```py
import gradio as gr

def update(value):
    print(value)
    return value, gr.Dataset(samples=[["a"],["b"]])

with gr.Blocks() as demo:
    with gr.Row():
        textbox = gr.Textbox()
        dataset = gr.Dataset(components = ["text"], samples = [["This"]], label="Saved Prompts")
        dataset.click(update, inputs=[dataset], outputs=[textbox, dataset])

demo.launch()
```

Closes: https://github.com/gradio-app/gradio/issues/8312
Closes: https://github.com/gradio-app/gradio/issues/7282
Closes: https://github.com/gradio-app/gradio/issues/6415

Also fixes the issue where clearing an `Interface` that included a `Dataset` would cause the Interface to crash. 

Closes: https://github.com/gradio-app/gradio/issues/6807