### PR TITLE
Fix resizer on altair

### DIFF
--- a/.changeset/few-camels-swim.md
+++ b/.changeset/few-camels-swim.md
@@ -1,0 +1,6 @@
+---
+"@gradio/plot": patch
+"gradio": patch
+---
+
+feat:Fix resizer on altair

--- a/js/plot/shared/plot_types/AltairPlot.svelte
+++ b/js/plot/shared/plot_types/AltairPlot.svelte
@@ -28,13 +28,17 @@
 		spec = set_config(spec, computed_style, value.chart as string, colors);
 	}
 	$: fit_width_to_parent =
-		spec.encoding?.column?.field || spec.encoding?.row?.field ? false : true; // vega seems to glitch with width when orientation is set
+		spec.encoding?.column?.field ||
+		spec.encoding?.row?.field ||
+		value.chart === undefined
+			? false
+			: true; // vega seems to glitch with width when orientation is set
 
 	const renderPlot = (): void => {
 		if (fit_width_to_parent) {
 			spec.width = Math.min(
 				parent_element.offsetWidth,
-				spec_width || parent_element.offsetWidth
+				spec_width || parent_element.offsetWidth,
 			);
 		}
 		vegaEmbed(element, spec, { actions: show_actions_button });

--- a/js/plot/shared/plot_types/AltairPlot.svelte
+++ b/js/plot/shared/plot_types/AltairPlot.svelte
@@ -38,7 +38,7 @@
 		if (fit_width_to_parent) {
 			spec.width = Math.min(
 				parent_element.offsetWidth,
-				spec_width || parent_element.offsetWidth,
+				spec_width || parent_element.offsetWidth
 			);
 		}
 		vegaEmbed(element, spec, { actions: show_actions_button });


### PR DESCRIPTION
when using altair with gr.Plot, the resizer is not guaranteed to work. It only works when using native plots (`gr.LinePlot`, `gr.BarPlot`, `gr.ScatterPlot`). Made it so resizing logic only applies when the chart type is provided, meaning this is a native plot.

test with `altair_plot` and `native_plots` demos/