### PR TITLE
Small fix to guide styling

### DIFF
--- a/.changeset/five-bags-dress.md
+++ b/.changeset/five-bags-dress.md
@@ -1,0 +1,5 @@
+---
+"website": minor
+---
+
+feat:Small fix to guide styling

--- a/js/_website/src/routes/[[version]]/guides/[guide]/+page.svelte
+++ b/js/_website/src/routes/[[version]]/guides/[guide]/+page.svelte
@@ -146,18 +146,18 @@
 						style="max-width: 12rem"
 						href="..{guide.url}">{guide.pretty_name}</a
 					>
-					
+
 					{#if guide_slug.length > 0}
-					<div
-						class="navigation max-w-full bg-gradient-to-r from-orange-50 to-orange-100 p-2 mx-2 border-l-2 border-orange-500 mb-2"
-					>
-						{#each guide_slug as heading}
-							<a
-								class="subheading block thin-link -indent-2 ml-4 mr-2"
-								href={heading.href}>{heading.text}</a
-							>
-						{/each}
-					</div>
+						<div
+							class="navigation max-w-full bg-gradient-to-r from-orange-50 to-orange-100 p-2 mx-2 border-l-2 border-orange-500 mb-2"
+						>
+							{#each guide_slug as heading}
+								<a
+									class="subheading block thin-link -indent-2 ml-4 mr-2"
+									href={heading.href}>{heading.text}</a
+								>
+							{/each}
+						</div>
 					{/if}
 				{:else}
 					<a

--- a/js/_website/src/routes/[[version]]/guides/[guide]/+page.svelte
+++ b/js/_website/src/routes/[[version]]/guides/[guide]/+page.svelte
@@ -146,7 +146,8 @@
 						style="max-width: 12rem"
 						href="..{guide.url}">{guide.pretty_name}</a
 					>
-
+					
+					{#if guide_slug.length > 0}
 					<div
 						class="navigation max-w-full bg-gradient-to-r from-orange-50 to-orange-100 p-2 mx-2 border-l-2 border-orange-500 mb-2"
 					>
@@ -157,6 +158,7 @@
 							>
 						{/each}
 					</div>
+					{/if}
 				{:else}
 					<a
 						class:hidden={!show_all &&


### PR DESCRIPTION
tiny fix that's been annoying me for a while. On guides without headings, there's no need to show a headings section under the guide name in the sidebar. 

![Screen Shot 2024-06-24 at 11 42 34 PM](https://github.com/gradio-app/gradio/assets/9021060/ca4cb208-1e9b-4e3c-b9a3-b3d27f200685)

vs 
 
![Screen Shot 2024-06-24 at 11 42 44 PM](https://github.com/gradio-app/gradio/assets/9021060/b2f798f0-ee20-4992-8188-db91989dd759)
