### PR TITLE
Bugfix: Allow multiple files to be uploaded via multimodal textbox

### DIFF
--- a/js/app/test/chatbot_multimodal.spec.ts
+++ b/js/app/test/chatbot_multimodal.spec.ts
@@ -52,6 +52,23 @@ test("images uploaded by a user should be shown in the chat", async ({
 	expect(bot_message).toBeTruthy();
 });
 
+test("Users can upload multiple images and they will be shown as thumbnails", async ({
+	page
+}) => {
+	const fileChooserPromise = page.waitForEvent("filechooser");
+	await page.getByTestId("upload-button").click();
+	const fileChooser = await fileChooserPromise;
+	await fileChooser.setFiles([
+		"./test/files/cheetah1.jpg",
+		"./test/files/cheetah1.jpg"
+	]);
+	expect
+		.poll(async () => await page.locator("thumbnail-image").count(), {
+			timeout: 5000
+		})
+		.toEqual(2);
+});
+
 test("audio uploaded by a user should be shown in the chatbot", async ({
 	page
 }) => {

--- a/js/file/Index.svelte
+++ b/js/file/Index.svelte
@@ -42,7 +42,7 @@
 		clear_status: LoadingStatus;
 		delete: FileData;
 	}>;
-	export let file_count: string;
+	export let file_count: "single" | "multiple" | "directory";
 	export let file_types: string[] = ["file"];
 
 	let old_value = value;

--- a/js/file/shared/FileUpload.svelte
+++ b/js/file/shared/FileUpload.svelte
@@ -12,7 +12,7 @@
 
 	export let label: string;
 	export let show_label = true;
-	export let file_count = "single";
+	export let file_count: "single" | "multiple" | "directory" = "single";
 	export let file_types: string[] | null = null;
 	export let selectable = false;
 	export let root: string;

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -161,6 +161,7 @@
 			for (let file of detail) {
 				value.files.push(file);
 			}
+			value = value;
 		} else {
 			value.files.push(detail);
 			value = value;
@@ -244,7 +245,7 @@
 		<Upload
 			bind:this={upload_component}
 			on:load={handle_upload}
-			filetype={accept_file_types}
+			file_count={"multiple"}
 			{root}
 			{max_file_size}
 			bind:dragging

--- a/js/upload/src/Upload.svelte
+++ b/js/upload/src/Upload.svelte
@@ -10,7 +10,7 @@
 	export let boundedheight = true;
 	export let center = true;
 	export let flex = true;
-	export let file_count = "single";
+	export let file_count: "single" | "multiple" | "directory" = "single";
 	export let disable_click = false;
 	export let root: string;
 	export let hidden = false;


### PR DESCRIPTION
## Description

The docs of multimodal textbox mentions that it "allows for the uploading of multimedia files" but only one file can be uploaded. So I think this is a bugfix as opposed to a new feature. Updating the e2e tests as well as the typehint for `file_count` in the Upload component.


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
