### PR TITLE
Changed gradio version check from print statement to warning

### DIFF
--- a/.changeset/fifty-books-fly.md
+++ b/.changeset/fifty-books-fly.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:Changed gradio version check from print statement to warning

--- a/gradio/analytics.py
+++ b/gradio/analytics.py
@@ -105,9 +105,9 @@ def version_check():
         if Version(latest_pkg_version) > Version(current_pkg_version):
             warnings.warn(
                 f"IMPORTANT: You are using gradio version {current_pkg_version}, "
-                f"however version {latest_pkg_version} is available, please upgrade."
+                f"however version {latest_pkg_version} is available, please upgrade. \n"
+                f"--------"
             )
-            warnings.warn("--------")
     except json.decoder.JSONDecodeError:
         warnings.warn("unable to parse version details from package URL.")
     except KeyError:

--- a/gradio/analytics.py
+++ b/gradio/analytics.py
@@ -103,11 +103,11 @@ def version_check():
         current_pkg_version = get_package_version()
         latest_pkg_version = httpx.get(url=PKG_VERSION_URL, timeout=3).json()["version"]
         if Version(latest_pkg_version) > Version(current_pkg_version):
-            print(
+            warnings.warn(
                 f"IMPORTANT: You are using gradio version {current_pkg_version}, "
                 f"however version {latest_pkg_version} is available, please upgrade."
             )
-            print("--------")
+            warnings.warn("--------")
     except json.decoder.JSONDecodeError:
         warnings.warn("unable to parse version details from package URL.")
     except KeyError:


### PR DESCRIPTION
## Description

Fix to the issue: "You are using gradio version" should be a warning #8595 

Closes: #8595 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
