### PR TITLE
Fix CORS issues with Lite Component Demos

### DIFF
--- a/.changeset/wild-cases-obey.md
+++ b/.changeset/wild-cases-obey.md
@@ -1,0 +1,5 @@
+---
+"website": minor
+---
+
+feat:Fix CORS issues with Lite Component Demos

--- a/js/_website/src/lib/templates/gradio/03_components/annotatedimage.svx
+++ b/js/_website/src/lib/templates/gradio/03_components/annotatedimage.svx
@@ -28,8 +28,8 @@ import numpy as np
 import requests 
 from io import BytesIO
 from PIL import Image
-base_image = "https://gradio-builds.s3.amazonaws.com/demo-files/base.png"
-building_image = requests.get("https://gradio-builds.s3.amazonaws.com/demo-files/buildings.png")
+base_image = "https://gradio-docs-json.s3.us-west-2.amazonaws.com/base.png"
+building_image = requests.get("https://gradio-docs-json.s3.us-west-2.amazonaws.com/buildings.png")
 building_image = np.asarray(Image.open(BytesIO(building_image.content)))[:, :, -1] > 0
 with gr.Blocks() as demo:
     gr.AnnotatedImage(

--- a/js/_website/src/lib/templates/gradio/03_components/audio.svx
+++ b/js/_website/src/lib/templates/gradio/03_components/audio.svx
@@ -26,7 +26,7 @@ gradio.Audio(···)
 <gradio-lite shared-worker>
 import gradio as gr
 with gr.Blocks() as demo:
-    gr.Audio("https://file-examples.com/storage/fe3cb26995666504a8d6180/2017/11/file_example_MP3_700KB.mp3")
+    gr.Audio("https://cdn.pixabay.com/download/audio/2022/03/09/audio_7e096b862f.mp3")
 demo.launch()
 </gradio-lite>
 </div>


### PR DESCRIPTION
Fixes the problems with [Audio](http://localhost:5173/main/docs/gradio/audio) and [AnnotatedImage](http://localhost:5173/main/docs/gradio/annotatedimage) component demos. 