### PR TITLE
Add c/cpp code support

### DIFF
--- a/.changeset/light-gifts-pull.md
+++ b/.changeset/light-gifts-pull.md
@@ -1,0 +1,6 @@
+---
+"@gradio/code": minor
+"gradio": minor
+---
+
+feat:Add c/cpp code support

--- a/gradio/components/code.py
+++ b/gradio/components/code.py
@@ -22,6 +22,8 @@ class Code(Component):
 
     languages = [
         "python",
+        "c",
+        "cpp",
         "markdown",
         "json",
         "html",
@@ -60,6 +62,8 @@ class Code(Component):
         value: str | Callable | tuple[str] | None = None,
         language: Literal[
             "python",
+            "c",
+            "cpp",
             "markdown",
             "json",
             "html",

--- a/js/code/shared/Download.svelte
+++ b/js/code/shared/Download.svelte
@@ -29,7 +29,7 @@
 			shell: "sh",
 			r: "r",
 			c: "c",
-			cpp: "cpp",
+			cpp: "cpp"
 		};
 
 		return exts[type] || "txt";

--- a/js/code/shared/Download.svelte
+++ b/js/code/shared/Download.svelte
@@ -27,7 +27,9 @@
 			dockerfile: "dockerfile",
 			sh: "sh",
 			shell: "sh",
-			r: "r"
+			r: "r",
+			c: "c",
+			cpp: "cpp",
 		};
 
 		return exts[type] || "txt";

--- a/js/code/shared/language.ts
+++ b/js/code/shared/language.ts
@@ -1,9 +1,12 @@
 import type { Extension } from "@codemirror/state";
 import { StreamLanguage } from "@codemirror/language";
 import { sql } from "@codemirror/legacy-modes/mode/sql";
+import { _ } from "svelte-i18n";
 
 const possible_langs = [
 	"python",
+	"c",
+	"cpp",
 	"markdown",
 	"json",
 	"html",
@@ -35,6 +38,14 @@ const sql_dialects = [
 
 const lang_map: Record<string, (() => Promise<Extension>) | undefined> = {
 	python: () => import("@codemirror/lang-python").then((m) => m.python()),
+	c: () => 
+		import("@codemirror/legacy-modes/mode/clike").then((m) =>
+			StreamLanguage.define(m.c)
+		),
+	cpp: () => 
+			import("@codemirror/legacy-modes/mode/clike").then((m) =>
+				StreamLanguage.define(m.cpp)
+			),
 	markdown: async () => {
 		const [md, frontmatter] = await Promise.all([
 			import("@codemirror/lang-markdown"),

--- a/js/code/shared/language.ts
+++ b/js/code/shared/language.ts
@@ -38,14 +38,14 @@ const sql_dialects = [
 
 const lang_map: Record<string, (() => Promise<Extension>) | undefined> = {
 	python: () => import("@codemirror/lang-python").then((m) => m.python()),
-	c: () => 
+	c: () =>
 		import("@codemirror/legacy-modes/mode/clike").then((m) =>
 			StreamLanguage.define(m.c)
 		),
-	cpp: () => 
-			import("@codemirror/legacy-modes/mode/clike").then((m) =>
-				StreamLanguage.define(m.cpp)
-			),
+	cpp: () =>
+		import("@codemirror/legacy-modes/mode/clike").then((m) =>
+			StreamLanguage.define(m.cpp)
+		),
 	markdown: async () => {
 		const [md, frontmatter] = await Promise.all([
 			import("@codemirror/lang-markdown"),


### PR DESCRIPTION
Adding c/cpp support to `gr.Code.languages`

Closes: #8584

c code example!
<img width="641" alt="Screenshot 2024-06-28 at 8 12 10 PM" src="https://github.com/gradio-app/gradio/assets/42229107/4973ac79-a879-46bf-b9b5-ee61b22672a0">

  
