### PR TITLE
Fix Progress Bars Guide Name

### DIFF
--- a/guides/03_additional-features/05_progress-bars.md
+++ b/guides/03_additional-features/05_progress-bars.md
@@ -1,4 +1,4 @@
-# Progress bars
+# Progress Bars
 
 Gradio supports the ability to create custom Progress Bars so that you have customizability and control over the progress update that you show to the user. In order to enable this, simply add an argument to your method that has a default value of a `gr.Progress` instance. Then you can update the progress levels by calling this instance directly with a float between 0 and 1, or using the `tqdm()` method of the `Progress` instance to track progress over an iterable, as shown below.
 


### PR DESCRIPTION
Tiny fix to the name of the Progress Bars guide in the gallery and navbar. 

<img width="438" alt="Screen Shot 2024-07-01 at 10 50 33 AM" src="https://github.com/gradio-app/gradio/assets/9021060/0d7a8c25-6924-4478-a21b-ea3a66844544">
