### PR TITLE
Warn against Falsy credentials

### DIFF
--- a/.changeset/chubby-spiders-love.md
+++ b/.changeset/chubby-spiders-love.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Warn against Falsy credentials

--- a/.changeset/chubby-spiders-love.md
+++ b/.changeset/chubby-spiders-love.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Warn against Falsy credentials

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2230,6 +2230,19 @@ Received outputs:
             self.auth = [auth]
         else:
             self.auth = auth
+
+        if (
+            self.auth
+            and not callable(self.auth)
+            and any(
+                not authenticable[0] or not authenticable[1]
+                for authenticable in self.auth
+            )
+        ):
+            raise ValueError(
+                "You must provide a username and password for authentication."
+            )
+
         self.auth_message = auth_message
         self.show_error = show_error
         self.height = height

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2231,17 +2231,15 @@ Received outputs:
         else:
             self.auth = auth
 
-        if (
-            self.auth
-            and not callable(self.auth)
-            and any(
-                not authenticable[0] or not authenticable[1]
-                for authenticable in self.auth
-            )
-        ):
-            raise ValueError(
-                "You must provide a username and password for authentication."
-            )
+        if self.auth and not callable(self.auth):
+            if any(not authenticable[0] for authenticable in self.auth):
+                warnings.warn(
+                    "You have provided an empty username in `auth`. Please provide a valid username."
+                )
+            if any(not authenticable[1] for authenticable in self.auth):
+                warnings.warn(
+                    "You have provided an empty password in `auth`. Please provide a valid password."
+                )
 
         self.auth_message = auth_message
         self.show_error = show_error


### PR DESCRIPTION
Allowing Falsy auth credentials will cause problems later, for example in `hmac.compare_digest(input_password.encode(), correct_password.encode())` as NoneType has no `encode` method. Moreover, allowing empty passwords would make no sense from a security point of view.

Let me know if any changes are required.
  
