### PR TITLE
Refactoring the playground component

### DIFF
--- a/.changeset/quick-files-tease.md
+++ b/.changeset/quick-files-tease.md
@@ -1,0 +1,6 @@
+---
+"@gradio/app": minor
+"gradio": minor
+---
+
+feat:Refactoring the playground component

--- a/js/app/src/lite/Playground.svelte
+++ b/js/app/src/lite/Playground.svelte
@@ -4,11 +4,11 @@
 	import { mount_css as default_mount_css } from "../css";
 	import type { Client as ClientType } from "@gradio/client";
 	import type { WorkerProxy } from "@gradio/wasm";
-	import { SvelteComponent, createEventDispatcher, onMount } from "svelte";
-	import Code from "@gradio/code";
+	import { createEventDispatcher, onMount } from "svelte";
+	import { Block } from "@gradio/atoms";
+	import { BaseCode as Code } from "@gradio/code";
 	import ErrorDisplay from "./ErrorDisplay.svelte";
 	import lightning from "../images/lightning.svg";
-	import type { LoadingStatus } from "js/statustracker";
 
 	export let autoscroll: boolean;
 	export let version: string;
@@ -29,23 +29,10 @@
 	export let src: string | null;
 
 	export let code: string | undefined;
-	export let error_display: SvelteComponent | null;
+	export let error_display: { is_embed: boolean; error: Error } | null;
 	export let layout: string | null = null;
 
 	const dispatch = createEventDispatcher();
-
-	let dummy_elem: any = { classList: { contains: () => false } };
-	let dummy_gradio: any = { dispatch: (_: any) => {} };
-	let dummy_loading_status: LoadingStatus = {
-		eta: 0,
-		queue_position: 0,
-		queue_size: 0,
-		status: "complete",
-		show_progress: "hidden",
-		scroll_to_output: false,
-		visible: false,
-		fn_index: 0
-	};
 
 	let loading_text = "";
 	export let loaded = false;
@@ -106,7 +93,6 @@
 
 	function apply_theme(target: HTMLDivElement, theme: "dark" | "light"): void {
 		const dark_class_element = is_embed ? target.parentElement! : document.body;
-		const bg_element = is_embed ? target : target.parentElement!;
 		if (theme === "dark") {
 			dark_class_element.classList.add("dark");
 		} else {
@@ -114,7 +100,7 @@
 		}
 	}
 
-	let active_theme_mode: ThemeMode;
+	let active_theme_mode: Exclude<ThemeMode, "system"> = "light";
 	let parent_container: HTMLDivElement;
 
 	onMount(() => {
@@ -172,29 +158,25 @@
 		>
 			<div class:code-editor-border={loaded} class="code-editor">
 				<div style="flex-grow: 1;">
-					{#if loaded}
-						<Code
-							bind:value={code}
-							label=""
-							language="python"
-							target={dummy_elem}
-							gradio={dummy_gradio}
-							lines={10}
-							interactive={true}
-							loading_status={dummy_loading_status}
-						/>
-					{:else}
-						<Code
-							bind:value={code}
-							label=""
-							language="python"
-							target={dummy_elem}
-							gradio={dummy_gradio}
-							lines={10}
-							interactive={false}
-							loading_status={dummy_loading_status}
-						/>
-					{/if}
+					<Block>
+						{#if loaded}
+							<Code
+								bind:value={code}
+								language="python"
+								lines={10}
+								readonly={false}
+								dark_mode={active_theme_mode === "dark"}
+							/>
+						{:else}
+							<Code
+								bind:value={code}
+								language="python"
+								lines={10}
+								readonly={false}
+								dark_mode={active_theme_mode === "dark"}
+							/>
+						{/if}
+					</Block>
 				</div>
 			</div>
 			{#if loaded}

--- a/js/app/src/lite/Playground.svelte
+++ b/js/app/src/lite/Playground.svelte
@@ -4,7 +4,7 @@
 	import { mount_css as default_mount_css } from "../css";
 	import type { Client as ClientType } from "@gradio/client";
 	import type { WorkerProxy } from "@gradio/wasm";
-	import { createEventDispatcher, onMount } from "svelte";
+	import { createEventDispatcher, onMount, SvelteComponent } from "svelte";
 	import { Block } from "@gradio/atoms";
 	import { BaseCode as Code } from "@gradio/code";
 	import ErrorDisplay from "./ErrorDisplay.svelte";
@@ -43,10 +43,15 @@
 		loaded = true;
 	});
 
+	let is_editing = false;
 	function shortcut_run(e: KeyboardEvent): void {
 		if (e.key == "Enter" && (e.metaKey || e.ctrlKey)) {
-			dispatch("code", { code });
 			e.preventDefault();
+
+			if (!is_editing) {
+				return;
+			}
+			dispatch("code", { code });
 		}
 	}
 
@@ -104,8 +109,8 @@
 	let parent_container: HTMLDivElement;
 
 	onMount(() => {
-		var code_editors = document.getElementsByClassName("code-editor");
-		for (var i = 0; i < code_editors.length; i++) {
+		const code_editors = document.getElementsByClassName("code-editor");
+		for (let i = 0; i < code_editors.length; i++) {
 			code_editors[i].addEventListener(
 				"keydown",
 				shortcut_run as EventListener,
@@ -113,6 +118,17 @@
 			);
 		}
 		active_theme_mode = handle_theme_mode(parent_container);
+
+		return () => {
+			const code_editors = document.getElementsByClassName("code-editor");
+			for (var i = 0; i < code_editors.length; i++) {
+				code_editors[i].removeEventListener(
+					"keydown",
+					shortcut_run as EventListener,
+					true
+				);
+			}
+		};
 	});
 
 	$: loading_text;
@@ -166,6 +182,12 @@
 								lines={10}
 								readonly={false}
 								dark_mode={active_theme_mode === "dark"}
+								on:focus={() => {
+									is_editing = true;
+								}}
+								on:blur={() => {
+									is_editing = false;
+								}}
 							/>
 						{:else}
 							<Code
@@ -174,6 +196,12 @@
 								lines={10}
 								readonly={false}
 								dark_mode={active_theme_mode === "dark"}
+								on:focus={() => {
+									is_editing = true;
+								}}
+								on:blur={() => {
+									is_editing = false;
+								}}
 							/>
 						{/if}
 					</Block>


### PR DESCRIPTION
## Description

This is not for a specific issue, but just a refactoring what I found during another work.
By using `{ BaseCode }` instead of `Code` exported from `@gradio/code`, we can remove some boilerplates.