### PR TITLE
Hide embedded components while loading 

### DIFF
--- a/js/_website/src/lib/assets/style.css
+++ b/js/_website/src/lib/assets/style.css
@@ -309,6 +309,10 @@ strong {
 .embedded-component .gradio-container footer {
 	display: none !important;
 }
+.embedded-component:has(.loading) {
+	visibility: hidden;
+	height: 0;
+}
 
 .obj .codeblock {
 	@apply my-4;


### PR DESCRIPTION
Hides the embedded components from the screen while they're loading. 

Before: 

