### PR TITLE
Set the default format of gr.Plot as png for Wasm mode

### DIFF
--- a/.changeset/three-eyes-know.md
+++ b/.changeset/three-eyes-know.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Set the default format of gr.Plot as png for Wasm mode

--- a/.changeset/three-eyes-know.md
+++ b/.changeset/three-eyes-know.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Set the default format of gr.Plot as png for Wasm mode

--- a/gradio/components/plot.py
+++ b/gradio/components/plot.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from gradio_client.documentation import document
 
-from gradio import processing_utils
+from gradio import processing_utils, wasm_utils
 from gradio.components.base import Component
 from gradio.data_classes import GradioModel
 from gradio.events import Events
@@ -44,7 +44,9 @@ class Plot(Component):
         self,
         value: Any | None = None,
         *,
-        format: str = "webp",
+        format: str = "png"
+        if wasm_utils.IS_WASM
+        else "webp",  # webp is a good default for speed (see #7845) but can't be used in Wasm because the the version of matplotlib used in Wasm (3.5.2 in the case of Pyodide 0.26.1) doesn't support it.
         label: str | None = None,
         every: Timer | float | None = None,
         inputs: Component | list[Component] | set[Component] | None = None,


### PR DESCRIPTION
## Description

Context: #8770

`gr.Plot` renders the plot before encoding it in `postprocess` by using `matplotlib`,
but the installed version of it in Wasm (3.5.2) doesn't support the `webp` format which is the default of the component. So use `png` as the default instead in Wasm.
`webp` itself is a good default for speed in general: https://github.com/gradio-app/gradio/pull/7845#issuecomment-2050668343
