### PR TITLE
Ensure `ImageEditor` brush color can be updated with `gr.update`

### DIFF
--- a/.changeset/silver-emus-attend.md
+++ b/.changeset/silver-emus-attend.md
@@ -1,0 +1,6 @@
+---
+"@gradio/imageeditor": patch
+"gradio": patch
+---
+
+fix:Ensure `ImageEditor` brush color can be updated with `gr.update`

--- a/js/imageeditor/shared/tools/Brush.svelte
+++ b/js/imageeditor/shared/tools/Brush.svelte
@@ -64,7 +64,7 @@
 		register_context,
 		editor_box,
 		crop,
-		toolbar_box,
+		toolbar_box
 	} = getContext<EditorContext>(EDITOR_KEY);
 
 	const { active_tool, register_tool, current_color } =
@@ -98,7 +98,7 @@
 			$pixi.renderer!,
 			$pixi.layer_container,
 			$current_layer,
-			mode,
+			mode
 		);
 
 		draw.start({
@@ -106,7 +106,7 @@
 			y: event.screen.y,
 			color: selected_color || undefined,
 			size: selected_size,
-			opacity: 1,
+			opacity: 1
 		});
 	}
 
@@ -129,7 +129,7 @@
 		if (drawing) {
 			draw.continue({
 				x: event.screen.x,
-				y: event.screen.y,
+				y: event.screen.y
 			});
 		}
 
@@ -151,7 +151,7 @@
 		if (brush_cursor) {
 			pos = {
 				x: event.clientX - $editor_box.child_left,
-				y: event.clientY - $editor_box.child_top,
+				y: event.clientY - $editor_box.child_top
 			};
 		}
 	}
@@ -171,11 +171,11 @@
 					brush_cursor = true;
 					document.body.style.cursor = "none";
 				}
-			},
+			}
 		);
 		$pixi?.layer_container[on_off](
 			"pointerleave",
-			() => ((brush_cursor = false), (document.body.style.cursor = "auto")),
+			() => ((brush_cursor = false), (document.body.style.cursor = "auto"))
 		);
 	}
 
@@ -185,12 +185,12 @@
 		},
 		reset_fn: () => {
 			toggle_listeners("off");
-		},
+		}
 	});
 
 	onMount(() => {
 		const unregister = register_tool(mode, {
-			cb: toggle_options,
+			cb: toggle_options
 		});
 
 		return () => {

--- a/js/imageeditor/shared/tools/Brush.svelte
+++ b/js/imageeditor/shared/tools/Brush.svelte
@@ -43,11 +43,11 @@
 	export let color_mode: Brush["color_mode"] | undefined = undefined;
 	export let mode: "erase" | "draw";
 
-	const processed_colors = colors
+	$: processed_colors = colors
 		? colors.map(process_color).filter((_, i) => i < 4)
 		: [];
 
-	let selected_color =
+	$: selected_color =
 		default_color === "auto"
 			? processed_colors[0]
 			: !default_color
@@ -64,7 +64,7 @@
 		register_context,
 		editor_box,
 		crop,
-		toolbar_box
+		toolbar_box,
 	} = getContext<EditorContext>(EDITOR_KEY);
 
 	const { active_tool, register_tool, current_color } =
@@ -98,7 +98,7 @@
 			$pixi.renderer!,
 			$pixi.layer_container,
 			$current_layer,
-			mode
+			mode,
 		);
 
 		draw.start({
@@ -106,7 +106,7 @@
 			y: event.screen.y,
 			color: selected_color || undefined,
 			size: selected_size,
-			opacity: 1
+			opacity: 1,
 		});
 	}
 
@@ -129,7 +129,7 @@
 		if (drawing) {
 			draw.continue({
 				x: event.screen.x,
-				y: event.screen.y
+				y: event.screen.y,
 			});
 		}
 
@@ -151,7 +151,7 @@
 		if (brush_cursor) {
 			pos = {
 				x: event.clientX - $editor_box.child_left,
-				y: event.clientY - $editor_box.child_top
+				y: event.clientY - $editor_box.child_top,
 			};
 		}
 	}
@@ -171,11 +171,11 @@
 					brush_cursor = true;
 					document.body.style.cursor = "none";
 				}
-			}
+			},
 		);
 		$pixi?.layer_container[on_off](
 			"pointerleave",
-			() => ((brush_cursor = false), (document.body.style.cursor = "auto"))
+			() => ((brush_cursor = false), (document.body.style.cursor = "auto")),
 		);
 	}
 
@@ -185,12 +185,12 @@
 		},
 		reset_fn: () => {
 			toggle_listeners("off");
-		}
+		},
 	});
 
 	onMount(() => {
 		const unregister = register_tool(mode, {
-			cb: toggle_options
+			cb: toggle_options,
 		});
 
 		return () => {


### PR DESCRIPTION
## Description

Fixes #6611.

This can be tested with the following reproduction:

```py
import gradio as gr


with gr.Blocks() as demo:
    img = gr.ImageEditor(
        brush=gr.Brush(
            default_color="rgb(200, 200, 200)",
            colors=["rgb(200, 200, 200)"],
            color_mode="fixed",
        ),
        interactive=True,
    )

    change_color = gr.Button(
        value="Change color",
    )

    change_color.click(
        fn=lambda: gr.update(
            brush=gr.Brush(default_color="rgb(0, 0, 0)", colors=["rgb(0, 0, 0)"])
        ),
        inputs=None,
        outputs=img,
    )

demo.launch(height=1024)
```

This does nothing on main but works in this PR.