### PR TITLE
Fix Lite's <Playground />

### DIFF
--- a/.changeset/full-hats-hunt.md
+++ b/.changeset/full-hats-hunt.md
@@ -1,0 +1,7 @@
+---
+"@gradio/app": minor
+"@gradio/code": minor
+"gradio": minor
+---
+
+feat:Fix Lite's <Playground />

--- a/js/app/src/lite/Playground.svelte
+++ b/js/app/src/lite/Playground.svelte
@@ -158,57 +158,53 @@
 			class="child-container"
 		>
 			<div class:code-editor-border={loaded} class="code-editor">
-				<div style="flex-grow: 1;">
-					<Block variant={"solid"} padding={false}>
-						{#if loaded}
-							<Code
-								bind:value={code}
-								language="python"
-								lines={10}
-								readonly={false}
-								dark_mode={active_theme_mode === "dark"}
-							/>
-						{:else}
-							<Code
-								bind:value={code}
-								language="python"
-								lines={10}
-								readonly={true}
-								dark_mode={active_theme_mode === "dark"}
-							/>
-						{/if}
-					</Block>
-				</div>
+				<Block variant={"solid"} padding={false}>
+					{#if loaded}
+						<Code
+							bind:value={code}
+							language="python"
+							lines={10}
+							readonly={false}
+							dark_mode={active_theme_mode === "dark"}
+						/>
+					{:else}
+						<Code
+							bind:value={code}
+							language="python"
+							lines={10}
+							readonly={true}
+							dark_mode={active_theme_mode === "dark"}
+						/>
+					{/if}
+				</Block>
 			</div>
 			{#if loaded}
 				<div class="preview">
-					<div class="flex-grow: 1;">
-						{#if !error_display}
-							<Index
-								{autoscroll}
-								{version}
-								{initial_height}
-								{app_mode}
-								{is_embed}
-								{theme_mode}
-								{control_page_title}
-								{container}
-								{info}
-								{eager}
-								{mount_css}
-								{Client}
-								bind:worker_proxy
-								{space}
-								{host}
-								{src}
-							/>
-						{:else}
-							<ErrorDisplay
-								is_embed={error_display.is_embed}
-								error={error_display.error}
-							/>
-						{/if}
-					</div>
+					{#if !error_display}
+						<Index
+							{autoscroll}
+							{version}
+							{initial_height}
+							{app_mode}
+							{is_embed}
+							{theme_mode}
+							{control_page_title}
+							{container}
+							{info}
+							{eager}
+							{mount_css}
+							{Client}
+							bind:worker_proxy
+							{space}
+							{host}
+							{src}
+						/>
+					{:else}
+						<ErrorDisplay
+							is_embed={error_display.is_embed}
+							error={error_display.error}
+						/>
+					{/if}
 				</div>
 			{/if}
 		</div>

--- a/js/app/src/lite/Playground.svelte
+++ b/js/app/src/lite/Playground.svelte
@@ -4,7 +4,7 @@
 	import { mount_css as default_mount_css } from "../css";
 	import type { Client as ClientType } from "@gradio/client";
 	import type { WorkerProxy } from "@gradio/wasm";
-	import { SvelteComponent, createEventDispatcher, onMount } from "svelte";
+	import { createEventDispatcher, onMount } from "svelte";
 	import { Block } from "@gradio/atoms";
 	import { BaseCode as Code } from "@gradio/code";
 	import ErrorDisplay from "./ErrorDisplay.svelte";
@@ -29,7 +29,7 @@
 	export let src: string | null;
 
 	export let code: string | undefined;
-	export let error_display: SvelteComponent | null;
+	export let error_display: { is_embed: boolean; error: Error } | null;
 	export let layout: string | null = null;
 
 	const dispatch = createEventDispatcher();

--- a/js/app/src/lite/Playground.svelte
+++ b/js/app/src/lite/Playground.svelte
@@ -104,16 +104,15 @@
 	let active_theme_mode: Exclude<ThemeMode, "system"> = "light";
 	let parent_container: HTMLDivElement;
 
+	let code_editor_container: HTMLDivElement;
 	onMount(() => {
-		var code_editors = document.getElementsByClassName("code-editor");
-		for (var i = 0; i < code_editors.length; i++) {
-			code_editors[i].addEventListener(
-				"keydown",
-				shortcut_run as EventListener,
-				true
-			);
-		}
 		active_theme_mode = handle_theme_mode(parent_container);
+
+		code_editor_container.addEventListener("keydown", shortcut_run, true);
+
+		return () => {
+			code_editor_container.removeEventListener("keydown", shortcut_run, true);
+		};
 	});
 
 	$: loading_text;
@@ -157,7 +156,11 @@
 			class:vertical={layout === "vertical"}
 			class="child-container"
 		>
-			<div class:code-editor-border={loaded} class="code-editor">
+			<div
+				class:code-editor-border={loaded}
+				class="code-editor"
+				bind:this={code_editor_container}
+			>
 				<Block variant={"solid"} padding={false}>
 					<Code
 						bind:value={code}

--- a/js/app/src/lite/Playground.svelte
+++ b/js/app/src/lite/Playground.svelte
@@ -159,23 +159,13 @@
 		>
 			<div class:code-editor-border={loaded} class="code-editor">
 				<Block variant={"solid"} padding={false}>
-					{#if loaded}
-						<Code
-							bind:value={code}
-							language="python"
-							lines={10}
-							readonly={false}
-							dark_mode={active_theme_mode === "dark"}
-						/>
-					{:else}
-						<Code
-							bind:value={code}
-							language="python"
-							lines={10}
-							readonly={true}
-							dark_mode={active_theme_mode === "dark"}
-						/>
-					{/if}
+					<Code
+						bind:value={code}
+						language="python"
+						lines={10}
+						readonly={!loaded}
+						dark_mode={active_theme_mode === "dark"}
+					/>
 				</Block>
 			</div>
 			{#if loaded}

--- a/js/app/src/lite/Playground.svelte
+++ b/js/app/src/lite/Playground.svelte
@@ -93,7 +93,6 @@
 
 	function apply_theme(target: HTMLDivElement, theme: "dark" | "light"): void {
 		const dark_class_element = is_embed ? target.parentElement! : document.body;
-		const bg_element = is_embed ? target : target.parentElement!;
 		if (theme === "dark") {
 			dark_class_element.classList.add("dark");
 		} else {

--- a/js/app/src/lite/Playground.svelte
+++ b/js/app/src/lite/Playground.svelte
@@ -5,10 +5,10 @@
 	import type { Client as ClientType } from "@gradio/client";
 	import type { WorkerProxy } from "@gradio/wasm";
 	import { SvelteComponent, createEventDispatcher, onMount } from "svelte";
-	import Code from "@gradio/code";
+	import { Block } from "@gradio/atoms";
+	import { BaseCode as Code } from "@gradio/code";
 	import ErrorDisplay from "./ErrorDisplay.svelte";
 	import lightning from "../images/lightning.svg";
-	import type { LoadingStatus } from "js/statustracker";
 
 	export let autoscroll: boolean;
 	export let version: string;
@@ -33,19 +33,6 @@
 	export let layout: string | null = null;
 
 	const dispatch = createEventDispatcher();
-
-	let dummy_elem: any = { classList: { contains: () => false } };
-	let dummy_gradio: any = { dispatch: (_: any) => {} };
-	let dummy_loading_status: LoadingStatus = {
-		eta: 0,
-		queue_position: 0,
-		queue_size: 0,
-		status: "complete",
-		show_progress: "hidden",
-		scroll_to_output: false,
-		visible: false,
-		fn_index: 0
-	};
 
 	let loading_text = "";
 	export let loaded = false;
@@ -114,7 +101,7 @@
 		}
 	}
 
-	let active_theme_mode: ThemeMode;
+	let active_theme_mode: Exclude<ThemeMode, "system"> = "light";
 	let parent_container: HTMLDivElement;
 
 	onMount(() => {
@@ -172,29 +159,25 @@
 		>
 			<div class:code-editor-border={loaded} class="code-editor">
 				<div style="flex-grow: 1;">
-					{#if loaded}
-						<Code
-							bind:value={code}
-							label=""
-							language="python"
-							target={dummy_elem}
-							gradio={dummy_gradio}
-							lines={10}
-							interactive={true}
-							loading_status={dummy_loading_status}
-						/>
-					{:else}
-						<Code
-							bind:value={code}
-							label=""
-							language="python"
-							target={dummy_elem}
-							gradio={dummy_gradio}
-							lines={10}
-							interactive={false}
-							loading_status={dummy_loading_status}
-						/>
-					{/if}
+					<Block variant={"solid"} padding={false}>
+						{#if loaded}
+							<Code
+								bind:value={code}
+								language="python"
+								lines={10}
+								readonly={false}
+								dark_mode={active_theme_mode === "dark"}
+							/>
+						{:else}
+							<Code
+								bind:value={code}
+								language="python"
+								lines={10}
+								readonly={true}
+								dark_mode={active_theme_mode === "dark"}
+							/>
+						{/if}
+					</Block>
 				</div>
 			</div>
 			{#if loaded}

--- a/js/code/shared/Code.svelte
+++ b/js/code/shared/Code.svelte
@@ -41,7 +41,7 @@
 		lang_extension = ext;
 	}
 
-	$: reconfigure(), lang_extension;
+	$: reconfigure(), lang_extension, readonly;
 	$: set_doc(value);
 	$: update_lines();
 


### PR DESCRIPTION
## Description

* Use `BaseCode` instead of `Code` which made the code simpler getting rid of `dummy_*` variables.
* Fixes [this issue](https://github.com/gradio-app/gradio/pull/7660#discussion_r1530483279) in e5dff89
* Attach the KeyDown event listener only to the DOM element inside the `<Playground />` component instead of searching all DOMs from the page so that "ctrl+Enter" key-down in a specific playground element in a page only triggers rerunning of that component, avoiding affecting other embedded playgrounds: a2eac0b