### PR TITLE
fix: wrong named param check for js client

### DIFF
--- a/client/js/src/helpers/api_info.ts
+++ b/client/js/src/helpers/api_info.ts
@@ -1,4 +1,4 @@
-import type { Status } from "../types";
+import type { EndpointInfo, Status } from "../types";
 import {
 	HOST_URL,
 	INVALID_URL_MSG,
@@ -384,11 +384,9 @@ export function handle_message(
 
 export const map_data_to_params = (
 	data: unknown[] | Record<string, unknown> = [],
-	api_info: ApiInfo<JsApiData | ApiData>
+	endpoint_info: EndpointInfo<JsApiData | ApiData>
 ): unknown[] => {
-	const parameters = Object.values(api_info.named_endpoints).flatMap(
-		(values) => values.parameters
-	);
+	const parameters = endpoint_info.parameters;
 
 	if (Array.isArray(data)) {
 		if (data.length > parameters.length) {

--- a/client/js/src/test/api_info.test.ts
+++ b/client/js/src/test/api_info.test.ts
@@ -573,31 +573,33 @@ describe("map_data_params", () => {
 		}
 	];
 
+	let endpoint_info = test_data.named_endpoints["/predict"];
+
 	it("should return an array of data when data is an array", () => {
 		const data = [1, 2];
 
-		const result = map_data_to_params(data, transformed_api_info);
+		const result = map_data_to_params(data, endpoint_info);
 		expect(result).toEqual(data);
 	});
 
 	it("should return an empty array when data is an empty array", () => {
 		const data = [];
 
-		const result = map_data_to_params(data, transformed_api_info);
+		const result = map_data_to_params(data, endpoint_info);
 		expect(result).toEqual(data);
 	});
 
 	it("should return an empty array when data is not defined", () => {
 		const data = undefined;
 
-		const result = map_data_to_params(data, transformed_api_info);
+		const result = map_data_to_params(data, endpoint_info);
 		expect(result).toEqual([]);
 	});
 
 	it("should return the data when too many arguments are provided for the endpoint", () => {
 		const data = [1, 2, 3, 4];
 
-		const result = map_data_to_params(data, transformed_api_info);
+		const result = map_data_to_params(data, endpoint_info);
 		expect(result).toEqual(data);
 	});
 
@@ -608,7 +610,7 @@ describe("map_data_params", () => {
 			param3: 3
 		};
 
-		const result = map_data_to_params(data, transformed_api_info);
+		const result = map_data_to_params(data, endpoint_info);
 		expect(result).toEqual([1, 2, 3]);
 	});
 
@@ -618,7 +620,7 @@ describe("map_data_params", () => {
 			param2: 2
 		};
 
-		const result = map_data_to_params(data, transformed_api_info);
+		const result = map_data_to_params(data, endpoint_info);
 		expect(result).toEqual([1, 2, 3]);
 	});
 
@@ -630,7 +632,7 @@ describe("map_data_params", () => {
 			param4: 4
 		};
 
-		expect(() => map_data_to_params(data, transformed_api_info)).toThrowError(
+		expect(() => map_data_to_params(data, endpoint_info)).toThrowError(
 			"Parameter `param4` is not a valid keyword argument. Please refer to the API for usage."
 		);
 	});
@@ -638,7 +640,7 @@ describe("map_data_params", () => {
 	it("should throw an error when no value is provided for a required parameter", () => {
 		const data = {};
 
-		expect(() => map_data_to_params(data, transformed_api_info)).toThrowError(
+		expect(() => map_data_to_params(data, endpoint_info)).toThrowError(
 			"No value provided for required parameter: param1"
 		);
 	});

--- a/client/js/src/utils/submit.ts
+++ b/client/js/src/utils/submit.ts
@@ -61,7 +61,7 @@ export function submit(
 			config
 		);
 
-		let resolved_data = map_data_to_params(data, api_info);
+		let resolved_data = map_data_to_params(data, endpoint_info);
 
 		let websocket: WebSocket;
 		let stream: EventSource | null;


### PR DESCRIPTION
## Description

The `map_data_to_params` function checks all parameters on all endpoints and causes a failure if a required parameter from another endpoint is not provided.

`map_data_to_params` should check parameters based on each endpoint, not the entire API.

Closes: #8819 

## Potential Improvement

Currently, my implementation passes the endpoint information (parameters, returns, etc.) into `map_data_to_params`, but only the parameters are used. It might be better to pass only the parameters.
