### PR TITLE
Fix dependency loop with statustracker and markdown 

### DIFF
--- a/.changeset/swift-ghosts-spend.md
+++ b/.changeset/swift-ghosts-spend.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/statustracker": minor
-"gradio": minor
+"@gradio/statustracker": patch
+"gradio": patch
 ---
 
 feat:Fix dependency loop with statustracker and markdown 

--- a/.changeset/swift-ghosts-spend.md
+++ b/.changeset/swift-ghosts-spend.md
@@ -1,0 +1,6 @@
+---
+"@gradio/statustracker": minor
+"gradio": minor
+---
+
+feat:Fix dependency loop with statustracker and markdown 

--- a/js/statustracker/package.json
+++ b/js/statustracker/package.json
@@ -18,7 +18,7 @@
 		"@gradio/atoms": "workspace:^",
 		"@gradio/icons": "workspace:^",
 		"@gradio/utils": "workspace:^",
-		"@gradio/markdown": "workspace:^"
+		"dompurify": "^3.0.3"
 	},
 	"devDependencies": {
 		"@gradio/preview": "workspace:^"

--- a/js/statustracker/package.json
+++ b/js/statustracker/package.json
@@ -18,7 +18,8 @@
 		"@gradio/atoms": "workspace:^",
 		"@gradio/icons": "workspace:^",
 		"@gradio/utils": "workspace:^",
-		"dompurify": "^3.0.3"
+		"dompurify": "^3.0.3",
+		"@types/dompurify": "^3.0.2"
 	},
 	"devDependencies": {
 		"@gradio/preview": "workspace:^"

--- a/js/statustracker/static/ToastContent.svelte
+++ b/js/statustracker/static/ToastContent.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Error, Info, Warning } from "@gradio/icons";
-	import { MarkdownCode } from "@gradio/markdown";
+	import DOMPurify from "dompurify";
 	import { createEventDispatcher, onMount } from "svelte";
 	import { fade } from "svelte/transition";
 	import type { ToastMessage } from "./types";
@@ -10,6 +10,26 @@
 	export let id: number;
 	export let duration: number | null = 10;
 	export let visible = true;
+
+	const is_external_url = (link: string | null): boolean => {
+		try {
+			return !!link && new URL(link, location.href).origin !== location.origin;
+		} catch (e) {
+			return false;
+		}
+	};
+
+	DOMPurify.addHook("afterSanitizeAttributes", function (node) {
+		if ("target" in node) {
+			if (is_external_url(node.getAttribute("href"))) {
+				node.setAttribute("target", "_blank");
+				node.setAttribute("rel", "noopener noreferrer");
+			}
+		}
+	});
+
+	$: message = DOMPurify.sanitize(message);
+
 
 	$: display = visible;
 	$: duration = duration || null;
@@ -56,7 +76,7 @@
 	<div class="toast-details {type}">
 		<div class="toast-title {type}">{type}</div>
 		<div class="toast-text {type}">
-			<MarkdownCode {message} chatbot={false} render_markdown={false} />
+			{@html message}
 		</div>
 	</div>
 

--- a/js/statustracker/static/ToastContent.svelte
+++ b/js/statustracker/static/ToastContent.svelte
@@ -30,7 +30,6 @@
 
 	$: message = DOMPurify.sanitize(message);
 
-
 	$: display = visible;
 	$: duration = duration || null;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1822,12 +1822,12 @@ importers:
       '@gradio/icons':
         specifier: workspace:^
         version: link:../icons
-      '@gradio/markdown':
-        specifier: workspace:^
-        version: link:../markdown
       '@gradio/utils':
         specifier: workspace:^
         version: link:../utils
+      dompurify:
+        specifier: ^3.0.3
+        version: 3.0.3
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1825,6 +1825,9 @@ importers:
       '@gradio/utils':
         specifier: workspace:^
         version: link:../utils
+      '@types/dompurify':
+        specifier: ^3.0.2
+        version: 3.0.2
       dompurify:
         specifier: ^3.0.3
         version: 3.0.3


### PR DESCRIPTION
There's a dependency loop introduced by https://github.com/gradio-app/gradio/pull/8817 where statustracker imports markdown which imports statustracker. 

This PR implements https://github.com/gradio-app/gradio/pull/8817 without using markdown. 