### PR TITLE
Latex Rendering Fix

### DIFF
--- a/.changeset/huge-donuts-draw.md
+++ b/.changeset/huge-donuts-draw.md
@@ -1,0 +1,6 @@
+---
+"@gradio/markdown": patch
+"gradio": patch
+---
+
+fix:Latex Rendering Fix

--- a/js/markdown/shared/MarkdownCode.svelte
+++ b/js/markdown/shared/MarkdownCode.svelte
@@ -45,24 +45,33 @@
 		}
 	});
 
+	function escapeRegExp(string: string): string {
+		return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	}
+
 	function process_message(value: string): string {
 		let parsedValue = value;
 
 		if (render_markdown) {
 			const latexBlocks: string[] = [];
-			parsedValue = parsedValue.replace(
-				/\$\$([\s\S]+?)\$\$/g,
-				(match, p1, offset) => {
+			latex_delimiters.forEach((delimiter, index) => {
+				const leftDelimiter = escapeRegExp(delimiter.left);
+				const rightDelimiter = escapeRegExp(delimiter.right);
+				const regex = new RegExp(
+					`${leftDelimiter}([\\s\\S]+?)${rightDelimiter}`,
+					"g"
+				);
+				parsedValue = parsedValue.replace(regex, (match) => {
 					latexBlocks.push(match);
 					return `%%%LATEX_BLOCK_${latexBlocks.length - 1}%%%`;
-				}
-			);
+				});
+			});
 
 			parsedValue = marked.parse(parsedValue) as string;
 
 			parsedValue = parsedValue.replace(
 				/%%%LATEX_BLOCK_(\d+)%%%/g,
-				(match, p1) => latexBlocks[parseInt(p1, 10)]
+				(p1) => latexBlocks[parseInt(p1, 10)]
 			);
 		}
 

--- a/js/markdown/shared/MarkdownCode.svelte
+++ b/js/markdown/shared/MarkdownCode.svelte
@@ -61,7 +61,7 @@
 					`${leftDelimiter}([\\s\\S]+?)${rightDelimiter}`,
 					"g"
 				);
-				parsedValue = parsedValue.replace(regex, (match) => {
+				parsedValue = parsedValue.replace(regex, (match, p1) => {
 					latexBlocks.push(match);
 					return `%%%LATEX_BLOCK_${latexBlocks.length - 1}%%%`;
 				});
@@ -71,7 +71,7 @@
 
 			parsedValue = parsedValue.replace(
 				/%%%LATEX_BLOCK_(\d+)%%%/g,
-				(p1) => latexBlocks[parseInt(p1, 10)]
+				(match, p1) => latexBlocks[parseInt(p1, 10)]
 			);
 		}
 


### PR DESCRIPTION
## Description
Fixes how latex is rendered. there was an issue where the markdown parser would apply its rules to latex equations which would cause rendering issues.


Closes: #8780

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
