### PR TITLE
Fix param table rendering 

### DIFF
--- a/.changeset/huge-pears-like.md
+++ b/.changeset/huge-pears-like.md
@@ -1,5 +1,5 @@
 ---
-"website": minor
+"website": patch
 ---
 
 feat:Fix param table rendering 

--- a/.changeset/huge-pears-like.md
+++ b/.changeset/huge-pears-like.md
@@ -1,0 +1,5 @@
+---
+"website": minor
+---
+
+feat:Fix param table rendering 

--- a/js/_website/src/routes/[[version]]/docs/gradio/[doc]/+page.svelte
+++ b/js/_website/src/routes/[[version]]/docs/gradio/[doc]/+page.svelte
@@ -92,6 +92,7 @@
 	canonical={$page.url.pathname}
 	description={"Gradio docs for using " + all_headers.page_title.title}
 />
+<link rel="stylesheet" href="https://gradio-hello-world.hf.space/theme.css" />
 
 <svelte:window bind:scrollY={y} />
 


### PR DESCRIPTION
What's happening is paramviewer's styling references css variables defined in the gradio theme, which is not on the page. The simplest fix i could think of was to just import the stylesheet from here: https://gradio-hello-world.hf.space/theme.css

I already do that for lite demos on the website. Which is why you'll only see this error when directly navigating to a page without demos or embedded components, for example: https://www.gradio.app/docs/gradio/render