### PR TITLE
Fix build for pre-release

### DIFF
--- a/.changeset/nasty-clowns-show.md
+++ b/.changeset/nasty-clowns-show.md
@@ -1,0 +1,6 @@
+---
+"@gradio/app": minor
+"gradio": minor
+---
+
+feat:Fix build for pre-release

--- a/.changeset/nasty-clowns-show.md
+++ b/.changeset/nasty-clowns-show.md
@@ -1,6 +1,7 @@
 ---
 "@gradio/app": minor
 "gradio": minor
+"website": minor
 ---
 
 feat:Fix build for pre-release

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -67,7 +67,7 @@ jobs:
       - name: build client
         run: pnpm --filter @gradio/client build
       - name: deploy json to aws
-        if: needs.changes.outputs.source_branch == 'changeset-release/main' && needs.changes.outputs.source_repo == 'gradio-app/gradio'
+        if: startsWith(needs.changes.outputs.source_branch, 'changeset-release/') && needs.changes.outputs.source_repo == 'gradio-app/gradio'
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWSACCESSKEYID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWSSECRETKEY }}

--- a/js/_website/generate_jsons/generate.py
+++ b/js/_website/generate_jsons/generate.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from subprocess import run
 import boto3
 from botocore import UNSIGNED
@@ -11,45 +12,79 @@ WEBSITE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 GRADIO_DIR = os.path.abspath(os.path.join(WEBSITE_DIR, "..", "..", "gradio"))
 ROOT_DIR = os.path.abspath(os.path.join(WEBSITE_DIR, "..", ".."))
 
+
 def make_dir(root, path):
     return os.path.abspath(os.path.join(root, path))
 
+
 def download_from_s3(bucket_name, s3_folder, local_dir):
-    print("Downloading templates from S3: " + bucket_name + "/" + s3_folder + " to " + local_dir)
-    s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))
+    print(
+        "Downloading templates from S3: "
+        + bucket_name
+        + "/"
+        + s3_folder
+        + " to "
+        + local_dir
+    )
+    s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
     objects = s3.list_objects_v2(Bucket=bucket_name, Prefix=s3_folder)
-    for obj in objects.get('Contents', []):
-        s3_key = obj['Key']
+    for obj in objects.get("Contents", []):
+        s3_key = obj["Key"]
         local_file_path = os.path.join(local_dir, os.path.relpath(s3_key, s3_folder))
         if not os.path.exists(os.path.dirname(local_file_path)):
             os.makedirs(os.path.dirname(local_file_path))
         s3.download_file(bucket_name, s3_key, local_file_path)
 
-   
+
+def convert_to_pypi_prerelease(version: str) -> str:
+    def replacement(match):
+        v, tag, tag_version = match.groups()
+        if tag == "beta":
+            return f"{v}b{tag_version}"
+        elif tag == "alpha":
+            return f"{v}a{tag_version}"
+        else:
+            return version
+
+    return re.sub(r"(\d+\.\d+\.\d+)-([-a-z]+)\.(\d+)", replacement, version)
+
+
 def get_latest_release():
     with open(make_dir(ROOT_DIR, "client/js/package.json")) as f:
         js_client_version = json.load(f)["version"]
     with open(make_dir(GRADIO_DIR, "package.json")) as f:
-        version = json.load(f)["version"]
+        version = convert_to_pypi_prerelease(json.load(f)["version"])
         with open(make_dir(WEBSITE_DIR, "src/lib/json/version.json"), "w+") as j:
-            json.dump({
-                "version": version
-                }, j)
+            json.dump({"version": version}, j)
         with open(make_dir(WEBSITE_DIR, "src/lib/json/wheel.json"), "w+") as j:
-            sha = run(["git", "log", "-1", "--format='%H'"], capture_output=True).stdout.decode("utf-8").strip("'\n")
-            json.dump({
-                        "gradio_install": f"pip install https://gradio-builds.s3.amazonaws.com/{sha}/gradio-{version}-py3-none-any.whl",
-                        "gradio_py_client_install": f"pip install 'gradio-client @ git+https://github.com/gradio-app/gradio@{sha}#subdirectory=client/python'",
-                        "gradio_js_client_install": f"npm install https://gradio-builds.s3.amazonaws.com/{sha}/gradio-client-{js_client_version}.tgz",
-                        }, j)
-        if not os.path.exists(make_dir(WEBSITE_DIR, f"src/lib/templates_{version.replace('.', '-')}")):
-            download_from_s3("gradio-docs-json", f"{version}/templates/", make_dir(WEBSITE_DIR, f"src/lib/templates_{version.replace('.', '-')}"))
+            sha = (
+                run(["git", "log", "-1", "--format='%H'"], capture_output=True)
+                .stdout.decode("utf-8")
+                .strip("'\n")
+            )
+            json.dump(
+                {
+                    "gradio_install": f"pip install https://gradio-builds.s3.amazonaws.com/{sha}/gradio-{version}-py3-none-any.whl",
+                    "gradio_py_client_install": f"pip install 'gradio-client @ git+https://github.com/gradio-app/gradio@{sha}#subdirectory=client/python'",
+                    "gradio_js_client_install": f"npm install https://gradio-builds.s3.amazonaws.com/{sha}/gradio-client-{js_client_version}.tgz",
+                },
+                j,
+            )
+        if not os.path.exists(
+            make_dir(WEBSITE_DIR, f"src/lib/templates_{version.replace('.', '-')}")
+        ):
+            download_from_s3(
+                "gradio-docs-json",
+                f"{version}/templates/",
+                make_dir(WEBSITE_DIR, f"src/lib/templates_{version.replace('.', '-')}"),
+            )
 
-            
+
 def create_dir_if_not_exists(path):
     if not os.path.exists(path):
         os.makedirs(path)
-        
+
+
 create_dir_if_not_exists(make_dir(WEBSITE_DIR, "src/lib/json"))
 create_dir_if_not_exists(make_dir(WEBSITE_DIR, "src/lib/json/guides"))
 

--- a/js/app/vite.config.ts
+++ b/js/app/vite.config.ts
@@ -16,6 +16,23 @@ const version_raw = JSON.parse(
 ).version.trim();
 const version = version_raw.replace(/\./g, "-");
 
+function convert_to_pypi_prerelease(version: string) {
+	return version.replace(
+		/(\d+\.\d+\.\d+)-([-a-z]+)\.(\d+)/,
+		(match, v, tag, tag_version) => {
+			if (tag === "beta") {
+				return `${v}b${tag_version}`;
+			} else if (tag === "alpha") {
+				return `${v}a${tag_version}`;
+			} else {
+				return client_version_raw;
+			}
+		}
+	);
+}
+
+const python_version = convert_to_pypi_prerelease(version_raw);
+
 const client_version_path = resolve(
 	__dirname,
 	"../../client/python/gradio_client/package.json"
@@ -25,6 +42,8 @@ const client_version_raw = JSON.parse(
 		encoding: "utf-8"
 	})
 ).version.trim();
+
+const client_python_version = convert_to_pypi_prerelease(client_version_raw);
 
 import {
 	inject_ejs,
@@ -185,11 +204,11 @@ export default defineConfig(({ mode }) => {
 				// For the Wasm app to import the wheel file URLs.
 				"gradio.whl": resolve(
 					__dirname,
-					`../../dist-lite/gradio-${version_raw}-py3-none-any.whl`
+					`../../dist-lite/gradio-${python_version}-py3-none-any.whl`
 				),
 				"gradio_client.whl": resolve(
 					__dirname,
-					`../../client/python/dist/gradio_client-${client_version_raw}-py3-none-any.whl`
+					`../../client/python/dist/gradio_client-${client_python_version}-py3-none-any.whl`
 				)
 			}
 		},

--- a/js/app/vite.config.ts
+++ b/js/app/vite.config.ts
@@ -25,7 +25,7 @@ function convert_to_pypi_prerelease(version: string) {
 			} else if (tag === "alpha") {
 				return `${v}a${tag_version}`;
 			} else {
-				return client_version_raw;
+				return version;
 			}
 		}
 	);


### PR DESCRIPTION
There is a discrepancy between the version formatting for pre-released which is causing an issue with the build for lite.

- js: `<x.y.z>-<beta|alpha>-<n>` eg: `5.0.0-beta.0`
- python: `<x.y.x><b|a><n>` eg: `5.0.0b0`

This just reformats for lite. This is tested for the v5 branch, if CI here is good I'll merge.