### PR TITLE
Make `update_root_in_config` atomic

### DIFF
--- a/.changeset/tame-clouds-draw.md
+++ b/.changeset/tame-clouds-draw.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Make `update_root_in_config` atomic

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
 
 config_lock = threading.Lock()
 
+
 class Obj:
     """
     Using a class to convert dictionaries into objects. Used by the `Request` class.

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -9,6 +9,7 @@ import os
 import re
 import shutil
 import sys
+import threading
 from collections import deque
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass as python_dataclass
@@ -50,6 +51,8 @@ if TYPE_CHECKING:
     from gradio.blocks import BlockFunction, Blocks
     from gradio.routes import App
 
+
+config_lock = threading.Lock()
 
 class Obj:
     """
@@ -646,10 +649,11 @@ def update_root_in_config(config: BlocksConfigDict, root: str) -> BlocksConfigDi
     root url has changed, all of the urls in the config that correspond to component
     file urls are updated to use the new root url.
     """
-    previous_root = config.get("root")
-    if previous_root is None or previous_root != root:
-        config["root"] = root
-        config = processing_utils.add_root_url(config, root, previous_root)  # type: ignore
+    with config_lock:
+        previous_root = config.get("root")
+        if previous_root is None or previous_root != root:
+            config["root"] = root
+            config = processing_utils.add_root_url(config, root, previous_root)  # type: ignore
     return config
 
 


### PR DESCRIPTION
Making `update_root_in_config` atomic is better from a security perspective. @aliabid94 could you check if this has any performance-related implications?