### PR TITLE
pnpm link deprecated

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -48,7 +48,7 @@ function npm_required() {
 #   None
 #######################################
 function pnpm_required() {
-  program_required "pnpm" "https://pnpm.io/7.x/installation"
+  program_required "pnpm" "https://pnpm.io/installation"
 }
 
 #######################################


### PR DESCRIPTION
Appears that the given pnpm link no longer exists. Suggesting a more generic one.
To get version 7.x, users will need to do the follow (for example, for version 7.1.0): 
`curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION="7.1.0" sh -`
But the gradio error I get suggests it should be ~9.1.0, which would be:
`curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION="9.1.0" sh -`
not sure how you want to handle that.