### PR TITLE
Checking on generalizing an `if` statement in the Video postprocess function

### DIFF
--- a/.changeset/cold-streets-clap.md
+++ b/.changeset/cold-streets-clap.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Checking on generalizing an `if` statement in the Video postprocess function

--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -247,7 +247,7 @@ class Video(Component):
         Returns:
             VideoData object containing the video and subtitle files.
         """
-        if value is None or all(x is None for x in value):
+        if value is None or (isinstance(value, (list, tuple)) and all(x is None for x in value)):
             return None
         if isinstance(value, (str, Path)):
             processed_files = (self._format_video(value), None)

--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -247,7 +247,7 @@ class Video(Component):
         Returns:
             VideoData object containing the video and subtitle files.
         """
-        if value is None or value == [None, None] or value == (None, None):
+        if value is None or all(x is None for x in value):
             return None
         if isinstance(value, (str, Path)):
             processed_files = (self._format_video(value), None)


### PR DESCRIPTION
I'm working on a PR to add the ability to insert watermarks into videos. This shares some logic with adding subtitles and reformatting videos, suggesting that the `postprocess` function for the Video component is a good one for me to add to for the additional functionality.

I'm submitting this PR to see if this one-line change is allowable or if it breaks something that is wholly intentional, such as asserting that the input MUST be a two-item set (tuple or list), and never longer than that. 
If we are a bit more general, allowing longer sets -- and specifically for my case, three items -- then I can pass in a watermark file as well, and we'd also have the flexibility for further additions in the future (metadata? audio? etc.)

An alternative to this PR which would more directly address my use case while also not changing the current logic would be:
`if value is None or value == [None, None] or value == (None, None) or value == [None, None, None] or value == (None, None, None):`
...But that strikes me as a bit nutty, so I thought I would take a step back and check on this more general form.

Would this first change here be okay? If yes, I can finish up the rest to submit the full PR.
  
