### PR TITLE
Fix Chatbot Multimodal Examples

### DIFF
--- a/.changeset/common-poets-retire.md
+++ b/.changeset/common-poets-retire.md
@@ -1,0 +1,6 @@
+---
+"@gradio/multimodaltextbox": patch
+"gradio": patch
+---
+
+fix:Fix Chatbot Multimodal Examples

--- a/js/multimodaltextbox/Example.svelte
+++ b/js/multimodaltextbox/Example.svelte
@@ -66,10 +66,11 @@
 		white-space: nowrap;
 	}
 
-	.container :global(img), .container :global(video) {
+	.container :global(img),
+	.container :global(video) {
 		object-fit: contain;
-		width: 250px;
-		height: 250px;
+		width: 100px;
+		height: 100px;
 	}
 
 	.container.selected {

--- a/js/multimodaltextbox/Example.svelte
+++ b/js/multimodaltextbox/Example.svelte
@@ -29,11 +29,13 @@
 </script>
 
 <div
+	class="container"
 	bind:clientWidth={size}
 	bind:this={el}
 	class:table={type === "table"}
 	class:gallery={type === "gallery"}
 	class:selected
+	class:border={value}
 >
 	<p>{value.text ? value.text : ""}</p>
 	{#each value.files as file}
@@ -44,7 +46,7 @@
 		{:else if file.mime_type && file.mime_type.includes("audio")}
 			<audio src={file.url} controls />
 		{:else}
-			{file.path}
+			{file.orig_name}
 		{/if}
 	{/each}
 </div>
@@ -61,14 +63,35 @@
 	div {
 		overflow: hidden;
 		min-width: var(--local-text-width);
-
 		white-space: nowrap;
 	}
 
-	/* :global(img) {
-		width: 100px;
-		height: 100px;
-	} */
+	.container :global(img), .container :global(video) {
+		object-fit: contain;
+		width: 250px;
+		height: 250px;
+	}
+
+	.container.selected {
+		border-color: var(--border-color-accent);
+	}
+	.border.table {
+		border: 2px solid var(--border-color-primary);
+	}
+
+	.container.table {
+		margin: 0 auto;
+		border-radius: var(--radius-lg);
+		overflow-x: auto;
+		width: max-content;
+		height: max-content;
+		object-fit: cover;
+		padding: var(--size-2);
+	}
+
+	.container.gallery {
+		object-fit: cover;
+	}
 
 	div > :global(p) {
 		font-size: var(--text-lg);

--- a/js/multimodaltextbox/Example.svelte
+++ b/js/multimodaltextbox/Example.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from "svelte";
 	import { Image } from "@gradio/image/shared";
+	import { Video } from "@gradio/video/shared";
 	import type { FileData } from "@gradio/client";
 
 	export let value: { text: string; files: FileData[] } = {
@@ -38,6 +39,10 @@
 	{#each value.files as file}
 		{#if file.mime_type && file.mime_type.includes("image")}
 			<Image src={file.url} alt="" />
+		{:else if file.mime_type && file.mime_type.includes("video")}
+			<Video src={file.url} alt="" loop={true} />
+		{:else if file.mime_type && file.mime_type.includes("audio")}
+			<audio src={file.url} controls />
 		{:else}
 			{file.path}
 		{/if}

--- a/js/multimodaltextbox/package.json
+++ b/js/multimodaltextbox/package.json
@@ -20,6 +20,7 @@
 		"@gradio/utils": "workspace:^",
 		"@gradio/upload": "workspace:^",
 		"@gradio/image": "workspace:^",
+		"@gradio/video": "workspace:^",
 		"@gradio/client": "workspace:^"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1553,6 +1553,9 @@ importers:
       '@gradio/utils':
         specifier: workspace:^
         version: link:../utils
+      '@gradio/video':
+        specifier: workspace:^
+        version: link:../video
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^


### PR DESCRIPTION
## Description
Fixes issue with image examples being too big. Also adds support for video and audio in `multimodaltextbox` examples, instead of just showing the filepath.

Main:
<img width="1257" alt="Screenshot 2024-07-24 at 1 53 38 PM" src="https://github.com/user-attachments/assets/87ad37c4-5d6f-4623-ad88-2eb2628fd7a1">

This PR:
<img width="1008" alt="Screenshot 2024-07-24 at 1 53 07 PM" src="https://github.com/user-attachments/assets/6700a45b-5d05-4259-b06e-eed18f40b376">


Closes: #8834

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
