### PR TITLE
Fix `Could not resolve "virtual:component-loader"` in gradio/utils package

### DIFF
--- a/.changeset/rude-women-fly.md
+++ b/.changeset/rude-women-fly.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/utils": minor
-"gradio": minor
+"@gradio/utils": patch
+"gradio": patch
 ---
 
-feat:Fix `Could not resolve "virtual:component-loader"` in gradio/utils package
+fix:Fix `Could not resolve "virtual:component-loader"` in gradio/utils package

--- a/.changeset/rude-women-fly.md
+++ b/.changeset/rude-women-fly.md
@@ -1,0 +1,6 @@
+---
+"@gradio/utils": minor
+"gradio": minor
+---
+
+feat:Fix `Could not resolve "virtual:component-loader"` in gradio/utils package

--- a/js/utils/src/utils.ts
+++ b/js/utils/src/utils.ts
@@ -237,6 +237,8 @@ export class Gradio<T extends Record<string, any> = Record<string, any>> {
 			import("virtual:component-loader").then((module) => {
 				this._load_component = module.load_component;
 				virtual_component_loader = module.load_component;
+			}).catch((e) => {
+				console.error("Error loading virtual component loader", e);
 			});
 		} else {
 			this._load_component = virtual_component_loader;

--- a/js/utils/src/utils.ts
+++ b/js/utils/src/utils.ts
@@ -234,12 +234,14 @@ export class Gradio<T extends Record<string, any> = Record<string, any>> {
 		this.client = client;
 
 		if (!virtual_component_loader) {
-			import("virtual:component-loader").then((module) => {
-				this._load_component = module.load_component;
-				virtual_component_loader = module.load_component;
-			}).catch((e) => {
-				console.error("Error loading virtual component loader", e);
-			});
+			import("virtual:component-loader")
+				.then((module) => {
+					this._load_component = module.load_component;
+					virtual_component_loader = module.load_component;
+				})
+				.catch((e) => {
+					console.error("Error loading virtual component loader", e);
+				});
 		} else {
 			this._load_component = virtual_component_loader;
 		}


### PR DESCRIPTION
## Description

Fixes 

```
Could not resolve "virtual:component-loader"

    node_modules/@gradio/utils/src/utils.ts:237:10:
      237 │       import("virtual:component-loader").then((module) ...
          ╵              ~~~~~~~~~~~~~~~~~~~~~~~~~~

  You can mark the path "virtual:component-loader" as external to
  exclude it from the bundle, which will remove this error and leave
  the unresolved path in the bundle. You can also add ".catch()" here
  to handle this failure at run-time instead of bundle-time.

```

which occurs when installing any gradio component with the newest version from npm in a typescript svelte project.

This bug prevents us from switching from an old version of @gradio/audio from 0.11.4 to 0.13.0 and of @gradio/atoms from 0.7.3 to 0.7.7.


  
