### PR TITLE
Fix flake in e2e chatbot test

### DIFF
--- a/js/app/test/chatbot_multimodal.spec.ts
+++ b/js/app/test/chatbot_multimodal.spec.ts
@@ -236,8 +236,11 @@ for (const msg_format of ["tuples", "messages"]) {
 		await page.getByTestId("textbox").click();
 		await page.getByTestId("textbox").fill("hello");
 		await page.keyboard.press("Enter");
-		await page.getByLabel("like", { exact: true }).click();
-		await page.getByLabel("dislike", { exact: true }).click();
+		await expect(
+			page.getByTestId("bot").first().getByRole("paragraph")
+		).toBeVisible();
+		await page.getByLabel("like", { exact: true }).first().click();
+		await page.getByLabel("dislike", { exact: true }).first().click();
 
 		expect(await page.getByLabel("clicked dislike").count()).toEqual(1);
 		expect(await page.getByLabel("clicked like").count()).toEqual(0);


### PR DESCRIPTION
## Description

There are dislike buttons for both the user and bot message. Depending on how fast the backend processes the response, the `await page.getByLabel("dislike", { exact: true }).click()` line will fail if the bot responded because it matches two ui elements. 

These changes should make the test more predictable

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
