### PR TITLE
Bump websockets version max for gradio-client

### DIFF
--- a/.changeset/five-crabs-listen.md
+++ b/.changeset/five-crabs-listen.md
@@ -1,0 +1,6 @@
+---
+"gradio": patch
+"gradio_client": patch
+---
+
+feat:Bump websockets version max for gradio-client

--- a/client/python/requirements.txt
+++ b/client/python/requirements.txt
@@ -3,4 +3,4 @@ httpx>=0.24.1
 huggingface_hub>=0.19.3
 packaging
 typing_extensions~=4.0
-websockets>=10.0,<12.0
+websockets>=10.0,<13.0


### PR DESCRIPTION
## Description

gradio-client has had a pinned version maximum for websockets of 12.0 that was created before websockets 12.0 was released.

websockets 12.0 has since been released, and the only backwards-incompatible change was ending support for python 3.7, which gradio-client and gradio don't support anymore either. 

To keep with the spirit of the original file, I've bumped up the version requirement to 13.0, which may in the future present other breaking changes.