### PR TITLE
Fix check icon in gr.JSON and gr.Code

### DIFF
--- a/.changeset/common-otters-dream.md
+++ b/.changeset/common-otters-dream.md
@@ -1,0 +1,8 @@
+---
+"@gradio/code": patch
+"@gradio/icons": patch
+"@gradio/json": patch
+"gradio": patch
+---
+
+fix:Fix check icon in gr.JSON and gr.Code

--- a/js/code/shared/Copy.svelte
+++ b/js/code/shared/Copy.svelte
@@ -31,17 +31,14 @@
 	on:click={handle_copy}
 	title="copy"
 	class:copied
-	aria-roledescription="Copy value"
-	aria-label="Copy"
+	aria-label={copied ? "Value copied" : "Copy value"}
 >
-	<Copy />
-	{#if copied}
-		<span
-			class="check"
-			transition:fade
-			aria-roledescription="Value copied"
-			aria-label="Copied"><Check /></span
-		>
+	{#if !copied}
+		<Copy />
+	{:else}
+		<span class="check">
+			<Check />
+		</span>
 	{/if}
 </button>
 
@@ -55,14 +52,11 @@
 	}
 
 	.check {
-		position: absolute;
 		top: 0;
 		right: 0;
 		z-index: var(--layer-top);
-		background: var(--background-fill-primary);
-		padding: var(--size-1);
+		background: var(--block-label-background-fill);
 		width: 100%;
 		height: 100%;
-		color: var(--body-text-color);
 	}
 </style>

--- a/js/icons/src/Check.svelte
+++ b/js/icons/src/Check.svelte
@@ -3,7 +3,8 @@
 	viewBox="2 0 20 20"
 	fill="none"
 	stroke="currentColor"
-	stroke-width="3"
+	aria-hidden="true"
+	stroke-width="2"
 	stroke-linecap="round"
 	stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg
 >

--- a/js/icons/src/Copy.svelte
+++ b/js/icons/src/Copy.svelte
@@ -1,4 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 33 33" color="currentColor"
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 33 33"
+	color="currentColor"
+	aria-hidden="true"
 	><path
 		fill="currentColor"
 		d="M28 10v18H10V10h18m0-2H10a2 2 0 0 0-2 2v18a2 2 0 0 0 2 2h18a2 2 0 0 0 2-2V10a2 2 0 0 0-2-2Z"

--- a/js/json/shared/JSON.svelte
+++ b/js/json/shared/JSON.svelte
@@ -47,14 +47,12 @@
 	<button
 		on:click={handle_copy}
 		title="copy"
-		class={copied ? "" : "copy-text"}
+		class={copied ? "copied" : "copy-text"}
 		aria-roledescription={copied ? "Copied value" : "Copy value"}
 		aria-label={copied ? "Copied" : "Copy"}
 	>
 		{#if copied}
-			<span in:fade={{ duration: 300 }}>
-				<Check />
-			</span>
+			<Check />
 		{:else}
 			<Copy />
 		{/if}
@@ -78,6 +76,20 @@
 {/if}
 
 <style>
+	:global(.copied svg) {
+		animation: fade ease 300ms;
+		animation-fill-mode: forwards;
+	}
+
+	@keyframes fade {
+		0% {
+			opacity: 0;
+		}
+		100% {
+			opacity: 1;
+		}
+	}
+
 	.json-holder {
 		padding: var(--size-2);
 	}


### PR DESCRIPTION
## Description

Fixes the check icon in gr.Code and gr.JSON

Before 🐛 
<img width="159" alt="Screenshot 2024-07-31 at 12 58 05" src="https://github.com/user-attachments/assets/cfb1046f-cd30-41cb-b9af-36e3b0b3f8a1">

![Kapture 2024-07-31 at 13 00 02](https://github.com/user-attachments/assets/509268cb-7b35-445f-8b4a-bb896496d427)

After

![Kapture 2024-07-31 at 13 01 23](https://github.com/user-attachments/assets/8e7af7ce-6d93-4ddb-ac89-7f53bf773033)

![Kapture 2024-07-31 at 13 02 36](https://github.com/user-attachments/assets/769a1ae2-e17b-4b7d-989e-ef86fca09552)

Note, I've made the check icon 1px thinner because I think that better matches the copy icon it goes with, and other icons we have. 

Closes: #8915

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
