### PR TITLE
Fix running local app with fake OAuth

### DIFF
--- a/.changeset/small-coins-rescue.md
+++ b/.changeset/small-coins-rescue.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix running local app with fake OAuth

--- a/gradio/oauth.py
+++ b/gradio/oauth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import time
 import typing
 import urllib.parse
 import warnings
@@ -296,7 +297,7 @@ def _get_mocked_oauth_info() -> typing.Dict:
         "expires_in": 3600,
         "id_token": "AAAAAAAAAAAAAAAAAAAAAAAAAA",
         "scope": "openid profile",
-        "expires_at": 1691676444,
+        "expires_at": int(time.time()) + 8 * 60 * 60,  # 8 hours
         "userinfo": {
             "sub": "11111111111111111111111",
             "name": user["fullname"],

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -114,6 +114,7 @@ class Obj:
             return self.__dict__.pop(item)
         return default
 
+
 @document()
 class Request:
     """

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -109,6 +109,10 @@ class Obj:
     def __repr__(self) -> str:
         return str(self.__dict__)
 
+    def pop(self, item, default=None):
+        if item in self:
+            return self.__dict__.pop(item)
+        return default
 
 @document()
 class Request:


### PR DESCRIPTION
In https://github.com/gradio-app/gradio/issues/8660, @abidlabs reported some issues when trying to debug locally a Gradio app that uses OAuth. Since "official" OAuth cannot be done locally (redirect to localhost is forbidden), we use fake data based on the user access token from the machine. This PR fixes 2 things:
- `expires_at` was set to a constant value in the past which was automatically logging out the user
- `Obj` class (used for `session`) did not implement `pop` which was causing a failure [here](https://github.com/gradio-app/gradio/blob/d1f044145ae93e5838042d9fb25f4f17def9c774/gradio/components/login_button.py#L108)

### How to test it? 

Copy this snippet in an `app.py` and run it:

```py
from huggingface_hub import list_models

import gradio as gr


def hello(profile: gr.OAuthProfile | None) -> str:
    if profile is None:
        return "I don't know you."
    return f"Hello {profile.name}"

def list_private_models(profile: gr.OAuthProfile | None, oauth_token: gr.OAuthToken | None) -> str:
    if oauth_token is None:
        return "Please log in to list private models."
    models = [
        f"{model.id} ({'private' if model.private else 'public'})"
        for model in list_models(author=profile.username, token=oauth_token.token)
    ]
    return "Models:\n\n" + "\n - ".join(models) + "."

with gr.Blocks() as demo:
    gr.Markdown(
        "# Gradio OAuth Space\n\nThis Space is a demo for the new **Sign in with Hugging Face** feature."
    )
    gr.LoginButton(logout_value="Logout ({})")
    m1 = gr.Markdown()
    m2 = gr.Markdown()
    demo.load(hello, inputs=None, outputs=m1)
    demo.load(list_private_models, inputs=None, outputs=m2)

demo.launch()
```