### PR TITLE
Add `overflow: wrap` to JSON to catch overflow in xs device widths 

### DIFF
--- a/.changeset/chilly-boxes-build.md
+++ b/.changeset/chilly-boxes-build.md
@@ -1,0 +1,6 @@
+---
+"@gradio/json": minor
+"gradio": minor
+---
+
+feat:Add `overflow: wrap` to JSON to catch overflow in xs device widths 

--- a/js/json/shared/JSON.svelte
+++ b/js/json/shared/JSON.svelte
@@ -80,6 +80,7 @@
 <style>
 	.json-holder {
 		padding: var(--size-2);
+		overflow-y: scroll;
 	}
 
 	.empty-wrapper {

--- a/js/json/shared/JSONNode.svelte
+++ b/js/json/shared/JSONNode.svelte
@@ -195,7 +195,7 @@
 	.line-number {
 		position: absolute;
 		left: 0;
-		width: calc(var(--size-10) - 4px);
+		width: calc(var(--size-7));
 		text-align: right;
 		color: var(--line-number-color);
 		user-select: none;


### PR DESCRIPTION
## Description

Add `overflow: wrap` to catch any overflow in gr.JSON when the device is extra small. 

Thanks for the catch @freddyaboulton!

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
