### PR TITLE
Adds `strict_cors` parameter to `launch()`

### DIFF
--- a/.changeset/hungry-tips-sin.md
+++ b/.changeset/hungry-tips-sin.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Adds `strict_cors` parameter to `launch()`

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2174,7 +2174,7 @@ Received outputs:
         max_file_size: str | int | None = None,
         _frontend: bool = True,
         enable_monitoring: bool = False,
-        strict_cors: bool = False
+        strict_cors: bool = True
     ) -> tuple[FastAPI, str, str]:
         """
         Launches a simple web server that serves the demo. Can also be used to create a
@@ -2210,7 +2210,7 @@ Received outputs:
             share_server_protocol: Use this to specify the protocol to use for the share links. Defaults to "https", unless a custom share_server_address is provided, in which case it defaults to "http". If you are using a custom share_server_address and want to use https, you must set this to "https".
             auth_dependency: A function that takes a FastAPI request and returns a string user ID or None. If the function returns None for a specific request, that user is not authorized to access the app (they will see a 401 Unauthorized response). To be used with external authentication systems like OAuth. Cannot be used with `auth`.
             max_file_size: The maximum file size in bytes that can be uploaded. Can be a string of the form "<value><unit>", where value is any positive integer and unit is one of "b", "kb", "mb", "gb", "tb". If None, no limit is set.
-            strict_cors: If True, prevents external domains from making requests to a Gradio server running on localhost. If False, allows requests if the hostname is localhost or, crucially, "null". This parameter should normally be True to prevent CSRF attacks but may need to be False when embedding a *locally-running Gradio app* using web components.
+            strict_cors: If True, prevents external domains from making requests to a Gradio server running on localhost. If False, allows requests to localhost that originate from localhost but also, crucially, from "null". This parameter should normally be True to prevent CSRF attacks but may need to be False when embedding a *locally-running Gradio app* using web components.
         Returns:
             app: FastAPI app object that is running the demo
             local_url: Locally accessible link to the demo
@@ -2274,7 +2274,6 @@ Received outputs:
             self.root_path = os.environ.get("GRADIO_ROOT_PATH", "")
         else:
             self.root_path = root_path
-        self.strict_cors = strict_cors
         self.show_api = show_api
 
         if allowed_paths:
@@ -2317,7 +2316,7 @@ Received outputs:
         self._queue.max_thread_count = max_threads
         # self.server_app is included for backwards compatibility
         self.server_app = self.app = App.create_app(
-            self, auth_dependency=auth_dependency, app_kwargs=app_kwargs
+            self, auth_dependency=auth_dependency, app_kwargs=app_kwargs, strict_cors=strict_cors
         )
 
         if self.is_running:

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2174,7 +2174,7 @@ Received outputs:
         max_file_size: str | int | None = None,
         _frontend: bool = True,
         enable_monitoring: bool = False,
-        strict_cors: bool = True
+        strict_cors: bool = True,
     ) -> tuple[FastAPI, str, str]:
         """
         Launches a simple web server that serves the demo. Can also be used to create a
@@ -2316,7 +2316,10 @@ Received outputs:
         self._queue.max_thread_count = max_threads
         # self.server_app is included for backwards compatibility
         self.server_app = self.app = App.create_app(
-            self, auth_dependency=auth_dependency, app_kwargs=app_kwargs, strict_cors=strict_cors
+            self,
+            auth_dependency=auth_dependency,
+            app_kwargs=app_kwargs,
+            strict_cors=strict_cors,
         )
 
         if self.is_running:

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2174,6 +2174,7 @@ Received outputs:
         max_file_size: str | int | None = None,
         _frontend: bool = True,
         enable_monitoring: bool = False,
+        strict_cors: bool = False
     ) -> tuple[FastAPI, str, str]:
         """
         Launches a simple web server that serves the demo. Can also be used to create a
@@ -2209,6 +2210,7 @@ Received outputs:
             share_server_protocol: Use this to specify the protocol to use for the share links. Defaults to "https", unless a custom share_server_address is provided, in which case it defaults to "http". If you are using a custom share_server_address and want to use https, you must set this to "https".
             auth_dependency: A function that takes a FastAPI request and returns a string user ID or None. If the function returns None for a specific request, that user is not authorized to access the app (they will see a 401 Unauthorized response). To be used with external authentication systems like OAuth. Cannot be used with `auth`.
             max_file_size: The maximum file size in bytes that can be uploaded. Can be a string of the form "<value><unit>", where value is any positive integer and unit is one of "b", "kb", "mb", "gb", "tb". If None, no limit is set.
+            strict_cors: If True, prevents external domains from making requests to a Gradio server running on localhost. If False, allows requests if the hostname is localhost or, crucially, "null". This parameter should normally be True to prevent CSRF attacks but may need to be False when embedding a *locally-running Gradio app* using web components.
         Returns:
             app: FastAPI app object that is running the demo
             local_url: Locally accessible link to the demo
@@ -2272,7 +2274,7 @@ Received outputs:
             self.root_path = os.environ.get("GRADIO_ROOT_PATH", "")
         else:
             self.root_path = root_path
-
+        self.strict_cors = strict_cors
         self.show_api = show_api
 
         if allowed_paths:

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -710,9 +710,12 @@ class CustomCORSMiddleware:
         }
         self.simple_headers = {"Access-Control-Allow-Credentials": "true"}
         # Any of these hosts suggests that the Gradio app is running locally.
-        # Note: "null" is a special case that happens if a Gradio app is running
-        # as an embedded web component in a local static webpage.
-        self.localhost_aliases = ["localhost", "127.0.0.1", "0.0.0.0", "null"]
+        self.localhost_aliases = ["localhost", "127.0.0.1", "0.0.0.0"]
+        if self.app.strict_cors:  # type: ignore
+            # Note: "null" is a special case that happens if a Gradio app is running
+            # as an embedded web component in a local static webpage. However, it can
+            # also be used maliciously for CSRF attacks, so it is not allowed by default.
+            self.localhost_aliases.append("null")
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -700,6 +700,7 @@ class CustomCORSMiddleware:
     def __init__(
         self,
         app: ASGIApp,
+        strict_cors: bool = True,
     ) -> None:
         self.app = app
         self.all_methods = ("DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT")
@@ -711,7 +712,7 @@ class CustomCORSMiddleware:
         self.simple_headers = {"Access-Control-Allow-Credentials": "true"}
         # Any of these hosts suggests that the Gradio app is running locally.
         self.localhost_aliases = ["localhost", "127.0.0.1", "0.0.0.0"]
-        if self.app.strict_cors:  # type: ignore
+        if not strict_cors:  # type: ignore
             # Note: "null" is a special case that happens if a Gradio app is running
             # as an embedded web component in a local static webpage. However, it can
             # also be used maliciously for CSRF attacks, so it is not allowed by default.

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -239,6 +239,7 @@ class App(FastAPI):
         blocks: gradio.Blocks,
         app_kwargs: Dict[str, Any] | None = None,
         auth_dependency: Callable[[fastapi.Request], str | None] | None = None,
+        strict_cors: bool = True,
     ) -> App:
         app_kwargs = app_kwargs or {}
         app_kwargs.setdefault("default_response_class", ORJSONResponse)
@@ -250,7 +251,7 @@ class App(FastAPI):
         app.configure_app(blocks)
 
         if not wasm_utils.IS_WASM:
-            app.add_middleware(CustomCORSMiddleware)
+            app.add_middleware(CustomCORSMiddleware, strict_cors=strict_cors)
 
         @app.get("/user")
         @app.get("/user/")

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -508,7 +508,7 @@ class TestRoutes:
         response = client.get("/config/")
         assert response.is_success
 
-    def test_cors_restrictions(self):
+    def test_default_cors_restrictions(self):
         io = gr.Interface(lambda s: s.name, gr.File(), gr.File())
         app, _, _ = io.launch(prevent_thread_lock=True)
         client = TestClient(app)
@@ -518,12 +518,41 @@ class TestRoutes:
         }
         file_response = client.get("/config", headers=custom_headers)
         assert "access-control-allow-origin" not in file_response.headers
+
+        custom_headers = {
+            "host": "localhost:7860",
+            "origin": "null",
+        }
+        file_response = client.get("/config", headers=custom_headers)
+        assert "access-control-allow-origin" not in file_response.headers
+
         custom_headers = {
             "host": "localhost:7860",
             "origin": "127.0.0.1",
         }
         file_response = client.get("/config", headers=custom_headers)
         assert file_response.headers["access-control-allow-origin"] == "127.0.0.1"
+
+        io.close()
+
+    def test_loose_cors_restrictions(self):
+        io = gr.Interface(lambda s: s.name, gr.File(), gr.File())
+        app, _, _ = io.launch(prevent_thread_lock=True, strict_cors=False)
+        client = TestClient(app)
+        custom_headers = {
+            "host": "localhost:7860",
+            "origin": "https://example.com",
+        }
+        file_response = client.get("/config", headers=custom_headers)
+        assert "access-control-allow-origin" not in file_response.headers
+
+        custom_headers = {
+            "host": "localhost:7860",
+            "origin": "null",
+        }
+        file_response = client.get("/config", headers=custom_headers)
+        assert file_response.headers["access-control-allow-origin"] == "null"
+
         io.close()
 
     def test_delete_cache(self, connect, gradio_temp_dir, capsys):


### PR DESCRIPTION
Added tests to ensure that CSRF attacks cannot happen. To test this change with regards to embedding, create a Gradio app, and then embed it with web components in a static file. Follow these steps:

1. create a gradio app:

```py
import gradio as gr

gr.Interface(lambda x:x, "text", "text").launch(strict_cors=False)
```


2. create an index.html file with

```
<script
	type="module"
	src="https://gradio.s3-us-west-2.amazonaws.com/4.40.0/gradio.js"
></script>

<gradio-app src="http://localhost:7860"></gradio-app>
```

If you open the file in a browser, the embedded app should work as long as you include the `strict_cors=False` parameter above.