### PR TITLE
fix: httpx timeouts cause gradio to fail during launch

### DIFF
--- a/.changeset/eager-roses-throw.md
+++ b/.changeset/eager-roses-throw.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:fix: httpx timeouts cause gradio to fail during launch

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -55,6 +55,6 @@ def url_ok(url: str) -> bool:
             if r.status_code in (200, 401, 302):  # 401 or 302 if auth is set
                 return True
             time.sleep(0.500)
-    except (ConnectionError, httpx.ConnectError):
+    except (ConnectionError, httpx.ConnectError, httpx.TimeoutException):
         return False
     return False


### PR DESCRIPTION
## Description

This has been fixed in https://github.com/gradio-app/gradio/pull/7707, but it seems it has been reintroduced during some other code changes/refactoring.

Closes: #8671

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`