### PR TITLE
Update gradio clients documentation examples for file handling

### DIFF
--- a/guides/08_gradio-clients-and-lite/01_getting-started-with-the-python-client.md
+++ b/guides/08_gradio-clients-and-lite/01_getting-started-with-the-python-client.md
@@ -11,12 +11,12 @@ Using the `gradio_client` library, we can easily use the Gradio as an API to tra
 Here's the entire code to do it:
 
 ```python
-from gradio_client import Client, file
+from gradio_client import Client, handle_file
 
 client = Client("abidlabs/whisper")
 
 client.predict(
-    audio=file("audio_sample.wav")
+    audio=handle_file("audio_sample.wav")
 )
 
 >> "This is a test of the whisper speech recognition model."
@@ -64,12 +64,12 @@ The `gradio_client` includes a class method: `Client.duplicate()` to make this p
 
 ```python
 import os
-from gradio_client import Client, file
+from gradio_client import Client, handle_file
 
 HF_TOKEN = os.environ.get("HF_TOKEN")
 
 client = Client.duplicate("abidlabs/whisper", hf_token=HF_TOKEN)
-client.predict(file("audio_sample.wav"))
+client.predict(handle_file("audio_sample.wav"))
 
 >> "This is a test of the whisper speech recognition model."
 ```
@@ -184,14 +184,14 @@ client = Client("abidlabs/image_generator")
 client.predict(text="an astronaut riding a camel", steps=25)
 ```
 
-For providing files or URLs as inputs, you should pass in the filepath or URL to the file enclosed within `gradio_client.file()`. This takes care of uploading the file to the Gradio server and ensures that the file is preprocessed correctly:
+For providing files or URLs as inputs, you should pass in the filepath or URL to the file enclosed within `gradio_client.handle_file()`. This takes care of uploading the file to the Gradio server and ensures that the file is preprocessed correctly:
 
 ```python
-from gradio_client import Client, file
+from gradio_client import Client, handle_file
 
 client = Client("abidlabs/whisper")
 client.predict(
-    audio=file("https://audio-samples.github.io/samples/mp3/blizzard_unconditional/sample-0.mp3")
+    audio=handle_file("https://audio-samples.github.io/samples/mp3/blizzard_unconditional/sample-0.mp3")
 )
 
 >> "My thought I have nobody by a beauty and will as you poured. Mr. Rochester is serve in that so don't find simpus, and devoted abode, to at might in a r—"
@@ -258,8 +258,8 @@ The `Job` class also has a `.cancel()` instance method that cancels jobs that ha
 
 ```py
 client = Client("abidlabs/whisper")
-job1 = client.submit(file("audio_sample1.wav"))
-job2 = client.submit(file("audio_sample2.wav"))
+job1 = client.submit(handle_file("audio_sample1.wav"))
+job2 = client.submit(handle_file("audio_sample2.wav"))
 job1.cancel()  # will return False, assuming the job has started
 job2.cancel()  # will return True, indicating that the job has been canceled
 ```

--- a/guides/08_gradio-clients-and-lite/02_getting-started-with-the-js-client.md
+++ b/guides/08_gradio-clients-and-lite/02_getting-started-with-the-js-client.md
@@ -11,7 +11,7 @@ Using the `@gradio/client` library, we can easily use the Gradio as an API to tr
 Here's the entire code to do it:
 
 ```js
-import { Client } from "@gradio/client";
+import { Client, handle_file } from "@gradio/client";
 
 const response = await fetch(
 	"https://github.com/audio-samples/audio-samples.github.io/raw/master/samples/wav/ted_speakers/SalmanKhan/sample-1.wav"
@@ -19,7 +19,7 @@ const response = await fetch(
 const audio_file = await response.blob();
 
 const app = await Client.connect("abidlabs/whisper");
-const transcription = await app.predict("/predict", [audio_file]);
+const transcription = await app.predict("/predict", [handle_file(audio_file)]);
 
 console.log(transcription.data);
 // [ "I said the same phrase 30 times." ]
@@ -76,7 +76,7 @@ While you can use any public Space as an API, you may get rate limited by Huggin
 `Client.duplicate` is almost identical to `Client.connect`, the only difference is under the hood:
 
 ```js
-import { Client } from "@gradio/client";
+import { Client, handle_file } from "@gradio/client";
 
 const response = await fetch(
 	"https://audio-samples.github.io/samples/mp3/blizzard_unconditional/sample-0.mp3"
@@ -84,7 +84,7 @@ const response = await fetch(
 const audio_file = await response.blob();
 
 const app = await Client.duplicate("abidlabs/whisper", { hf_token: "hf_..." });
-const transcription = await app.predict("/predict", [audio_file]);
+const transcription = await app.predict("/predict", [handle_file(audio_file)]);
 ```
 
 If you have previously duplicated a Space, re-running `Client.duplicate` will _not_ create a new Space. Instead, the client will attach to the previously-created Space. So it is safe to re-run the `Client.duplicate` method multiple times with the same space.
@@ -203,7 +203,7 @@ const result = await app.predict("/predict", [4, "add", 5]);
 For certain inputs, such as images, you should pass in a `Buffer`, `Blob` or `File` depending on what is most convenient. In node, this would be a `Buffer` or `Blob`; in a browser environment, this would be a `Blob` or `File`.
 
 ```js
-import { Client } from "@gradio/client";
+import { Client, handle_file } from "@gradio/client";
 
 const response = await fetch(
 	"https://audio-samples.github.io/samples/mp3/blizzard_unconditional/sample-0.mp3"
@@ -211,7 +211,7 @@ const response = await fetch(
 const audio_file = await response.blob();
 
 const app = await Client.connect("abidlabs/whisper");
-const result = await app.predict("/predict", [audio_file]);
+const result = await app.predict("/predict", [handle_file(audio_file)]);
 ```
 
 ## Using events

--- a/guides/08_gradio-clients-and-lite/02_getting-started-with-the-js-client.md
+++ b/guides/08_gradio-clients-and-lite/02_getting-started-with-the-js-client.md
@@ -66,7 +66,7 @@ You can also connect to private Spaces by passing in your HF token with the `hf_
 ```js
 import { Client } from "@gradio/client";
 
-const app = Client.connect("abidlabs/my-private-space", { hf_token="hf_..." })
+const app = Client.connect("abidlabs/my-private-space", { hf_token: "hf_..." })
 ```
 
 ## Duplicating a Space for private use

--- a/guides/08_gradio-clients-and-lite/07_fastapi-app-with-the-gradio-client.md
+++ b/guides/08_gradio-clients-and-lite/07_fastapi-app-with-the-gradio-client.md
@@ -35,12 +35,12 @@ Luckily for us, there's an existing Space we can use to make this process easier
 Open a new Python file, say `main.py`, and start by importing the `Client` class from `gradio_client` and connecting it to this Space:
 
 ```py
-from gradio_client import Client
+from gradio_client import Client, handle_file
 
 client = Client("abidlabs/music-separation")
 
 def acapellify(audio_path):
-    result = client.predict(audio_path, api_name="/predict")
+    result = client.predict(handle_file(audio_path), api_name="/predict")
     return result[0]
 ```
 


### PR DESCRIPTION
## Description

Updated examples in documentation for Gradio python and js clients to replace deprecated file() function by handle_file() in order to make usage and comprehension clearer.
Fixed also a small synthax typo.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
