### PR TITLE
Allow empty value in gr.Number 

### DIFF
--- a/.changeset/deep-teams-jump.md
+++ b/.changeset/deep-teams-jump.md
@@ -1,0 +1,6 @@
+---
+"@gradio/number": patch
+"gradio": patch
+---
+
+fix:Allow empty value in gr.Number 

--- a/gradio/components/number.py
+++ b/gradio/components/number.py
@@ -121,17 +121,13 @@ class Number(FormComponent):
         """
         if payload is None:
             return None
-        try:
-            value = float(payload)
-        except ValueError:
-            return None
 
-        if self.minimum is not None and value < self.minimum:
-            raise Error(f"Value {value} is less than minimum value {self.minimum}.")
-        elif self.maximum is not None and value > self.maximum:
-            raise Error(f"Value {value} is greater than maximum value {self.maximum}.")
+        if self.minimum is not None and payload < self.minimum:
+            raise Error(f"Value {payload} is less than minimum value {self.minimum}.")
+        elif self.maximum is not None and payload > self.maximum:
+            raise Error(f"Value {payload} is greater than maximum value {self.maximum}.")
 
-        return self._round_to_precision(value, self.precision)
+        return self._round_to_precision(payload, self.precision)
 
     def postprocess(self, value: float | int | None) -> float | int | None:
         """
@@ -141,10 +137,6 @@ class Number(FormComponent):
             The (optionally rounded) field value as a `float` or `int` depending on `precision`.
         """
         if value is None:
-            return None
-        try:
-            value = float(value)
-        except ValueError:
             return None
         return self._round_to_precision(value, self.precision)
 

--- a/gradio/components/number.py
+++ b/gradio/components/number.py
@@ -121,13 +121,17 @@ class Number(FormComponent):
         """
         if payload is None:
             return None
-        elif self.minimum is not None and payload < self.minimum:
-            raise Error(f"Value {payload} is less than minimum value {self.minimum}.")
-        elif self.maximum is not None and payload > self.maximum:
-            raise Error(
-                f"Value {payload} is greater than maximum value {self.maximum}."
-            )
-        return self._round_to_precision(payload, self.precision)
+        try:
+            value = float(payload)
+        except ValueError:
+            return None
+
+        if self.minimum is not None and value < self.minimum:
+            raise Error(f"Value {value} is less than minimum value {self.minimum}.")
+        elif self.maximum is not None and value > self.maximum:
+            raise Error(f"Value {value} is greater than maximum value {self.maximum}.")
+
+        return self._round_to_precision(value, self.precision)
 
     def postprocess(self, value: float | int | None) -> float | int | None:
         """
@@ -137,6 +141,10 @@ class Number(FormComponent):
             The (optionally rounded) field value as a `float` or `int` depending on `precision`.
         """
         if value is None:
+            return None
+        try:
+            value = float(value)
+        except ValueError:
             return None
         return self._round_to_precision(value, self.precision)
 

--- a/gradio/components/number.py
+++ b/gradio/components/number.py
@@ -125,7 +125,9 @@ class Number(FormComponent):
         if self.minimum is not None and payload < self.minimum:
             raise Error(f"Value {payload} is less than minimum value {self.minimum}.")
         elif self.maximum is not None and payload > self.maximum:
-            raise Error(f"Value {payload} is greater than maximum value {self.maximum}.")
+            raise Error(
+                f"Value {payload} is greater than maximum value {self.maximum}."
+            )
 
         return self._round_to_precision(payload, self.precision)
 

--- a/js/number/Index.svelte
+++ b/js/number/Index.svelte
@@ -21,7 +21,7 @@
 	export let container = true;
 	export let scale: number | null = null;
 	export let min_width: number | undefined = undefined;
-	export let value = 0;
+	export let value: number | null = null;
 	export let show_label: boolean;
 	export let minimum: number | undefined = undefined;
 	export let maximum: number | undefined = undefined;
@@ -31,13 +31,27 @@
 	export let interactive: boolean;
 
 	function handle_change(): void {
-		if (!isNaN(value) && value !== null) {
-			gradio.dispatch("change");
-			if (!value_is_output) {
-				gradio.dispatch("input");
+		if (input_value === "") {
+			value = null;
+		} else {
+			const parsed_value = parseFloat(input_value);
+			if (!isNaN(parsed_value)) {
+				value = parsed_value;
 			}
 		}
+
+		gradio.dispatch("change");
+		if (!value_is_output) {
+			gradio.dispatch("input");
+		}
 	}
+
+	let input_value: string = value === null ? "" : value.toString();
+
+	$: if (value !== null && value.toString() !== input_value) {
+		input_value = value.toString();
+	}
+
 	afterUpdate(() => {
 		value_is_output = false;
 	});
@@ -74,7 +88,7 @@
 		<input
 			aria-label={label}
 			type="number"
-			bind:value
+			bind:value={input_value}
 			min={minimum}
 			max={maximum}
 			{step}

--- a/js/number/Index.svelte
+++ b/js/number/Index.svelte
@@ -21,7 +21,7 @@
 	export let container = true;
 	export let scale: number | null = null;
 	export let min_width: number | undefined = undefined;
-	export let value: number | null = null;
+	export let value: number | null = 0;
 	export let show_label: boolean;
 	export let minimum: number | undefined = undefined;
 	export let maximum: number | undefined = undefined;
@@ -30,29 +30,17 @@
 	export let step: number | null = null;
 	export let interactive: boolean;
 
-	let input_value = "";
-	let input_elem: HTMLInputElement;
-
-	$: {
-		input_value = value === null || value === undefined ? "" : value.toString();
-		if (input_elem) input_elem.value = input_value;
-	}
-
 	function handle_change(): void {
-		const parsed =
-			input_value === ""
-				? null
-				: isNaN(parseFloat(input_value))
-					? null
-					: parseFloat(input_value);
-		if (value !== parsed) {
-			value = parsed;
+		if (!isNaN(parseInt(input_value)) && value !== null) {
+			value = parseInt(input_value);
 			gradio.dispatch("change");
 			if (!value_is_output) {
 				gradio.dispatch("input");
 			}
 		}
 	}
+
+	let input_value: string = value === null ? "" : value.toString();
 
 	afterUpdate(() => {
 		value_is_output = false;
@@ -67,12 +55,7 @@
 		}
 	}
 
-	onMount(() => {
-		if (input_elem) {
-			input_elem.value = input_value;
-		}
-	});
-
+	$: input_value, handle_change();
 	$: disabled = !interactive;
 </script>
 
@@ -94,15 +77,14 @@
 	<label class="block" class:container>
 		<BlockTitle {show_label} {info}>{label}</BlockTitle>
 		<input
-			bind:this={input_elem}
 			aria-label={label}
 			type="text"
 			bind:value={input_value}
 			min={minimum}
 			max={maximum}
 			{step}
-			on:input={handle_change}
 			on:change={handle_change}
+			on:input={handle_change}
 			on:keypress={handle_keypress}
 			on:blur={() => gradio.dispatch("blur")}
 			on:focus={() => gradio.dispatch("focus")}

--- a/js/number/Index.svelte
+++ b/js/number/Index.svelte
@@ -30,6 +30,8 @@
 	export let step: number | null = null;
 	export let interactive: boolean;
 
+	$: input_value = value === null ? "" : value.toString();
+
 	function handle_change(): void {
 		if (input_value === "") {
 			value = null;
@@ -44,12 +46,6 @@
 		if (!value_is_output) {
 			gradio.dispatch("input");
 		}
-	}
-
-	let input_value: string = value === null ? "" : value.toString();
-
-	$: if (value !== null && value.toString() !== input_value) {
-		input_value = value.toString();
 	}
 
 	afterUpdate(() => {

--- a/js/number/Index.svelte
+++ b/js/number/Index.svelte
@@ -60,7 +60,7 @@
 		}
 	}
 
-	$: value, handle_change();
+	$: input_value, value, handle_change();
 	$: disabled = !interactive;
 </script>
 
@@ -83,7 +83,7 @@
 		<BlockTitle {show_label} {info}>{label}</BlockTitle>
 		<input
 			aria-label={label}
-			type="number"
+			type="string"
 			bind:value={input_value}
 			min={minimum}
 			max={maximum}
@@ -106,7 +106,7 @@
 		border: var(--input-border-width) solid var(--input-border-color);
 		border-radius: var(--input-radius);
 	}
-	input[type="number"] {
+	input[type="string"] {
 		display: block;
 		position: relative;
 		outline: none !important;

--- a/js/number/Index.svelte
+++ b/js/number/Index.svelte
@@ -40,7 +40,7 @@
 		}
 	}
 
-	let input_value: string = value === null ? "" : value.toString();
+	$: input_value = value === null ? "" : value.toString();
 
 	afterUpdate(() => {
 		value_is_output = false;
@@ -55,7 +55,6 @@
 		}
 	}
 
-	$: input_value, handle_change();
 	$: disabled = !interactive;
 </script>
 

--- a/js/number/Number.stories.svelte
+++ b/js/number/Number.stories.svelte
@@ -18,13 +18,6 @@
 />
 
 <Story
-	name="Number with min 20 and max 100"
-	args={{
-		value: null
-	}}
-/>
-
-<Story
 	name="Number with empty value"
 	args={{
 		value: null

--- a/js/number/Number.stories.svelte
+++ b/js/number/Number.stories.svelte
@@ -18,6 +18,13 @@
 />
 
 <Story
+	name="Number with empty value"
+	args={{
+		value: null
+	}}
+/>
+
+<Story
 	name="Number with step of 10"
 	args={{
 		step: 10

--- a/js/number/Number.stories.svelte
+++ b/js/number/Number.stories.svelte
@@ -18,6 +18,13 @@
 />
 
 <Story
+	name="Number with min 20 and max 100"
+	args={{
+		value: null
+	}}
+/>
+
+<Story
 	name="Number with empty value"
 	args={{
 		value: null


### PR DESCRIPTION
## Description

We should allow empty values to be shown on the frontend in gr.Number when its None/null. I've not changed the data type of `value` itself but rather created a new variable which is used for displaying the value as a empty string when the value is null, and it updates whenever value updates. 

Demo:

```
import gradio as gr

with gr.Blocks() as demo:
    gr.Number(value=None)

demo.launch()
```

Closes: #6728

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
