### PR TITLE
Have gr.on set value at start as well

### DIFF
--- a/gradio/events.py
+++ b/gradio/events.py
@@ -646,7 +646,7 @@ def on(
             [EventListenerMethod(input, "change") for input in inputs]
             if inputs is not None
             else []
-        )  # type: ignore
+        ) + [EventListenerMethod(root_block, "load")]
     else:
         methods = [
             EventListenerMethod(t.__self__ if t.has_trigger else None, t.event_name)  # type: ignore

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -564,7 +564,7 @@ def on(
     for all events in the triggers list.
 
     Parameters:
-        triggers: List of triggers to listen to, e.g. [btn.click, number.change]. If None, will listen to changes to any inputs.
+        triggers: List of triggers to listen to, e.g. [btn.click, number.change]. If None, will run on app load and changes to any inputs.
         fn: the function to call when this event is triggered. Often a machine learning model's prediction function. Each parameter of the function corresponds to one input component, and the function should return a single value or a tuple of values, with each element in the tuple corresponding to one output component.
         inputs: List of gradio.components to use as inputs. If the function takes no inputs, this should be an empty list.
         outputs: List of gradio.components to use as outputs. If the function returns no outputs, this should be an empty list.

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -646,7 +646,7 @@ def on(
             [EventListenerMethod(input, "change") for input in inputs]
             if inputs is not None
             else []
-        ) + [EventListenerMethod(root_block, "load")]
+        ) + [EventListenerMethod(root_block, "load")]  # type: ignore
     else:
         methods = [
             EventListenerMethod(t.__self__ if t.has_trigger else None, t.event_name)  # type: ignore


### PR DESCRIPTION
If you have a demo like this:
```python
with gr.Blocks() as demo:
    a = gr.Number(1)
    b = gr.Number(1)
    c = gr.Number()

    @gr.on(inputs=[a,b], outputs=c)
    def add(x,y):
        return x + y

demo.launch()
```

c will only be set to the value of a + b when they change, not initially when the demo runs. Usually users would want the initial value to also be a function of the inputs (when no trigger is specified).

This is also consistent with the behaviour of gr.render and value=fn, e.g. both of these would set c to 2 intitially:

```python
with gr.Blocks() as demo:
    a = gr.Number(1)
    b = gr.Number(1)

    @gr.render(inputs=[a, b])
    def renderfn(x, y):
        gr.Number(x + y)

demo.launch()
```

```python
with gr.Blocks() as demo:
    a = gr.Number(1)
    b = gr.Number(1)
    c = gr.Number(lambda x, y: x + y, inputs=[a, b])

demo.launch()
```
Technically breaking so going into 5.0