### PR TITLE
Catch OSErrors in `HuggingFaceDatasetSaver._deserialize_components`

### DIFF
--- a/.changeset/better-results-try.md
+++ b/.changeset/better-results-try.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Catch OSErrors in `HuggingFaceDatasetSaver._deserialize_components`

--- a/gradio/flagging.py
+++ b/gradio/flagging.py
@@ -430,7 +430,7 @@ class HuggingFaceDatasetSaver(FlaggingCallback):
                 if not deserialized_path.exists():
                     raise FileNotFoundError(f"File {deserialized} not found")
                 row.append(str(deserialized_path.relative_to(self.dataset_dir)))
-            except (FileNotFoundError, TypeError, ValueError):
+            except (FileNotFoundError, TypeError, ValueError, OSError):
                 deserialized = "" if deserialized is None else str(deserialized)
                 row.append(deserialized)
 


### PR DESCRIPTION
## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #9077

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
