### PR TITLE
Set non-zero exit codes for custom component build and install commands when failures occur

### DIFF
--- a/.changeset/every-parks-count.md
+++ b/.changeset/every-parks-count.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Set non-zero exit codes for custom component build and install commands when failures occur

--- a/gradio/cli/commands/components/build.py
+++ b/gradio/cli/commands/components/build.py
@@ -172,7 +172,7 @@ def _build(
         if pipe.returncode != 0:
             live.update(":red_square: Build failed!")
             live.update(pipe.stderr)
-            raise SystemExit("Frontend build failed")
+            raise SystemExit("Python build failed")
         else:
             live.update(":white_check_mark: Build succeeded!")
             live.update(

--- a/gradio/cli/commands/components/build.py
+++ b/gradio/cli/commands/components/build.py
@@ -162,7 +162,7 @@ def _build(
                 live.update(":red_square: Build failed!")
                 live.update(pipe.stderr)
                 live.update(pipe.stdout)
-                return
+                raise SystemExit("Frontend build failed")
             else:
                 live.update(":white_check_mark: Build succeeded!")
 
@@ -172,6 +172,7 @@ def _build(
         if pipe.returncode != 0:
             live.update(":red_square: Build failed!")
             live.update(pipe.stderr)
+            raise SystemExit("Frontend build failed")
         else:
             live.update(":white_check_mark: Build succeeded!")
             live.update(

--- a/gradio/cli/commands/components/install_component.py
+++ b/gradio/cli/commands/components/install_component.py
@@ -71,6 +71,8 @@ def _install_command(
     if pipe.returncode != 0:
         live.update(":red_square: Python installation [bold][red]failed[/][/]")
         live.update(pipe.stderr)
+        raise SystemExit("Python installation failed")
+
     else:
         live.update(":white_check_mark: Python install succeeded!")
 
@@ -85,6 +87,7 @@ def _install_command(
             live.update(":red_square: NPM install [bold][red]failed[/][/]")
             live.update(pipe.stdout)
             live.update(pipe.stderr)
+            raise SystemExit("NPM install failed")
         else:
             live.update(":white_check_mark: NPM install succeeded!")
 


### PR DESCRIPTION
## Description

Closes #9071 


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
