### PR TITLE
Be able to set optimizeDeps options in gradio.config.js

### DIFF
--- a/js/preview/src/dev.ts
+++ b/js/preview/src/dev.ts
@@ -60,6 +60,7 @@ export async function create_server({
 			build: {
 				target: config.build.target
 			},
+			optimizeDeps: config.optimizeDeps,
 			plugins: [
 				...plugins(config),
 				make_gradio_plugin({
@@ -122,6 +123,7 @@ export interface ComponentConfig {
 	build: {
 		target: string | string[];
 	};
+	optimizeDeps: object;
 }
 
 async function generate_imports(
@@ -147,7 +149,8 @@ async function generate_imports(
 		},
 		build: {
 			target: []
-		}
+		},
+		optimizeDeps: {}
 	};
 
 	await Promise.all(
@@ -163,6 +166,7 @@ async function generate_imports(
 				component_config.plugins = m.default.plugins || [];
 				component_config.svelte.preprocess = m.default.svelte?.preprocess || [];
 				component_config.build.target = m.default.build?.target || "modules";
+				component_config.optimizeDeps = m.default.optimizeDeps || {};
 			} else {
 			}
 		})


### PR DESCRIPTION
## Description

Fixes a corner case in pdf component ( https://github.com/freddyaboulton/gradio-pdf/issues/9 ) but I think it would be useful in general.

I tested by copying the build preview index.js file to the pdf components node_modules. And I also tested that not modifying gradio.config.js works as expected.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
