### PR TITLE
CI dependency hardening

### DIFF
--- a/.github/actions/install-all-deps/action.yml
+++ b/.github/actions/install-all-deps/action.yml
@@ -67,7 +67,7 @@ runs:
           gradio-lib-${{inputs.os}}-latest-pip-
         key: "gradio-lib-${{inputs.os}}-latest-pip-${{ hashFiles('client/python/requirements.txt') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('test/requirements.txt') }}-${{ hashFiles('client/python/test/requirements.txt') }}${{ inputs.test == 'true' && '-test' || ''}}"
     - name: Install ffmpeg
-      uses: FedericoCarboni/setup-ffmpeg@v2
+      uses: FedericoCarboni/setup-ffmpeg@583042d32dd1cabb8bd09df03bde06080da5c87c # @v2
     - name: Install test dependencies
       if: inputs.test == 'true' && steps.cache.outputs.cache-hit != 'true'
       shell: bash

--- a/.github/actions/install-frontend-deps/action.yml
+++ b/.github/actions/install-frontend-deps/action.yml
@@ -22,7 +22,7 @@ runs:
           gradio/templates/*
         key: gradio-lib-front-end-${{ hashFiles('js/**', 'client/js/**')}}
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # @v4
       with:
         version: 9.1.x
     - uses: actions/setup-node@v4

--- a/.github/workflows/delete-stale-spaces.yml
+++ b/.github/workflows/delete-stale-spaces.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Set daysStale
         env:
           DEFAULT_DAYS_STALE: "7"
-        run: echo "DAYS_STALE=${{ github.event.inputs.daysStale || env.DEFAULT_DAYS_STALE }}" >> $GITHUB_ENV
+          DAYS_STALE: ${{ github.event.inputs.daysStale  || env.DEFAULT_DAYS_STALE}}
+        run: echo DAYS_STALE=  "$DAYS_STALE"  >> $GITHUB_ENV
       - name: Find and delete stale spaces
         run: |
           python scripts/delete_old_spaces.py $DAYS_STALE \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
           pnpm --filter @gradio/client --filter @gradio/lite --filter @gradio/preview build
       - name: create and publish versions
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@aba318e9165b45b7948c60273e0b72fce0a64eb9 # @v1
         with:
           version: pnpm ci:version
           commit: "chore: update versions"

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -96,7 +96,7 @@ jobs:
         run: echo "{}" > package.json
       - name: publish to chromatic
         id: publish-chromatic
-        uses: chromaui/action@v11
+        uses: chromaui/action@fdbe7756d4dbf493e2fbb822df73be7accd07e1c # @v11
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.COMMIT_STATUS }}

--- a/.github/workflows/test-hygiene.yml
+++ b/.github/workflows/test-hygiene.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Assert Notebooks Match
         run: git status | grep "nothing to commit, working tree clean"
       - name: Check for large files
-        uses: actionsdesk/lfs-warning@v3.3
+        uses: actionsdesk/lfs-warning@4b98a8a5e6c429c23c34eee02d71553bca216425 # @v3.3
         with:
           filesizelimit: 5MB


### PR DESCRIPTION
Of the following actions:

- dorny/paths-filter@v3 
- FedericoCarboni/setup-ffmpeg@v2 
- pnpm/action-setup@v2 
- chromaui/action@v11 
- changesets/action@v1 
- actionsdesk/lfs-warning@v3.3
 
 We no longer use:

 - dorny/paths-filter@v3 
 
 The others have been pinned tot he appropriate SHA with a comment detailing the version tag it corresponds to. Gradio specific or official github actions have been left as they are.
 
The delete stale space workflow has also been tweaked to circumvent potential command injection attacks.

  
