### PR TITLE
Reset `Dataset` page to 0 when samples change

### DIFF
--- a/.changeset/petite-animals-raise.md
+++ b/.changeset/petite-animals-raise.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataset": patch
+"gradio": patch
+---
+
+fix:Reset `Dataset` page to 0 when samples change

--- a/js/dataset/Index.svelte
+++ b/js/dataset/Index.svelte
@@ -14,6 +14,7 @@
 	export let label = "Examples";
 	export let headers: string[];
 	export let samples: any[][] | null = null;
+	let old_samples: any[][] | null = null;
 	export let sample_labels: string[] | null = null;
 	export let elem_id = "";
 	export let elem_classes: string[] = [];
@@ -35,6 +36,7 @@
 		? `/proxy=${proxy_url}file=`
 		: `${root}/file=`;
 	let page = 0;
+	
 	$: gallery = components.length < 2 || sample_labels !== null;
 	let paginate = samples ? samples.length > samples_per_page : false;
 
@@ -57,6 +59,10 @@
 			samples = sample_labels.map((e) => [e]);
 		} else if (!samples) {
 			samples = [];
+		}
+		if (samples !== old_samples) {
+			page = 0;
+			old_samples = samples;
 		}
 		paginate = samples.length > samples_per_page;
 		if (paginate) {

--- a/js/dataset/Index.svelte
+++ b/js/dataset/Index.svelte
@@ -36,7 +36,7 @@
 		? `/proxy=${proxy_url}file=`
 		: `${root}/file=`;
 	let page = 0;
-	
+
 	$: gallery = components.length < 2 || sample_labels !== null;
 	let paginate = samples ? samples.length > samples_per_page : false;
 


### PR DESCRIPTION
Resets the page of the Dataset component to page 0 when the samples change, preventing issues like this: https://github.com/gradio-app/gradio/issues/9083

Closes: https://github.com/gradio-app/gradio/issues/9083