### PR TITLE
fix: gradio will use internal address to load static resource in client in proxy case

### DIFF
--- a/.changeset/plenty-ideas-yell.md
+++ b/.changeset/plenty-ideas-yell.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": minor
+"gradio": minor
+---
+
+feat:fix: gradio will use internal address to load static resource in client in proxy case

--- a/client/js/src/helpers/init_helpers.ts
+++ b/client/js/src/helpers/init_helpers.ts
@@ -27,7 +27,11 @@ export function resolve_root(
 	prioritize_base: boolean
 ): string {
 	if (root_path.startsWith("http://") || root_path.startsWith("https://")) {
-		return prioritize_base ? base_url : root_path;
+		const url: URL = new URL(root_path);
+		const internal_base_url: string = `${url.protocol}//${url.host}`;
+		//for proxy case, we should use the public address rather than internal address
+		const rootPath: string = root_path.replace(internal_base_url, base_url);
+		return prioritize_base ? base_url : rootPath;
 	}
 	return base_url + root_path;
 }

--- a/client/js/src/utils/submit.ts
+++ b/client/js/src/utils/submit.ts
@@ -284,7 +284,7 @@ export function submit(
 
 					let url = new URL(
 						`${ws_protocol}://${resolve_root(
-							host,
+							config.root,
 							config.path as string,
 							true
 						)}/queue/join${url_params ? "?" + url_params : ""}`


### PR DESCRIPTION
## Description
the access flow looks like following, the problem is that gradio will load css or js with internal proxy server address,
the correct behavior is gradio should use public server to load static resources in the client. 

<img width="853" alt="image" src="https://github.com/user-attachments/assets/0eba9822-c6c6-4d71-b9de-0c85b5ebf5b1">

![img_v3_02dm_a17bb8ad-664b-4095-a4d2-24cbb0446d7g](https://github.com/user-attachments/assets/11790960-ee6b-4783-9092-7a41fdc61e61)


Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

Tested in my cs arch
  
