### PR TITLE
Better text styling on docs

### DIFF
--- a/.changeset/wise-sites-learn.md
+++ b/.changeset/wise-sites-learn.md
@@ -1,0 +1,5 @@
+---
+"website": minor
+---
+
+feat:Better text styling on docs

--- a/js/_website/src/lib/assets/style.css
+++ b/js/_website/src/lib/assets/style.css
@@ -143,6 +143,11 @@
 .obj h4 {
 	@apply mt-8 text-xl text-orange-500 font-light;
 }
+
+.obj p {
+	@apply mb-2 text-lg;
+}
+
 /* playground */
 
 .current-playground-demo {


### PR DESCRIPTION
Some content on the docs has weird spacing, like https://www.gradio.app/docs/gradio/chatbot cc @freddyaboulton 

Just adds margin and increases the font 

Before             |  After
:-------------------------:|:-------------------------:
![Screenshot 2024-08-13 at 11 24 58 PM](https://github.com/user-attachments/assets/99740dbb-4eff-46c5-832a-491e78136c45) | ![Screenshot 2024-08-13 at 11 24 41 PM](https://github.com/user-attachments/assets/588d6305-5c65-48ca-a45b-3004423a702d)

We can change it up more if this isn't good