### PR TITLE
add default description to share button

### DIFF
--- a/js/atoms/src/ShareButton.svelte
+++ b/js/atoms/src/ShareButton.svelte
@@ -15,6 +15,8 @@
 	export let value: any;
 	export let i18n: I18nFormatter;
 	let pending = false;
+
+	const defaultDescription = "Check out this awesome project on Gradio!";
 </script>
 
 <IconButton
@@ -24,7 +26,12 @@
 	on:click={async () => {
 		try {
 			pending = true;
-			const formatted = await formatter(value);
+			let formatted = await formatter(value);
+
+			if (!formatted || formatted.trim() === "") {
+				formatted = defaultDescription;
+			}
+
 			dispatch("share", {
 				description: formatted
 			});


### PR DESCRIPTION
## Description

Added the following default `description` to Gradio UI to resolve `400: Description is required` on Hugging Face Spaces.

```python
	const defaultDescription = "Check out this awesome project on Gradio!";

<IconButton
	Icon={Community}
	label={i18n("common.share")}
	{pending}
	on:click={async () => {
		try {
			pending = true;
			let formatted = await formatter(value);

			if (!formatted || formatted.trim() === "") {
				formatted = defaultDescription;
			}
```

Closes: #8909 
  
