### PR TITLE
Upgrade CI to use Python 3.10

### DIFF
--- a/.github/actions/install-all-deps/action.yml
+++ b/.github/actions/install-all-deps/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: "false"
   python_version:
     description: "Python version"
-    default: "3.8"
+    default: "3.10"
   os:
     description: "OS"
     default: "ubuntu-latest"

--- a/.github/workflows/delete-stale-spaces.yml
+++ b/.github/workflows/delete-stale-spaces.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install pip
         run: python -m pip install pip wheel requests
       - name: Install Hub Client Library

--- a/.github/workflows/previews-build.yml
+++ b/.github/workflows/previews-build.yml
@@ -46,7 +46,7 @@ jobs:
         uses: "gradio-app/gradio/.github/actions/install-all-deps@main"
         with:
           always_install_pnpm: true
-          python_version: "3.9"
+          python_version: "3.10"
           build_lite: "true"
       - name: Package Lite NPM package
         working-directory: js/lite

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -59,7 +59,7 @@ jobs:
         id: install_deps
         uses: "gradio-app/gradio/.github/actions/install-all-deps@main"
         with:
-          python_version: "3.8"
+          python_version: "3.10"
           os: ${{ matrix.os }}
           test: true
       - name: Lint


### PR DESCRIPTION
In order to upgrade our codebase to use Python 3.10, I'd like to first get in this PR which sets CI to use Python 3.10. This will make it easier to test any changes I make in https://github.com/gradio-app/gradio/pull/9129