### PR TITLE
Allow `gr.Request` to work with ZeroGPU

### DIFF
--- a/.changeset/olive-loops-look.md
+++ b/.changeset/olive-loops-look.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Allow `gr.Request` to work with ZeroGPU

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -126,15 +126,18 @@ class Request:
     query parameters and other information about the request from within the prediction
     function. The class is a thin wrapper around the fastapi.Request class. Attributes
     of this class include: `headers`, `client`, `query_params`, `session_hash`, and `path_params`. If
-    auth is enabled, the `username` attribute can be used to get the logged in user.
+    auth is enabled, the `username` attribute can be used to get the logged in user. In some environments,
+    the `requests.headers` and `requests.query_params` attributes of this class are automatically
+    converted to to dictionaries, so we recommend converting them to dictionaries before accessing
+    attributes for consistent behavior in different environments.
     Example:
         import gradio as gr
         def echo(text, request: gr.Request):
             if request:
-                print("Request headers dictionary:", request.headers)
-                print("IP address:", request.client.host)
+                print("Request headers dictionary:", dict(request.headers))
                 print("Query parameters:", dict(request.query_params))
-                print("Session hash:", request.session_hash)
+                print("IP address:", request.client.host)
+                print("Gradio session hash:", request.session_hash)
             return text
         io = gr.Interface(echo, "textbox", "textbox").launch()
     Demos: request_ip_headers

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -2,6 +2,7 @@
 
 import functools
 import os
+import pickle
 import tempfile
 import time
 from contextlib import asynccontextmanager, closing
@@ -814,6 +815,30 @@ class TestPassingRequest:
             data={"username": "admin", "password": "password"},
         )
         response = client.post("/api/predict/", json={"data": ["test"]})
+        assert response.status_code == 200
+        output = dict(response.json())
+        assert output["data"] == ["test"]
+
+    def test_request_is_pickle_able(self):
+        """
+        For ZeroGPU, we need to ensure that the gr.Request object is pickle-able.
+        """
+        def identity(name, request: gr.Request):
+            pickled = pickle.dumps(request)
+            unpickled = pickle.loads(pickled)
+            assert request.client.host == unpickled.client.host
+            assert request.client.port == unpickled.client.port
+            assert dict(request.query_params) == dict(unpickled.query_params)
+            assert dict(request.headers) == dict(unpickled.headers)
+            assert request.username == unpickled.username
+            return name
+
+        app, _, _ = gr.Interface(identity, "textbox", "textbox").launch(
+            prevent_thread_lock=True,
+        )
+        client = TestClient(app)
+
+        response = client.post("/api/predict?a=b", json={"data": ["test"]})
         assert response.status_code == 200
         output = dict(response.json())
         assert output["data"] == ["test"]

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -830,6 +830,7 @@ class TestPassingRequest:
             assert request.client.host == unpickled.client.host
             assert request.client.port == unpickled.client.port
             assert dict(request.query_params) == dict(unpickled.query_params)
+            assert request.query_params["a"] == unpickled.query_params["a"]
             assert dict(request.headers) == dict(unpickled.headers)
             assert request.username == unpickled.username
             return name

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -819,7 +819,7 @@ class TestPassingRequest:
         output = dict(response.json())
         assert output["data"] == ["test"]
 
-    def test_request_is_pickle_able(self):
+    def test_request_is_pickleable(self):
         """
         For ZeroGPU, we need to ensure that the gr.Request object is pickle-able.
         """

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -823,6 +823,7 @@ class TestPassingRequest:
         """
         For ZeroGPU, we need to ensure that the gr.Request object is pickle-able.
         """
+
         def identity(name, request: gr.Request):
             pickled = pickle.dumps(request)
             unpickled = pickle.loads(pickled)


### PR DESCRIPTION
Closes: https://github.com/gradio-app/gradio/issues/8844. So the underlying issue is that the `fastapi.Request` class is not pickleable. Making it pickleable is tricky because it contains lots of attributes that are custom classes, which themselves are not serializeable. So what I've done here is extract the main attributes that we mention in our docs are users are likely using and ensured that they are preserved when the `gr.Request` object is picked and unpickled. I've added unit tests to confirm this. @hysts, quick favor -- if you have a chance to test on ZeroGPU directly, that'd be awesome. 