### PR TITLE
Open media type files in browser

### DIFF
--- a/.changeset/legal-donkeys-accept.md
+++ b/.changeset/legal-donkeys-accept.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Open media type files in browser
+fix:Open media type files in browser

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -606,14 +606,16 @@ class App(FastAPI):
                     )
                     return response
 
-            mime_type, _ = mimetypes.guess_type(abs_path)            
+            mime_type, _ = mimetypes.guess_type(abs_path)
             content_disposition_type = "attachment"
             media_type = "application/octet-stream"
             if mime_type:
                 media_type = mime_type
-                if mime_type.startswith(("image/", "audio/", "video/")):
-                    if not mime_type == "image/svg+xml":
-                        content_disposition_type = "inline"
+                if (
+                    mime_type.startswith(("image/", "audio/", "video/"))
+                    and mime_type != "image/svg+xml"
+                ):
+                    content_disposition_type = "inline"
 
             return FileResponse(
                 abs_path,

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -544,6 +544,7 @@ class App(FastAPI):
             file_extension = os.path.splitext(url_path)[1].lower()
             if file_extension in XSS_VULNERABLE_EXTENSIONS:
                 rp_resp.headers.update({"Content-Disposition": "attachment"})
+                rp_resp.headers.update({"Content-Type": "application/octet-stream"})
             return StreamingResponse(
                 rp_resp.aiter_raw(),
                 status_code=rp_resp.status_code,

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -606,11 +606,20 @@ class App(FastAPI):
                     )
                     return response
 
+            mime_type, _ = mimetypes.guess_type(abs_path)            
+            content_disposition_type = "attachment"
+            media_type = "application/octet-stream"
+            if mime_type:
+                media_type = mime_type
+                if mime_type.startswith(("image/", "audio/", "video/")):
+                    if not mime_type == "image/svg+xml":
+                        content_disposition_type = "inline"
+
             return FileResponse(
                 abs_path,
                 headers={"Accept-Ranges": "bytes"},
-                content_disposition_type="attachment",
-                media_type="application/octet-stream",
+                content_disposition_type=content_disposition_type,
+                media_type=media_type,
             )
 
         @app.get(

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -635,6 +635,7 @@ class App(FastAPI):
                 headers={"Accept-Ranges": "bytes"},
                 content_disposition_type=content_disposition_type,
                 media_type=media_type,
+                filename=abs_path.name,
             )
 
         @app.get(

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -275,9 +275,11 @@ class TestRoutes:
 
         file_response = client.get(f"/file={image_file.name}")
         assert file_response.headers["Content-Type"] == "image/png"
+        assert "inline" in file_response.headers["Content-Disposition"]
 
         file_response = client.get(f"/file={html_file.name}")
         assert file_response.headers["Content-Type"] == "application/octet-stream"
+        assert "attachment" in file_response.headers["Content-Disposition"]
 
     def test_allowed_and_blocked_paths(self):
         with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -254,6 +254,31 @@ class TestRoutes:
         assert len(file_response.text) == len(media_data.BASE64_IMAGE)
         io.close()
 
+    def test_response_attachment_format(self):
+        image_file = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".png")
+        image_file.write(media_data.BASE64_IMAGE)
+        image_file.flush()
+
+        html_file = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".html")
+        html_file.write("<html>Hello, world!</html>")
+        html_file.flush()
+
+        io = gr.Interface(lambda s: s.name, gr.File(), gr.File())
+        app, _, _ = io.launch(
+            prevent_thread_lock=True,
+            allowed_paths=[
+                os.path.dirname(image_file.name),
+                os.path.dirname(html_file.name),
+            ],
+        )
+        client = TestClient(app)
+
+        file_response = client.get(f"/file={image_file.name}")
+        assert file_response.headers["Content-Type"] == "image/png"
+
+        file_response = client.get(f"/file={html_file.name}")
+        assert file_response.headers["Content-Type"] == "application/octet-stream"
+
     def test_allowed_and_blocked_paths(self):
         with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
             io = gr.Interface(lambda s: s.name, gr.File(), gr.File())


### PR DESCRIPTION
We made a change the all `file=` endpoints loaded as attachments. However, it is fine to allow all media types (except SVG, which could contain JS) to load in the browser. This PR makes that change. 

Closes: https://github.com/gradio-app/gradio/issues/9137