### PR TITLE
Fix scripts/run_lite.sh and scripts/build_lite.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"description": "Gradio UI packages",
 	"scripts": {
 		"dev": "pnpm css && pnpm --filter @gradio/preview build && pnpm --filter @self/spa dev",
+		"dev:lite": "pnpm package && pnpm --filter @gradio/lite dev",
 		"css": "pnpm --filter @gradio/theme generate",
 		"build": "pnpm css && pnpm --filter @self/spa build --emptyOutDir && pnpm --filter @gradio/preview build",
 		"build:lite": "pnpm package && pnpm --filter @gradio/lite build",

--- a/scripts/build_lite.sh
+++ b/scripts/build_lite.sh
@@ -8,4 +8,4 @@ pnpm_required
 rm -rf gradio/_frontend_code
 rm -rf gradio/templates/*
 
-pnpm --filter @gradio/lite build
+pnpm build:lite

--- a/scripts/run_lite.sh
+++ b/scripts/run_lite.sh
@@ -26,4 +26,4 @@ fi
 
 pnpm --filter @gradio/client build
 
-pnpm --filter @gradio/lite dev
+pnpm dev:lite


### PR DESCRIPTION
Based on #9163. 
This PR updates `scripts/*_lite.sh` to run with the changes by #9163.