### PR TITLE
Remove `ruff` from runtime dependencies

### DIFF
--- a/.changeset/plain-rules-cross.md
+++ b/.changeset/plain-rules-cross.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:Remove `ruff` from runtime dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,3 @@ urllib3~=2.0  # urllib3 is used for Lite support. Version spec can be omitted be
 uvicorn>=0.14.0; sys.platform != 'emscripten'
 typer>=0.12,<1.0; sys.platform != 'emscripten'
 tomlkit==0.12.0
-ruff>=0.2.2; sys.platform != 'emscripten'


### PR DESCRIPTION
## Description

`ruff` should probably not be a runtime dependency for all non-wasm users of Gradio.

This was changed in https://github.com/gradio-app/gradio/pull/7744 so cc @whitphx.