### PR TITLE
 Add a 'None' option to the gradio.Image component to disable image_m…

### DIFF
--- a/.changeset/nice-berries-end.md
+++ b/.changeset/nice-berries-end.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat: Add a 'None' option to the gradio.Image component to disable image_m…

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -52,7 +52,7 @@ class Image(StreamingInput, Component):
         width: int | str | None = None,
         image_mode: Literal[
             "1", "L", "P", "RGB", "RGBA", "CMYK", "YCbCr", "LAB", "HSV", "I", "F"
-        ] | None = None,
+        ] | None = "RGB",
         sources: list[Literal["upload", "webcam", "clipboard"]]
         | Literal["upload", "webcam", "clipboard"]
         | None = None,
@@ -83,7 +83,7 @@ class Image(StreamingInput, Component):
             format: File format (e.g. "png" or "gif") to save image if it does not already have a valid format (e.g. if the image is being returned to the frontend as a numpy array or PIL Image).  The format should be supported by the PIL library. This parameter has no effect on SVG files.
             height: The height of the displayed image, specified in pixels if a number is passed, or in CSS units if a string is passed.
             width: The width of the displayed image, specified in pixels if a number is passed, or in CSS units if a string is passed.
-            image_mode: "RGB" if color, or "L" if black and white. See https://pillow.readthedocs.io/en/stable/handbook/concepts.html for other supported image modes and their meaning. This parameter has no effect on SVG or GIF files.
+            image_mode: "RGB" if color, or "L" if black and white. See https://pillow.readthedocs.io/en/stable/handbook/concepts.html for other supported image modes and their meaning. This parameter has no effect on SVG or GIF files. If set to None, the image_mode will be inferred from the image file.
             sources: List of sources for the image. "upload" creates a box where user can drop an image file, "webcam" allows user to take snapshot from their webcam, "clipboard" allows users to paste an image from the clipboard. If None, defaults to ["upload", "webcam", "clipboard"] if streaming is False, otherwise defaults to ["webcam"].
             type: The format the image is converted before being passed into the prediction function. "numpy" converts the image to a numpy array with shape (height, width, 3) and values from 0 to 255, "pil" converts the image to a PIL image object, "filepath" passes a str path to a temporary file containing the image. If the image is SVG, the `type` is ignored and the filepath of the SVG is returned. To support animated GIFs in input, the `type` should be set to "filepath" or "pil".
             label: The label for this component. Appears above the component and is also used as the header if there are a table of examples for this component. If None and used in a `gr.Interface`, the label will be the name of the parameter this component is assigned to.

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -51,8 +51,8 @@ class Image(StreamingInput, Component):
         height: int | str | None = None,
         width: int | str | None = None,
         image_mode: Literal[
-            "1", "L", "P", "RGB", "RGBA", "CMYK", "YCbCr", "LAB", "HSV", "I", "F", "None"
-        ] = "RGB",
+            "1", "L", "P", "RGB", "RGBA", "CMYK", "YCbCr", "LAB", "HSV", "I", "F"
+        ] | None = None,
         sources: list[Literal["upload", "webcam", "clipboard"]]
         | Literal["upload", "webcam", "clipboard"]
         | None = None,
@@ -199,7 +199,7 @@ class Image(StreamingInput, Component):
         if suffix.lower() != "gif" and im is not None:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                if self.image_mode != "None":
+                if self.image_mode is not None:
                     im = im.convert(self.image_mode)
         return image_utils.format_image(
             im,

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -51,7 +51,7 @@ class Image(StreamingInput, Component):
         height: int | str | None = None,
         width: int | str | None = None,
         image_mode: Literal[
-            "1", "L", "P", "RGB", "RGBA", "CMYK", "YCbCr", "LAB", "HSV", "I", "F"
+            "1", "L", "P", "RGB", "RGBA", "CMYK", "YCbCr", "LAB", "HSV", "I", "F", "None"
         ] = "RGB",
         sources: list[Literal["upload", "webcam", "clipboard"]]
         | Literal["upload", "webcam", "clipboard"]
@@ -199,7 +199,8 @@ class Image(StreamingInput, Component):
         if suffix.lower() != "gif" and im is not None:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                im = im.convert(self.image_mode)
+                if self.image_mode != "None":
+                    im = im.convert(self.image_mode)
         return image_utils.format_image(
             im,
             cast(Literal["numpy", "pil", "filepath"], self.type),

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -52,7 +52,8 @@ class Image(StreamingInput, Component):
         width: int | str | None = None,
         image_mode: Literal[
             "1", "L", "P", "RGB", "RGBA", "CMYK", "YCbCr", "LAB", "HSV", "I", "F"
-        ] | None = "RGB",
+        ]
+        | None = "RGB",
         sources: list[Literal["upload", "webcam", "clipboard"]]
         | Literal["upload", "webcam", "clipboard"]
         | None = None,


### PR DESCRIPTION
Add a 'None' option to the gradio.Image component to disable image_mode conversion. This commit will avoid convert behavior in prepress phase forcefully.

Closes: https://github.com/gradio-app/gradio/issues/9222