### PR TITLE
Fix for create_or_modify_pyi read_text Windows Issue in component_meta.py

### DIFF
--- a/.changeset/eighty-jeans-unite.md
+++ b/.changeset/eighty-jeans-unite.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix for create_or_modify_pyi read_text Windows Issue in component_meta.py

--- a/gradio/component_meta.py
+++ b/gradio/component_meta.py
@@ -93,7 +93,7 @@ def create_or_modify_pyi(
 ):
     source_file = Path(inspect.getfile(component_class))
 
-    source_code = source_file.read_text(encoding='utf-8')
+    source_code = source_file.read_text(encoding="utf-8")
 
     current_impl, lineno = extract_class_source_code(source_code, class_name)
 

--- a/gradio/component_meta.py
+++ b/gradio/component_meta.py
@@ -93,7 +93,7 @@ def create_or_modify_pyi(
 ):
     source_file = Path(inspect.getfile(component_class))
 
-    source_code = source_file.read_text()
+    source_code = source_file.read_text(encoding='utf-8')
 
     current_impl, lineno = extract_class_source_code(source_code, class_name)
 


### PR DESCRIPTION
Sometimes the `read_text()` call in `create_or_modify_pyi` will not use expected encoding when reading the `source_file`. 

## Description

This will declare the encoding that `read_text` is supposed to use. It is reading files that are encoded in 'utf-8'. Windows seems to sometimes default to 'CP-1252', but not always. Issue was not present when tested in Unix. I think it is safer to explicitly declare the encoding to be 'utf-8' since the gradio source files that are being read are encoded in 'utf-8'.

Closes: #8316 and Closes: #9241
