### PR TITLE
Adds ability to wait for file uploads before triggering event

### DIFF
--- a/js/audio/Index.svelte
+++ b/js/audio/Index.svelte
@@ -40,6 +40,9 @@
 	export let pending: boolean;
 	export let streaming: boolean;
 	export let stream_every: number;
+	export let input_ready: boolean;
+	let uploading = false;
+	$: input_ready = !uploading;
 
 	let stream_state = "closed";
 	let _modify_stream: (state: "open" | "closed" | "waiting") => void;
@@ -242,6 +245,7 @@
 			{handle_reset_value}
 			{editable}
 			bind:dragging
+			bind:uploading
 			on:edit={() => gradio.dispatch("edit")}
 			on:play={() => gradio.dispatch("play")}
 			on:pause={() => gradio.dispatch("pause")}

--- a/js/audio/interactive/InteractiveAudio.svelte
+++ b/js/audio/interactive/InteractiveAudio.svelte
@@ -39,6 +39,7 @@
 	export let upload: Client["upload"];
 	export let stream_handler: Client["stream"];
 	export let stream_every: number;
+	export let uploading = false;
 
 	let time_limit: number | null = null;
 	let stream_state: "open" | "waiting" | "closed" = "closed";
@@ -275,6 +276,7 @@
 				filetype="audio/aac,audio/midi,audio/mpeg,audio/ogg,audio/wav,audio/x-wav,audio/opus,audio/webm,audio/flac,audio/vnd.rn-realaudio,audio/x-ms-wma,audio/x-aiff,audio/amr,audio/*"
 				on:load={handle_load}
 				bind:dragging
+				bind:uploading
 				on:error={({ detail }) => dispatch("error", detail)}
 				{root}
 				{max_file_size}

--- a/js/file/Index.svelte
+++ b/js/file/Index.svelte
@@ -44,6 +44,9 @@
 	}>;
 	export let file_count: "single" | "multiple" | "directory";
 	export let file_types: string[] = ["file"];
+	export let input_ready: boolean;
+	let uploading = false;
+	$: input_ready = !uploading;
 
 	let old_value = value;
 	$: if (JSON.stringify(old_value) !== JSON.stringify(value)) {
@@ -98,6 +101,7 @@
 			selectable={_selectable}
 			{root}
 			{height}
+			bind:uploading
 			max_file_size={gradio.max_file_size}
 			on:change={({ detail }) => {
 				value = detail;

--- a/js/file/shared/FileUpload.svelte
+++ b/js/file/shared/FileUpload.svelte
@@ -21,6 +21,7 @@
 	export let max_file_size: number | null = null;
 	export let upload: Client["upload"];
 	export let stream_handler: Client["stream"];
+	export let uploading = false;
 
 	async function handle_upload({
 		detail
@@ -71,6 +72,7 @@
 		{max_file_size}
 		{root}
 		bind:dragging
+		bind:uploading
 		on:error
 		{stream_handler}
 		{upload}

--- a/js/image/Index.svelte
+++ b/js/image/Index.svelte
@@ -17,7 +17,7 @@
 	import { Block, Empty, UploadText } from "@gradio/atoms";
 	import { Image } from "@gradio/icons";
 	import { StatusTracker } from "@gradio/statustracker";
-	import type { FileData } from "@gradio/client";
+	import { upload, type FileData } from "@gradio/client";
 	import type { LoadingStatus } from "@gradio/statustracker";
 
 	type sources = "upload" | "webcam" | "clipboard" | null;
@@ -64,7 +64,9 @@
 	export let mirror_webcam: boolean;
 	export let placeholder: string | undefined = undefined;
 	export let show_fullscreen_button: boolean;
-
+	export let input_ready: boolean;
+	let uploading = false;
+	$: input_ready = !uploading;
 	export let gradio: Gradio<{
 		input: never;
 		change: never;
@@ -184,6 +186,7 @@
 
 		<ImageUploader
 			bind:this={upload_component}
+			bind:uploading
 			bind:active_source
 			bind:value
 			bind:dragging

--- a/js/image/shared/ImageUploader.svelte
+++ b/js/image/shared/ImageUploader.svelte
@@ -38,7 +38,7 @@
 	export let set_time_limit: (arg0: number) => void;
 
 	let upload_input: Upload;
-	let uploading = false;
+	export let uploading = false;
 	export let active_source: source_type = null;
 
 	function handle_upload({ detail }: CustomEvent<FileData>): void {

--- a/js/model3D/Index.svelte
+++ b/js/model3D/Index.svelte
@@ -31,6 +31,9 @@
 	export let gradio: Gradio;
 	export let height: number | undefined = undefined;
 	export let zoom_speed = 1;
+	export let input_ready: boolean;
+	let uploading = false;
+	$: input_ready = !uploading;
 
 	// alpha, beta, radius
 	export let camera_position: [number | null, number | null, number | null] = [
@@ -113,6 +116,7 @@
 			{value}
 			{camera_position}
 			{zoom_speed}
+			bind:uploading
 			on:change={({ detail }) => (value = detail)}
 			on:drag={({ detail }) => (dragging = detail)}
 			on:change={({ detail }) => gradio.dispatch("change", detail)}

--- a/js/model3D/shared/Model3DUpload.svelte
+++ b/js/model3D/shared/Model3DUpload.svelte
@@ -18,6 +18,7 @@
 	export let zoom_speed = 1;
 	export let pan_speed = 1;
 	export let max_file_size: number | null = null;
+	export let uploading = false;
 
 	// alpha, beta, radius
 	export let camera_position: [number | null, number | null, number | null] = [
@@ -96,6 +97,7 @@
 		{max_file_size}
 		filetype={[".stl", ".obj", ".gltf", ".glb", "model/obj", ".splat", ".ply"]}
 		bind:dragging
+		bind:uploading
 		on:error
 	>
 		<slot />

--- a/js/video/Index.svelte
+++ b/js/video/Index.svelte
@@ -54,6 +54,9 @@
 	export let mirror_webcam: boolean;
 	export let include_audio: boolean;
 	export let loop = false;
+	export let input_ready: boolean;
+	let uploading = false;
+	$: input_ready = !uploading;
 
 	let _video: FileData | null = null;
 	let _subtitle: FileData | null = null;
@@ -189,6 +192,7 @@
 			on:change={handle_change}
 			on:drag={({ detail }) => (dragging = detail)}
 			on:error={handle_error}
+			bind:uploading
 			{label}
 			{show_label}
 			{show_download_button}

--- a/js/video/shared/InteractiveVideo.svelte
+++ b/js/video/shared/InteractiveVideo.svelte
@@ -32,6 +32,7 @@
 	export let upload: Client["upload"];
 	export let stream_handler: Client["stream"];
 	export let loop: boolean;
+	export let uploading = false;
 
 	const dispatch = createEventDispatcher<{
 		change: FileData | null;
@@ -79,6 +80,7 @@
 			{#if active_source === "upload"}
 				<Upload
 					bind:dragging
+					bind:uploading
 					filetype="video/x-m4v,video/*"
 					on:load={handle_load}
 					{max_file_size}


### PR DESCRIPTION
## Description

Adds `input_ready` param to wait on triggering events when file is still uploading.

Closes: #6219

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
