### PR TITLE
Adds a "huggingface" button variant, and makes it the default for `gr.LoginButton` and `gr.DuplicateButton`

### DIFF
--- a/.changeset/few-clowns-notice.md
+++ b/.changeset/few-clowns-notice.md
@@ -1,0 +1,6 @@
+---
+"@gradio/button": minor
+"gradio": minor
+---
+
+feat:Adds a "clear" button variant, and makes it the default for `gr.LoginButton`

--- a/.changeset/few-clowns-notice.md
+++ b/.changeset/few-clowns-notice.md
@@ -3,4 +3,4 @@
 "gradio": minor
 ---
 
-feat:Adds a "clear" button variant, and makes it the default for `gr.LoginButton` and `gr.DuplicateButton`
+feat:Adds a "huggingface" button variant, and makes it the default for `gr.LoginButton` and `gr.DuplicateButton`

--- a/gradio/components/button.py
+++ b/gradio/components/button.py
@@ -28,7 +28,7 @@ class Button(Component):
         *,
         every: Timer | float | None = None,
         inputs: Component | Sequence[Component] | set[Component] | None = None,
-        variant: Literal["primary", "secondary", "stop", "clear"] = "secondary",
+        variant: Literal["primary", "secondary", "stop", "huggingface"] = "secondary",
         size: Literal["sm", "lg"] | None = None,
         icon: str | None = None,
         link: str | None = None,
@@ -46,7 +46,7 @@ class Button(Component):
             value: Default text for the button to display. If callable, the function will be called whenever the app loads to set the initial value of the component.
             every: Continously calls `value` to recalculate it if `value` is a function (has no effect otherwise). Can provide a Timer whose tick resets `value`, or a float that provides the regular interval for the reset Timer.
             inputs: Components that are used as inputs to calculate `value` if `value` is a function (has no effect otherwise). `value` is recalculated any time the inputs change.
-            variant: 'primary' for main call-to-action, 'secondary' for a more subdued style, 'stop' for a stop button, 'clear' for no background color.
+            variant: 'primary' for main call-to-action, 'secondary' for a more subdued style, 'stop' for a stop button, 'huggingface' for no background color (appears white in light mode, black in dark mode).
             size: Size of the button. Can be "sm" or "lg".
             icon: URL or path to the icon file to display within the button. If None, no icon will be displayed.
             link: URL to open when the button is clicked. If None, no link will be used.

--- a/gradio/components/button.py
+++ b/gradio/components/button.py
@@ -28,7 +28,7 @@ class Button(Component):
         *,
         every: Timer | float | None = None,
         inputs: Component | Sequence[Component] | set[Component] | None = None,
-        variant: Literal["primary", "secondary", "stop"] = "secondary",
+        variant: Literal["primary", "secondary", "stop", "clear"] = "secondary",
         size: Literal["sm", "lg"] | None = None,
         icon: str | None = None,
         link: str | None = None,
@@ -46,7 +46,7 @@ class Button(Component):
             value: Default text for the button to display. If callable, the function will be called whenever the app loads to set the initial value of the component.
             every: Continously calls `value` to recalculate it if `value` is a function (has no effect otherwise). Can provide a Timer whose tick resets `value`, or a float that provides the regular interval for the reset Timer.
             inputs: Components that are used as inputs to calculate `value` if `value` is a function (has no effect otherwise). `value` is recalculated any time the inputs change.
-            variant: 'primary' for main call-to-action, 'secondary' for a more subdued style, 'stop' for a stop button.
+            variant: 'primary' for main call-to-action, 'secondary' for a more subdued style, 'stop' for a stop button, 'clear' for no background color.
             size: Size of the button. Can be "sm" or "lg".
             icon: URL or path to the icon file to display within the button. If None, no icon will be displayed.
             link: URL to open when the button is clicked. If None, no link will be used.

--- a/gradio/components/duplicate_button.py
+++ b/gradio/components/duplicate_button.py
@@ -29,7 +29,7 @@ class DuplicateButton(Button):
         *,
         every: Timer | float | None = None,
         inputs: Component | Sequence[Component] | set[Component] | None = None,
-        variant: Literal["primary", "secondary", "stop", "clear"] = "clear",
+        variant: Literal["primary", "secondary", "stop", "huggingface"] = "huggingface",
         size: Literal["sm", "lg"] | None = "sm",
         icon: str | None = None,
         link: str | None = None,
@@ -48,7 +48,7 @@ class DuplicateButton(Button):
             value: Default text for the button to display. If callable, the function will be called whenever the app loads to set the initial value of the component.
             every: Continously calls `value` to recalculate it if `value` is a function (has no effect otherwise). Can provide a Timer whose tick resets `value`, or a float that provides the regular interval for the reset Timer.
             inputs: Components that are used as inputs to calculate `value` if `value` is a function (has no effect otherwise). `value` is recalculated any time the inputs change.
-            variant: 'primary' for main call-to-action, 'secondary' for a more subdued style, 'stop' for a stop button.
+            variant: 'primary' for main call-to-action, 'secondary' for a more subdued style, 'stop' for a stop button, 'huggingface' for no background color (appears white in light mode, black in dark mode).
             size: Size of the button. Can be "sm" or "lg".
             icon: URL or path to the icon file to display within the button. If None, no icon will be displayed.
             link: URL to open when the button is clicked. If None, no link will be used.

--- a/gradio/components/duplicate_button.py
+++ b/gradio/components/duplicate_button.py
@@ -29,7 +29,7 @@ class DuplicateButton(Button):
         *,
         every: Timer | float | None = None,
         inputs: Component | Sequence[Component] | set[Component] | None = None,
-        variant: Literal["primary", "secondary", "stop"] = "secondary",
+        variant: Literal["primary", "secondary", "stop", "clear"] = "clear",
         size: Literal["sm", "lg"] | None = "sm",
         icon: str | None = None,
         link: str | None = None,

--- a/gradio/components/login_button.py
+++ b/gradio/components/login_button.py
@@ -33,7 +33,7 @@ class LoginButton(Button):
         *,
         every: Timer | float | None = None,
         inputs: Component | Sequence[Component] | set[Component] | None = None,
-        variant: Literal["primary", "secondary", "stop", "clear"] = "clear",
+        variant: Literal["primary", "secondary", "stop", "huggingface"] = "huggingface",
         size: Literal["sm", "lg"] | None = None,
         icon: str
         | None = "https://huggingface.co/front/assets/huggingface_logo-noborder.svg",

--- a/gradio/components/login_button.py
+++ b/gradio/components/login_button.py
@@ -33,7 +33,7 @@ class LoginButton(Button):
         *,
         every: Timer | float | None = None,
         inputs: Component | Sequence[Component] | set[Component] | None = None,
-        variant: Literal["primary", "secondary", "stop"] = "secondary",
+        variant: Literal["primary", "secondary", "stop", "clear"] = "clear",
         size: Literal["sm", "lg"] | None = None,
         icon: str
         | None = "https://huggingface.co/front/assets/huggingface_logo-noborder.svg",
@@ -44,7 +44,7 @@ class LoginButton(Button):
         elem_classes: list[str] | str | None = None,
         render: bool = True,
         key: int | str | None = None,
-        scale: int | None = 0,
+        scale: int | None = None,
         min_width: int | None = None,
     ):
         """

--- a/js/button/shared/Button.svelte
+++ b/js/button/shared/Button.svelte
@@ -4,7 +4,8 @@
 	export let elem_id = "";
 	export let elem_classes: string[] = [];
 	export let visible = true;
-	export let variant: "primary" | "secondary" | "stop" | "clear" = "secondary";
+	export let variant: "primary" | "secondary" | "stop" | "huggingface" =
+		"secondary";
 	export let size: "sm" | "lg" = "lg";
 	export let value: string | null = null;
 	export let link: string | null = null;
@@ -120,7 +121,7 @@
 		color: var(--button-secondary-text-color);
 	}
 
-	.clear {
+	.huggingface {
 		border: var(--button-border-width) solid
 			var(--button-secondary-border-color);
 		background: var(--background-fill-primary);

--- a/js/button/shared/Button.svelte
+++ b/js/button/shared/Button.svelte
@@ -120,7 +120,7 @@
 		color: var(--button-secondary-text-color);
 	}
 
-	.clear{
+	.clear {
 		border: var(--button-border-width) solid
 			var(--button-secondary-border-color);
 	}

--- a/js/button/shared/Button.svelte
+++ b/js/button/shared/Button.svelte
@@ -123,6 +123,8 @@
 	.clear {
 		border: var(--button-border-width) solid
 			var(--button-secondary-border-color);
+		background: var(--background-fill-primary);
+
 	}
 
 	.secondary:hover,

--- a/js/button/shared/Button.svelte
+++ b/js/button/shared/Button.svelte
@@ -124,7 +124,6 @@
 		border: var(--button-border-width) solid
 			var(--button-secondary-border-color);
 		background: var(--background-fill-primary);
-
 	}
 
 	.secondary:hover,

--- a/js/button/shared/Button.svelte
+++ b/js/button/shared/Button.svelte
@@ -4,7 +4,7 @@
 	export let elem_id = "";
 	export let elem_classes: string[] = [];
 	export let visible = true;
-	export let variant: "primary" | "secondary" | "stop" = "secondary";
+	export let variant: "primary" | "secondary" | "stop" | "clear" = "secondary";
 	export let size: "sm" | "lg" = "lg";
 	export let value: string | null = null;
 	export let link: string | null = null;
@@ -118,6 +118,11 @@
 			var(--button-secondary-border-color);
 		background: var(--button-secondary-background-fill);
 		color: var(--button-secondary-text-color);
+	}
+
+	.clear{
+		border: var(--button-border-width) solid
+			var(--button-secondary-border-color);
 	}
 
 	.secondary:hover,


### PR DESCRIPTION
For more consistency with HF Hub branding, this PR adds a "huggingface" button variant, and makes it the default for `gr.LoginButton`

Here are the "primary", "secondary", and "clear" variants:

<img width="1264" alt="image" src="https://github.com/user-attachments/assets/685a5f44-fb1d-4831-b518-7b7c69743f2a">

<img width="1242" alt="image" src="https://github.com/user-attachments/assets/6a9e24c5-9381-4111-879c-32a32cbbaf87">

Compare with HF Hub branding: https://huggingface.co/docs/hub/en/oauth#branding

<img width="370" alt="image" src="https://github.com/user-attachments/assets/0caf96b9-0987-41fb-9752-cb6f8f10a22b">

Closes: https://github.com/gradio-app/gradio/issues/5628

wdyt @hannahblair @Wauplin @gary149 @julien-c 