### PR TITLE
Raise error instead of warning if checksums for binary do not match

### DIFF
--- a/.changeset/seven-deer-occur.md
+++ b/.changeset/seven-deer-occur.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Raise error instead of warning if checksums for binary do not match

--- a/gradio/tunneling.py
+++ b/gradio/tunneling.py
@@ -95,8 +95,10 @@ class Tunnel:
                 calculated_hash = sha.hexdigest()
 
                 if calculated_hash != CHECKSUMS[BINARY_URL]:
-                    warnings.warn(
-                        f"Checksum of downloaded binary for creating share links does not match expected value. Please verify the integrity of the downloaded binary located at {BINARY_PATH}."
+                    raise ValueError(
+                        "Checksum of downloaded binary for creating share links does not match expected value."
+                        f"Please verify the integrity of the downloaded binary located at {BINARY_PATH}."
+                        "If you believe this is an error, please create a GitHub issue: https://github.com/gradio-app/gradio/issues"
                     )
 
     def start_tunnel(self) -> str:

--- a/gradio/tunneling.py
+++ b/gradio/tunneling.py
@@ -7,7 +7,6 @@ import stat
 import subprocess
 import sys
 import time
-import warnings
 from pathlib import Path
 
 import httpx


### PR DESCRIPTION
Context: [internal conversation](https://huggingface.slack.com/archives/C06V0AAK7QB/p1725461274060749)