### PR TITLE
Fix stop recording button colors

### DIFF
--- a/.changeset/sad-chicken-sleep.md
+++ b/.changeset/sad-chicken-sleep.md
@@ -1,0 +1,6 @@
+---
+"@gradio/image": patch
+"gradio": patch
+---
+
+feat:Fix stop recording button colors

--- a/js/image/shared/Webcam.svelte
+++ b/js/image/shared/Webcam.svelte
@@ -424,6 +424,7 @@
 	.color-primary {
 		fill: var(--primary-600);
 		stroke: var(--primary-600);
+		color: var(--primary-600);
 	}
 
 	.flip {


### PR DESCRIPTION
## Description

Recent changes to the Square icon accidentally changed the color of the webcam stop recording button.

Before
<img width="147" alt="Screenshot 2024-09-04 at 8 03 38 PM" src="https://github.com/user-attachments/assets/7e984231-9284-49f8-b53f-fe1ea8cc5d33">

After
<img width="190" alt="Screenshot 2024-09-04 at 8 03 22 PM" src="https://github.com/user-attachments/assets/2eba44e4-d598-40c8-8452-0fa64af75144">



Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
