### PR TITLE
Fix scrollbars everywhere

### DIFF
--- a/.changeset/warm-impalas-turn.md
+++ b/.changeset/warm-impalas-turn.md
@@ -1,0 +1,6 @@
+---
+"@gradio/json": minor
+"gradio": minor
+---
+
+feat:Fix scrollbars everywhere

--- a/js/json/Index.svelte
+++ b/js/json/Index.svelte
@@ -70,9 +70,3 @@
 
 	<JSON {value} {open} {theme_mode} {show_indices} />
 </Block>
-
-<style>
-	:global(.block) {
-		overflow-y: scroll !important;
-	}
-</style>

--- a/js/json/Index.svelte
+++ b/js/json/Index.svelte
@@ -29,7 +29,7 @@
 	export let open = false;
 	export let theme_mode: "system" | "light" | "dark";
 	export let show_indices: boolean;
-	export let height: string | number | undefined;
+	export let height: string | number | undefined = undefined;
 
 	$: {
 		if (value !== old_value) {
@@ -70,3 +70,10 @@
 
 	<JSON {value} {open} {theme_mode} {show_indices} />
 </Block>
+
+<style>
+	:global(.json) {
+		display: flex;
+		flex-direction: column;
+	}
+</style>

--- a/js/json/Index.svelte
+++ b/js/json/Index.svelte
@@ -37,6 +37,8 @@
 			gradio.dispatch("change");
 		}
 	}
+
+	let label_height = 0;
 </script>
 
 <Block
@@ -51,15 +53,17 @@
 	allow_overflow={false}
 	{height}
 >
-	{#if label}
-		<BlockLabel
-			Icon={JSONIcon}
-			{show_label}
-			{label}
-			float={false}
-			disable={container === false}
-		/>
-	{/if}
+	<div bind:clientHeight={label_height}>
+		{#if label}
+			<BlockLabel
+				Icon={JSONIcon}
+				{show_label}
+				{label}
+				float={false}
+				disable={container === false}
+			/>
+		{/if}
+	</div>
 
 	<StatusTracker
 		autoscroll={gradio.autoscroll}
@@ -68,12 +72,5 @@
 		on:clear_status={() => gradio.dispatch("clear_status", loading_status)}
 	/>
 
-	<JSON {value} {open} {theme_mode} {show_indices} />
+	<JSON {value} {open} {theme_mode} {show_indices} {label_height} />
 </Block>
-
-<style>
-	:global(.json) {
-		display: flex;
-		flex-direction: column;
-	}
-</style>

--- a/js/json/shared/JSON.svelte
+++ b/js/json/shared/JSON.svelte
@@ -91,7 +91,8 @@
 
 	.json-holder {
 		padding: var(--size-2);
-		overflow-y: scroll;
+		overflow-y: auto;
+		max-height: 100%;
 	}
 
 	.empty-wrapper {

--- a/js/json/shared/JSON.svelte
+++ b/js/json/shared/JSON.svelte
@@ -9,6 +9,9 @@
 	export let open = false;
 	export let theme_mode: "system" | "light" | "dark" = "system";
 	export let show_indices = false;
+	export let label_height: number;
+
+	$: json_max_height = `calc(100% - ${label_height}px)`;
 
 	let copied = false;
 	let timer: NodeJS.Timeout;
@@ -56,7 +59,7 @@
 			<Copy />
 		{/if}
 	</button>
-	<div class="json-holder">
+	<div class="json-holder" style:max-height={json_max_height}>
 		<JSONNode
 			{value}
 			depth={0}
@@ -92,7 +95,6 @@
 	.json-holder {
 		padding: var(--size-2);
 		overflow-y: auto;
-		max-height: 100%;
 	}
 
 	.empty-wrapper {


### PR DESCRIPTION
In the JSON component we added scrollbars to all .blocks, adding scrollbars everywhere. So if any component had a JSON component, we got scrollbars everywhere. Removed this CSS.

<img width="218" alt="Screenshot 2024-09-06 at 7 28 35 AM" src="https://github.com/user-attachments/assets/a4941893-6ad3-437f-aa23-9ecb661eb0d1">
