### PR TITLE
Pin `fastapi<0.113.0` in `requirements.txt`

### DIFF
--- a/.changeset/tall-maps-relate.md
+++ b/.changeset/tall-maps-relate.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:fastapi requirement

--- a/.changeset/tall-maps-relate.md
+++ b/.changeset/tall-maps-relate.md
@@ -2,4 +2,4 @@
 "gradio": patch
 ---
 
-feat:Pin `fastapi<0.113.0` in `requirements.txt`
+fix:Pin `fastapi<0.113.0` in `requirements.txt`

--- a/.changeset/tall-maps-relate.md
+++ b/.changeset/tall-maps-relate.md
@@ -2,4 +2,4 @@
 "gradio": patch
 ---
 
-feat:fastapi requirement
+feat:Pin `fastapi<0.113.0` in `requirements.txt`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles>=22.0,<24.0
 anyio>=3.0,<5.0
-fastapi
+fastapi<0.113.0
 ffmpy
 gradio_client==1.3.0
 httpx>=0.24.1


### PR DESCRIPTION
Fairly certain the latest `fastapi` release is broken, pinning to any earlier version for now

Closes: https://github.com/gradio-app/gradio/issues/9275