### PR TITLE
Match style of textbox stop button to submit button

### DIFF
--- a/.changeset/warm-lemons-mate.md
+++ b/.changeset/warm-lemons-mate.md
@@ -1,0 +1,8 @@
+---
+"@gradio/icons": minor
+"@gradio/multimodaltextbox": minor
+"@gradio/textbox": minor
+"gradio": minor
+---
+
+feat:Change textbox stop button styling

--- a/.changeset/warm-lemons-mate.md
+++ b/.changeset/warm-lemons-mate.md
@@ -5,4 +5,4 @@
 "gradio": minor
 ---
 
-feat:Change textbox stop button styling
+feat:Match style of textbox stop button to submit button

--- a/js/icons/src/Square.svelte
+++ b/js/icons/src/Square.svelte
@@ -1,6 +1,6 @@
 <script>
 	export let fill = "currentColor";
-	export let stroke_width = 1;
+	export let stroke_width = 1.5;
 </script>
 
 <svg

--- a/js/icons/src/Square.svelte
+++ b/js/icons/src/Square.svelte
@@ -1,11 +1,16 @@
+<script>
+	export let fill = "currentColor";
+	export let stroke_width = 1;
+</script>
+
 <svg
 	xmlns="http://www.w3.org/2000/svg"
 	width="100%"
 	height="100%"
 	viewBox="0 0 24 24"
-	fill="currentColor"
+	{fill}
 	stroke="currentColor"
-	stroke-width="1.5"
+	stroke-width={`${stroke_width}`}
 	stroke-linecap="round"
 	stroke-linejoin="round"
 	class="feather feather-square"

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -366,7 +366,7 @@
 					on:click={handle_stop}
 				>
 					{#if stop_btn === true}
-						<Square fill={"none"} stroke_width={2.5}/>
+						<Square fill={"none"} stroke_width={2.5} />
 					{:else}
 						{stop_btn}
 					{/if}

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -366,7 +366,7 @@
 					on:click={handle_stop}
 				>
 					{#if stop_btn === true}
-						<Square />
+						<Square fill={"none"} stroke_width={2.5}/>
 					{:else}
 						{stop_btn}
 					{/if}
@@ -446,17 +446,19 @@
 		padding: 0 10px;
 	}
 
+	.stop-button,
 	.upload-button,
 	.submit-button {
 		background: var(--button-secondary-background-fill);
-		color: var(--button-secondary-text-color);
 	}
 
+	.stop-button:hover,
 	.upload-button:hover,
 	.submit-button:hover {
 		background: var(--button-secondary-background-fill-hover);
 	}
 
+	.stop-button:active,
 	.upload-button:active,
 	.submit-button:active {
 		box-shadow: var(--button-shadow-active);
@@ -471,17 +473,9 @@
 		width: 17px;
 	}
 
-	.stop-button {
-		background: var(--button-cancel-background-fill);
-		color: var(--button-cancel-text-color);
-	}
-	.stop-button:hover {
-		background: var(--button-cancel-background-fill-hover);
-		color: var(--button-cancel-text-color-hover);
-	}
 	.stop-button :global(svg) {
-		height: 18px;
-		width: 18px;
+		height: 16px;
+		width: 16px;
 	}
 
 	.loader {

--- a/js/textbox/shared/Textbox.svelte
+++ b/js/textbox/shared/Textbox.svelte
@@ -309,7 +309,7 @@
 				on:click={handle_stop}
 			>
 				{#if stop_btn === true}
-					<Square fill="none" stroke_width={2.5}/>
+					<Square fill="none" stroke_width={2.5} />
 				{:else}
 					{stop_btn}
 				{/if}

--- a/js/textbox/shared/Textbox.svelte
+++ b/js/textbox/shared/Textbox.svelte
@@ -309,7 +309,7 @@
 				on:click={handle_stop}
 			>
 				{#if stop_btn === true}
-					<Square />
+					<Square fill="none" stroke_width={2.5}/>
 				{:else}
 					{stop_btn}
 				{/if}
@@ -420,13 +420,16 @@
 		margin-bottom: 5px;
 		z-index: var(--layer-1);
 	}
+	.stop-button,
 	.submit-button {
 		background: var(--button-secondary-background-fill);
 		color: var(--button-secondary-text-color);
 	}
+	.stop-button:hover,
 	.submit-button:hover {
 		background: var(--button-secondary-background-fill-hover);
 	}
+	.stop-button:active,
 	.submit-button:active {
 		box-shadow: var(--button-shadow-active);
 	}
@@ -434,17 +437,10 @@
 		height: 22px;
 		width: 22px;
 	}
-	.stop-button {
-		background: var(--button-cancel-background-fill);
-		color: var(--button-cancel-text-color);
-	}
-	.stop-button:hover {
-		background: var(--button-cancel-background-fill-hover);
-		color: var(--button-cancel-text-color-hover);
-	}
+
 	.stop-button :global(svg) {
-		height: 18px;
-		width: 18px;
+		height: 16px;
+		width: 16px;
 	}
 	.padded-button {
 		padding: 0 10px;


### PR DESCRIPTION
## Description

Modify textbox stop button styling to match that the submit button. Happy to tweak further.

### Dark mode
<img width="102" alt="Screenshot 2024-09-06 at 12 26 47 AM" src="https://github.com/user-attachments/assets/bdf77a11-eb17-4dbe-8c29-5ac1ce6b562b">

### Light mode
<img width="91" alt="image" src="https://github.com/user-attachments/assets/476be216-f13d-4fdb-8216-4a71dc3da65a">



## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
