### PR TITLE
Remove two dependencies: `importlib_resources` and `urllib3` (if not in Wasm)

### DIFF
--- a/.changeset/cute-rules-write.md
+++ b/.changeset/cute-rules-write.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:Remove another dependency: `importlib_resources`
+feat:Remove two dependencies: `importlib_resources` and `urllib3` (if not in Wasm)

--- a/.changeset/cute-rules-write.md
+++ b/.changeset/cute-rules-write.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Remove another dependency: `importlib_resources`

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hashlib
-import importlib
 import importlib.resources
 import inspect
 import json
@@ -109,13 +108,13 @@ STATIC_TEMPLATE_LIB = cast(
 STATIC_PATH_LIB = cast(
     DeveloperPath,
     importlib.resources.files("gradio")
-    .joinpath("templates", "frontend", "static")
+    .joinpath("templates/frontend/static")
     .as_posix(),  # type: ignore
 )
 BUILD_PATH_LIB = cast(
     DeveloperPath,
     importlib.resources.files("gradio")
-    .joinpath("templates", "frontend", "assets")
+    .joinpath("templates/frontend/assets")
     .as_posix(),  # type: ignore
 )
 VERSION = get_package_version()

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -108,11 +108,15 @@ STATIC_TEMPLATE_LIB = cast(
 )
 STATIC_PATH_LIB = cast(
     DeveloperPath,
-    importlib.resources.files("gradio").joinpath("templates", "frontend", "static").as_posix(),  # type: ignore
+    importlib.resources.files("gradio")
+    .joinpath("templates", "frontend", "static")
+    .as_posix(),  # type: ignore
 )
 BUILD_PATH_LIB = cast(
     DeveloperPath,
-    importlib.resources.files("gradio").joinpath("templates", "frontend", "assets").as_posix(),  # type: ignore
+    importlib.resources.files("gradio")
+    .joinpath("templates", "frontend", "assets")
+    .as_posix(),  # type: ignore
 )
 VERSION = get_package_version()
 XSS_SAFE_MIMETYPES = {

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hashlib
+import importlib
+import importlib.resources
 import inspect
 import json
 import math
@@ -45,7 +47,6 @@ from fastapi.templating import Jinja2Templates
 from gradio_client import utils as client_utils
 from gradio_client.documentation import document
 from gradio_client.utils import ServerMessage
-from importlib_resources import files
 from jinja2.exceptions import TemplateNotFound
 from multipart.multipart import parse_options_header
 from starlette.background import BackgroundTask
@@ -103,15 +104,15 @@ mimetypes.init()
 
 STATIC_TEMPLATE_LIB = cast(
     DeveloperPath,
-    files("gradio").joinpath("templates").as_posix(),  # type: ignore
+    importlib.resources.files("gradio").joinpath("templates").as_posix(),  # type: ignore
 )
 STATIC_PATH_LIB = cast(
     DeveloperPath,
-    files("gradio").joinpath("templates", "frontend", "static").as_posix(),  # type: ignore
+    importlib.resources.files("gradio").joinpath("templates", "frontend", "static").as_posix(),  # type: ignore
 )
 BUILD_PATH_LIB = cast(
     DeveloperPath,
-    files("gradio").joinpath("templates", "frontend", "assets").as_posix(),  # type: ignore
+    importlib.resources.files("gradio").joinpath("templates", "frontend", "assets").as_posix(),  # type: ignore
 )
 VERSION = get_package_version()
 XSS_SAFE_MIMETYPES = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ ffmpy
 gradio_client==1.4.0-beta.1
 httpx>=0.24.1
 huggingface_hub>=0.19.3
-importlib_resources>=1.3,<7.0
 Jinja2<4.0
 markupsafe~=2.0
 numpy>=1.0,<3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pydub
 pyyaml>=5.0,<7.0
 semantic_version~=2.0
 typing_extensions~=4.0
-urllib3~=2.0  # urllib3 is used for Lite support. Version spec can be omitted because urllib3==2.1.0 is prebuilt for Pyodide and urllib>=2.2.0 supports Pyodide as well.
+urllib3~=2.0; sys.platform == 'emscripten'  # urllib3 is used for Lite support. Version spec can be omitted because urllib3==2.1.0 is prebuilt for Pyodide and urllib>=2.2.0 supports Pyodide as well.
 uvicorn>=0.14.0; sys.platform != 'emscripten'
 typer>=0.12,<1.0; sys.platform != 'emscripten'
 tomlkit==0.12.0


### PR DESCRIPTION
`importlib_resources` is not needed anymore since `importlib.resources.files` exists in Python 3.10 and higher: https://docs.python.org/3.10/library/importlib.html?highlight=importlib#importlib.resources.files

`urllib3` is only needed in Gradio-lite so I've updated the requirements.txt accordingly