### PR TITLE
Fix typo in `tunneling.py`

### DIFF
--- a/.changeset/floppy-keys-heal.md
+++ b/.changeset/floppy-keys-heal.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix typo in `tunneling.py`

--- a/gradio/tunneling.py
+++ b/gradio/tunneling.py
@@ -71,7 +71,7 @@ class Tunnel:
 
     @staticmethod
     def download_binary():
-        if Path(BINARY_PATH).exists():
+        if not Path(BINARY_PATH).exists():
             resp = httpx.get(BINARY_URL, timeout=30)
 
             if resp.status_code == 403:


### PR DESCRIPTION
Fix mistake from https://github.com/gradio-app/gradio/commit/6309a48e3a89a13137ec9d61c1c722eb59b8e3dc#diff-26073d5b5461562f83e4f50470636e2d595c5dd03c9b5223efb59575645e7eb2L72 that  would prevent frpc from being downloaded