### PR TITLE
Small tweak to how thoughts are shown in `gr.Chatbot`

### DIFF
--- a/.changeset/breezy-olives-wonder.md
+++ b/.changeset/breezy-olives-wonder.md
@@ -1,0 +1,6 @@
+---
+"@gradio/chatbot": minor
+"gradio": minor
+---
+
+feat:Small tweak to how thoughts are shown in `gr.Chatbot`

--- a/js/chatbot/shared/ChatBot.svelte
+++ b/js/chatbot/shared/ChatBot.svelte
@@ -422,7 +422,7 @@
 								>
 									{#if message.type === "text"}
 										{#if message.metadata.title}
-											<MessageBox title={message.metadata.title}>
+											<MessageBox title={message.metadata.title} expanded={is_last_bot_message(messages, value)}>
 												<Markdown
 													message={message.content}
 													{latex_delimiters}

--- a/js/chatbot/shared/ChatBot.svelte
+++ b/js/chatbot/shared/ChatBot.svelte
@@ -422,7 +422,10 @@
 								>
 									{#if message.type === "text"}
 										{#if message.metadata.title}
-											<MessageBox title={message.metadata.title} expanded={is_last_bot_message(messages, value)}>
+											<MessageBox
+												title={message.metadata.title}
+												expanded={is_last_bot_message(messages, value)}
+											>
 												<Markdown
 													message={message.content}
 													{latex_delimiters}

--- a/js/chatbot/shared/MessageBox.svelte
+++ b/js/chatbot/shared/MessageBox.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	let expanded = false;
+	export let expanded = false;
 	export let title: string;
 
 	function toggleExpanded(): void {


### PR DESCRIPTION
A small tweak, as I was testing the ability to show "thoughts" in `gr.Chatbot`: now accordions will shown expanded if they are the last message in the Chatbot history:

```py
import gradio as gr
import time

thought = "I need to use the weather API tool"

def return_thought():
    value = [{"role": "user", "content": "What is the weather in San Francisco?"}]
    value += [{"role": "assistant", "content": "", "metadata": {"title":  "🧠 Thinking"}}]
    for i in range(len(thought)):
        value[-1]["content"] = thought[:i+1]
        time.sleep(0.02)
        yield value
    value += [{"role": "assistant", "content": "85 degrees"}]
    value += [{"role": "user", "content": "What is the weather in Miami?"}]
    yield value
    value += [{"role": "assistant", "content": "", "metadata": {"title":  "🧠 Thinking"}}]
    for i in range(len(thought)):
        value[-1]["content"] = thought[:i+1]
        time.sleep(0.02)
        yield value
    yield value + [{"role": "assistant", "content": "95 degrees"}]

with gr.Blocks() as demo:
    c = gr.Chatbot(type="messages")
    demo.load(return_thought, None, c)

demo.launch()
```

<img width="1248" alt="image" src="https://github.com/user-attachments/assets/c0f6da72-70e9-4525-8949-a1120872cedb">
