### PR TITLE
Fix File Types for MultimodalTextbox

### DIFF
--- a/.changeset/tough-rooms-flash.md
+++ b/.changeset/tough-rooms-flash.md
@@ -1,0 +1,6 @@
+---
+"@gradio/multimodaltextbox": patch
+"gradio": patch
+---
+
+fix:Fix File Types for MultimodalTextbox

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -65,18 +65,6 @@
 		dispatch("change", value);
 		oldValue = value.text;
 	}
-	let accept_file_types: string | null;
-	if (file_types == null) {
-		accept_file_types = null;
-	} else {
-		file_types = file_types.map((x) => {
-			if (x.startsWith(".")) {
-				return x;
-			}
-			return x + "/*";
-		});
-		accept_file_types = file_types.join(", ");
-	}
 
 	$: if (value === null) value = { text: "", files: [] };
 	$: value, el && lines !== max_lines && resize(el, lines, max_lines);
@@ -306,6 +294,7 @@
 				bind:this={upload_component}
 				on:load={handle_upload}
 				{file_count}
+				filetype={file_types}
 				{root}
 				{max_file_size}
 				bind:dragging


### PR DESCRIPTION
## Description
Seems like `file_types` was broken completely for `multimodaltextbox`. 
Would be nice to see if this also fixes the issue on Windows @yvrjsharma.

Also noticed dragging and dropping is broken for multimodaltextbox. Opened an issue here: 9392

Closes: #8801

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
