### PR TITLE
Tweaks to SSR mode

### DIFF
--- a/demo/hello_blocks/run.py
+++ b/demo/hello_blocks/run.py
@@ -1,7 +1,9 @@
 import gradio as gr
 
+
 def greet(name):
     return "Hello " + name + "!"
+
 
 with gr.Blocks() as demo:
     name = gr.Textbox(label="Name")

--- a/demo/hello_blocks/run.py
+++ b/demo/hello_blocks/run.py
@@ -1,9 +1,7 @@
 import gradio as gr
 
-
 def greet(name):
     return "Hello " + name + "!"
-
 
 with gr.Blocks() as demo:
     name = gr.Textbox(label="Name")

--- a/demo/hello_world/run.py
+++ b/demo/hello_world/run.py
@@ -5,7 +5,7 @@ def greet(name):
     return "Hello " + name + "!"
 
 
-demo = gr.Interface(fn=greet, inputs="textbox", outputs="textbox")
+demo = gr.Interface(fn=greet, inputs="textbox", outputs="textbox", spa_mode=False)
 
 if __name__ == "__main__":
-    demo.launch(ssr_mode=True)
+    demo.launch()

--- a/demo/hello_world/run.py
+++ b/demo/hello_world/run.py
@@ -5,7 +5,7 @@ def greet(name):
     return "Hello " + name + "!"
 
 
-demo = gr.Interface(fn=greet, inputs="textbox", outputs="textbox", spa_mode=False)
+demo = gr.Interface(fn=greet, inputs="textbox", outputs="textbox")
 
 if __name__ == "__main__":
-    demo.launch()
+    demo.launch(ssr_mode=True)

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2391,19 +2391,12 @@ Received outputs:
             )
         )
         node_path = os.environ.get("GRADIO_NODE_PATH", get_node_path())
-        self.node_server_name = None
-        self.node_port = None
-        if not Blocks.node_process:
-            (node_server_name, node_process, node_port) = start_node_server(
-                server_name=node_server_name,
-                server_port=node_port,
-                node_path=node_path,
-                ssr_mode=self.ssr_mode,
+        self.node_server_name, self.node_process, self.node_port = start_node_server(
+            server_name=node_server_name,
+            server_port=node_port,
+            node_path=node_path,
+            ssr_mode=self.ssr_mode,
             )
-            Blocks.node_process = node_process
-            self.node_server_name = node_server_name
-            self.node_port = node_port
-            self.node_process = node_process
         # self.server_app is included for backwards compatibility
         self.server_app = self.app = App.create_app(
             self,

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -974,9 +974,6 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
     Demos: blocks_hello, blocks_flipper, blocks_kinematics
     Guides: blocks-and-event-listeners, controlling-layout, state-in-blocks, custom-CSS-and-JS, using-blocks-like-functions
     """
-
-    node_process: subprocess.Popen[bytes] | None = None
-
     def __init__(
         self,
         theme: Theme | str | None = None,

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2393,7 +2393,6 @@ Received outputs:
         node_path = os.environ.get("GRADIO_NODE_PATH", get_node_path())
         self.node_server_name = None
         self.node_port = None
-        print("self.ssr_mode", self.ssr_mode)
         if not Blocks.node_process:
             (node_server_name, node_process, node_port) = start_node_server(
                 server_name=node_server_name,
@@ -2405,7 +2404,6 @@ Received outputs:
             self.node_server_name = node_server_name
             self.node_port = node_port
             self.node_process = node_process
-        print("self.node_process", self.node_process)
         # self.server_app is included for backwards compatibility
         self.server_app = self.app = App.create_app(
             self,

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -991,7 +991,6 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
         fill_height: bool = False,
         fill_width: bool = False,
         delete_cache: tuple[int, int] | None = None,
-        spa_mode: bool | None = None,
         node_server_name: str | None = None,
         node_port: int | None = None,
         **kwargs,
@@ -1008,18 +1007,8 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
             fill_height: Whether to vertically expand top-level child components to the height of the window. If True, expansion occurs when the scale value of the child components >= 1.
             fill_width: Whether to horizontally expand to fill container fully. If False, centers and constrains app to a maximum width. Only applies if this is the outermost `Blocks` in your Gradio app.
             delete_cache: A tuple corresponding [frequency, age] both expressed in number of seconds. Every `frequency` seconds, the temporary files created by this Blocks instance will be deleted if more than `age` seconds have passed since the file was created. For example, setting this to (86400, 86400) will delete temporary files every day. The cache will be deleted entirely when the server restarts. If None, no cache deletion will occur.
-            spa_mode: Whether to enable single-page application mode. If None, will use GRADIO_SPA_MODE environment variable or default to False.
         """
         self.limiter = None
-        self.spa_mode = (
-            False
-            if wasm_utils.IS_WASM
-            else (
-                spa_mode
-                if spa_mode is not None
-                else os.getenv("GRADIO_SPA_MODE", "True").lower() == "true"
-            )
-        )
         if theme is None:
             theme = DefaultTheme()
         elif isinstance(theme, str):
@@ -1139,7 +1128,6 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
                 server_name=node_server_name,
                 server_port=node_port,
                 node_path=node_path,
-                spa_mode=self.spa_mode,
             )
             Blocks.node_process = node_process
             self.node_server_name = node_server_name
@@ -2270,9 +2258,10 @@ Received outputs:
         share_server_protocol: Literal["http", "https"] | None = None,
         auth_dependency: Callable[[fastapi.Request], str | None] | None = None,
         max_file_size: str | int | None = None,
-        _frontend: bool = True,
         enable_monitoring: bool | None = None,
         strict_cors: bool = True,
+        ssr_mode: bool | None = None,
+        _frontend: bool = True,
     ) -> tuple[routes.App, str, str]:
         """
         Launches a simple web server that serves the demo. Can also be used to create a
@@ -2307,8 +2296,9 @@ Received outputs:
             share_server_protocol: Use this to specify the protocol to use for the share links. Defaults to "https", unless a custom share_server_address is provided, in which case it defaults to "http". If you are using a custom share_server_address and want to use https, you must set this to "https".
             auth_dependency: A function that takes a FastAPI request and returns a string user ID or None. If the function returns None for a specific request, that user is not authorized to access the app (they will see a 401 Unauthorized response). To be used with external authentication systems like OAuth. Cannot be used with `auth`.
             max_file_size: The maximum file size in bytes that can be uploaded. Can be a string of the form "<value><unit>", where value is any positive integer and unit is one of "b", "kb", "mb", "gb", "tb". If None, no limit is set.
-            strict_cors: If True, prevents external domains from making requests to a Gradio server running on localhost. If False, allows requests to localhost that originate from localhost but also, crucially, from "null". This parameter should normally be True to prevent CSRF attacks but may need to be False when embedding a *locally-running Gradio app* using web components.
             enable_monitoring: Enables traffic monitoring of the app through the /monitoring endpoint. By default is None, which enables this endpoint. If explicitly True, will also print the monitoring URL to the console. If False, will disable monitoring altogether.
+            strict_cors: If True, prevents external domains from making requests to a Gradio server running on localhost. If False, allows requests to localhost that originate from localhost but also, crucially, from "null". This parameter should normally be True to prevent CSRF attacks but may need to be False when embedding a *locally-running Gradio app* using web components.
+            ssr_mode: If True, the Gradio app will be rendered using server-side rendering mode, which is typically more performant and provides better SEO, but this requires Node 18+ to be installed on the system. If False, the app will be rendered using client-side rendering mode. If None, will use GRADIO_SSR_MODE environment variable or default to False.
         Returns:
             app: FastAPI app object that is running the demo
             local_url: Locally accessible link to the demo
@@ -2413,12 +2403,23 @@ Received outputs:
         self.max_threads = max_threads
         self._queue.max_thread_count = max_threads
 
+        self.ssr_mode = (
+            False
+            if wasm_utils.IS_WASM
+            else (
+                ssr_mode
+                if ssr_mode is not None
+                else os.getenv("GRADIO_SSR_MODE", "False").lower() == "true"
+            )
+        )
+
         # self.server_app is included for backwards compatibility
         self.server_app = self.app = App.create_app(
             self,
             auth_dependency=auth_dependency,
             app_kwargs=app_kwargs,
             strict_cors=strict_cors,
+            ssr_mode=self.ssr_mode,
         )
 
         if self.is_running:
@@ -2438,7 +2439,6 @@ Received outputs:
                 # which the frontend app will directly communicate with through the Worker API,
                 # and we don't need to start a server.
                 wasm_utils.register_app(self.app)
-                self.spa_mode = True
             else:
                 from gradio import http_server
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2396,18 +2396,19 @@ Received outputs:
         node_path = os.environ.get("GRADIO_NODE_PATH", get_node_path())
         self.node_server_name = None
         self.node_port = None
-
+        print("self.ssr_mode", self.ssr_mode)
         if not Blocks.node_process:
             (node_server_name, node_process, node_port) = start_node_server(
                 server_name=node_server_name,
                 server_port=node_port,
                 node_path=node_path,
+                ssr_mode=self.ssr_mode,
             )
             Blocks.node_process = node_process
             self.node_server_name = node_server_name
             self.node_port = node_port
             self.node_process = node_process
-
+        print("self.node_process", self.node_process)
         # self.server_app is included for backwards compatibility
         self.server_app = self.app = App.create_app(
             self,
@@ -2470,7 +2471,7 @@ Received outputs:
                 else "http"
             )
             if not wasm_utils.IS_WASM and not self.is_colab and not quiet:
-                s = strings.en["RUNNING_LOCALLY"] if self.node_process else strings.en["RUNNING_LOCALLY_SSR"]
+                s = strings.en["RUNNING_LOCALLY_SSR"] if self.node_process else strings.en["RUNNING_LOCALLY"]
                 print(
                     s.format(
                         self.protocol, self.server_name, self.server_port

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -390,9 +390,7 @@ class Block:
                 return client_utils.synchronize_async(
                     processing_utils.async_move_files_to_cache, data, self
                 )
-            except (
-                AttributeError
-            ):  # Can be raised if this function is called before the Block is fully initialized.
+            except AttributeError:  # Can be raised if this function is called before the Block is fully initialized.
                 return data
 
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -9,7 +9,6 @@ import os
 import random
 import secrets
 import string
-import subprocess
 import sys
 import threading
 import time
@@ -974,6 +973,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
     Demos: blocks_hello, blocks_flipper, blocks_kinematics
     Guides: blocks-and-event-listeners, controlling-layout, state-in-blocks, custom-CSS-and-JS, using-blocks-like-functions
     """
+
     def __init__(
         self,
         theme: Theme | str | None = None,
@@ -2466,12 +2466,12 @@ Received outputs:
                 else "http"
             )
             if not wasm_utils.IS_WASM and not self.is_colab and not quiet:
-                s = strings.en["RUNNING_LOCALLY_SSR"] if self.node_process else strings.en["RUNNING_LOCALLY"]
-                print(
-                    s.format(
-                        self.protocol, self.server_name, self.server_port
-                    )
+                s = (
+                    strings.en["RUNNING_LOCALLY_SSR"]
+                    if self.node_process
+                    else strings.en["RUNNING_LOCALLY"]
                 )
+                print(s.format(self.protocol, self.server_name, self.server_port))
 
             self._queue.set_server_app(self.server_app)
 

--- a/gradio/node_server.py
+++ b/gradio/node_server.py
@@ -24,14 +24,14 @@ def start_node_server(
     server_name: str | None = None,
     server_port: int | None = None,
     node_path: str | None = None,
-    spa_mode: bool | None = None,
+    ssr_mode: bool | None = None,
 ) -> tuple[str | None, subprocess.Popen[bytes] | None, int | None]:
     """Launches a local server running the provided Interface
     Parameters:
         server_name: to make app accessible on local network, set this to "0.0.0.0". Can be set by environment variable GRADIO_SERVER_NAME.
         server_port: will start gradio app on this port (if available). Can be set by environment variable GRADIO_SERVER_PORT.
         node_path: the path to the node executable. Can be set by environment variable GRADIO_NODE_PATH.
-        spa_mode: If True, will not start the node server and will serve the SPA from the Python server
+        ssr_mode: If False, will not start the node server and will serve the SPA from the Python server
 
     Returns:
         server_name: the name of the server (default is "localhost")
@@ -58,7 +58,7 @@ def start_node_server(
     node_process = None
     node_port = None
 
-    if not spa_mode:
+    if ssr_mode:
         (node_process, node_port) = start_node_process(
             node_path=node_path or os.getenv("GRADIO_NODE_PATH"),
             server_name=host,

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -302,6 +302,7 @@ class App(FastAPI):
         app_kwargs: dict[str, Any] | None = None,
         auth_dependency: Callable[[fastapi.Request], str | None] | None = None,
         strict_cors: bool = True,
+        ssr_mode: bool = False,
     ) -> App:
         app_kwargs = app_kwargs or {}
         app_kwargs.setdefault("default_response_class", ORJSONResponse)
@@ -317,7 +318,7 @@ class App(FastAPI):
         if not wasm_utils.IS_WASM:
             app.add_middleware(CustomCORSMiddleware, strict_cors=strict_cors)
 
-        if not blocks.spa_mode:
+        if ssr_mode:
 
             @app.middleware("http")
             async def conditional_routing_middleware(request: Request, call_next):

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -224,7 +224,6 @@ class App(FastAPI):
         node_port: int,
         python_port: int,
     ) -> Response:
-
         full_path = request.url.path
         if request.url.query:
             full_path += f"?{request.url.query}"
@@ -414,9 +413,7 @@ class App(FastAPI):
                 not callable(app.auth)
                 and username in app.auth
                 and compare_passwords_securely(password, app.auth[username])  # type: ignore
-            ) or (
-                callable(app.auth) and app.auth.__call__(username, password)
-            ):  # type: ignore
+            ) or (callable(app.auth) and app.auth.__call__(username, password)):  # type: ignore
                 token = secrets.token_urlsafe(16)
                 app.tokens[token] = username
                 response = JSONResponse(content={"success": True})

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1450,7 +1450,7 @@ def mount_gradio_app(
         favicon_path: If a path to a file (.png, .gif, or .ico) is provided, it will be used as the favicon for this gradio app's page.
         show_error: If True, any errors in the gradio app will be displayed in an alert modal and printed in the browser console log. Otherwise, errors will only be visible in the terminal session running the Gradio app.
         max_file_size: The maximum file size in bytes that can be uploaded. Can be a string of the form "<value><unit>", where value is any positive integer and unit is one of "b", "kb", "mb", "gb", "tb". If None, no limit is set.
-        ssr_mode: If True, the Gradio app will be rendered using server-side rendering mode, which is typically more performant and provides better SEO, but this requires Node 18+ to be installed on the system. If False, the app will be rendered using client-side rendering mode. If None, will use GRADIO_SSR_MODE environment variable or default to False.    
+        ssr_mode: If True, the Gradio app will be rendered using server-side rendering mode, which is typically more performant and provides better SEO, but this requires Node 18+ to be installed on the system. If False, the app will be rendered using client-side rendering mode. If None, will use GRADIO_SSR_MODE environment variable or default to False.
     Example:
         from fastapi import FastAPI
         import gradio as gr
@@ -1510,7 +1510,10 @@ def mount_gradio_app(
     )
 
     gradio_app = App.create_app(
-        blocks, app_kwargs=app_kwargs, auth_dependency=auth_dependency, ssr_mode=ssr_mode,
+        blocks,
+        app_kwargs=app_kwargs,
+        auth_dependency=auth_dependency,
+        ssr_mode=ssr_mode,
     )
     old_lifespan = app.router.lifespan_context
 

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1432,6 +1432,7 @@ def mount_gradio_app(
     favicon_path: str | None = None,
     show_error: bool = True,
     max_file_size: str | int | None = None,
+    ssr_mode: bool | None = None,
 ) -> fastapi.FastAPI:
     """Mount a gradio.Blocks to an existing FastAPI application.
 
@@ -1449,6 +1450,7 @@ def mount_gradio_app(
         favicon_path: If a path to a file (.png, .gif, or .ico) is provided, it will be used as the favicon for this gradio app's page.
         show_error: If True, any errors in the gradio app will be displayed in an alert modal and printed in the browser console log. Otherwise, errors will only be visible in the terminal session running the Gradio app.
         max_file_size: The maximum file size in bytes that can be uploaded. Can be a string of the form "<value><unit>", where value is any positive integer and unit is one of "b", "kb", "mb", "gb", "tb". If None, no limit is set.
+        ssr_mode: If True, the Gradio app will be rendered using server-side rendering mode, which is typically more performant and provides better SEO, but this requires Node 18+ to be installed on the system. If False, the app will be rendered using client-side rendering mode. If None, will use GRADIO_SSR_MODE environment variable or default to False.    
     Example:
         from fastapi import FastAPI
         import gradio as gr
@@ -1497,8 +1499,18 @@ def mount_gradio_app(
     if root_path is not None:
         blocks.root_path = root_path
 
+    ssr_mode = (
+        False
+        if wasm_utils.IS_WASM
+        else (
+            ssr_mode
+            if ssr_mode is not None
+            else os.getenv("GRADIO_SSR_MODE", "False").lower() == "true"
+        )
+    )
+
     gradio_app = App.create_app(
-        blocks, app_kwargs=app_kwargs, auth_dependency=auth_dependency
+        blocks, app_kwargs=app_kwargs, auth_dependency=auth_dependency, ssr_mode=ssr_mode,
     )
     old_lifespan = app.router.lifespan_context
 

--- a/gradio/strings.py
+++ b/gradio/strings.py
@@ -9,7 +9,7 @@ MESSAGING_API_ENDPOINT = "https://api.gradio.app/gradio-messaging/en"
 
 en = {
     "RUNNING_LOCALLY": "* Running on local URL:  {}://{}:{}",
-    "RUNNING_LOCALLY_SSR": "* Running on local URL:  {} (SSR mode ⚡)",
+    "RUNNING_LOCALLY_SSR": "* Running on local URL:  {}://{}:{}, with SSR ⚡",
     "SHARE_LINK_DISPLAY": "* Running on public URL: {}",
     "COULD_NOT_GET_SHARE_LINK": "\nCould not create share link. Please check your internet connection or our status page: https://status.gradio.app.",
     "COULD_NOT_GET_SHARE_LINK_MISSING_FILE": "\nCould not create share link. Missing file: {}. \n\nPlease check your internet connection. This can happen if your antivirus software blocks the download of this file. You can install manually by following these steps: \n\n1. Download this file: {}\n2. Rename the downloaded file to: {}\n3. Move the file to this location: {}",

--- a/gradio/strings.py
+++ b/gradio/strings.py
@@ -9,7 +9,7 @@ MESSAGING_API_ENDPOINT = "https://api.gradio.app/gradio-messaging/en"
 
 en = {
     "RUNNING_LOCALLY": "* Running on local URL:  {}://{}:{}",
-    "RUNNING_LOCALLY_SSR": "* Running on local URL:  {} (SSR mode)",
+    "RUNNING_LOCALLY_SSR": "* Running on local URL:  {} (SSR mode ⚡)",
     "SHARE_LINK_DISPLAY": "* Running on public URL: {}",
     "COULD_NOT_GET_SHARE_LINK": "\nCould not create share link. Please check your internet connection or our status page: https://status.gradio.app.",
     "COULD_NOT_GET_SHARE_LINK_MISSING_FILE": "\nCould not create share link. Missing file: {}. \n\nPlease check your internet connection. This can happen if your antivirus software blocks the download of this file. You can install manually by following these steps: \n\n1. Download this file: {}\n2. Rename the downloaded file to: {}\n3. Move the file to this location: {}",

--- a/gradio/strings.py
+++ b/gradio/strings.py
@@ -8,8 +8,8 @@ from gradio import wasm_utils
 MESSAGING_API_ENDPOINT = "https://api.gradio.app/gradio-messaging/en"
 
 en = {
-    "RUNNING_LOCALLY": "* Running on local URL:  {}",
-    "RUNNING_LOCALLY_SEPARATED": "* Running on local URL:  {}://{}:{}",
+    "RUNNING_LOCALLY": "* Running on local URL:  {}://{}:{}",
+    "RUNNING_LOCALLY_SSR": "* Running on local URL:  {} (SSR mode)",
     "SHARE_LINK_DISPLAY": "* Running on public URL: {}",
     "COULD_NOT_GET_SHARE_LINK": "\nCould not create share link. Please check your internet connection or our status page: https://status.gradio.app.",
     "COULD_NOT_GET_SHARE_LINK_MISSING_FILE": "\nCould not create share link. Missing file: {}. \n\nPlease check your internet connection. This can happen if your antivirus software blocks the download of this file. You can install manually by following these steps: \n\n1. Download this file: {}\n2. Rename the downloaded file to: {}\n3. Move the file to this location: {}",


### PR DESCRIPTION
Makes the two changes I suggested on the SSR PR:

(1) Renames `spa_mode` to `ssr_mode` 

(2) Moves the parameter to `launch()`, which means that it can be used with Interface, ChatInterface, Blocks, etc. Also added to `gr.mount_gradio_app`, meaning it can be used when Gradio is part of larger FastAPI apps

