### PR TITLE
Center icon in button when no text is present

### DIFF
--- a/.changeset/cruel-heads-hunt.md
+++ b/.changeset/cruel-heads-hunt.md
@@ -1,0 +1,6 @@
+---
+"@gradio/button": patch
+"gradio": patch
+---
+
+fix:Center icon in button when no text is present

--- a/js/button/Button.stories.svelte
+++ b/js/button/Button.stories.svelte
@@ -79,6 +79,18 @@
 	}}
 />
 <Story
+	name="Button with external image icon and no text"
+	args={{
+		interactive: true,
+		icon: {
+			url: "https://huggingface.co/front/assets/huggingface_logo-noborder.svg",
+			path: "https://huggingface.co/front/assets/huggingface_logo-noborder.svg"
+		},
+		value: ""
+	}}
+/>
+
+<Story
 	name="Button with visible equal to false"
 	args={{
 		visible: false

--- a/js/button/shared/Button.svelte
+++ b/js/button/shared/Button.svelte
@@ -50,7 +50,7 @@
 		{disabled}
 	>
 		{#if icon}
-			<img class="button-icon" src={icon.url} alt={`${value} icon`} />
+			<img class="button-icon" class:right-padded={value} src={icon.url} alt={`${value} icon`} />
 		{/if}
 		<slot />
 	</button>
@@ -177,6 +177,8 @@
 	.button-icon {
 		width: var(--text-xl);
 		height: var(--text-xl);
+	}
+	.button-icon.right-padded {
 		margin-right: var(--spacing-xl);
 	}
 </style>

--- a/js/button/shared/Button.svelte
+++ b/js/button/shared/Button.svelte
@@ -50,7 +50,12 @@
 		{disabled}
 	>
 		{#if icon}
-			<img class="button-icon" class:right-padded={value} src={icon.url} alt={`${value} icon`} />
+			<img
+				class="button-icon"
+				class:right-padded={value}
+				src={icon.url}
+				alt={`${value} icon`}
+			/>
 		{/if}
 		<slot />
 	</button>


### PR DESCRIPTION
Small design issue, but when an icon was present in a button and no text was present, the icon would be off-centered due to right padding. This PR closes: https://github.com/gradio-app/gradio/issues/9352

To repro, just run something like:

```py
import gradio as gr

with gr.Blocks() as demo:
    gr.Button(icon="cheetah.jpg", min_width=0)
    gr.Button(icon="cheetah.jpg", value="", min_width=0)

demo.launch()
```

and view on a mobile / small width