### PR TITLE
Remove checkbox and radio borders

### DIFF
--- a/.changeset/tasty-bobcats-yell.md
+++ b/.changeset/tasty-bobcats-yell.md
@@ -1,0 +1,7 @@
+---
+"@gradio/checkboxgroup": minor
+"@gradio/radio": minor
+"gradio": minor
+---
+
+feat:Remove checkbox and radio borders

--- a/gradio/themes/base.py
+++ b/gradio/themes/base.py
@@ -1434,7 +1434,7 @@ class Base(ThemeClass):
             self, "checkbox_label_gap", "*spacing_lg"
         )
         self.checkbox_label_padding = checkbox_label_padding or getattr(
-            self, "checkbox_label_padding", "*spacing_md calc(2 * *spacing_md)"
+            self, "checkbox_label_padding", "*spacing_xs calc(2 * *spacing_xs)"
         )
         self.checkbox_label_shadow = checkbox_label_shadow or getattr(
             self, "checkbox_label_shadow", "none"

--- a/gradio/themes/monochrome.py
+++ b/gradio/themes/monochrome.py
@@ -77,7 +77,7 @@ class Monochrome(Base):
             checkbox_background_color_selected_dark="*neutral_700",
             checkbox_border_color_selected_dark="*neutral_800",
             # Padding
-            checkbox_label_padding="*spacing_md",
+            checkbox_label_padding="*spacing_xs",
             button_large_padding="*spacing_lg",
             button_small_padding="*spacing_sm",
             # Borders

--- a/js/checkboxgroup/Index.svelte
+++ b/js/checkboxgroup/Index.svelte
@@ -107,8 +107,6 @@
 		transition: var(--button-transition);
 		cursor: pointer;
 		box-shadow: var(--checkbox-label-shadow);
-		border: var(--checkbox-label-border-width) solid
-			var(--checkbox-label-border-color);
 		border-radius: var(--button-small-radius);
 		background: var(--checkbox-label-background-fill);
 		padding: var(--checkbox-label-padding);
@@ -118,8 +116,8 @@
 		line-height: var(--line-md);
 	}
 
-	label:hover {
-		background: var(--checkbox-label-background-fill-hover);
+	label:first-child {
+		padding-left: 0;
 	}
 	label:focus {
 		background: var(--checkbox-label-background-fill-focus);
@@ -158,7 +156,7 @@
 	}
 
 	input:hover {
-		border-color: var(--checkbox-border-color-hover);
+		border-color: var(--checkbox-background-color-selected);
 		background-color: var(--checkbox-background-color-hover);
 	}
 

--- a/js/radio/shared/Radio.svelte
+++ b/js/radio/shared/Radio.svelte
@@ -48,22 +48,11 @@
 		transition: var(--button-transition);
 		cursor: pointer;
 		box-shadow: var(--checkbox-label-shadow);
-		border: var(--checkbox-label-border-width) solid
-			var(--checkbox-label-border-color);
 		border-radius: var(--button-small-radius);
-		background: var(--checkbox-label-background-fill);
-		padding: var(--checkbox-label-padding);
 		color: var(--checkbox-label-text-color);
 		font-weight: var(--checkbox-label-text-weight);
 		font-size: var(--checkbox-label-text-size);
 		line-height: var(--line-md);
-	}
-
-	label:hover {
-		background: var(--checkbox-label-background-fill-hover);
-	}
-	label:focus {
-		background: var(--checkbox-label-background-fill-focus);
 	}
 
 	label.selected {
@@ -103,13 +92,15 @@
 	}
 
 	input:hover {
-		border-color: var(--checkbox-border-color-hover);
+		border-color: var(--checkbox-background-color-selected);
 		background-color: var(--checkbox-background-color-hover);
+		cursor: pointer;
 	}
 
 	input:focus {
 		border-color: var(--checkbox-border-color-focus);
 		background-color: var(--checkbox-background-color-focus);
+		cursor: pointer;
 	}
 
 	input:checked:focus {


### PR DESCRIPTION
## Description

Removes the checkbox and radio borders. Amends the new hover effect slightly to accommodate this.

| new | base |
|--------|--------|
| <img width="441" alt="Screenshot 2024-09-24 at 18 32 15" src="https://github.com/user-attachments/assets/da99f947-e908-4cc9-aae3-9ef122d43724"> | <img width="468" alt="Screenshot 2024-09-24 at 18 32 36" src="https://github.com/user-attachments/assets/a79137b8-45da-4b53-ab72-a262270be21d"> | 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
