### PR TITLE
Fix `slider-color` var

### DIFF
--- a/.changeset/khaki-ways-agree.md
+++ b/.changeset/khaki-ways-agree.md
@@ -1,0 +1,6 @@
+---
+"@gradio/slider": minor
+"gradio": minor
+---
+
+feat:Fix `slider-color` var

--- a/gradio/themes/base.py
+++ b/gradio/themes/base.py
@@ -1596,7 +1596,7 @@ class Base(ThemeClass):
             self, "prose_header_text_weight", "600"
         )
         self.slider_color = slider_color or getattr(
-            self, "slider_color", colors.blue.c600
+            self, "slider_color", "*color_accent"
         )
         self.slider_color_dark = slider_color_dark or getattr(
             self, "slider_color_dark", None

--- a/js/slider/Index.svelte
+++ b/js/slider/Index.svelte
@@ -209,7 +209,7 @@
 	input[type="range"]::-webkit-slider-runnable-track {
 		background: linear-gradient(
 			to right,
-			var(--color-accent) var(--range_progress),
+			var(--slider-color) var(--range_progress),
 			var(--neutral-200) var(--range_progress)
 		);
 	}
@@ -236,7 +236,7 @@
 
 	input[type="range"]::-moz-range-progress {
 		height: var(--size-2);
-		background-color: var(--color-accent);
+		background-color: var(--slider-color);
 		border-radius: var(--radius-xl);
 	}
 


### PR DESCRIPTION
## Description

Tiny fix to ensure the custom `slider-color` var is respected. 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
