### PR TITLE
Fix node process to run with correct server name

### DIFF
--- a/.changeset/thin-boxes-matter.md
+++ b/.changeset/thin-boxes-matter.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix node process to run with correct server name

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2424,15 +2424,14 @@ Received inputs:
         self.node_path = os.environ.get(
             "GRADIO_NODE_PATH", "" if wasm_utils.IS_WASM else get_node_path()
         )
-        self.node_server_name = node_server_name
-        self.node_port = node_port
-
-        self.node_server_name, self.node_process, self.node_port = start_node_server(
-            server_name=self.node_server_name,
-            server_port=self.node_port,
-            node_path=self.node_path,
-            ssr_mode=self.ssr_mode,
-        )
+        if self.ssr_mode:
+            self.node_server_name, self.node_process, self.node_port = start_node_server(
+                server_name=node_server_name,
+                server_port=node_port,
+                node_path=self.node_path,
+            )
+        else:
+            self.node_server_name = self.node_port = self.node_process = None
 
         # self.server_app is included for backwards compatibility
         self.server_app = self.app = App.create_app(

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2425,10 +2425,12 @@ Received inputs:
             "GRADIO_NODE_PATH", "" if wasm_utils.IS_WASM else get_node_path()
         )
         if self.ssr_mode:
-            self.node_server_name, self.node_process, self.node_port = start_node_server(
-                server_name=node_server_name,
-                server_port=node_port,
-                node_path=self.node_path,
+            self.node_server_name, self.node_process, self.node_port = (
+                start_node_server(
+                    server_name=node_server_name,
+                    server_port=node_port,
+                    node_path=self.node_path,
+                )
             )
         else:
             self.node_server_name = self.node_port = self.node_process = None

--- a/gradio/node_server.py
+++ b/gradio/node_server.py
@@ -26,7 +26,6 @@ def start_node_server(
     server_name: str | None = None,
     server_port: int | None = None,
     node_path: str | None = None,
-    ssr_mode: bool | None = None,
 ) -> tuple[str | None, subprocess.Popen[bytes] | None, int | None]:
     """Launches a local server running the provided Interface
     Parameters:
@@ -60,12 +59,11 @@ def start_node_server(
     node_process = None
     node_port = None
 
-    if ssr_mode:
-        (node_process, node_port) = start_node_process(
-            node_path=node_path or os.getenv("GRADIO_NODE_PATH"),
-            server_name=host,
-            server_ports=server_ports,
-        )
+    (node_process, node_port) = start_node_process(
+        node_path=node_path or os.getenv("GRADIO_NODE_PATH"),
+        server_name=host,
+        server_ports=server_ports,
+    )
 
     return server_name, node_process, node_port
 

--- a/gradio/node_server.py
+++ b/gradio/node_server.py
@@ -56,10 +56,7 @@ def start_node_server(
         else range(INITIAL_PORT_VALUE + 1, INITIAL_PORT_VALUE + 1 + TRY_NUM_PORTS)
     )
 
-    node_process = None
-    node_port = None
-
-    (node_process, node_port) = start_node_process(
+    node_process, node_port = start_node_process(
         node_path=node_path or os.getenv("GRADIO_NODE_PATH"),
         server_name=host,
         server_ports=server_ports,

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -374,8 +374,7 @@ class App(FastAPI):
                     try:
                         return await App.proxy_to_node(
                             request,
-                            os.getenv("GRADIO_SERVER_NAME", blocks.local_url)
-                            or "0.0.0.0",
+                            blocks.node_server_name or "0.0.0.0",
                             blocks.node_port,
                             App.app_port,
                             request.url.scheme,
@@ -1581,12 +1580,12 @@ def mount_gradio_app(
     blocks.node_server_name = node_server_name
     blocks.node_port = node_port
 
-    blocks.node_server_name, blocks.node_process, blocks.node_port = start_node_server(
-        server_name=blocks.node_server_name,
-        server_port=blocks.node_port,
-        node_path=blocks.node_path,
-        ssr_mode=blocks.ssr_mode,
-    )
+    if blocks.ssr_mode:
+        blocks.node_server_name, blocks.node_process, blocks.node_port = start_node_server(
+            server_name=blocks.node_server_name,
+            server_port=blocks.node_port,
+            node_path=blocks.node_path,
+        )
 
     gradio_app = App.create_app(
         blocks,

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1581,10 +1581,12 @@ def mount_gradio_app(
     blocks.node_port = node_port
 
     if blocks.ssr_mode:
-        blocks.node_server_name, blocks.node_process, blocks.node_port = start_node_server(
-            server_name=blocks.node_server_name,
-            server_port=blocks.node_port,
-            node_path=blocks.node_path,
+        blocks.node_server_name, blocks.node_process, blocks.node_port = (
+            start_node_server(
+                server_name=blocks.node_server_name,
+                server_port=blocks.node_port,
+                node_path=blocks.node_path,
+            )
         )
 
     gradio_app = App.create_app(


### PR DESCRIPTION
Previously, the `ssr_mode` parameter was not working unless the GRADIO_SERVER_NAME parameter was also set. You can test this by running 

```py
import gradio as gr

demo = gr.Interface(lambda x: x, "text", "text")

demo.launch(ssr_mode=True)
```

which would produce a stacktrace:

```py
* Running on local URL:  http://127.0.0.1:7872/, with SSR ⚡
[Errno 8] nodename nor servname provided, or not known
[Errno 8] nodename nor servname provided, or not known
[Errno 8] nodename nor servname provided, or not known
[Errno 8] nodename nor servname provided, or not known
[Errno 8] nodename nor servname provided, or not known
```

With this PR, SSR mode should work correctly