### PR TITLE
Fix change triggers for dropdown and radio

### DIFF
--- a/.changeset/wicked-snails-drum.md
+++ b/.changeset/wicked-snails-drum.md
@@ -1,0 +1,7 @@
+---
+"@gradio/dropdown": minor
+"@gradio/radio": minor
+"gradio": minor
+---
+
+feat:Fix change triggers for dropdown and radio

--- a/js/dropdown/shared/Dropdown.svelte
+++ b/js/dropdown/shared/Dropdown.svelte
@@ -80,12 +80,10 @@
 		}
 	}
 
-	$: {
-		if (value != old_value) {
-			set_input_text();
-			handle_change(dispatch, value, value_is_output);
-			old_value = value;
-		}
+	$: if (JSON.stringify(old_value) !== JSON.stringify(value)) {
+		set_input_text();
+		handle_change(dispatch, value, value_is_output);
+		old_value = value;
 	}
 
 	function set_choice_names_values(): void {

--- a/js/radio/Index.svelte
+++ b/js/radio/Index.svelte
@@ -36,8 +36,13 @@
 		gradio.dispatch("change");
 	}
 
-	$: value, handle_change();
-
+	let old_value = value;
+	$: {
+		if (value !== old_value) {
+			old_value = value;
+			handle_change();
+		}
+	}
 	$: disabled = !interactive;
 </script>
 


### PR DESCRIPTION
## Description
Fixes: gr.Dropdown and gr.Radio fire `.change()` events when page loads.

Closes: #9492

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
