### PR TITLE
Fix single select dropdown

### DIFF
--- a/.changeset/smooth-places-walk.md
+++ b/.changeset/smooth-places-walk.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dropdown": minor
+"gradio": minor
+---
+
+feat:Fix single select dropdown

--- a/js/dropdown/Index.svelte
+++ b/js/dropdown/Index.svelte
@@ -17,9 +17,11 @@
 	export let elem_id = "";
 	export let elem_classes: string[] = [];
 	export let visible = true;
-	export let value: string | string[] | undefined = undefined;
-	export let value_is_output = false;
 	export let multiselect = false;
+	export let value: string | string[] | undefined = multiselect
+		? []
+		: undefined;
+	export let value_is_output = false;
 	export let max_choices: number | null = null;
 	export let choices: [string, string | number][];
 	export let show_label: boolean;

--- a/js/dropdown/Index.svelte
+++ b/js/dropdown/Index.svelte
@@ -12,18 +12,18 @@
 	import { StatusTracker } from "@gradio/statustracker";
 	import type { LoadingStatus } from "@gradio/statustracker";
 
+	type Item = string | number;
+
 	export let label = "Dropdown";
 	export let info: string | undefined = undefined;
 	export let elem_id = "";
 	export let elem_classes: string[] = [];
 	export let visible = true;
 	export let multiselect = false;
-	export let value: string | string[] | undefined = multiselect
-		? []
-		: undefined;
+	export let value: Item | Item[] | undefined = multiselect ? [] : undefined;
 	export let value_is_output = false;
 	export let max_choices: number | null = null;
-	export let choices: [string, string | number][];
+	export let choices: [string, Item][];
 	export let show_label: boolean;
 	export let filterable: boolean;
 	export let container = true;

--- a/js/dropdown/dropdown.test.ts
+++ b/js/dropdown/dropdown.test.ts
@@ -472,7 +472,7 @@ describe("Dropdown", () => {
 		await expect(item.value).toBe("apple_choice");
 	});
 
-	test("ensure dropdown can have an empty value", async () => {
+	test("ensure dropdown can have the first item of the choices as a default value", async () => {
 		const { getByLabelText } = await render(Dropdown, {
 			show_label: true,
 			loading_status,
@@ -488,7 +488,7 @@ describe("Dropdown", () => {
 		const item: HTMLInputElement = getByLabelText(
 			"Dropdown"
 		) as HTMLInputElement;
-		await expect(item.value).toBe("");
+		await expect(item.value).toBe("apple_choice");
 	});
 
 	test("ensure dropdown works when initial value is undefined and allow custom value is set", async () => {
@@ -508,6 +508,6 @@ describe("Dropdown", () => {
 		const item: HTMLInputElement = getByLabelText(
 			"Dropdown"
 		) as HTMLInputElement;
-		await expect(item.value).toBe("");
+		await expect(item.value).toBe("apple_choice");
 	});
 });

--- a/js/dropdown/shared/Dropdown.svelte
+++ b/js/dropdown/shared/Dropdown.svelte
@@ -6,14 +6,15 @@
 	import type { SelectData, KeyUpData } from "@gradio/utils";
 	import { handle_filter, handle_change, handle_shared_keys } from "./utils";
 
+	type Item = string | number;
+
 	export let label: string;
 	export let info: string | undefined = undefined;
-	export let value: string | number | (string | number)[] | undefined =
-		undefined;
-	let old_value: string | number | (string | number)[] | undefined = undefined;
+	export let value: Item | Item[] | undefined = undefined;
+	let old_value: typeof value = undefined;
 	export let value_is_output = false;
-	export let choices: [string, string | number][];
-	let old_choices: [string, string | number][];
+	export let choices: [string, Item][];
+	let old_choices: typeof choices;
 	export let disabled = false;
 	export let show_label: boolean;
 	export let container = true;

--- a/js/dropdown/shared/Dropdown.svelte
+++ b/js/dropdown/shared/Dropdown.svelte
@@ -8,8 +8,9 @@
 
 	export let label: string;
 	export let info: string | undefined = undefined;
-	export let value: string | number | (string | number)[] | undefined = [];
-	let old_value: string | number | (string | number)[] | undefined = [];
+	export let value: string | number | (string | number)[] | undefined =
+		undefined;
+	let old_value: string | number | (string | number)[] | undefined = undefined;
 	export let value_is_output = false;
 	export let choices: [string, string | number][];
 	let old_choices: [string, string | number][];

--- a/js/dropdown/shared/Multiselect.svelte
+++ b/js/dropdown/shared/Multiselect.svelte
@@ -1,20 +1,22 @@
 <script lang="ts">
 	import { afterUpdate, createEventDispatcher } from "svelte";
-	import { _, number } from "svelte-i18n";
+	import { _ } from "svelte-i18n";
 	import { BlockTitle } from "@gradio/atoms";
 	import { Remove, DropdownArrow } from "@gradio/icons";
 	import type { KeyUpData, SelectData, I18nFormatter } from "@gradio/utils";
 	import DropdownOptions from "./DropdownOptions.svelte";
 	import { handle_filter, handle_change, handle_shared_keys } from "./utils";
 
+	type Item = string | number;
+
 	export let label: string;
 	export let info: string | undefined = undefined;
-	export let value: string | number | (string | number)[] | undefined = [];
-	let old_value: string | number | (string | number)[] | undefined = [];
+	export let value: Item | Item[] | undefined = [];
+	let old_value: typeof value = [];
 	export let value_is_output = false;
 	export let max_choices: number | null = null;
-	export let choices: [string, string | number][];
-	let old_choices: [string, string | number][];
+	export let choices: [string, Item][];
+	let old_choices: typeof choices;
 	export let disabled = false;
 	export let show_label: boolean;
 	export let container = true;


### PR DESCRIPTION
## Description

`gr.Dropdown(multiselect=False)` sets the default value as `[]` of type `list`. It's a confusing behavior.

The fix is in a04ad54 where the default value is changed from `[]` to `undefined`.
As a result, the following `value` initializer that seems to have not been reached before became effective and the first item of `choices` is now set as the default value.

https://github.com/gradio-app/gradio/blob/0ab6ac5dc01b69e4f2462d00c4910f3354441227/js/dropdown/shared/Dropdown.svelte#L59-L65

I think
* setting a list value `[]` as the default value of a single-select dropdown is obviously a bug.
* but setting the first value of `choices` instead of `None` is an opinionated behavior, while I think it's desirable as the user can eliminate the null-checking from the user-defined `fn`. If it's a problem I will fix it.

For example,
[the tone generator example](https://github.com/gradio-app/gradio/blob/5.0-dev/demo/generate_tone/run.py) looks like this, where the non-null dropdown value is set by default:
![CleanShot 2024-10-04 at 12 14 04@2x](https://github.com/user-attachments/assets/60417500-adfc-4687-97bc-e77289d66496)
