### PR TITLE
Fix Lite to work on FireFox

### DIFF
--- a/.changeset/eager-humans-try.md
+++ b/.changeset/eager-humans-try.md
@@ -1,0 +1,6 @@
+---
+"@gradio/wasm": minor
+"gradio": minor
+---
+
+feat:Fix Lite to work on FireFox

--- a/js/wasm/src/cross-origin-worker.ts
+++ b/js/wasm/src/cross-origin-worker.ts
@@ -32,19 +32,9 @@ export class CrossOriginWorkerMaker {
 	constructor(url: URL, options?: WorkerOptions & { shared?: boolean }) {
 		const { shared = false, ...workerOptions } = options ?? {};
 
-		try {
-			// This is the normal way to load a worker script, which is the best straightforward if possible.
-			this.worker = shared
-				? new SharedWorker(url, workerOptions)
-				: new Worker(url, workerOptions);
-		} catch (e) {
-			console.debug(
-				`Failed to load a worker script from ${url.toString()}. Trying to load a cross-origin worker...`
-			);
-			const worker_blob_url = get_blob_url(url);
-			this.worker = shared
-				? new SharedWorker(worker_blob_url, workerOptions)
-				: new Worker(worker_blob_url, workerOptions);
-		}
+		const worker_blob_url = get_blob_url(url);
+		this.worker = shared
+			? new SharedWorker(worker_blob_url, workerOptions)
+			: new Worker(worker_blob_url, workerOptions);
 	}
 }


### PR DESCRIPTION
## Description

Context: [internal link](https://huggingface.slack.com/archives/C02QZLG8GMN/p1727352575363519?thread_ts=1727341327.772879&cid=C02QZLG8GMN)

Lite doesn't work on FireFox when the script is loaded in the cross-origin manner as below (this screenshot was taken in an env where the Lite is served from `localhost:8000` and the parent page is from `localhost:8080`).
![CleanShot 2024-10-04 at 14 34 51@2x](https://github.com/user-attachments/assets/f4a3f42e-336c-440d-bb8b-22b3aafafbd6)

This is because, on FireFox, `new WebWorker()` throws the `SecurityError` asynchronously, while it's synchronous on Chrome, so the synchronous `try-catch` surrounding it doesn't work.

We have been using the normal initializer `new WebWorker(url)` first and the cross-origin initializer as a fall-back,
but in this PR we gave up using the normal one and switched to use the cross-origin one in any cases for simplicity sake.