### PR TITLE
Equal height columns

### DIFF
--- a/.changeset/chilly-dragons-smoke.md
+++ b/.changeset/chilly-dragons-smoke.md
@@ -1,0 +1,7 @@
+---
+"@gradio/column": minor
+"@gradio/row": minor
+"gradio": minor
+---
+
+feat:changes

--- a/.changeset/chilly-dragons-smoke.md
+++ b/.changeset/chilly-dragons-smoke.md
@@ -4,4 +4,4 @@
 "gradio": minor
 ---
 
-feat:changes
+feat:Equal height columns

--- a/gradio/layouts/form.py
+++ b/gradio/layouts/form.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from gradio.blocks import BlockContext, Blocks
 from gradio.component_meta import ComponentMeta
+from gradio.layouts.column import Column
 from gradio.layouts.row import Row
 
 if TYPE_CHECKING:
@@ -38,6 +39,13 @@ class Form(BlockContext, metaclass=ComponentMeta):
             scale = getattr(child, "scale", None)
             self.scale += 1 if scale is None else scale
             self.min_width += getattr(child, "min_width", 0) or 0
+        elif (
+            isinstance(self.parent, Column)
+            and isinstance(self.parent.parent, Row)
+            and self.parent.parent.equal_height
+        ):
+            scale = getattr(child, "scale", None)
+            self.scale += 1 if scale is None else scale
         elif isinstance(self.parent, Blocks) and self.parent.fill_height:
             scale = getattr(child, "scale", None)
             self.scale += 0 if scale is None else scale

--- a/js/column/Index.svelte
+++ b/js/column/Index.svelte
@@ -17,7 +17,7 @@
 
 <div
 	id={elem_id}
-	class={elem_classes.join(" ")}
+	class="column {elem_classes.join(' ')}"
 	class:gap
 	class:compact={variant === "compact"}
 	class:panel={variant === "panel"}

--- a/js/row/Index.svelte
+++ b/js/row/Index.svelte
@@ -39,7 +39,7 @@
 	style:max-height={get_dimension(max_height)}
 	style:min-height={get_dimension(min_height)}
 	id={elem_id}
-	class={elem_classes.join(" ")}
+	class="row {elem_classes.join(' ')}"
 >
 	{#if loading_status && show_progress && gradio}
 		<StatusTracker
@@ -84,6 +84,12 @@
 
 	.stretch {
 		align-items: stretch;
+	}
+
+	.stretch > :global(.column > *),
+	.stretch > :global(.column > .form > *) {
+		flex-grow: 1;
+		flex-shrink: 0;
 	}
 
 	div > :global(*),


### PR DESCRIPTION
Allows columns to have expanding content in "equal_height" rows, e.g.:

```python
import gradio as gr

with gr.Blocks() as demo:
    with gr.Row(equal_height=True):
        with gr.Column(scale=2):
            gr.Dropdown(choices=['a', 'b', 'c'], interactive=True)
            gr.Button("Btn 1")
            gr.Button("Btn 2")
        with gr.Column(scale=2):
            gr.Slider(interactive=True)
            gr.Button("Btn 3")
        gr.Image()

demo.launch()
```
<img width="1244" alt="Screenshot 2024-10-07 at 7 10 06 PM" src="https://github.com/user-attachments/assets/d2ac53e2-503b-49aa-9e0d-02163ca2b543">


Fixes: #3202