### PR TITLE
Disable the submit button and enter-key submit when the text is empty

### DIFF
--- a/.changeset/smooth-fans-hide.md
+++ b/.changeset/smooth-fans-hide.md
@@ -1,0 +1,7 @@
+---
+"@gradio/multimodaltextbox": minor
+"@gradio/textbox": minor
+"gradio": minor
+---
+
+feat:Disable the submit button and enter-key submit when the text is empty

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -68,6 +68,7 @@
 
 	$: if (value === null) value = { text: "", files: [] };
 	$: value, el && lines !== max_lines && resize(el, lines, max_lines);
+	$: can_submit = value.text !== "";
 
 	const dispatch = createEventDispatcher<{
 		change: typeof value;
@@ -127,7 +128,9 @@
 		await tick();
 		if (e.key === "Enter" && e.shiftKey && lines > 1) {
 			e.preventDefault();
-			dispatch("submit");
+			if (can_submit) {
+				dispatch("submit");
+			}
 		} else if (
 			e.key === "Enter" &&
 			!e.shiftKey &&
@@ -135,7 +138,9 @@
 			max_lines >= 1
 		) {
 			e.preventDefault();
-			dispatch("submit");
+			if (can_submit) {
+				dispatch("submit");
+			}
 		}
 	}
 
@@ -341,6 +346,7 @@
 					class="submit-button"
 					class:padded-button={submit_btn !== true}
 					on:click={handle_submit}
+					disabled={!can_submit}
 				>
 					{#if submit_btn === true}
 						<Send />
@@ -455,6 +461,13 @@
 	.upload-button:active,
 	.submit-button:active {
 		box-shadow: var(--button-shadow-active);
+	}
+
+	.stop-button:disabled,
+	.upload-button:disabled,
+	.submit-button:disabled {
+		background: var(--button-secondary-background-fill);
+		cursor: initial;
 	}
 
 	.submit-button :global(svg) {

--- a/js/textbox/shared/Textbox.svelte
+++ b/js/textbox/shared/Textbox.svelte
@@ -41,6 +41,7 @@
 	const show_textbox_border = !submit_btn;
 
 	$: value, el && lines !== max_lines && resize({ target: el });
+	$: can_submit = value !== "";
 
 	$: if (value === null) value = "";
 
@@ -112,7 +113,9 @@
 		await tick();
 		if (e.key === "Enter" && e.shiftKey && lines > 1) {
 			e.preventDefault();
-			dispatch("submit");
+			if (can_submit) {
+				dispatch("submit");
+			}
 		} else if (
 			e.key === "Enter" &&
 			!e.shiftKey &&
@@ -120,7 +123,9 @@
 			max_lines >= 1
 		) {
 			e.preventDefault();
-			dispatch("submit");
+			if (can_submit) {
+				dispatch("submit");
+			}
 		}
 	}
 
@@ -299,6 +304,7 @@
 				class="submit-button"
 				class:padded-button={submit_btn !== true}
 				on:click={handle_submit}
+				disabled={!can_submit}
 			>
 				{#if submit_btn === true}
 					<Send />
@@ -439,6 +445,11 @@
 	.stop-button:active,
 	.submit-button:active {
 		box-shadow: var(--button-shadow-active);
+	}
+	.stop-button:disabled,
+	.submit-button:disabled {
+		background: var(--button-secondary-background-fill);
+		cursor: pointer;
 	}
 	.submit-button :global(svg) {
 		height: 22px;


### PR DESCRIPTION
## Description

Suggestion: the submit button and the Enter-key submit should be disabled when the text is empty. I felt weird when using `gr.ChatInterface` where I could submit empty chat texts.