### PR TITLE
Equal height in row false by default

### DIFF
--- a/.changeset/easy-snakes-arrive.md
+++ b/.changeset/easy-snakes-arrive.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Equal height in row false by default

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -495,7 +495,7 @@ class Interface(Blocks):
             )  # type: ignore
             input_component_column = None
 
-            with Row(equal_height=False):
+            with Row():
                 if self.interface_type in [
                     InterfaceTypes.STANDARD,
                     InterfaceTypes.INPUT_ONLY,

--- a/gradio/layouts/row.py
+++ b/gradio/layouts/row.py
@@ -34,7 +34,7 @@ class Row(BlockContext, metaclass=ComponentMeta):
         height: int | str | None = None,
         max_height: int | str | None = None,
         min_height: int | str | None = None,
-        equal_height: bool = True,
+        equal_height: bool = False,
         show_progress: bool = False,
     ):
         """

--- a/guides/03_building-with-blocks/02_controlling-layout.md
+++ b/guides/03_building-with-blocks/02_controlling-layout.md
@@ -13,11 +13,11 @@ with gr.Blocks() as demo:
         btn2 = gr.Button("Button 2")
 ```
 
-By default, every element in a Row will have the same height. Configure this with the `equal_height` argument.
+You can set every element in a Row to have the same height. Configure this with the `equal_height` argument.
 
 ```python
 with gr.Blocks() as demo:
-    with gr.Row(equal_height=False):
+    with gr.Row(equal_height=True):
         textbox = gr.Textbox()
         btn2 = gr.Button("Button 2")
 ```


### PR DESCRIPTION
Makes equal height false by default in rows:

```python
with gr.Blocks() as demo:
    with gr.Row():
        name = gr.Dropdown(["Alice", "Bob", "Charlie"], label="Name")
        output = gr.Textbox(label="Output Box")
        greet_btn = gr.Button("Greet")
```

before:
<img width="1249" alt="Screenshot 2024-10-08 at 11 58 49 AM" src="https://github.com/user-attachments/assets/c8641ee1-7846-40cd-b3df-801ba819dd09">


after:
<img width="1244" alt="Screenshot 2024-10-08 at 11 59 06 AM" src="https://github.com/user-attachments/assets/90c8a684-a5a9-4e36-88ac-62b190f0a3cd">

