### PR TITLE
Tweak gr.Dataframe menu UX

### DIFF
--- a/.changeset/heavy-memes-create.md
+++ b/.changeset/heavy-memes-create.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": minor
+"gradio": minor
+---
+
+feat:Tweak gr.Dataframe menu UX

--- a/js/dataframe/shared/CellMenu.svelte
+++ b/js/dataframe/shared/CellMenu.svelte
@@ -15,6 +15,8 @@
 	export let i18n: I18nFormatter;
 	let menu_element: HTMLDivElement;
 
+	$: is_header = row === -1;
+
 	onMount(() => {
 		position_menu();
 	});
@@ -43,14 +45,16 @@
 </script>
 
 <div bind:this={menu_element} class="cell-menu">
-	<button on:click={() => on_add_row_above(row)}>
-		<Arrow transform="rotate(-90 12 12)" />
-		{i18n("dataframe.add_row_above")}
-	</button>
-	<button on:click={() => on_add_row_below(row)}>
-		<Arrow transform="rotate(90 12 12)" />
-		{i18n("dataframe.add_row_below")}
-	</button>
+	{#if !is_header}
+		<button on:click={() => on_add_row_above(row)}>
+			<Arrow transform="rotate(-90 12 12)" />
+			{i18n("dataframe.add_row_above")}
+		</button>
+		<button on:click={() => on_add_row_below(row)}>
+			<Arrow transform="rotate(90 12 12)" />
+			{i18n("dataframe.add_row_below")}
+		</button>
+	{/if}
 	<button on:click={() => on_add_column_left(col)}>
 		<Arrow transform="rotate(180 12 12)" />
 		{i18n("dataframe.add_column_left")}

--- a/js/dataframe/shared/CellMenu.svelte
+++ b/js/dataframe/shared/CellMenu.svelte
@@ -5,12 +5,11 @@
 
 	export let x: number;
 	export let y: number;
-	export let on_add_row_above: (index: number) => void;
-	export let on_add_row_below: (index: number) => void;
-	export let on_add_column_left: (index: number) => void;
-	export let on_add_column_right: (index: number) => void;
+	export let on_add_row_above: () => void;
+	export let on_add_row_below: () => void;
+	export let on_add_column_left: () => void;
+	export let on_add_column_right: () => void;
 	export let row: number;
-	export let col: number;
 
 	export let i18n: I18nFormatter;
 	let menu_element: HTMLDivElement;
@@ -46,20 +45,20 @@
 
 <div bind:this={menu_element} class="cell-menu">
 	{#if !is_header}
-		<button on:click={() => on_add_row_above(row)}>
+		<button on:click={() => on_add_row_above()}>
 			<Arrow transform="rotate(-90 12 12)" />
 			{i18n("dataframe.add_row_above")}
 		</button>
-		<button on:click={() => on_add_row_below(row)}>
+		<button on:click={() => on_add_row_below()}>
 			<Arrow transform="rotate(90 12 12)" />
 			{i18n("dataframe.add_row_below")}
 		</button>
 	{/if}
-	<button on:click={() => on_add_column_left(col)}>
+	<button on:click={() => on_add_column_left()}>
 		<Arrow transform="rotate(180 12 12)" />
 		{i18n("dataframe.add_column_left")}
 	</button>
-	<button on:click={() => on_add_column_right(col + 1)}>
+	<button on:click={() => on_add_column_right()}>
 		<Arrow transform="rotate(0 12 12)" />
 		{i18n("dataframe.add_column_right")}
 	</button>

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -879,40 +879,41 @@
 							}}
 						>
 							<div class="cell-wrap">
-								<EditableCell
-									bind:value={_headers[i].value}
-									bind:el={els[id].input}
-									{latex_delimiters}
-									{line_breaks}
-									edit={header_edit === i}
-									on:keydown={end_header_edit}
-									on:dblclick={() => edit_header(i)}
-									{select_on_focus}
-									header
-									{root}
-								/>
-
-								<!-- TODO: fix -->
-								<!-- svelte-ignore a11y-click-events-have-key-events -->
-								<!-- svelte-ignore a11y-no-static-element-interactions-->
-								<div
-									class:sorted={sort_by === i}
-									class:des={sort_by === i && sort_direction === "des"}
-									class="sort-button {sort_direction} "
-									on:click={(event) => {
-										event.stopPropagation();
-										handle_sort(i);
-									}}
-								>
-									<svg
-										width="1em"
-										height="1em"
-										viewBox="0 0 9 7"
-										fill="none"
-										xmlns="http://www.w3.org/2000/svg"
+								<div class="header-content">
+									<EditableCell
+										bind:value={_headers[i].value}
+										bind:el={els[id].input}
+										{latex_delimiters}
+										{line_breaks}
+										edit={header_edit === i}
+										on:keydown={end_header_edit}
+										on:dblclick={() => edit_header(i)}
+										{select_on_focus}
+										header
+										{root}
+									/>
+									<!-- TODO: fix -->
+									<!-- svelte-ignore a11y-click-events-have-key-events -->
+									<!-- svelte-ignore a11y-no-static-element-interactions-->
+									<div
+										class:sorted={sort_by === i}
+										class:des={sort_by === i && sort_direction === "des"}
+										class="sort-button {sort_direction}"
+										on:click={(event) => {
+											event.stopPropagation();
+											handle_sort(i);
+										}}
 									>
-										<path d="M4.49999 0L8.3971 6.75H0.602875L4.49999 0Z" />
-									</svg>
+										<svg
+											width="1em"
+											height="1em"
+											viewBox="0 0 9 7"
+											fill="none"
+											xmlns="http://www.w3.org/2000/svg"
+										>
+											<path d="M4.49999 0L8.3971 6.75H0.602875L4.49999 0Z" />
+										</svg>
+									</div>
 								</div>
 
 								{#if editable}
@@ -1162,9 +1163,19 @@
 		position: relative;
 		display: flex;
 		align-items: center;
+		justify-content: space-between;
 		outline: none;
 		height: var(--size-full);
 		min-height: var(--size-9);
+		overflow: hidden;
+	}
+
+	.header-content {
+		display: flex;
+		align-items: center;
+		overflow: hidden;
+		flex-grow: 1;
+		min-width: 0;
 	}
 
 	.row_odd {
@@ -1187,11 +1198,15 @@
 	}
 
 	.cell-menu-button {
+		flex-shrink: 0;
 		display: none;
 		background-color: var(--block-background-fill);
 		border: 1px solid var(--border-color-primary);
 		border-radius: var(--block-radius);
 		width: var(--size-5);
+		height: var(--size-5);
+		min-width: var(--size-5);
+		padding: 0;
 		margin-right: var(--spacing-sm);
 		z-index: var(--layer-2);
 	}
@@ -1201,6 +1216,18 @@
 	}
 
 	.cell-menu-button.visible {
-		display: block;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	th .cell-wrap {
+		padding-right: var(--spacing-sm);
+	}
+
+	th .header-content {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 </style>

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -480,6 +480,8 @@
 		selected_header = false;
 		selected = false;
 		active_cell = null;
+		active_cell_menu = null;
+		active_header_menu = null;
 	}
 
 	function guess_delimitaor(
@@ -693,12 +695,14 @@
 		const row_index = position === "above" ? index : index + 1;
 		add_row(row_index);
 		active_cell_menu = null;
+		active_header_menu = null;
 	}
 
 	function add_col_at(index: number, position: "left" | "right"): void {
 		const col_index = position === "left" ? index : index + 1;
 		add_col(col_index);
 		active_cell_menu = null;
+		active_header_menu = null;
 	}
 
 	onMount(() => {


### PR DESCRIPTION
## Description

Context menu button now shows when you click on a cell (same for mobile). Context menus when clicking on headers will also only show add column options (not add row options)

![Kapture 2024-10-09 at 02 51 18](https://github.com/user-attachments/assets/244a72ac-21e8-43d6-bfd6-3b1d884dec11)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
