### PR TITLE
fixed #9449 : stop_btn not working on gr.ChatInterface or with custom chat bot after retry_btn click - connection errored out error 

### DIFF
--- a/demo/chatinterface_streaming_echo/run.py
+++ b/demo/chatinterface_streaming_echo/run.py
@@ -3,10 +3,10 @@ import gradio as gr
 
 def slow_echo(message, history):
     for i in range(len(message)):
-        time.sleep(0.05)
+        time.sleep(0.5)
         yield "You typed: " + message[: i + 1]
 
-demo = gr.ChatInterface(slow_echo, type="messages")
+demo = gr.ChatInterface(slow_echo).queue()
 
 if __name__ == "__main__":
     demo.launch()


### PR DESCRIPTION
## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

When you click the stop_btn while a response is being streamed, especially after clicking the retry_btn, a "Connection errored out" error occurs.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
