### PR TITLE
Fix: `file_types` checking bug

### DIFF
--- a/.changeset/thick-teeth-crash.md
+++ b/.changeset/thick-teeth-crash.md
@@ -1,0 +1,6 @@
+---
+"gradio": patch
+"gradio_client": patch
+---
+
+fix:Fix: `file_types` checking bug

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -689,17 +689,15 @@ def get_extension(encoding: str) -> str | None:
 
 def is_valid_file(file_path: str, file_types: list[str]) -> bool:
     mime_type = get_mimetype(file_path)
-    if mime_type is None:
-        return False
     for file_type in file_types:
         if file_type == "file":
             return True
         if file_type.startswith("."):
             file_type = file_type.lstrip(".").lower()
-            mime_type_split = mime_type.lower().split("/")
-            if file_type == mime_type_split[1]:
+            file_ext = Path(file_path).suffix.lstrip(".").lower()
+            if file_type == file_ext:
                 return True
-        elif mime_type.startswith(f"{file_type}/"):
+        elif mime_type is not None and mime_type.startswith(f"{file_type}/"):
             return True
     return False
 


### PR DESCRIPTION
## Description

In the case the user specifies a file extension in `file_types`, we don't need to guess the mime type of the allowed file (which causes errors on unconventional file extensions). Instead, we can just check if the file extensions match.

Closes: #9646

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
