### PR TITLE
Fix progress bar compatibility with generators

### DIFF
--- a/.changeset/khaki-sites-bow.md
+++ b/.changeset/khaki-sites-bow.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix progress bar compatibility with generators

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -764,7 +764,7 @@ class Progress(Iterable):
                 self.iterables.append(new_iterable)
                 callback(self.iterables)
                 return self
-            length = len(iterable) if hasattr(iterable, "__len__") else None  # type: ignore
+            length = len(iterable) if hasattr(iterable, "__len__") else total # type: ignore
             self.iterables.append(
                 TrackedIterable(iter(iterable), 0, length, desc, unit, _tqdm)
             )

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -764,7 +764,7 @@ class Progress(Iterable):
                 self.iterables.append(new_iterable)
                 callback(self.iterables)
                 return self
-            length = len(iterable) if hasattr(iterable, "__len__") else total # type: ignore
+            length = len(iterable) if hasattr(iterable, "__len__") else total  # type: ignore
             self.iterables.append(
                 TrackedIterable(iter(iterable), 0, length, desc, unit, _tqdm)
             )

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -646,7 +646,7 @@ class Queue:
                         event,
                         ProcessCompletedMessage(
                             output=content,
-                            title=content["title"],  # type: ignore
+                            title=content.get("title", "Error"),  # type: ignore
                             success=False,
                         ),
                     )


### PR DESCRIPTION
## Description

- Fix to make progress bar compatiable with generators

<img width="1235" alt="image" src="https://github.com/user-attachments/assets/5d8a36ad-f5fb-4eb4-bc42-85f5e7909772">

Closes: #3841

There's no attribute `__len__` in generators, and even when users explicitly set the `total` argument, it defaults to None, preventing proper functionality with generators.

So we will use `total` as `length` if the object has no attribute `__len__`. 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
 
