### PR TITLE
Add a port timeout detection feature for gradio/preview. 

### DIFF
--- a/.changeset/honest-forks-pay.md
+++ b/.changeset/honest-forks-pay.md
@@ -1,5 +1,5 @@
 ---
-"@gradio/preview": minor
+"@gradio/preview": patch
 ---
 
 fix:Add a port timeout detection feature for gradio/preview. 

--- a/.changeset/honest-forks-pay.md
+++ b/.changeset/honest-forks-pay.md
@@ -1,0 +1,5 @@
+---
+"@gradio/preview": minor
+---
+
+fix:Add a port timeout detection feature for gradio/preview. 

--- a/js/preview/src/index.ts
+++ b/js/preview/src/index.ts
@@ -129,6 +129,10 @@ export async function find_free_ports(
 export function is_free_port(port: number): Promise<boolean> {
 	return new Promise((accept, reject) => {
 		const sock = net.createConnection(port, "127.0.0.1");
+		setTimeout(() => {
+			sock.destroy();
+			reject(new Error(`Timeout while detecting free port with 127.0.0.1:${port} `));
+		}, 3000);
 		sock.once("connect", () => {
 			sock.end();
 			accept(false);

--- a/js/preview/src/index.ts
+++ b/js/preview/src/index.ts
@@ -131,7 +131,9 @@ export function is_free_port(port: number): Promise<boolean> {
 		const sock = net.createConnection(port, "127.0.0.1");
 		setTimeout(() => {
 			sock.destroy();
-			reject(new Error(`Timeout while detecting free port with 127.0.0.1:${port} `));
+			reject(
+				new Error(`Timeout while detecting free port with 127.0.0.1:${port} `)
+			);
 		}, 3000);
 		sock.once("connect", () => {
 			sock.end();


### PR DESCRIPTION
This feature can help users receive more informative messages when running 'gradio cc dev' in case of network issues

## Description

In WSL2, accessing the localhost at 127.0.0.1 may result in a hang due to network isolation between WSL2 and the Windows host. As a result, using the 'is_free_port' function to check ports can lead to a blocking state.

