### PR TITLE
Custom component fixes

### DIFF
--- a/.changeset/hot-dancers-drop.md
+++ b/.changeset/hot-dancers-drop.md
@@ -1,6 +1,8 @@
 ---
 "@gradio/atoms": patch
 "@gradio/markdown": patch
+"@gradio/sanitize": patch
+"@self/build": patch
 "gradio": patch
 ---
 

--- a/.changeset/hot-dancers-drop.md
+++ b/.changeset/hot-dancers-drop.md
@@ -1,0 +1,7 @@
+---
+"@gradio/atoms": patch
+"@gradio/markdown": patch
+"gradio": patch
+---
+
+fix:Custom component fixes

--- a/js/atoms/package.json
+++ b/js/atoms/package.json
@@ -8,7 +8,8 @@
 	"license": "ISC",
 	"dependencies": {
 		"@gradio/icons": "workspace:^",
-		"@gradio/utils": "workspace:^"
+		"@gradio/utils": "workspace:^",
+		"@gradio/markdown": "workspace:^"
 	},
 	"peerDependencies": {
 		"svelte": "^4.0.0"

--- a/js/build/out/index.js
+++ b/js/build/out/index.js
@@ -149,7 +149,8 @@ var ignore_list = [
   "tooltip",
   "upload",
   "utils",
-  "wasm"
+  "wasm",
+  "sanitize"
 ];
 function generate_component_imports() {
   const exports = readdirSync(join(__dirname, "..", "..")).map((dir) => {

--- a/js/build/src/index.ts
+++ b/js/build/src/index.ts
@@ -211,7 +211,8 @@ const ignore_list = [
 	"tooltip",
 	"upload",
 	"utils",
-	"wasm"
+	"wasm",
+	"sanitize"
 ];
 function generate_component_imports(): string {
 	const exports = readdirSync(join(__dirname, "..", ".."))

--- a/js/markdown/package.json
+++ b/js/markdown/package.json
@@ -26,10 +26,10 @@
 		"@gradio/icons": "workspace:^",
 		"@gradio/statustracker": "workspace:^",
 		"@gradio/utils": "workspace:^",
+		"@gradio/sanitize": "workspace:^",
 		"@types/dompurify": "^3.0.2",
 		"@types/katex": "^0.16.0",
 		"@types/prismjs": "1.26.4",
-		"amuchina": "^1.0.12",
 		"dom-parser": "^1.1.5",
 		"github-slugger": "^2.0.0",
 		"isomorphic-dompurify": "^2.14.0",
@@ -37,12 +37,10 @@
 		"marked": "^12.0.0",
 		"marked-gfm-heading-id": "^3.1.2",
 		"marked-highlight": "^2.0.1",
-		"prismjs": "1.29.0",
-		"sanitize-html": "^2.13.0"
+		"prismjs": "1.29.0"
 	},
 	"devDependencies": {
-		"@gradio/preview": "workspace:^",
-		"@types/sanitize-html": "^2.13.0"
+		"@gradio/preview": "workspace:^"
 	},
 	"peerDependencies": {
 		"svelte": "^4.0.0"

--- a/js/markdown/shared/MarkdownCode.svelte
+++ b/js/markdown/shared/MarkdownCode.svelte
@@ -3,7 +3,6 @@
 	import render_math_in_element from "katex/contrib/auto-render";
 	import "katex/dist/katex.min.css";
 	import { create_marked } from "./utils";
-	import sanitize_server from "sanitize-html";
 	import Amuchina from "amuchina";
 	import "./prism.css";
 
@@ -32,7 +31,17 @@
 	const amuchina = new Amuchina();
 	const is_browser = typeof window !== "undefined";
 
-	let sanitize = is_browser ? sanitize_browser : sanitize_server;
+	let sanitize: (arg0: string) => string;
+	function resolve_sanitze(is_browser: boolean): (arg0: string) => string {
+		if (is_browser) {
+			sanitize = sanitize_browser;
+		}
+		import("sanitize-html").then((sanitize_server) => {
+			sanitize = sanitize_server.default || sanitize_server;
+		});
+	}
+
+	$: resolve_sanitze(is_browser);
 
 	function sanitize_browser(source: string): string {
 		const node = new DOMParser().parseFromString(source, "text/html");

--- a/js/markdown/shared/MarkdownCode.svelte
+++ b/js/markdown/shared/MarkdownCode.svelte
@@ -3,7 +3,7 @@
 	import render_math_in_element from "katex/contrib/auto-render";
 	import "katex/dist/katex.min.css";
 	import { create_marked } from "./utils";
-	import Amuchina from "amuchina";
+	import { sanitize } from "@gradio/sanitize";
 	import "./prism.css";
 
 	export let chatbot = true;
@@ -27,62 +27,6 @@
 		line_breaks,
 		latex_delimiters
 	});
-
-	const amuchina = new Amuchina();
-	const is_browser = typeof window !== "undefined";
-
-	let sanitize: (arg0: string) => string;
-	function resolve_sanitze(is_browser: boolean): void {
-		if (is_browser) {
-			sanitize = sanitize_browser;
-		}
-		import("sanitize-html").then((sanitize_server) => {
-			sanitize = sanitize_server.default || sanitize_server;
-		});
-	}
-
-	$: resolve_sanitze(is_browser);
-
-	function sanitize_browser(source: string): string {
-		const node = new DOMParser().parseFromString(source, "text/html");
-		walk_nodes(node.body, "A", (node) => {
-			if (node instanceof HTMLElement && "target" in node) {
-				if (is_external_url(node.getAttribute("href"))) {
-					node.setAttribute("target", "_blank");
-					node.setAttribute("rel", "noopener noreferrer");
-				}
-			}
-		});
-
-		return amuchina.sanitize(node).body.innerHTML;
-	}
-
-	function walk_nodes(
-		node: Node | null | HTMLElement,
-		test: string | ((node: Node | HTMLElement) => boolean),
-		callback: (node: Node | HTMLElement) => void
-	): void {
-		if (
-			node &&
-			((typeof test === "string" && node.nodeName === test) ||
-				(typeof test === "function" && test(node)))
-		) {
-			callback(node);
-		}
-		const children = node?.childNodes || [];
-		for (let i = 0; i < children.length; i++) {
-			// @ts-ignore
-			walk_nodes(children[i], test, callback);
-		}
-	}
-
-	const is_external_url = (link: string | null): boolean => {
-		try {
-			return !!link && new URL(link).origin !== new URL(root).origin;
-		} catch (e) {
-			return false;
-		}
-	};
 
 	function escapeRegExp(string: string): string {
 		return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -115,7 +59,7 @@
 		}
 
 		if (sanitize_html && sanitize) {
-			parsedValue = sanitize(parsedValue);
+			parsedValue = sanitize(parsedValue, root);
 		}
 
 		return parsedValue;

--- a/js/markdown/shared/MarkdownCode.svelte
+++ b/js/markdown/shared/MarkdownCode.svelte
@@ -32,7 +32,7 @@
 	const is_browser = typeof window !== "undefined";
 
 	let sanitize: (arg0: string) => string;
-	function resolve_sanitze(is_browser: boolean): (arg0: string) => string {
+	function resolve_sanitze(is_browser: boolean): void {
 		if (is_browser) {
 			sanitize = sanitize_browser;
 		}

--- a/js/sanitize/browser.ts
+++ b/js/sanitize/browser.ts
@@ -1,0 +1,43 @@
+import Amuchina from "amuchina";
+
+const is_external_url = (link: string | null, root: string): boolean => {
+	try {
+		return !!link && new URL(link).origin !== new URL(root).origin;
+	} catch (e) {
+		return false;
+	}
+};
+
+export function sanitize(source: string, root: string): string {
+	const amuchina = new Amuchina();
+	const node = new DOMParser().parseFromString(source, "text/html");
+	walk_nodes(node.body, "A", (node) => {
+		if (node instanceof HTMLElement && "target" in node) {
+			if (is_external_url(node.getAttribute("href"), root)) {
+				node.setAttribute("target", "_blank");
+				node.setAttribute("rel", "noopener noreferrer");
+			}
+		}
+	});
+
+	return amuchina.sanitize(node).body.innerHTML;
+}
+
+function walk_nodes(
+	node: Node | null | HTMLElement,
+	test: string | ((node: Node | HTMLElement) => boolean),
+	callback: (node: Node | HTMLElement) => void
+): void {
+	if (
+		node &&
+		((typeof test === "string" && node.nodeName === test) ||
+			(typeof test === "function" && test(node)))
+	) {
+		callback(node);
+	}
+	const children = node?.childNodes || [];
+	for (let i = 0; i < children.length; i++) {
+		// @ts-ignore
+		walk_nodes(children[i], test, callback);
+	}
+}

--- a/js/sanitize/index.d.ts
+++ b/js/sanitize/index.d.ts
@@ -1,0 +1,1 @@
+export declare function sanitize(source: string, root: string): string;

--- a/js/sanitize/package.json
+++ b/js/sanitize/package.json
@@ -1,0 +1,34 @@
+{
+	"name": "@gradio/sanitize",
+	"version": "0.1.0",
+	"description": "Gradio UI packages",
+	"type": "module",
+	"author": "",
+	"main": "./dist/server.js",
+	"license": "ISC",
+	"dependencies": {
+		"sanitize-html": "^2.13.0",
+		"amuchina": "^1.0.12"
+	},
+	"devDependencies": {
+		"@types/sanitize-html": "^2.13.0"
+	},
+	"main_changeset": true,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/gradio-app/gradio.git",
+		"directory": "js/utils"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"browser": "./dist/browser.js",
+			"import": "./dist/server.js",
+			"default": "./dist/server.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"scripts": {
+		"package": "svelte-package --input=. --cwd=../../.config/"
+	}
+}

--- a/js/sanitize/server.ts
+++ b/js/sanitize/server.ts
@@ -1,0 +1,5 @@
+import { default as sanitize_html_ } from "sanitize-html";
+
+export function sanitize(source: string, root: string): string {
+	return sanitize_html_(source);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -625,6 +625,9 @@ importers:
       '@gradio/icons':
         specifier: workspace:^
         version: link:../icons
+      '@gradio/markdown':
+        specifier: workspace:^
+        version: link:../markdown
       '@gradio/utils':
         specifier: workspace:^
         version: link:../utils

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1672,6 +1672,9 @@ importers:
       '@gradio/icons':
         specifier: workspace:^
         version: link:../icons
+      '@gradio/sanitize':
+        specifier: workspace:^
+        version: link:../sanitize
       '@gradio/statustracker':
         specifier: workspace:^
         version: link:../statustracker
@@ -1687,9 +1690,6 @@ importers:
       '@types/prismjs':
         specifier: 1.26.4
         version: 1.26.4
-      amuchina:
-        specifier: ^1.0.12
-        version: 1.0.12
       dom-parser:
         specifier: ^1.1.5
         version: 1.1.5
@@ -1714,9 +1714,6 @@ importers:
       prismjs:
         specifier: 1.29.0
         version: 1.29.0
-      sanitize-html:
-        specifier: ^2.13.0
-        version: 2.13.0
       svelte:
         specifier: ^4.0.0
         version: 4.2.15
@@ -1724,9 +1721,6 @@ importers:
       '@gradio/preview':
         specifier: workspace:^
         version: link:../preview
-      '@types/sanitize-html':
-        specifier: ^2.13.0
-        version: 2.13.0
 
   js/model3D:
     dependencies:
@@ -2036,6 +2030,19 @@ importers:
       '@gradio/utils':
         specifier: workspace:^
         version: link:../utils
+
+  js/sanitize:
+    dependencies:
+      amuchina:
+        specifier: ^1.0.12
+        version: 1.0.12
+      sanitize-html:
+        specifier: ^2.13.0
+        version: 2.13.0
+    devDependencies:
+      '@types/sanitize-html':
+        specifier: ^2.13.0
+        version: 2.13.0
 
   js/simpledropdown:
     dependencies:


### PR DESCRIPTION
## Description

@gradio/markdown is not a dependency of @gradio/atoms so dev/build was broken for components that used them.

The `sanitize-html` library cannot be imported in the browser I think (uses `require` and has no export named `default`). I tried messing with `optimizeDeps` in the component config but it didn't work. So just changing the code in MarkdownCode to defer the import.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
