### PR TITLE
Restore light/dark custom setting

### DIFF
--- a/.changeset/calm-emus-post.md
+++ b/.changeset/calm-emus-post.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Restore light/dark custom setting
+fix:Restore light/dark custom setting

--- a/.changeset/calm-emus-post.md
+++ b/.changeset/calm-emus-post.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Restore light/dark custom setting

--- a/gradio/themes/base.py
+++ b/gradio/themes/base.py
@@ -86,7 +86,7 @@ class ThemeClass:
             + "\n}"
         )
         dark_css_code = (
-            "@media (prefers-color-scheme: dark) {\n:root {\n"
+            "\n:root .dark {\n"
             + "\n".join([f"  --{attr}: {val};" for attr, val in dark_css.items()])
             + "\n}\n}"
         )


### PR DESCRIPTION
Restores the ability to set the light / dark theme via:
- embedding attribute <gradio-app theme="dark">
- url param "http://localhost:7860/?__theme=dark"