### PR TITLE
Fix Lite dependencies

### DIFF
--- a/.changeset/calm-roses-suffer.md
+++ b/.changeset/calm-roses-suffer.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/wasm": minor
-"gradio": minor
+"@gradio/wasm": patch
+"gradio": patch
 ---
 
 feat:Fix Lite dependencies

--- a/.changeset/calm-roses-suffer.md
+++ b/.changeset/calm-roses-suffer.md
@@ -3,4 +3,4 @@
 "gradio": patch
 ---
 
-feat:Fix Lite dependencies
+fix:Fix Lite dependencies

--- a/.changeset/calm-roses-suffer.md
+++ b/.changeset/calm-roses-suffer.md
@@ -1,0 +1,6 @@
+---
+"@gradio/wasm": minor
+"gradio": minor
+---
+
+feat:Fix Lite dependencies

--- a/js/wasm/src/webworker/index.ts
+++ b/js/wasm/src/webworker/index.ts
@@ -80,15 +80,6 @@ async function initializeEnvironment(
 	updateProgress("Loading Gradio wheels");
 	await pyodide.loadPackage(["ssl", "setuptools"]);
 	await micropip.add_mock_package("ffmpy", "0.3.0");
-	await micropip.install.callKwargs(
-		[
-			"typing-extensions>=4.8.0", // Typing extensions needs to be installed first otherwise the versions from the pyodide lockfile is used which is incompatible with the latest fastapi.
-			"markdown-it-py[linkify]~=2.2.0", // On 3rd June 2023, markdown-it-py 3.0.0 has been released. The `gradio` package depends on its `>=2.0.0` version so its 3.x will be resolved. However, it conflicts with `mdit-py-plugins`'s dependency `markdown-it-py >=1.0.0,<3.0.0` and micropip currently can't resolve it. So we explicitly install the compatible version of the library here.
-			"anyio==3.*", // `fastapi` depends on `anyio>=3.4.0,<5` so its 4.* can be installed, but it conflicts with the anyio version `httpx` depends on, `==3.*`. Seems like micropip can't resolve it for now, so we explicitly install the compatible version of the library here.
-			"fastapi<0.111.0" // `fastapi==0.111.0` added `ujson` as a dependency, but it's not available on Pyodide yet.
-		],
-		{ keep_going: true }
-	);
 	await micropip.install.callKwargs(gradioWheelUrls, {
 		keep_going: true
 	});

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ python-multipart>=0.0.9  # required for fastapi forms
 pydub
 pyyaml>=5.0,<7.0
 semantic_version~=2.0
-starlette>=0.40.0,<1.0
+starlette>=0.40.0,<1.0; sys.platform != 'emscripten'
 typing_extensions~=4.0
 urllib3~=2.0; sys.platform == 'emscripten'  # urllib3 is used for Lite support. Version spec can be omitted because urllib3==2.1.0 is prebuilt for Pyodide and urllib>=2.2.0 supports Pyodide as well.
 uvicorn>=0.14.0; sys.platform != 'emscripten'


### PR DESCRIPTION
## Description

* Starlette was updated in https://github.com/gradio-app/gradio/pull/9712 but installing the pinned version causes an error on Lite. `requirements.txt` is fixed.
* Also deleted out-of-date package installations in `webworker/index.ts`.

Resolves #9721