### PR TITLE
fix css syntax error

### DIFF
--- a/.changeset/stale-jobs-reply.md
+++ b/.changeset/stale-jobs-reply.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:fix css syntax error
+fix:fix css syntax error

--- a/.changeset/stale-jobs-reply.md
+++ b/.changeset/stale-jobs-reply.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:fix css syntax error

--- a/gradio/themes/base.py
+++ b/gradio/themes/base.py
@@ -88,7 +88,7 @@ class ThemeClass:
         dark_css_code = (
             "\n:root .dark {\n"
             + "\n".join([f"  --{attr}: {val};" for attr, val in dark_css.items()])
-            + "\n}\n}"
+            + "\n}"
         )
 
         font_css = "\n".join(self._font_css)


### PR DESCRIPTION
## Description

There was a CSS syntax error in the theme creation script, an extra curly brace was being added.

Fixes the failing storybook build.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
