### PR TITLE
Tiny README.md fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ English | [中文](readme_files/zh-cn#readme)
 <div>
 
 <div align="center">
-
 <span>
 <a href="https://www.producthunt.com/posts/gradio-5-0?embed=true&utm_source=badge-featured&utm_medium=badge&utm_souce=badge-gradio&#0045;5&#0045;0" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=501906&theme=light" alt="Gradio&#0032;5&#0046;0 - the&#0032;easiest&#0032;way&#0032;to&#0032;build&#0032;AI&#0032;web&#0032;apps | Product Hunt" style="width: 150px; height: 54px;" width="150" height="54" /></a>
 <a href="https://trendshift.io/repositories/2145" target="_blank"><img src="https://trendshift.io/api/badge/repositories/2145" alt="gradio-app%2Fgradio | Trendshift" style="width: 150px; height: 55px;" width="150" height="55"/></a>


### PR DESCRIPTION
## Description

There was a rogue `-` between the badges in the README

old
<img width="309" alt="Screenshot 2024-10-17 at 14 12 09" src="https://github.com/user-attachments/assets/17f31f27-77d3-4ce8-b21b-a5a0b0d9682e">

new
<img width="315" alt="Screenshot 2024-10-17 at 14 11 47" src="https://github.com/user-attachments/assets/61e43888-1a33-492d-921e-8fd023ffb769">

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
