### PR TITLE
Update client.py: raise error on 429 get_config

### DIFF
--- a/.changeset/chatty-pants-check.md
+++ b/.changeset/chatty-pants-check.md
@@ -1,0 +1,6 @@
+---
+"gradio": patch
+"gradio_client": patch
+---
+
+fix:Update client.py: raise error on 429 get_config

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -869,6 +869,10 @@ class Client:
             raise AuthenticationError(
                 f"Could not load {self.src} as credentials were not provided. Please login."
             )
+        elif r.status_code == 429:
+            raise utils.TooManyRequestsError(
+                f"Too many requests to the API, please try again later."
+            ) from None
         else:  # to support older versions of Gradio
             r = httpx.get(
                 self.src_prefixed,

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -875,7 +875,7 @@ class Client:
             ) from None
         else:  # to support older versions of Gradio
             r = httpx.get(
-                self.src_prefixed,
+                self.src,
                 headers=self.headers,
                 cookies=self.cookies,
                 verify=self.ssl_verify,

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -871,7 +871,7 @@ class Client:
             )
         elif r.status_code == 429:
             raise utils.TooManyRequestsError(
-                f"Too many requests to the API, please try again later."
+                "Too many requests to the API, please try again later."
             ) from None
         else:  # to support older versions of Gradio
             r = httpx.get(


### PR DESCRIPTION
## Description

If the Gradio server says there are Too Many Requests, I think it be best to acknowledge it and not immediatly try to make another request again.

Does not affect the `self.src_prefixed` which still may not have been declared.

Closes: #9683