### PR TITLE
added audioop-lts module to support pydub for python3.13+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ uvicorn>=0.14.0; sys.platform != 'emscripten'
 typer>=0.12,<1.0; sys.platform != 'emscripten'
 tomlkit==0.12.0
 ruff>=0.2.2; sys.platform != 'emscripten'
+audioop-lts; python_version >= "3.13" #it provides support for 'audioop' module removed in latest python version used by pydub


### PR DESCRIPTION
## Description

While testing the Gradio library locally, I encountered an issue where the audioop module has been removed in Python 3.13+, causing import errors within the pydub library. To address this, I added the audioop-lts module to provide support and resolve the issue. 

Related to: #9696 

## 🎯 PRs Should Target Issues

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
