### PR TITLE
Fix broken image select

### DIFF
--- a/.changeset/busy-lions-pull.md
+++ b/.changeset/busy-lions-pull.md
@@ -1,0 +1,6 @@
+---
+"@gradio/upload": patch
+"gradio": patch
+---
+
+fix:Fix broken image select

--- a/js/upload/src/Upload.svelte
+++ b/js/upload/src/Upload.svelte
@@ -317,16 +317,6 @@
 		width: var(--size-full);
 	}
 
-	.hidden {
-		display: none;
-		position: absolute;
-		flex-grow: 0;
-	}
-
-	.hidden :global(svg) {
-		display: none;
-	}
-
 	.center {
 		display: flex;
 		justify-content: center;
@@ -337,6 +327,16 @@
 		justify-content: center;
 		align-items: center;
 	}
+	.hidden {
+		display: none;
+		position: absolute;
+		flex-grow: 0;
+	}
+
+	.hidden :global(svg) {
+		display: none;
+	}
+
 	.disable_click {
 		cursor: default;
 	}


### PR DESCRIPTION
gr.Image() had broken select listener. Was due to Upload button appearing on top of image so it was preventing pointer events, because display:flex was overrriding display:none of Upload.svelte. Rearranged css rules so flex is overriden by none.

Fixes: #9182

Wanted to add a functional test but seems like we already have one in [fix_image_select/js/spa/test/image_component_events.spec.ts#L129 ](https://vscode.dev/github/gradio-app/gradio/blob/fix_image_select/js/spa/test/image_component_events.spec.ts#L129), unfortunately seems like playwright clicks through the upload.