### PR TITLE
Only publish wheel to pypi

### DIFF
--- a/build_pypi.sh
+++ b/build_pypi.sh
@@ -15,4 +15,4 @@ aws s3 cp gradio/templates/frontend "s3://gradio/${new_version}/" --recursive --
 
 rm -rf dist/*
 rm -rf build/*
-python3 -m build
+python3 -m build -w


### PR DESCRIPTION
## Description

Cut down pypi storage in half by not uploading the source distribution. People can get the source distribution from github tagged releases. Not sure of any unintended breaking "changes" though. Maybe people who use `pip install --no-binary`. But not sure why they would do that.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
