### PR TITLE
Allow smoother plot changes

### DIFF
--- a/.changeset/salty-showers-study.md
+++ b/.changeset/salty-showers-study.md
@@ -1,0 +1,6 @@
+---
+"@gradio/plot": minor
+"gradio": minor
+---
+
+feat:Allow smoother plot changes

--- a/js/plot/shared/Plot.svelte
+++ b/js/plot/shared/Plot.svelte
@@ -4,7 +4,6 @@
 	import { Empty } from "@gradio/atoms";
 	import type { ThemeMode } from "js/core/src/components/types";
 	import type { Gradio, SelectData } from "@gradio/utils";
-	import { _ } from "svelte-i18n";
 
 	export let value;
 	let _value;
@@ -39,7 +38,7 @@
 		let type = value?.type;
 		if (type !== _type) {
 			PlotComponent = null;
-		}			
+		}
 		if (type && type in plotTypeMapping && is_browser) {
 			if (loadedPlotTypeMapping[type]) {
 				PlotComponent = loadedPlotTypeMapping[type];

--- a/js/plot/shared/Plot.svelte
+++ b/js/plot/shared/Plot.svelte
@@ -4,8 +4,10 @@
 	import { Empty } from "@gradio/atoms";
 	import type { ThemeMode } from "js/core/src/components/types";
 	import type { Gradio, SelectData } from "@gradio/utils";
+	import { _ } from "svelte-i18n";
 
 	export let value;
+	let _value;
 	export let colors: string[] = [];
 	export let theme_mode: ThemeMode;
 	export let caption: string;
@@ -27,36 +29,49 @@
 		matplotlib: () => import("./plot_types/MatplotlibPlot.svelte")
 	};
 
-	const is_browser = typeof window !== "undefined";
+	let loadedPlotTypeMapping = {};
 
-	$: {
+	const is_browser = typeof window !== "undefined";
+	let key = 0;
+
+	$: if (value !== _value) {
+		key += 1;
 		let type = value?.type;
 		if (type !== _type) {
 			PlotComponent = null;
-		}
+		}			
 		if (type && type in plotTypeMapping && is_browser) {
-			plotTypeMapping[type]().then((module) => {
-				PlotComponent = module.default;
-			});
+			if (loadedPlotTypeMapping[type]) {
+				PlotComponent = loadedPlotTypeMapping[type];
+			} else {
+				plotTypeMapping[type]().then((module) => {
+					PlotComponent = module.default;
+					loadedPlotTypeMapping[type] = PlotComponent;
+				});
+			}
 		}
+		_value = value;
+		_type = type;
 	}
 </script>
 
 {#if value && PlotComponent}
-	<svelte:component
-		this={PlotComponent}
-		{value}
-		{colors}
-		{theme_mode}
-		{caption}
-		{bokeh_version}
-		{show_actions_button}
-		{gradio}
-		{_selectable}
-		{x_lim}
-		on:load
-		on:select
-	/>
+	{#key key}
+		<svelte:component
+			this={PlotComponent}
+			{value}
+			{colors}
+			{theme_mode}
+			{caption}
+			{bokeh_version}
+			{show_actions_button}
+			{gradio}
+			{_selectable}
+			{x_lim}
+			on:load
+			on:select
+		/>
+	{/key}
 {:else}
 	<Empty unpadded_box={true} size="large"><PlotIcon /></Empty>
 {/if}


### PR DESCRIPTION
If a non-native plot was changed, there was a bit of a stutter between loading plots, as shown with the demo below:

```python
import plotly.express as px
import pandas as pd
import gradio as gr
import numpy as np

# Create a sample dataframe
df = pd.DataFrame(
    {
        "Year": [2020, 2021, 2022, 2023, 2024, 2025] * 3,
        "State": ["NY"] * 6 + ["CA"] * 6 + ["TX"] * 6,
        "Value": np.random.randint(1, 100, 18),
    }
)


def manually_animated_choropleth(year):
    _df = df[df["Year"] == year]
    fig = px.choropleth(
        data_frame=_df,
        locations="State",
        locationmode="USA-states",
        color="Value",
        color_continuous_scale="Viridis",
        scope="usa",
    )
    return fig


with gr.Blocks() as demo:
    year = gr.Slider(minimum=2020, maximum=2025, step=1, label="Year")
    chloropleth_map = gr.Plot()

    demo.load(
        manually_animated_choropleth,
        inputs=[year],
        outputs=chloropleth_map,
    )
    year.change(
        manually_animated_choropleth,
        inputs=[year],
        outputs=chloropleth_map,
        show_progress=False,
    )

demo.launch()
```

BEFORE:
![Recording 2024-10-21 at 16 05 31](https://github.com/user-attachments/assets/339f1e3d-b4e5-452f-8588-5098b19f4440)

AFTER: 
![Recording 2024-10-21 at 16 01 16](https://github.com/user-attachments/assets/d9c09c5d-404d-4319-bde9-716f791f4083)

Based on request here: https://huggingface.slack.com/archives/C02QZLG8GMN/p1729531450521999
