### PR TITLE
Exclude python-multipart 0.0.13

### DIFF
--- a/.changeset/warm-roses-begin.md
+++ b/.changeset/warm-roses-begin.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Exclude python-multipart 0.0.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ packaging
 pandas>=1.0,<3.0
 pillow>=8.0,<11.0
 pydantic>=2.0
-python-multipart>=0.0.9  # required for fastapi forms
+python-multipart>=0.0.9,!=0.0.13  # required for fastapi forms. 0.0.13 was yanked from PyPI but micropip now ignores the yanked flag so we explicitly exclude it.
 pydub
 pyyaml>=5.0,<7.0
 semantic_version~=2.0


### PR DESCRIPTION
## Description

Closes: #9774

Looks like it's a problem on `micropip` that the yanked version is installed (I raised a ticket: https://github.com/pyodide/micropip/issues/146). For now we need to exclude the version explicitly.