### PR TITLE
Make name optional

### DIFF
--- a/.changeset/nasty-dodos-mix.md
+++ b/.changeset/nasty-dodos-mix.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Make name optional

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -35,8 +35,8 @@ if TYPE_CHECKING:
 
 @document()
 def load(
-    name: str,
-    src: Callable[[str, str | None], Blocks]
+    name: str | None = None,
+    src: Callable[[str | None, str | None], Blocks]
     | Literal["models", "spaces"]
     | None = None,
     token: str | None = None,
@@ -63,6 +63,10 @@ def load(
             "The `hf_token` parameter is deprecated. Please use the equivalent `token` parameter instead."
         )
     if src is None:
+        if name is None:
+            raise ValueError(
+                "Either `src` parameter must be provided, or `name` must be provided."
+            )
         # Separate the repo type (e.g. "model") from repo name (e.g. "google/vit-base-patch16-224")
         tokens = name.split("/")
         if len(tokens) <= 1:
@@ -72,6 +76,10 @@ def load(
         src = tokens[0]  # type: ignore
         name = "/".join(tokens[1:])
     if src in ["huggingface", "models", "spaces"]:
+        if name is None:
+            raise ValueError(
+                "The `name` parameter must be provided when loading a model or Space from Hugging Face."
+            )
         return load_blocks_from_huggingface(
             name=name, src=src, hf_token=token, **kwargs
         )


### PR DESCRIPTION
We've heard requests from integration partners that they'd like to have a "default model", which should be used when a `name` is not provided. This adds support for that.

cc @AK391 @yvrjsharma 

Test with:

```py
import gradio as gr

def registry_with_default(name: str | None, token: str | None):
    if name is None:
        return gr.Interface(lambda x:x, "textbox", "textbox", title="Default model")
    else:        
        return gr.Interface(lambda x:x, "textbox", "textbox", title=name)

gr.load(src=registry_with_default).launch()
```