### PR TITLE
Allow accepting user-provided-tokens in `gr.load`

### DIFF
--- a/.github/actions/install-frontend-deps/action.yml
+++ b/.github/actions/install-frontend-deps/action.yml
@@ -25,7 +25,7 @@ runs:
       with:
         path: |
           js/lite/dist/**
-        key: gradio-lib-front-end-lite-${{ hashFiles('js/**', 'client/js/**', gradio/**)}}
+        key: gradio-lib-front-end-lite-${{ hashFiles('js/**', 'client/js/**', 'gradio/**')}}
     - name: Install pnpm
       uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # @v4
       with:

--- a/.github/actions/install-frontend-deps/action.yml
+++ b/.github/actions/install-frontend-deps/action.yml
@@ -13,12 +13,19 @@ runs:
   using: "composite"
   steps:
     - uses: actions/cache@v4
-      id: frontend-cache
+      id: frontend-core-cache
+      if: inputs.skip_build == 'false'
       with:
         path: |
           gradio/templates/**
-          js/lite/dist/**
         key: gradio-lib-front-end-${{ hashFiles('js/**', 'client/js/**')}}
+    - uses: actions/cache@v4
+      id: frontend-lite-cache
+      if: inputs.build_lite == 'true'
+      with:
+        path: |
+          js/lite/dist/**
+        key: gradio-lib-front-end-lite-${{ hashFiles('js/**', 'client/js/**', gradio/**)}}
     - name: Install pnpm
       uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # @v4
       with:
@@ -35,15 +42,11 @@ runs:
       shell: bash
       run: pnpm css
     - name: Build frontend
-      if: inputs.skip_build == 'false' && steps.frontend-cache.outputs.cache-hit != 'true'
+      if: inputs.skip_build == 'false' && steps.frontend-core-cache.outputs.cache-hit != 'true'
       shell: bash
       run: pnpm build
-    - name: generate types
-      if: inputs.skip_build == 'false' || inputs.build_lite == 'true'
-      shell: bash
-      run: pnpm package
     - name: Build frontend lite
-      if: inputs.build_lite == 'true' && steps.frontend-cache.outputs.cache-hit != 'true'
+      if: inputs.build_lite == 'true' && steps.frontend-lite-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         . venv/bin/activate

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -30,7 +30,6 @@ from gradio.processing_utils import save_base64_to_cache, to_binary
 
 if TYPE_CHECKING:
     from gradio.blocks import Blocks
-    from gradio.components import Textbox
     from gradio.interface import Interface
 
 
@@ -51,7 +50,7 @@ def load(
         name: the name of the model (e.g. "google/vit-base-patch16-224") or Space (e.g. "flax-community/spanish-gpt2"). This is the first parameter passed into the `src` function. Can also be formatted as {src}/{repo name} (e.g. "models/google/vit-base-patch16-224") if `src` is not provided.
         src: function that accepts a string model `name` and a string or None `token` and returns a Gradio app. Alternatively, this parameter takes one of two strings for convenience: "models" (for loading a Hugging Face model through the Inference API) or "spaces" (for loading a Hugging Face Space). If None, uses the prefix of the `name` parameter to determine `src`.
         token: optional token that is passed as the second parameter to the `src` function. For Hugging Face repos, uses the local HF token when loading models but not Spaces (when loading Spaces, only provide a token if you are loading a trusted private Space as the token can be read by the Space you are loading). Find HF tokens here: https://huggingface.co/settings/tokens.
-        accept_token: if True, a Textbox component is rendered to allow the user to provide a token, which will be used instead of the `token` parameter when calling the API. You can also pass in a `Textbox` component instance, whose value will be used as the token.
+        accept_token: if True, a Textbox component is first rendered to allow the user to provide a token, which will be used instead of the `token` parameter when calling the loaded model or Space.
         kwargs: additional keyword parameters to pass into the `src` function. If `src` is "models" or "Spaces", these parameters are passed into the `gr.Interface` or `gr.ChatInterface` constructor.
     Returns:
         a Gradio Blocks app for the given model

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -42,7 +42,7 @@ def load(
     | None = None,
     token: str | None = None,
     hf_token: str | None = None,
-    accept_token: bool | Textbox = False,
+    accept_token: bool = False,
     **kwargs,
 ) -> Blocks:
     """

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -80,21 +80,22 @@ def load(
             "The `src` parameter must be one of 'huggingface', 'models', 'spaces', or a function that accepts a model name (and optionally, a token), and returns a Gradio app."
         )
 
-    def create_blocks():
+    def create_blocks(token_value):
         if isinstance(src, Callable):
-            return src(name, token, **kwargs)
+            return src(name, token_value, **kwargs)
         return load_blocks_from_huggingface(
-            name=name, src=src, hf_token=token, **kwargs
+            name=name, src=src, hf_token=token_value, **kwargs
         )
 
     if not user_provides_token:
-        return create_blocks()
+        return create_blocks(token)
     else:
         import gradio as gr
 
         with gr.Blocks(fill_height=True) as demo:
             if user_provides_token is True:
                 textbox = gr.Textbox(
+                    value="",
                     type="password",
                     label="Token",
                     info="Enter your token and press enter.",
@@ -102,7 +103,7 @@ def load(
             else:
                 textbox = user_provides_token
 
-            gr.render(inputs=[textbox], triggers=[textbox.submit])(create_blocks)()
+            gr.render(inputs=[textbox], triggers=[textbox.submit])(create_blocks)(textbox)
 
         return demo
 

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -91,7 +91,11 @@ def load(
 
         with gr.Blocks(fill_height=True) as demo:
             if user_provides_token is True:
-                textbox = gr.Textbox(type="password", label="Token", info="Enter your token and press enter.")
+                textbox = gr.Textbox(
+                    type="password",
+                    label="Token",
+                    info="Enter your token and press enter.",
+                )
             else:
                 textbox = user_provides_token
 
@@ -102,6 +106,7 @@ def load(
                 return load_blocks_from_huggingface(
                     name=name, src=src, hf_token=token_value, **kwargs
                 )
+
         return demo
 
 

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -42,7 +42,7 @@ def load(
     | None = None,
     token: str | None = None,
     hf_token: str | None = None,
-    user_provides_token: bool | Textbox = False,
+    accept_token: bool | Textbox = False,
     **kwargs,
 ) -> Blocks:
     """
@@ -51,7 +51,7 @@ def load(
         name: the name of the model (e.g. "google/vit-base-patch16-224") or Space (e.g. "flax-community/spanish-gpt2"). This is the first parameter passed into the `src` function. Can also be formatted as {src}/{repo name} (e.g. "models/google/vit-base-patch16-224") if `src` is not provided.
         src: function that accepts a string model `name` and a string or None `token` and returns a Gradio app. Alternatively, this parameter takes one of two strings for convenience: "models" (for loading a Hugging Face model through the Inference API) or "spaces" (for loading a Hugging Face Space). If None, uses the prefix of the `name` parameter to determine `src`.
         token: optional token that is passed as the second parameter to the `src` function. For Hugging Face repos, uses the local HF token when loading models but not Spaces (when loading Spaces, only provide a token if you are loading a trusted private Space as the token can be read by the Space you are loading). Find HF tokens here: https://huggingface.co/settings/tokens.
-        user_provides_token: if True, a Textbox component is rendered to allow the user to provide a token, which will be used instead of the `token` parameter when calling the API. You can also pass in a `Textbox` component instance, whose value will be used as the token.
+        accept_token: if True, a Textbox component is rendered to allow the user to provide a token, which will be used instead of the `token` parameter when calling the API. You can also pass in a `Textbox` component instance, whose value will be used as the token.
         kwargs: additional keyword parameters to pass into the `src` function. If `src` is "models" or "Spaces", these parameters are passed into the `gr.Interface` or `gr.ChatInterface` constructor.
     Returns:
         a Gradio Blocks app for the given model
@@ -80,7 +80,7 @@ def load(
             "The `src` parameter must be one of 'huggingface', 'models', 'spaces', or a function that accepts a model name (and optionally, a token), and returns a Gradio app."
         )
 
-    if not user_provides_token:
+    if not accept_token:
         if isinstance(src, Callable):
             return src(name, token, **kwargs)
         return load_blocks_from_huggingface(
@@ -90,14 +90,11 @@ def load(
         import gradio as gr
 
         with gr.Blocks(fill_height=True) as demo:
-            if user_provides_token is True:
-                textbox = gr.Textbox(
-                    type="password",
-                    label="Token",
-                    info="Enter your token and press enter.",
-                )
-            else:
-                textbox = user_provides_token
+            textbox = gr.Textbox(
+                type="password",
+                label="Token",
+                info="Enter your token and press enter.",
+            )
 
             @gr.render(inputs=[textbox], triggers=[textbox.submit])
             def create(token_value):

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -79,7 +79,7 @@ def load(
         raise ValueError(
             "The `src` parameter must be one of 'huggingface', 'models', 'spaces', or a function that accepts a model name (and optionally, a token), and returns a Gradio app."
         )
-    
+
     def create_blocks():
         if isinstance(src, Callable):
             return src(name, token, **kwargs)

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -80,22 +80,18 @@ def load(
             "The `src` parameter must be one of 'huggingface', 'models', 'spaces', or a function that accepts a model name (and optionally, a token), and returns a Gradio app."
         )
 
-    def create_blocks(token_value):
-        if isinstance(src, Callable):
-            return src(name, token_value, **kwargs)
-        return load_blocks_from_huggingface(
-            name=name, src=src, hf_token=token_value, **kwargs
-        )
-
     if not user_provides_token:
-        return create_blocks(token)
+        if isinstance(src, Callable):
+            return src(name, token, **kwargs)
+        return load_blocks_from_huggingface(
+            name=name, src=src, hf_token=token, **kwargs
+        )
     else:
         import gradio as gr
 
         with gr.Blocks(fill_height=True) as demo:
             if user_provides_token is True:
                 textbox = gr.Textbox(
-                    value="",
                     type="password",
                     label="Token",
                     info="Enter your token and press enter.",
@@ -103,7 +99,13 @@ def load(
             else:
                 textbox = user_provides_token
 
-            gr.render(inputs=[textbox], triggers=[textbox.submit])(create_blocks)(textbox)
+            @gr.render(inputs=[textbox], triggers=[textbox.submit])
+            def create(token_value):
+                if isinstance(src, Callable):
+                    return src(name, token_value, **kwargs)
+                return load_blocks_from_huggingface(
+                    name=name, src=src, hf_token=token_value, **kwargs
+                )
 
         return demo
 

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -79,13 +79,16 @@ def load(
         raise ValueError(
             "The `src` parameter must be one of 'huggingface', 'models', 'spaces', or a function that accepts a model name (and optionally, a token), and returns a Gradio app."
         )
-
-    if not user_provides_token:
+    
+    def create_blocks():
         if isinstance(src, Callable):
             return src(name, token, **kwargs)
         return load_blocks_from_huggingface(
             name=name, src=src, hf_token=token, **kwargs
         )
+
+    if not user_provides_token:
+        return create_blocks()
     else:
         import gradio as gr
 
@@ -99,13 +102,7 @@ def load(
             else:
                 textbox = user_provides_token
 
-            @gr.render(inputs=[textbox], triggers=[textbox.submit])
-            def create(token_value):
-                if isinstance(src, Callable):
-                    return src(name, token_value, **kwargs)
-                return load_blocks_from_huggingface(
-                    name=name, src=src, hf_token=token_value, **kwargs
-                )
+            gr.render(inputs=[textbox], triggers=[textbox.submit])(create_blocks)()
 
         return demo
 


### PR DESCRIPTION
Adds a `user_provides_token` parameter to `gr.load` that creates a `Textbox` where a user can provide their own API token. This should be hopefully encourage api developers to create Gradio demos very easily and share them with other collaborators or on Spaces without the developer needing to hardcode a token.

Here's example usage:

```py
import gradio as gr
import sambanova_gradio

gr.load("Meta-Llama-3.1-70B-Instruct-8k", src=sambanova_gradio.registry, accept_token=True).launch()
```

https://github.com/user-attachments/assets/d1a79b3b-8e71-4531-93f3-2a5b2d23939e

cc @AK391 @yvrjsharma. Uses `@gr.render` under the hood -- very cool @aliabid94!