### PR TITLE
Fix the tab names in the playground

### DIFF
--- a/.changeset/legal-months-speak.md
+++ b/.changeset/legal-months-speak.md
@@ -1,0 +1,5 @@
+---
+"website": minor
+---
+
+feat:Fix the tab names in the playground

--- a/js/_website/src/lib/components/DemosLite.svelte
+++ b/js/_website/src/lib/components/DemosLite.svelte
@@ -449,14 +449,14 @@
 
 	const TABS: Tab[] = [
 		{
-			name: "Code",
+			label: "Code",
 			id: "code",
 			visible: true,
 			interactive: true,
 			elem_id: "code"
 		},
 		{
-			name: "Packages",
+			label: "Packages",
 			id: "packages",
 			visible: true,
 			interactive: true,
@@ -546,7 +546,7 @@
 						>
 							<TabItem
 								id={TABS[0].id}
-								name={TABS[0].name}
+								label={TABS[0].label}
 								visible={TABS[0].visible}
 								interactive={TABS[0].interactive}
 								elem_classes={["editor-tabitem"]}
@@ -564,7 +564,7 @@
 							</TabItem>
 							<TabItem
 								id={TABS[1].id}
-								name={TABS[1].name}
+								label={TABS[1].label}
 								visible={TABS[1].visible}
 								interactive={TABS[1].interactive}
 								elem_classes={["editor-tabitem"]}


### PR DESCRIPTION
## Description
The tab names are now "undefined".
![CleanShot 2024-10-23 at 11 38 28@2x](https://github.com/user-attachments/assets/384681d6-7281-49db-ba28-a243db1ddd3c)

Related to https://github.com/gradio-app/gradio/pull/9653/files#diff-e0279a31c4775aa9eedbbd4c28688d756f12f301651723b02c39e9521951766c