### PR TITLE
support gradio apps on spaces served on subpaths

### DIFF
--- a/.changeset/odd-wolves-taste.md
+++ b/.changeset/odd-wolves-taste.md
@@ -3,4 +3,4 @@
 "gradio": patch
 ---
 
-fix:support spaces served on subpaths
+fix:support gradio apps on spaces served on subpaths

--- a/.changeset/odd-wolves-taste.md
+++ b/.changeset/odd-wolves-taste.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": patch
+"gradio": patch
+---
+
+fix:support spaces served on subpaths

--- a/client/js/src/helpers/api_info.ts
+++ b/client/js/src/helpers/api_info.ts
@@ -15,7 +15,7 @@ import type {
 import { determine_protocol } from "./init_helpers";
 
 export const RE_SPACE_NAME = /^[a-zA-Z0-9_\-\.]+\/[a-zA-Z0-9_\-\.]+$/;
-export const RE_SPACE_DOMAIN = /.*hf\.space\/{0,1}$/;
+export const RE_SPACE_DOMAIN = /.*hf\.space\/{0,1}.*$/;
 
 export async function process_endpoint(
 	app_reference: string,
@@ -58,7 +58,7 @@ export async function process_endpoint(
 			determine_protocol(_app_reference);
 
 		return {
-			space_id: host.replace(".hf.space", ""),
+			space_id: host.split("/")[0].replace(".hf.space", ""),
 			ws_protocol,
 			http_protocol,
 			host

--- a/client/js/src/helpers/init_helpers.ts
+++ b/client/js/src/helpers/init_helpers.ts
@@ -182,13 +182,6 @@ export function determine_protocol(endpoint: string): {
 	if (endpoint.startsWith("http")) {
 		const { protocol, host, pathname } = new URL(endpoint);
 
-		if (host.endsWith("hf.space")) {
-			return {
-				ws_protocol: "wss",
-				host: host,
-				http_protocol: protocol as "http:" | "https:"
-			};
-		}
 		return {
 			ws_protocol: protocol === "https:" ? "wss" : "ws",
 			http_protocol: protocol as "http:" | "https:",

--- a/client/js/src/test/api_info.test.ts
+++ b/client/js/src/test/api_info.test.ts
@@ -486,6 +486,18 @@ describe("process_endpoint", () => {
 		expect(response.space_id).toBe("hmb-hello-world");
 		expect(response.host).toBe("hmb-hello-world.hf.space");
 	});
+
+	it("handles huggingface subpath urls", async () => {
+		const app_reference =
+			"https://pngwn-pr-demos-test.hf.space/demo/audio_debugger/";
+		const response = await process_endpoint(app_reference);
+		expect(response.space_id).toBe("pngwn-pr-demos-test");
+		expect(response.host).toBe(
+			"pngwn-pr-demos-test.hf.space/demo/audio_debugger"
+		);
+
+		expect(response.http_protocol).toBe("https:");
+	});
 });
 
 describe("join_urls", () => {


### PR DESCRIPTION
## Description

It is possible to be using a subpath URL even when hosting on spaces which the client doesn't currently take into account. I have tweaked the client to support this.

This is what was breaking our demo space.