### PR TITLE
Fix Loading SSR'd apps via gr.load

### DIFF
--- a/.changeset/long-wolves-serve.md
+++ b/.changeset/long-wolves-serve.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix Loading SSR'd apps via gr.load


### PR DESCRIPTION
## Description

The current logic for fetching the config in `gr.load` fails if the app is SSR'd as `window.gradio_config` is not in the page. So made some modifications to fetch from the `/config` route if it exists and fallback to `window.gradio_config` if it fails.

Test with `gr.load("gradio/calculator", src="spaces")`

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
