### PR TITLE
Fix a bug in example textbox rendering when it is initially invisible

### DIFF
--- a/.changeset/clear-falcons-lose.md
+++ b/.changeset/clear-falcons-lose.md
@@ -1,0 +1,8 @@
+---
+"@gradio/multimodaltextbox": patch
+"@gradio/simpletextbox": patch
+"@gradio/textbox": patch
+"gradio": patch
+---
+
+fix:Fix a bug in example textbox rendering when it is initially invisible

--- a/js/multimodaltextbox/Example.svelte
+++ b/js/multimodaltextbox/Example.svelte
@@ -15,12 +15,11 @@
 	let el: HTMLDivElement;
 
 	function set_styles(element: HTMLElement, el_width: number): void {
-		if (!element || !el_width) return;
-		el.style.setProperty(
+		element.style.setProperty(
 			"--local-text-width",
-			`${el_width < 150 ? el_width : 200}px`
+			`${el_width && el_width < 150 ? el_width : 200}px`
 		);
-		el.style.whiteSpace = "unset";
+		element.style.whiteSpace = "unset";
 	}
 
 	onMount(() => {

--- a/js/simpletextbox/Example.svelte
+++ b/js/simpletextbox/Example.svelte
@@ -9,12 +9,11 @@
 	let el: HTMLDivElement;
 
 	function set_styles(element: HTMLElement, el_width: number): void {
-		if (!element || !el_width) return;
-		el.style.setProperty(
+		element.style.setProperty(
 			"--local-text-width",
-			`${el_width < 150 ? el_width : 200}px`
+			`${el_width && el_width < 150 ? el_width : 200}px`
 		);
-		el.style.whiteSpace = "unset";
+		element.style.whiteSpace = "unset";
 	}
 
 	onMount(() => {

--- a/js/textbox/Example.svelte
+++ b/js/textbox/Example.svelte
@@ -9,12 +9,11 @@
 	let el: HTMLDivElement;
 
 	function set_styles(element: HTMLElement, el_width: number): void {
-		if (!element || !el_width) return;
-		el.style.setProperty(
+		element.style.setProperty(
 			"--local-text-width",
-			`${el_width < 150 ? el_width : 200}px`
+			`${el_width && el_width < 150 ? el_width : 200}px`
 		);
-		el.style.whiteSpace = "unset";
+		element.style.whiteSpace = "unset";
 	}
 
 	onMount(() => {


### PR DESCRIPTION
## Description

This PR fixes a bug where some styling was not applied to example textboxes on render if they were initially invisible.
Specifically, the `white-space` css property was not being set due to the component having no width on rendering.

The fix is to not return from `set_styles()` if `el_width` is undefined (or 0) but instead to handle that case in the ternary operator where `el_width` is used. As `set_styles()` is called in `onMount()` and `el` is bound to the html element, which at this point in the lifecycle is guaranteed to be mounted, the check for `element` being undefined is not necessary.

Closes: #9830
  
