### PR TITLE
Pin multipart version to fix issues with yanking

### DIFF
--- a/.changeset/cyan-lights-sleep.md
+++ b/.changeset/cyan-lights-sleep.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:Pin multipart version to fix issues with yanking

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ packaging
 pandas>=1.0,<3.0
 pillow>=8.0,<12.0
 pydantic>=2.0
-python-multipart>=0.0.9,!=0.0.13  # required for fastapi forms. 0.0.13 was yanked from PyPI but micropip now ignores the yanked flag so we explicitly exclude it.
+python-multipart==0.0.12 # required for fastapi forms. pinning to avoid yanking issues with micropip.
 pydub
 pyyaml>=5.0,<7.0
 ruff>=0.2.2; sys.platform != 'emscripten'


### PR DESCRIPTION
Just pins python-multipart to 0.0.12 to avoid issues with yanked versions