### PR TITLE
Add requirements.txt to the gradio-lib-front-end-lite cache key

### DIFF
--- a/.github/actions/install-frontend-deps/action.yml
+++ b/.github/actions/install-frontend-deps/action.yml
@@ -25,7 +25,7 @@ runs:
       with:
         path: |
           js/lite/dist/**
-        key: gradio-lib-front-end-lite-${{ hashFiles('js/**', 'client/js/**', 'gradio/**')}}
+        key: gradio-lib-front-end-lite-${{ hashFiles('js/**', 'client/js/**', 'gradio/**', 'requirements.txt')}}
     - name: Install pnpm
       uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # @v4
       with:


### PR DESCRIPTION
## Description

The built LIte cache should be purged when `requirements.txt` is changed.
Context: https://huggingface.slack.com/archives/C055NMB0S87/p1729832794471549?thread_ts=1729810407.444559&cid=C055NMB0S87