### PR TITLE
Fix: Resolve copy button visibility issue in Textbox component

### DIFF
--- a/.changeset/tidy-bikes-allow.md
+++ b/.changeset/tidy-bikes-allow.md
@@ -1,0 +1,6 @@
+---
+"@gradio/textbox": patch
+"gradio": patch
+---
+
+fix:Fix: Resolve copy button visibility issue in Textbox component

--- a/js/textbox/shared/Textbox.svelte
+++ b/js/textbox/shared/Textbox.svelte
@@ -198,102 +198,102 @@
 
 <!-- svelte-ignore a11y-autofocus -->
 <label class:container class:show_textbox_border>
-    <BlockTitle {root} {show_label} {info}>{label}</BlockTitle>
+	<BlockTitle {root} {show_label} {info}>{label}</BlockTitle>
 
-    <div class="textbox-container">
-        <div class="input-container">
-            {#if lines === 1 && max_lines === 1}
-                <input
-                    data-testid="textbox"
-                    type={type}
-                    class="scroll-hide"
-                    dir={rtl ? "rtl" : "ltr"}
-                    bind:value
-                    bind:this={el}
-                    {placeholder}
-                    {disabled}
-                    {autofocus}
-                    maxlength={max_length}
-                    on:keypress={handle_keypress}
-                    on:blur
-                    on:select={handle_select}
-                    on:focus
-                    style={text_align ? "text-align: " + text_align : ""}
-                />
-            {:else}
-                <textarea
-                    data-testid="textbox"
-                    use:text_area_resize={value}
-                    class="scroll-hide"
-                    dir={rtl ? "rtl" : "ltr"}
-                    class:no-label={!show_label && (submit_btn || stop_btn)}
-                    bind:value
-                    bind:this={el}
-                    {placeholder}
-                    rows={lines}
-                    {disabled}
-                    {autofocus}
-                    maxlength={max_length}
-                    on:keypress={handle_keypress}
-                    on:blur
-                    on:select={handle_select}
-                    on:focus
-                    on:scroll={handle_scroll}
-                    style={text_align ? "text-align: " + text_align : ""}
-                />
-            {/if}
+	<div class="textbox-container">
+		<div class="input-container">
+			{#if lines === 1 && max_lines === 1}
+				<input
+					data-testid="textbox"
+					{type}
+					class="scroll-hide"
+					dir={rtl ? "rtl" : "ltr"}
+					bind:value
+					bind:this={el}
+					{placeholder}
+					{disabled}
+					{autofocus}
+					maxlength={max_length}
+					on:keypress={handle_keypress}
+					on:blur
+					on:select={handle_select}
+					on:focus
+					style={text_align ? "text-align: " + text_align : ""}
+				/>
+			{:else}
+				<textarea
+					data-testid="textbox"
+					use:text_area_resize={value}
+					class="scroll-hide"
+					dir={rtl ? "rtl" : "ltr"}
+					class:no-label={!show_label && (submit_btn || stop_btn)}
+					bind:value
+					bind:this={el}
+					{placeholder}
+					rows={lines}
+					{disabled}
+					{autofocus}
+					maxlength={max_length}
+					on:keypress={handle_keypress}
+					on:blur
+					on:select={handle_select}
+					on:focus
+					on:scroll={handle_scroll}
+					style={text_align ? "text-align: " + text_align : ""}
+				/>
+			{/if}
 
-            {#if submit_btn}
-                <button
-                    class="submit-button"
-                    class:padded-button={submit_btn !== true}
-                    on:click={handle_submit}
-                >
-                    {#if submit_btn === true}
-                        <Send />
-                    {:else}
-                        {submit_btn}
-                    {/if}
-                </button>
-            {/if}
+			{#if submit_btn}
+				<button
+					class="submit-button"
+					class:padded-button={submit_btn !== true}
+					on:click={handle_submit}
+				>
+					{#if submit_btn === true}
+						<Send />
+					{:else}
+						{submit_btn}
+					{/if}
+				</button>
+			{/if}
 
-            {#if stop_btn}
-                <button
-                    class="stop-button"
-                    class:padded-button={stop_btn !== true}
-                    on:click={handle_stop}
-                >
-                    {#if stop_btn === true}
-                        <Square fill="none" stroke_width={2.5} />
-                    {:else}
-                        {stop_btn}
-                    {/if}
-                </button>
-            {/if}
-        </div>
+			{#if stop_btn}
+				<button
+					class="stop-button"
+					class:padded-button={stop_btn !== true}
+					on:click={handle_stop}
+				>
+					{#if stop_btn === true}
+						<Square fill="none" stroke_width={2.5} />
+					{:else}
+						{stop_btn}
+					{/if}
+				</button>
+			{/if}
+		</div>
 
-        {#if show_copy_button}
-            {#if copied}
-                <button
-                    in:fade={{ duration: 300 }}
-                    class="copy-button"
-                    aria-label="Copied"
-                    aria-roledescription="Text copied"
-                >
-                    <Check />
-                </button>
-            {:else}
-                <button
-                    on:click={handle_copy}
-                    class="copy-button"
-                    aria-label="Copy"
-                    aria-roledescription="Copy text"
-                >
-                    <Copy />
-                </button>
-            {/if}
-        {/if}
-    </div>
+		{#if show_copy_button}
+			{#if copied}
+				<button
+					in:fade={{ duration: 300 }}
+					class="copy-button"
+					aria-label="Copied"
+					aria-roledescription="Text copied"
+				>
+					<Check />
+				</button>
+			{:else}
+				<button
+					on:click={handle_copy}
+					class="copy-button"
+					aria-label="Copy"
+					aria-roledescription="Copy text"
+				>
+					<Copy />
+				</button>
+			{/if}
+		{/if}
+	</div>
 </label>
 
 <style>
@@ -302,15 +302,15 @@
 		width: 100%;
 	}
 	.textbox-container {
-        position: relative;
-        width: 100%;
-    }
-    .input-container {
-        display: flex;
-        position: relative;
-        align-items: flex-end;
-        width: 100%;
-    }
+		position: relative;
+		width: 100%;
+	}
+	.input-container {
+		display: flex;
+		position: relative;
+		align-items: flex-end;
+		width: 100%;
+	}
 	input,
 	textarea {
 		flex-grow: 1;

--- a/js/textbox/shared/Textbox.svelte
+++ b/js/textbox/shared/Textbox.svelte
@@ -198,129 +198,102 @@
 
 <!-- svelte-ignore a11y-autofocus -->
 <label class:container class:show_textbox_border>
-	<BlockTitle {root} {show_label} {info}>{label}</BlockTitle>
+    <BlockTitle {root} {show_label} {info}>{label}</BlockTitle>
 
-	<div class="input-container">
-		{#if lines === 1 && max_lines === 1}
-			{#if type === "text"}
-				<input
-					data-testid="textbox"
-					type="text"
-					class="scroll-hide"
-					dir={rtl ? "rtl" : "ltr"}
-					bind:value
-					bind:this={el}
-					{placeholder}
-					{disabled}
-					{autofocus}
-					maxlength={max_length}
-					on:keypress={handle_keypress}
-					on:blur
-					on:select={handle_select}
-					on:focus
-					style={text_align ? "text-align: " + text_align : ""}
-				/>
-			{:else if type === "password"}
-				<input
-					data-testid="password"
-					type="password"
-					class="scroll-hide"
-					bind:value
-					bind:this={el}
-					{placeholder}
-					{disabled}
-					{autofocus}
-					maxlength={max_length}
-					on:keypress={handle_keypress}
-					on:blur
-					on:select={handle_select}
-					on:focus
-					autocomplete=""
-				/>
-			{:else if type === "email"}
-				<input
-					data-testid="textbox"
-					type="email"
-					class="scroll-hide"
-					bind:value
-					bind:this={el}
-					{placeholder}
-					{disabled}
-					{autofocus}
-					maxlength={max_length}
-					on:keypress={handle_keypress}
-					on:blur
-					on:select={handle_select}
-					on:focus
-					autocomplete="email"
-				/>
-			{/if}
-		{:else}
-			{#if show_label && show_copy_button}
-				{#if copied}
-					<button
-						in:fade={{ duration: 300 }}
-						class="copy-button"
-						aria-label="Copied"
-						aria-roledescription="Text copied"><Check /></button
-					>
-				{:else}
-					<button
-						on:click={handle_copy}
-						class="copy-button"
-						aria-label="Copy"
-						aria-roledescription="Copy text"><Copy /></button
-					>
-				{/if}
-			{/if}
-			<textarea
-				data-testid="textbox"
-				use:text_area_resize={value}
-				class="scroll-hide"
-				dir={rtl ? "rtl" : "ltr"}
-				class:no-label={!show_label && (submit_btn || stop_btn)}
-				bind:value
-				bind:this={el}
-				{placeholder}
-				rows={lines}
-				{disabled}
-				{autofocus}
-				maxlength={max_length}
-				on:keypress={handle_keypress}
-				on:blur
-				on:select={handle_select}
-				on:focus
-				on:scroll={handle_scroll}
-				style={text_align ? "text-align: " + text_align : ""}
-			/>
-		{/if}
-		{#if submit_btn}
-			<button
-				class="submit-button"
-				class:padded-button={submit_btn !== true}
-				on:click={handle_submit}
-			>
-				{#if submit_btn === true}
-					<Send />
-				{:else}
-					{submit_btn}
-				{/if}
-			</button>
-		{/if}
-		{#if stop_btn}
-			<button
-				class="stop-button"
-				class:padded-button={stop_btn !== true}
-				on:click={handle_stop}
-			>
-				{#if stop_btn === true}
-					<Square fill="none" stroke_width={2.5} />
-				{:else}
-					{stop_btn}
-				{/if}
-			</button>
-		{/if}
-	</div>
+    <div class="textbox-container">
+        <div class="input-container">
+            {#if lines === 1 && max_lines === 1}
+                <input
+                    data-testid="textbox"
+                    type={type}
+                    class="scroll-hide"
+                    dir={rtl ? "rtl" : "ltr"}
+                    bind:value
+                    bind:this={el}
+                    {placeholder}
+                    {disabled}
+                    {autofocus}
+                    maxlength={max_length}
+                    on:keypress={handle_keypress}
+                    on:blur
+                    on:select={handle_select}
+                    on:focus
+                    style={text_align ? "text-align: " + text_align : ""}
+                />
+            {:else}
+                <textarea
+                    data-testid="textbox"
+                    use:text_area_resize={value}
+                    class="scroll-hide"
+                    dir={rtl ? "rtl" : "ltr"}
+                    class:no-label={!show_label && (submit_btn || stop_btn)}
+                    bind:value
+                    bind:this={el}
+                    {placeholder}
+                    rows={lines}
+                    {disabled}
+                    {autofocus}
+                    maxlength={max_length}
+                    on:keypress={handle_keypress}
+                    on:blur
+                    on:select={handle_select}
+                    on:focus
+                    on:scroll={handle_scroll}
+                    style={text_align ? "text-align: " + text_align : ""}
+                />
+            {/if}
+
+            {#if submit_btn}
+                <button
+                    class="submit-button"
+                    class:padded-button={submit_btn !== true}
+                    on:click={handle_submit}
+                >
+                    {#if submit_btn === true}
+                        <Send />
+                    {:else}
+                        {submit_btn}
+                    {/if}
+                </button>
+            {/if}
+
+            {#if stop_btn}
+                <button
+                    class="stop-button"
+                    class:padded-button={stop_btn !== true}
+                    on:click={handle_stop}
+                >
+                    {#if stop_btn === true}
+                        <Square fill="none" stroke_width={2.5} />
+                    {:else}
+                        {stop_btn}
+                    {/if}
+                </button>
+            {/if}
+        </div>
+
+        {#if show_copy_button}
+            {#if copied}
+                <button
+                    in:fade={{ duration: 300 }}
+                    class="copy-button"
+                    aria-label="Copied"
+                    aria-roledescription="Text copied"
+                >
+                    <Check />
+                </button>
+            {:else}
+                <button
+                    on:click={handle_copy}
+                    class="copy-button"
+                    aria-label="Copy"
+                    aria-roledescription="Copy text"
+                >
+                    <Copy />
+                </button>
+            {/if}
+        {/if}
+    </div>
 </label>
 
 <style>
@@ -328,7 +301,16 @@
 		display: block;
 		width: 100%;
 	}
-
+	.textbox-container {
+        position: relative;
+        width: 100%;
+    }
+    .input-container {
+        display: flex;
+        position: relative;
+        align-items: flex-end;
+        width: 100%;
+    }
 	input,
 	textarea {
 		flex-grow: 1;
@@ -404,6 +386,7 @@
 		color: var(--block-label-color);
 		font: var(--font-sans);
 		font-size: var(--button-small-text-size);
+		z-index: 2;
 	}
 
 	/* Same submit button style as MultimodalTextbox for the consistent UI */

--- a/js/textbox/shared/Textbox.svelte
+++ b/js/textbox/shared/Textbox.svelte
@@ -3,7 +3,7 @@
 		beforeUpdate,
 		afterUpdate,
 		createEventDispatcher,
-		tick
+		tick,
 	} from "svelte";
 	import { BlockTitle } from "@gradio/atoms";
 	import { Copy, Check, Send, Square } from "@gradio/icons";
@@ -103,7 +103,7 @@
 		const text = target.value;
 		const index: [number, number] = [
 			target.selectionStart as number,
-			target.selectionEnd as number
+			target.selectionEnd as number,
 		];
 		dispatch("select", { value: text.substring(...index), index: index });
 	}
@@ -148,7 +148,7 @@
 	}
 
 	async function resize(
-		event: Event | { target: HTMLTextAreaElement | HTMLInputElement }
+		event: Event | { target: HTMLTextAreaElement | HTMLInputElement },
 	): Promise<void> {
 		await tick();
 		if (lines === max_lines) return;
@@ -181,7 +181,7 @@
 
 	function text_area_resize(
 		_el: HTMLTextAreaElement,
-		_value: string
+		_value: string,
 	): any | undefined {
 		if (lines === max_lines) return;
 		_el.style.overflowY = "scroll";
@@ -191,21 +191,38 @@
 		resize({ target: _el });
 
 		return {
-			destroy: () => _el.removeEventListener("input", resize)
+			destroy: () => _el.removeEventListener("input", resize),
 		};
 	}
 </script>
 
 <!-- svelte-ignore a11y-autofocus -->
 <label class:container class:show_textbox_border>
+	{#if show_label && show_copy_button}
+		{#if copied}
+			<button
+				in:fade={{ duration: 300 }}
+				class="copy-button"
+				aria-label="Copied"
+				aria-roledescription="Text copied"><Check /></button
+			>
+		{:else}
+			<button
+				on:click={handle_copy}
+				class="copy-button"
+				aria-label="Copy"
+				aria-roledescription="Copy text"><Copy /></button
+			>
+		{/if}
+	{/if}
 	<BlockTitle {root} {show_label} {info}>{label}</BlockTitle>
 
-	<div class="textbox-container">
-		<div class="input-container">
-			{#if lines === 1 && max_lines === 1}
+	<div class="input-container">
+		{#if lines === 1 && max_lines === 1}
+			{#if type === "text"}
 				<input
 					data-testid="textbox"
-					{type}
+					type="text"
 					class="scroll-hide"
 					dir={rtl ? "rtl" : "ltr"}
 					bind:value
@@ -220,17 +237,31 @@
 					on:focus
 					style={text_align ? "text-align: " + text_align : ""}
 				/>
-			{:else}
-				<textarea
+			{:else if type === "password"}
+				<input
+					data-testid="password"
+					type="password"
+					class="scroll-hide"
+					bind:value
+					bind:this={el}
+					{placeholder}
+					{disabled}
+					{autofocus}
+					maxlength={max_length}
+					on:keypress={handle_keypress}
+					on:blur
+					on:select={handle_select}
+					on:focus
+					autocomplete=""
+				/>
+			{:else if type === "email"}
+				<input
 					data-testid="textbox"
-					use:text_area_resize={value}
+					type="email"
 					class="scroll-hide"
-					dir={rtl ? "rtl" : "ltr"}
-					class:no-label={!show_label && (submit_btn || stop_btn)}
 					bind:value
 					bind:this={el}
 					{placeholder}
-					rows={lines}
 					{disabled}
 					{autofocus}
 					maxlength={max_length}
@@ -238,60 +269,56 @@
 					on:blur
 					on:select={handle_select}
 					on:focus
-					on:scroll={handle_scroll}
-					style={text_align ? "text-align: " + text_align : ""}
+					autocomplete="email"
 				/>
 			{/if}
-
-			{#if submit_btn}
-				<button
-					class="submit-button"
-					class:padded-button={submit_btn !== true}
-					on:click={handle_submit}
-				>
-					{#if submit_btn === true}
-						<Send />
-					{:else}
-						{submit_btn}
-					{/if}
-				</button>
-			{/if}
-
-			{#if stop_btn}
-				<button
-					class="stop-button"
-					class:padded-button={stop_btn !== true}
-					on:click={handle_stop}
-				>
-					{#if stop_btn === true}
-						<Square fill="none" stroke_width={2.5} />
-					{:else}
-						{stop_btn}
-					{/if}
-				</button>
-			{/if}
-		</div>
-
-		{#if show_copy_button}
-			{#if copied}
-				<button
-					in:fade={{ duration: 300 }}
-					class="copy-button"
-					aria-label="Copied"
-					aria-roledescription="Text copied"
-				>
-					<Check />
-				</button>
-			{:else}
-				<button
-					on:click={handle_copy}
-					class="copy-button"
-					aria-label="Copy"
-					aria-roledescription="Copy text"
-				>
-					<Copy />
-				</button>
-			{/if}
+		{:else}
+			<textarea
+				data-testid="textbox"
+				use:text_area_resize={value}
+				class="scroll-hide"
+				dir={rtl ? "rtl" : "ltr"}
+				class:no-label={!show_label && (submit_btn || stop_btn)}
+				bind:value
+				bind:this={el}
+				{placeholder}
+				rows={lines}
+				{disabled}
+				{autofocus}
+				maxlength={max_length}
+				on:keypress={handle_keypress}
+				on:blur
+				on:select={handle_select}
+				on:focus
+				on:scroll={handle_scroll}
+				style={text_align ? "text-align: " + text_align : ""}
+			/>
+		{/if}
+		{#if submit_btn}
+			<button
+				class="submit-button"
+				class:padded-button={submit_btn !== true}
+				on:click={handle_submit}
+			>
+				{#if submit_btn === true}
+					<Send />
+				{:else}
+					{submit_btn}
+				{/if}
+			</button>
+		{/if}
+		{#if stop_btn}
+			<button
+				class="stop-button"
+				class:padded-button={stop_btn !== true}
+				on:click={handle_stop}
+			>
+				{#if stop_btn === true}
+					<Square fill="none" stroke_width={2.5} />
+				{:else}
+					{stop_btn}
+				{/if}
+			</button>
 		{/if}
 	</div>
 </label>
@@ -301,16 +328,7 @@
 		display: block;
 		width: 100%;
 	}
-	.textbox-container {
-		position: relative;
-		width: 100%;
-	}
-	.input-container {
-		display: flex;
-		position: relative;
-		align-items: flex-end;
-		width: 100%;
-	}
+
 	input,
 	textarea {
 		flex-grow: 1;
@@ -374,7 +392,7 @@
 		right: var(--block-label-margin);
 		align-items: center;
 		box-shadow: var(--shadow-drop);
-		border: 1px solid var(--color-border-primary);
+		border: 1px solid var(--border-color-primary);
 		border-top: none;
 		border-right: none;
 		border-radius: var(--block-label-right-radius);
@@ -386,7 +404,6 @@
 		color: var(--block-label-color);
 		font: var(--font-sans);
 		font-size: var(--button-small-text-size);
-		z-index: 2;
 	}
 
 	/* Same submit button style as MultimodalTextbox for the consistent UI */

--- a/js/textbox/shared/Textbox.svelte
+++ b/js/textbox/shared/Textbox.svelte
@@ -3,7 +3,7 @@
 		beforeUpdate,
 		afterUpdate,
 		createEventDispatcher,
-		tick,
+		tick
 	} from "svelte";
 	import { BlockTitle } from "@gradio/atoms";
 	import { Copy, Check, Send, Square } from "@gradio/icons";
@@ -103,7 +103,7 @@
 		const text = target.value;
 		const index: [number, number] = [
 			target.selectionStart as number,
-			target.selectionEnd as number,
+			target.selectionEnd as number
 		];
 		dispatch("select", { value: text.substring(...index), index: index });
 	}
@@ -148,7 +148,7 @@
 	}
 
 	async function resize(
-		event: Event | { target: HTMLTextAreaElement | HTMLInputElement },
+		event: Event | { target: HTMLTextAreaElement | HTMLInputElement }
 	): Promise<void> {
 		await tick();
 		if (lines === max_lines) return;
@@ -181,7 +181,7 @@
 
 	function text_area_resize(
 		_el: HTMLTextAreaElement,
-		_value: string,
+		_value: string
 	): any | undefined {
 		if (lines === max_lines) return;
 		_el.style.overflowY = "scroll";
@@ -191,7 +191,7 @@
 		resize({ target: _el });
 
 		return {
-			destroy: () => _el.removeEventListener("input", resize),
+			destroy: () => _el.removeEventListener("input", resize)
 		};
 	}
 </script>


### PR DESCRIPTION
## Description

This PR resolves the issue with the misplaced/invisible copy button in the gr.Textbox component when show_copy_button=True. The button was previously positioned inside the textarea, leading to improper alignment and invisibility.

Main changes include:

- Added a new wrapper <div class="textbox-container"> to give the copy button a separate positioning context.
- Moved the copy button outside of the input/textarea container for better alignment.
- Removed the copy button from within the textarea section to prevent overlap.
- Updated styles to adjust positioning and styling:

Closes: #9569

Thank you for considering this fix! I appreciate your time and look forward to your feedback.
