### PR TITLE
Adds `.expand()` and `.collapse()` events to `gr.Accordion`

### DIFF
--- a/.changeset/beige-badgers-argue.md
+++ b/.changeset/beige-badgers-argue.md
@@ -1,0 +1,6 @@
+---
+"@gradio/accordion": minor
+"gradio": minor
+---
+
+feat:Adds `.expand()` and `.collapse()` events to `gr.Accordion`

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -923,3 +923,11 @@ class Events:
         callback=lambda block: setattr(block, "_retryable", True),
         config_data=lambda: {"_retryable": False},
     )
+    expand = EventListener(
+        "expand",
+        doc="This listener is triggered when the {{ component }} is expanded.",
+    )
+    collapse = EventListener(
+        "collapse",
+        doc="This listener is triggered when the {{ component }} is collapsed.",
+    )

--- a/gradio/layouts/accordion.py
+++ b/gradio/layouts/accordion.py
@@ -6,6 +6,7 @@ from gradio_client.documentation import document
 
 from gradio.blocks import BlockContext
 from gradio.component_meta import ComponentMeta
+from gradio.events import Events
 
 if TYPE_CHECKING:
     pass
@@ -20,7 +21,7 @@ class Accordion(BlockContext, metaclass=ComponentMeta):
             gr.Markdown("lorem ipsum")
     """
 
-    EVENTS = ["expand", "collapse"]
+    EVENTS = [Events.expand, Events.collapse]
 
     def __init__(
         self,

--- a/gradio/layouts/accordion.py
+++ b/gradio/layouts/accordion.py
@@ -20,7 +20,7 @@ class Accordion(BlockContext, metaclass=ComponentMeta):
             gr.Markdown("lorem ipsum")
     """
 
-    EVENTS = []
+    EVENTS = ["expand", "collapse"]
 
     def __init__(
         self,

--- a/js/accordion/Index.svelte
+++ b/js/accordion/Index.svelte
@@ -26,8 +26,8 @@
 		{...loading_status}
 	/>
 
-	<Accordion 
-		{label} 
+	<Accordion
+		{label}
 		bind:open
 		on:expand={() => gradio.dispatch("expand")}
 		on:collapse={() => gradio.dispatch("collapse")}

--- a/js/accordion/Index.svelte
+++ b/js/accordion/Index.svelte
@@ -13,7 +13,10 @@
 	export let visible = true;
 	export let open = true;
 	export let loading_status: LoadingStatus;
-	export let gradio: Gradio;
+	export let gradio: Gradio<{
+		expand: never;
+		collapse: never;
+	}>;
 </script>
 
 <Block {elem_id} {elem_classes} {visible}>
@@ -23,7 +26,12 @@
 		{...loading_status}
 	/>
 
-	<Accordion {label} bind:open>
+	<Accordion 
+		{label} 
+		bind:open
+		on:expand={() => gradio.dispatch("expand")}
+		on:collapse={() => gradio.dispatch("collapse")}
+	>
 		<Column>
 			<slot />
 		</Column>

--- a/js/accordion/shared/Accordion.svelte
+++ b/js/accordion/shared/Accordion.svelte
@@ -4,12 +4,12 @@
 		expand: void;
 		collapse: void;
 	}>();
-	
+
 	export let open = true;
 	export let label = "";
 </script>
 
-<button 
+<button
 	on:click={() => {
 		open = !open;
 		if (open) {
@@ -17,8 +17,8 @@
 		} else {
 			dispatch("collapse");
 		}
-	}} 
-	class="label-wrap" 
+	}}
+	class="label-wrap"
 	class:open
 >
 	<span>{label}</span>

--- a/js/accordion/shared/Accordion.svelte
+++ b/js/accordion/shared/Accordion.svelte
@@ -1,9 +1,26 @@
 <script lang="ts">
+	import { createEventDispatcher } from "svelte";
+	const dispatch = createEventDispatcher<{
+		expand: void;
+		collapse: void;
+	}>();
+	
 	export let open = true;
 	export let label = "";
 </script>
 
-<button on:click={() => (open = !open)} class="label-wrap" class:open>
+<button 
+	on:click={() => {
+		open = !open;
+		if (open) {
+			dispatch("expand");
+		} else {
+			dispatch("collapse");
+		}
+	}} 
+	class="label-wrap" 
+	class:open
+>
 	<span>{label}</span>
 	<span style:transform={open ? "rotate(0)" : "rotate(90deg)"} class="icon">
 		▼


### PR DESCRIPTION
This PR was produced via programmatic use of `aider` + a lot of human intervention. More details available [internally](https://huggingface.slack.com/archives/C02SPHC1KD1/p1730334560275149)

Test with:

```py
import gradio as gr

with gr.Blocks() as demo:
    with gr.Accordion("See Details") as accordion:
        gr.Markdown("lorem ipsum")

    t = gr.Textbox()

    accordion.expand(lambda: "Accordion is expanded", None, t)
    accordion.collapse(lambda: "Accordion is collapsed", None, t)

if __name__ == "__main__":
    demo.launch()
```

Closes: https://github.com/gradio-app/gradio/issues/5197