### PR TITLE
Enforce `meta` key present during preprocess in FileData payloads

### DIFF
--- a/.changeset/four-swans-throw.md
+++ b/.changeset/four-swans-throw.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Enforce `meta` key present during preprocess in FileData payloads

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -18,12 +18,7 @@ from collections import defaultdict
 from collections.abc import AsyncIterator, Callable, Coroutine, Sequence, Set
 from pathlib import Path
 from types import ModuleType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Literal, Union, cast
 from urllib.parse import urlparse, urlunparse
 
 import anyio
@@ -1702,10 +1697,12 @@ Received inputs:
                         check_in_upload_folder=not explicit_call,
                     )
                     if getattr(block, "data_model", None) and inputs_cached is not None:
-                        if issubclass(block.data_model, GradioModel):  # type: ignore
-                            inputs_cached = block.data_model(**inputs_cached)  # type: ignore
-                        elif issubclass(block.data_model, GradioRootModel):  # type: ignore
-                            inputs_cached = block.data_model(root=inputs_cached)  # type: ignore
+                        data_model = cast(
+                            Union[GradioModel, GradioRootModel], block.data_model
+                        )
+                        inputs_cached = data_model.model_validate(
+                            inputs_cached, context={"validate_meta": True}
+                        )
                     processed_input.append(block.preprocess(inputs_cached))
         else:
             processed_input = inputs

--- a/gradio/data_classes.py
+++ b/gradio/data_classes.py
@@ -221,17 +221,17 @@ class FileData(GradioModel):
         meta: Additional metadata used internally (should not be changed).
     """
 
-    path: str
-    url: Optional[str] = None
-    size: Optional[int] = None
-    orig_name: Optional[str] = None
+    path: str  # server filepath
+    url: Optional[str] = None  # normalised server url
+    size: Optional[int] = None  # size in bytes
+    orig_name: Optional[str] = None  # original filename
     mime_type: Optional[str] = None
     is_stream: bool = False
     meta: dict = {"_type": "gradio.FileData"}
 
     @model_validator(mode="before")
     @classmethod
-    def validate_python(cls, v, info: ValidationInfo):
+    def validate_model(cls, v, info: ValidationInfo):
         if (
             info.context
             and info.context.get("validate_meta")

--- a/gradio/data_classes.py
+++ b/gradio/data_classes.py
@@ -21,7 +21,7 @@ from typing import (
 
 from fastapi import Request
 from gradio_client.documentation import document
-from gradio_client.utils import traverse
+from gradio_client.utils import is_file_obj_with_meta, traverse
 from pydantic import (
     BaseModel,
     GetCoreSchemaHandler,
@@ -235,7 +235,7 @@ class FileData(GradioModel):
         if (
             info.context
             and info.context.get("validate_meta")
-            and v.get("meta", {}) != {"_type": "gradio.FileData"}
+            and not is_file_obj_with_meta(v)
         ):
             raise ValueError(
                 "The 'meta' field must be explicitly provided in the input data and be equal to {'_type': 'gradio.FileData'}."

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -513,7 +513,9 @@ def move_files_to_cache(
     if isinstance(data, (GradioRootModel, GradioModel)):
         data = data.model_dump()
 
-    return client_utils.traverse(data, _move_to_cache, client_utils.is_file_obj)
+    return client_utils.traverse(
+        data, _move_to_cache, client_utils.is_file_obj_with_meta
+    )
 
 
 def _check_allowed(path: str | Path, check_in_upload_folder: bool):
@@ -633,7 +635,7 @@ async def async_move_files_to_cache(
     if isinstance(data, (GradioRootModel, GradioModel)):
         data = data.model_dump()
     return await client_utils.async_traverse(
-        data, _move_to_cache, client_utils.is_file_obj
+        data, _move_to_cache, client_utils.is_file_obj_with_meta
     )
 
 

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -513,9 +513,7 @@ def move_files_to_cache(
     if isinstance(data, (GradioRootModel, GradioModel)):
         data = data.model_dump()
 
-    return client_utils.traverse(
-        data, _move_to_cache, client_utils.is_file_obj_with_meta
-    )
+    return client_utils.traverse(data, _move_to_cache, client_utils.is_file_obj)
 
 
 def _check_allowed(path: str | Path, check_in_upload_folder: bool):
@@ -635,7 +633,7 @@ async def async_move_files_to_cache(
     if isinstance(data, (GradioRootModel, GradioModel)):
         data = data.model_dump()
     return await client_utils.async_traverse(
-        data, _move_to_cache, client_utils.is_file_obj_with_meta
+        data, _move_to_cache, client_utils.is_file_obj
     )
 
 

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1613,3 +1613,30 @@ def test_attacker_cannot_change_root_in_config(
         t.join()
 
     assert not any(results), "attacker was able to modify a victim's config root url"
+
+
+def test_file_without_meta_key_not_moved():
+    demo = gr.Interface(
+        fn=lambda s: str(s), inputs=gr.File(type="binary"), outputs="textbox"
+    )
+
+    app, _, _ = demo.launch(prevent_thread_lock=True)
+    test_client = TestClient(app)
+    try:
+        with test_client:
+            req = test_client.post(
+                "gradio_api/run/predict",
+                json={
+                    "data": [
+                        {
+                            "path": "test/test_files/alphabet.txt",
+                            "orig_name": "test.txt",
+                            "size": 4,
+                            "mime_type": "text/plain",
+                        }
+                    ]
+                },
+            )
+            assert req.status_code == 500
+    finally:
+        demo.close()

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -339,6 +339,7 @@ class TestRoutes:
                     {
                         "path": file_response.json()[0],
                         "size": os.path.getsize("test/test_files/alphabet.txt"),
+                        "meta": {"_type": "gradio.FileData"},
                     }
                 ],
                 "fn_index": 0,


### PR DESCRIPTION
## Description

If a component expects a FileData from a client, then the request payload should contain the `meta` key.


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
