### PR TITLE
Clearer error message in CheckboxGroup's preprocess function

### DIFF
--- a/.changeset/breezy-ants-count.md
+++ b/.changeset/breezy-ants-count.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Clearer error message in CheckboxGroup's preprocess function

--- a/gradio/components/checkboxgroup.py
+++ b/gradio/components/checkboxgroup.py
@@ -123,7 +123,7 @@ class CheckboxGroup(FormComponent):
         for value in payload:
             if value not in choice_values:
                 raise Error(
-                    f"Value: {value} is not in the list of choices: {choice_values}"
+                    f"Value: {value!r} (type: {type(value)}) is not in the list of choices: {choice_values}"
                 )
         if self.type == "value":
             return payload

--- a/test/components/test_checkbox_group.py
+++ b/test/components/test_checkbox_group.py
@@ -20,6 +20,15 @@ class TestCheckboxGroup:
         with pytest.raises(gr.Error):
             checkboxes_input.preprocess(["a", "b", "c"])
 
+        # Check that the error message clearly indicates the error source in cases where data
+        # representation could be ambiguous e.g. "1" (str) vs 1 (int)
+        checkboxes_input = gr.CheckboxGroup([1, 2, 3])
+        # Since pytest.raises takes a regular expression in the `match` argument, we need to escape brackets
+        # that have special meaning in regular expressions
+        expected_error_message = r"Value: '1' \(type: <class 'str'>\) is not in the list of choices: \[1, 2, 3\]"
+        with pytest.raises(gr.Error, match=expected_error_message):
+            checkboxes_input.preprocess(["1", "2", "3"])
+        
         # When a Gradio app is loaded with gr.load, the tuples are converted to lists,
         # so we need to test that case as well
         checkboxgroup = gr.CheckboxGroup(["a", "b", ["c", "c full"]])  # type: ignore

--- a/test/components/test_checkbox_group.py
+++ b/test/components/test_checkbox_group.py
@@ -28,7 +28,7 @@ class TestCheckboxGroup:
         expected_error_message = r"Value: '1' \(type: <class 'str'>\) is not in the list of choices: \[1, 2, 3\]"
         with pytest.raises(gr.Error, match=expected_error_message):
             checkboxes_input.preprocess(["1", "2", "3"])
-        
+
         # When a Gradio app is loaded with gr.load, the tuples are converted to lists,
         # so we need to test that case as well
         checkboxgroup = gr.CheckboxGroup(["a", "b", ["c", "c full"]])  # type: ignore


### PR DESCRIPTION
## Description

This PR improves the error message in `preprocess` function of `gradio.components.checkboxgroup.CheckboxGroup` class by:
- Using `repr` instead of `str` representation which can be helpful in cases where `str` representation is ambiguous e.g. "1" vs 1 (see the linked issue for a detailed use-case.)
- Including type information in the error message.

Additionally, I have updated the tests in`test/components/test_checkbox_group.py` to test specifically for this ambiguous case.

Closes: #9902 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`