### PR TITLE
Clearer error message in Dropdown's and Radio's preprocess function

### DIFF
--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -196,7 +196,7 @@ class Dropdown(FormComponent):
                 for value in payload:
                     if value not in choice_values:
                         raise Error(
-                            f"Value: {value} is not in the list of choices: {choice_values}"
+                            f"Value: {value!r} (type: {type(value)}) is not in the list of choices: {choice_values}"
                         )
             elif payload not in choice_values:
                 raise Error(

--- a/gradio/components/radio.py
+++ b/gradio/components/radio.py
@@ -117,7 +117,7 @@ class Radio(FormComponent):
         choice_values = [value for _, value in self.choices]
         if payload not in choice_values:
             raise Error(
-                f"Value: {payload} is not in the list of choices: {choice_values}"
+                f"Value: {payload!r} (type: {type(payload)}) is not in the list of choices: {choice_values}"
             )
 
         if self.type == "value":

--- a/test/components/test_dropdown.py
+++ b/test/components/test_dropdown.py
@@ -14,6 +14,15 @@ class TestDropdown:
         assert dropdown_input.preprocess("c full") == "c full"
         assert dropdown_input.postprocess("c full") == ["c full"]
 
+        # Check that the error message clearly indicates the error source in cases where data
+        # representation could be ambiguous e.g. "1" (str) vs 1 (int)
+        dropdown_input = gr.Dropdown([1, 2, 3])
+        # Since pytest.raises takes a regular expression in the `match` argument, we need to escape brackets
+        # that have special meaning in regular expressions
+        expected_error_message = r"Value: '1' \(type: <class 'str'>\) is not in the list of choices: \[1, 2, 3\]"
+        with pytest.raises(gr.Error, match=expected_error_message):
+            dropdown_input.preprocess(["1", "2", "3"])
+        
         # When an external Gradio app is loaded with gr.load, the tuples are converted to lists,
         # so we test that case as well
         dropdown = gr.Dropdown(["a", "b", ["c", "c full"]])  # type: ignore

--- a/test/components/test_radio.py
+++ b/test/components/test_radio.py
@@ -12,6 +12,16 @@ class TestRadio:
         radio_input = gr.Radio(["a", "b", "c"])
         assert radio_input.preprocess("c") == "c"
         assert radio_input.postprocess("a") == "a"
+
+        # Check that the error message clearly indicates the error source in cases where data
+        # representation could be ambiguous e.g. "1" (str) vs 1 (int)
+        radio_input = gr.Radio([1, 2, 3])
+        # Since pytest.raises takes a regular expression in the `match` argument, we need to escape brackets
+        # that have special meaning in regular expressions
+        expected_error_message = r"Value: '1' \(type: <class 'str'>\) is not in the list of choices: \[1, 2, 3\]"
+        with pytest.raises(gr.Error, match=expected_error_message):
+            radio_input.preprocess("1")
+        
         radio_input = gr.Radio(
             choices=["a", "b", "c"], value="a", label="Pick Your One Input"
         )


### PR DESCRIPTION
## Description

This PR improves the error message in `preprocess` function of `gr.Dropdown` and `gr.Radio` classes by:
- Using `repr` instead of `str` representation which can be helpful in cases where `str` representation is ambiguous e.g. `"1"` vs `1` (see the linked issue for a detailed use-case.)
- Including type information in the error message.

Additionally, I have updated the tests in `test/components/test_dropdown.py` and `test/components/test_radio.py` to test specifically for this ambiguous case.

Closes: #9909 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
