### PR TITLE
Explain that PYTHONPATH must be updated

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,9 @@ if __name__ == "__main__":
    demo.launch()
 ```
 
+Make sure your `PYTHONPATH` includes the directory where this repository is cloned, e.g.,
+`export PYTHONPATH="./"`
+
 then run:
 
 ```
@@ -345,6 +348,19 @@ bash scripts/build_frontend.sh
 ```FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory``` when running `scripts/build_frontend.sh`.
 
 Run `scripts/build_frontend.sh` with the environment variable `NODE_OPTIONS=--max_old_space_size=2048` to increase the heap size.
+
+---
+
+In the case of:
+- Unexpected Exceptions being thrown;
+- The following warning:
+`IMPORTANT: You are using gradio version <earlier version>, however version <later version> is available, please upgrade.`
+
+Make sure your `PYTHONPATH` includes the directory where this repository is cloned, e.g.:
+
+```export PYTHONPATH="./"```
+
+This ensures that when `gradio` is imported in a python program, it is this current version from this repository.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,9 +109,6 @@ if __name__ == "__main__":
    demo.launch()
 ```
 
-Make sure your `PYTHONPATH` includes the directory where this repository is cloned, e.g.,
-`export PYTHONPATH="./"`
-
 then run:
 
 ```
@@ -119,6 +116,9 @@ gradio app.py
 ```
 
 This will start the backend server in reload mode, which will watch for changes in the `gradio` folder and reload the app if changes are made. By default, Gradio will launch on port 7860. You can also just use `python app.py`, but this won't automatically trigger updates. 
+
+Note: if you have `gradio` installed elsewhere in your system, you may need to uninstall it or at least make sure your `PYTHONPATH` includes the directory where the Gradio repository is cloned, e.g.,
+`export PYTHONPATH="./"`
 
 
 If you're making frontend changes, start the frontend server:
@@ -352,11 +352,11 @@ Run `scripts/build_frontend.sh` with the environment variable `NODE_OPTIONS=--ma
 ---
 
 In the case of:
-- Unexpected Exceptions being thrown;
+- Unexpected exceptions being thrown, or
 - The following warning:
 `IMPORTANT: You are using gradio version <earlier version>, however version <later version> is available, please upgrade.`
 
-Make sure your `PYTHONPATH` includes the directory where this repository is cloned, e.g.:
+ensure your `PYTHONPATH` includes the directory where the Gradio repository is cloned, e.g.:
 
 ```export PYTHONPATH="./"```
 


### PR DESCRIPTION
## Description

Cloning this repository, then building & running scripts, can run into the issue of `import gradio` in python pulling `gradio` in from somewhere else (such as the virtual environment). To address this, users need to tell python where to look in order to use the cloned git repo for `gradio`.

Further details in https://huggingface.slack.com/archives/C02SPHC1KD1/p1731207233633159?thread_ts=1731206608.882719&cid=C02SPHC1KD1 for more

Closes: [#9924](https://github.com/gradio-app/gradio/issues/9924)
  
