### PR TITLE
Fix random_demos.py ValueError issues

### DIFF
--- a/demo/random_demos.py
+++ b/demo/random_demos.py
@@ -2,15 +2,13 @@
 
 Usage: python random_demos.py <num_demos>
 Example: python random_demos.py 8
-
-Assumes:
-- This is being run from the gradio/demo/ directory
 """
 
 from __future__ import annotations
 
 import argparse
 import importlib
+import pathlib
 import os
 import random
 
@@ -21,12 +19,13 @@ parser.add_argument("num_demos", help="number of demos to launch", type=int, def
 args = parser.parse_args()
 
 # get the list of directory names
-demos_list = next(os.walk('.'))[1]
+demos_list = next(os.walk(pathlib.Path(__file__).parent))[1]
 
 # Some demos are just too large or need to be run in a special way, so we'll just skip them
-demos_list.remove('streaming_wav2vec')
-demos_list.remove('blocks_neural_instrument_coding')
-demos_list.remove('.gradio/flagged')
+large_demos = ['streaming_wav2vec', 'blocks_neural_instrument_coding', '.gradio/flagged']
+for large_demo in large_demos:
+    if large_demo in demos_list:
+        demos_list.remove(large_demo)
 
 for d, demo_name in enumerate(random.sample(demos_list, args.num_demos)):
     print(f"Launching demo {d+1}/{args.num_demos}: {demo_name}")


### PR DESCRIPTION
## Description

1. Removes assumption/requirement that the script is run specifically in the demo/ directory.
2. Removes assumption/requirement that there are 3 unwanted large demos that should be removed.  (Note: currently, of the 3 demo directories that are hardcoded, the `.gradio/flagged` demo isn't there, so the code will throw an error even if the first issue is addressed.)

Closes: [#9926](https://github.com/gradio-app/gradio/issues/9926)

  
