### PR TITLE
Allow settings custom headers in js client

### DIFF
--- a/.changeset/smart-houses-deny.md
+++ b/.changeset/smart-houses-deny.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": minor
+"gradio": minor
+---
+
+feat:Allow settings custom headers in js client

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -70,6 +70,11 @@ export class Client {
 		if (this && this.cookies) {
 			headers.append("Cookie", this.cookies);
 		}
+		if (this && this.options.headers) {
+			for (const name in this.options.headers) {
+				headers.append(name, this.options.headers[name]);
+			}
+		}
 
 		return fetch(input, { ...init, headers });
 	}
@@ -78,6 +83,11 @@ export class Client {
 		const headers = new Headers();
 		if (this && this.cookies) {
 			headers.append("Cookie", this.cookies);
+		}
+		if (this && this.options.headers) {
+			for (const name in this.options.headers) {
+				headers.append(name, this.options.headers[name]);
+			}
 		}
 
 		this.abort_controller = new AbortController();

--- a/client/js/src/helpers/init_helpers.ts
+++ b/client/js/src/helpers/init_helpers.ts
@@ -35,13 +35,15 @@ export function resolve_root(
 export async function get_jwt(
 	space: string,
 	token: `hf_${string}`,
-	cookies?: string | null
+	cookies?: string | null,
+	additional_headers?: Record<string, string>
 ): Promise<string | false> {
 	try {
 		const r = await fetch(`https://huggingface.co/api/spaces/${space}/jwt`, {
 			headers: {
 				Authorization: `Bearer ${token}`,
-				...(cookies ? { Cookie: cookies } : {})
+				...(cookies ? { Cookie: cookies } : {}),
+				...(additional_headers || {})
 			}
 		});
 

--- a/client/js/src/helpers/init_helpers.ts
+++ b/client/js/src/helpers/init_helpers.ts
@@ -35,15 +35,13 @@ export function resolve_root(
 export async function get_jwt(
 	space: string,
 	token: `hf_${string}`,
-	cookies?: string | null,
-	additional_headers?: Record<string, string>
+	cookies?: string | null
 ): Promise<string | false> {
 	try {
 		const r = await fetch(`https://huggingface.co/api/spaces/${space}/jwt`, {
 			headers: {
 				Authorization: `Bearer ${token}`,
-				...(cookies ? { Cookie: cookies } : {}),
-				...(additional_headers || {})
+				...(cookies ? { Cookie: cookies } : {})
 			}
 		});
 

--- a/client/js/src/types.ts
+++ b/client/js/src/types.ts
@@ -299,7 +299,7 @@ export interface ClientOptions {
 	auth?: [string, string] | null;
 	with_null_state?: boolean;
 	events?: EventType[];
-	headers?: Record<string, string>
+	headers?: Record<string, string>;
 }
 
 export interface FileData {

--- a/client/js/src/types.ts
+++ b/client/js/src/types.ts
@@ -299,6 +299,7 @@ export interface ClientOptions {
 	auth?: [string, string] | null;
 	with_null_state?: boolean;
 	events?: EventType[];
+	headers?: Record<string, string>
 }
 
 export interface FileData {


### PR DESCRIPTION
## Description

When using the javascript client, allow setting custom HTTP headers on `Client.connect`.
Note that this is already implemented for client/python by #7334

Usage example:
```js
const client = Client.connect(url,
    headers: {'ngrok-skip-browser-warning': 'true'}
})
```

Closes: #9929
Closes: #7833

## Tests

I didn't add any new test, since I couldn't find any other test using `fetch`
