### PR TITLE
Fix typo in Exception raised by base.py

### DIFF
--- a/gradio/components/base.py
+++ b/gradio/components/base.py
@@ -448,7 +448,7 @@ def get_component_instance(
         component_obj = comp
     else:
         raise ValueError(
-            f"Component must provided as a `str` or `dict` or `Component` but is {comp}"
+            f"Component must be provided as a `str` or `dict` or `Component` but is {comp}"
         )
 
     if render and not component_obj.is_rendered:


### PR DESCRIPTION
Super minor. Just adding the word 'be' to a raised ValueError.
