### PR TITLE
Change test RGB image from a .png to a .jpg

### DIFF
--- a/test/components/test_label.py
+++ b/test/components/test_label.py
@@ -71,7 +71,7 @@ class TestLabel:
         """
         Interface, process
         """
-        x_img = FileData(path="test/test_files/bus.png")
+        x_img = FileData(path="test/test_files/cheetah1.jpg")
 
         def rgb_distribution(img):
             rgb_dist = np.mean(img, axis=(0, 1))
@@ -88,8 +88,8 @@ class TestLabel:
         assert output == {
             "label": "red",
             "confidences": [
-                {"label": "red", "confidence": 0.44},
-                {"label": "green", "confidence": 0.28},
-                {"label": "blue", "confidence": 0.28},
+                {"label": "red", "confidence": 0.36},
+                {"label": "green", "confidence": 0.33},
+                {"label": "blue", "confidence": 0.31},
             ],
         }


### PR DESCRIPTION
## Description

To support transparency on .png images (#9932), .png images would no longer be automatically converted to RGB. However, this test relies on that conversion. As such, PR #9932 fails and cannot be merged.

To maintain the RGB test, I'm switching to another image -- a jpg -- which will allow this test to work as I believe it's intended to.

Perhaps an additional test for images with transparency is also warranted.

I'm not marking this as a 'bug' as it would not emerge as a 'bug' unless PR #9932 is merged.
  
