### PR TITLE
Some changes to `scripts/run_all_tests.sh`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,9 +10,9 @@ Before your create a PR, please check to see if there is [an existing issue](htt
 
 Not adhering to this guideline will result in the PR being closed. 
 
-## Tests
+## Testing and Formatting Your Code
 
-1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`
+1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`
 
-2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
+2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
   

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ We use Pytest, Playwright and Vitest to test our code.
 - The Python tests are located in `/test`. To run these tests:
 
 ```
-bash scripts/run_all_tests.sh
+bash scripts/run_backend_tests.sh
 ```
 
 - The frontend unit tests are any defined with the filename `*.test.ts`. To run them:

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -1,6 +1,0 @@
-#!/bin/bash -eu
-
-cd "$(dirname ${0})/.."
-
-echo "Running the tests..."
-python -m pytest --cov=gradio --durations=20 --durations-min=1 test

--- a/scripts/run_backend_tests.sh
+++ b/scripts/run_backend_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eu
+
+cd "$(dirname ${0})/.."
+
+echo "Running the backend unit tests..."
+python -m pytest test -m "not flaky"


### PR DESCRIPTION
As @meg-huggingface pointed out, our test script includes flaky tests, so I've made the following changes:

* Renamed `run_all_tests` to the more appropriate: `run_backend_tests`
* In this script, I only run the non-flaky tests since I think that's reasonable enough for contributors to deal with.

Closes: https://github.com/gradio-app/gradio/issues/9940