### PR TITLE
Allow dataframe column content to wrap

### DIFF
--- a/.changeset/eighty-turtles-accept.md
+++ b/.changeset/eighty-turtles-accept.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": patch
+"gradio": patch
+---
+
+fix:Allow dataframe column content to wrap

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -1241,8 +1241,8 @@
 	}
 
 	th .header-content {
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
+		white-space: normal;
+		overflow-wrap: break-word;
+		word-break: break-word;
 	}
 </style>


### PR DESCRIPTION
## Description

I'm not 100% sure why the wrap CSS was fixed to no-wrap beforehand; it makes sense to allow the wrap to me. 

Closes: #9937

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Tests

1. PRs will only be merged if tests pass on CI. To run the tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the tests: `bash scripts/run_all_tests.sh`

2. You may need to run the linters: `bash scripts/format_backend.sh` and `bash scripts/format_frontend.sh`
  
