### PR TITLE
Call `run_extra_startup_events` in Lite

### DIFF
--- a/.changeset/purple-bugs-see.md
+++ b/.changeset/purple-bugs-see.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Call `run_extra_startup_events` in Lite

--- a/.changeset/purple-bugs-see.md
+++ b/.changeset/purple-bugs-see.md
@@ -2,4 +2,4 @@
 "gradio": patch
 ---
 
-feat:Call `run_extra_startup_events` in Lite
+fix:Call `run_extra_startup_events` in Lite

--- a/.changeset/purple-bugs-see.md
+++ b/.changeset/purple-bugs-see.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Call `run_extra_startup_events` in Lite

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import copy
 import dataclasses
 import hashlib
@@ -2532,6 +2533,12 @@ Received inputs:
                 # In contrast, in the Wasm env, we can't do that because `threading` is not supported and all async tasks will run in the same event loop, `pyodide.webloop.WebLoop` in the main thread.
                 # So we need to manually cancel them. See `self.close()`..
                 self.run_startup_events()
+                # In the normal mode, self.run_extra_startup_events() is awaited like https://github.com/gradio-app/gradio/blob/2afcad80abd489111e47cf586a2a8221cc3dc9b6/gradio/routes.py#L1442.
+                # But in the Wasm env, we need to call the start up events here as described above, so we can't await it as here is not in an async function.
+                # So we use run_until_complete() instead. This is a best-effort fallback in the Wasm env but it doesn't guarantee that all the tasks are completed before they are needed.
+                asyncio.get_event_loop().run_until_complete(
+                    self.run_extra_startup_events()
+                )
 
         self.is_sagemaker = (
             False  # TODO: fix Gradio's behavior in sagemaker and other hosted notebooks

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2535,10 +2535,8 @@ Received inputs:
                 self.run_startup_events()
                 # In the normal mode, self.run_extra_startup_events() is awaited like https://github.com/gradio-app/gradio/blob/2afcad80abd489111e47cf586a2a8221cc3dc9b6/gradio/routes.py#L1442.
                 # But in the Wasm env, we need to call the start up events here as described above, so we can't await it as here is not in an async function.
-                # So we use run_until_complete() instead. This is a best-effort fallback in the Wasm env but it doesn't guarantee that all the tasks are completed before they are needed.
-                asyncio.get_event_loop().run_until_complete(
-                    self.run_extra_startup_events()
-                )
+                # So we use create_task() instead. This is a best-effort fallback in the Wasm env but it doesn't guarantee that all the tasks are completed before they are needed.
+                asyncio.create_task(self.run_extra_startup_events())
 
         self.is_sagemaker = (
             False  # TODO: fix Gradio's behavior in sagemaker and other hosted notebooks


### PR DESCRIPTION
## Description

Found that `run_extra_startup_events` is not called in the Lite env.

Closes: https://github.com/gradio-app/gradio/issues/9491