### PR TITLE
fix typing of launcher function

### DIFF
--- a/.changeset/large-words-happen.md
+++ b/.changeset/large-words-happen.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:fix typing of launcher function

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -35,7 +35,6 @@ from gradio import (
     networking,
     processing_utils,
     queueing,
-    routes,
     strings,
     themes,
     utils,
@@ -70,6 +69,7 @@ from gradio.exceptions import (
 from gradio.helpers import create_tracker, skip, special_args
 from gradio.node_server import start_node_server
 from gradio.route_utils import API_PREFIX, MediaStream
+from gradio.routes import VERSION, App, Request
 from gradio.state_holder import SessionState, StateHolder
 from gradio.themes import Default as DefaultTheme
 from gradio.themes import ThemeClass as Theme
@@ -1507,7 +1507,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
         block_fn: BlockFunction | int,
         processed_input: list[Any],
         iterator: AsyncIterator[Any] | None = None,
-        requests: routes.Request | list[routes.Request] | None = None,
+        requests: Request | list[Request] | None = None,
         event_id: str | None = None,
         event_data: EventData | None = None,
         in_event_listener: bool = False,
@@ -1932,7 +1932,7 @@ Received inputs:
         block_fn: BlockFunction | int,
         inputs: list[Any],
         state: SessionState | None = None,
-        request: routes.Request | list[routes.Request] | None = None,
+        request: Request | list[Request] | None = None,
         iterator: AsyncIterator | None = None,
         session_hash: str | None = None,
         event_id: str | None = None,
@@ -2106,7 +2106,7 @@ Received inputs:
 
     def get_config_file(self) -> BlocksConfigDict:
         config: BlocksConfigDict = {
-            "version": routes.VERSION,
+            "version": VERSION,
             "api_prefix": API_PREFIX,
             "mode": self.mode,
             "app_id": self.app_id,
@@ -2172,7 +2172,7 @@ Received inputs:
         else:
             self.parent.children.extend(self.children)
         self.config = self.get_config_file()
-        self.app = routes.App.create_app(self)
+        self.app = App.create_app(self)
         self.progress_tracking = any(
             block_fn.tracks_progress for block_fn in self.fns.values()
         )
@@ -2225,7 +2225,7 @@ Received inputs:
             default_concurrency_limit=default_concurrency_limit,
         )
         self.config = self.get_config_file()
-        self.app = routes.App.create_app(self)
+        self.app = App.create_app(self)
         return self
 
     def validate_queue_settings(self):
@@ -2282,7 +2282,7 @@ Received inputs:
         node_port: int | None = None,
         ssr_mode: bool | None = None,
         _frontend: bool = True,
-    ) -> tuple[routes.App, str, str]:
+    ) -> tuple[App, str, str]:
         """
         Launches a simple web server that serves the demo. Can also be used to create a
         public link used by anyone to access the demo from their browser by setting share=True.


### PR DESCRIPTION
## Description

Pyright complains about the type of `gr.launch` being partially unknown:

![image](https://github.com/user-attachments/assets/84a7f5fa-f117-4b74-8fcf-782ac3367c1f)

I am not sure exactly why but it seems that pyright does not recognize definitions that are imported and subsequently used like this
```python
from gradio import routes
...
routes.App
````
The issue can be solved by importing the definitions and using them like
```python
from routes import App 
...
App
```
It should be mentioned that this is only an issue when using gradio (or any other package I assume) as a library in another application. Pyright has no problem (at least for me) recognizing the current importing scheme when working directly inside the gradio project.

If you know of a better solution to this problem I can implement that instead. I just do not know any other way to fix this problem currently 😄 

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
