### PR TITLE
Fix example loading issue

### DIFF
--- a/.changeset/real-words-listen.md
+++ b/.changeset/real-words-listen.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix example loading issue

--- a/.changeset/real-words-listen.md
+++ b/.changeset/real-words-listen.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Fix example loading issue
+fix:Fix example loading issue

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -342,7 +342,10 @@ class Examples:
             else:
 
                 def load_example(example_tuple):
-                    _, example_value = example_tuple
+                    example_index, _ = example_tuple
+                    # Get the original value, even if it has None values
+                    # _get_processed_example will remove optional values
+                    example_value = self.examples[example_index]
                     processed_example = self._get_processed_example(example_value)
                     if len(self.inputs_with_examples) == 1:
                         return update(

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -309,9 +309,11 @@ class Examples:
                     postprocess=True,
                 )
                 sub.append(prediction_value)
-        return [
-            ex for (ex, keep) in zip(sub, self.input_has_examples, strict=False) if keep
-        ]
+        if len(sub) > len(self.input_has_examples):
+            return [
+                ex for (ex, keep) in zip(sub, self.input_has_examples, strict=False) if keep
+            ]
+        return sub
 
     def create(self) -> None:
         """Creates the Dataset component to hold the examples"""
@@ -342,10 +344,7 @@ class Examples:
             else:
 
                 def load_example(example_tuple):
-                    example_index, _ = example_tuple
-                    # Get the original value, even if it has None values
-                    # _get_processed_example will remove optional values
-                    example_value = self.examples[example_index]
+                    _, example_value = example_tuple
                     processed_example = self._get_processed_example(example_value)
                     if len(self.inputs_with_examples) == 1:
                         return update(

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -295,11 +295,23 @@ class Examples:
                 )
 
     def _get_processed_example(self, example):
+        """
+        This function is used to get the post-processed example values, ready to be used
+        in the frontend for each input component. For example, if the input components are
+        image components, the post-processed example values will be the a list of ImageData dictionaries
+        with the path, url, size, mime_type, orig_name, and is_stream keys. For any input components
+        that should be skipped (b/c they are None for all samples), they will simply be absent
+        from the returned list
+
+        Parameters:
+            example: a list of example values for each input component, excluding those components
+            that have all None values
+        """
         if example in self.non_none_processed_examples:
             return self.non_none_processed_examples[example]
         with utils.set_directory(self.working_directory):
             sub = []
-            for component, sample in zip(self.inputs, example, strict=False):
+            for component, sample in zip(self.inputs_with_examples, example, strict=False):
                 prediction_value = component.postprocess(sample)
                 if isinstance(prediction_value, (GradioRootModel, GradioModel)):
                     prediction_value = prediction_value.model_dump()
@@ -309,12 +321,6 @@ class Examples:
                     postprocess=True,
                 )
                 sub.append(prediction_value)
-        if len(sub) > len(self.input_has_examples):
-            return [
-                ex
-                for (ex, keep) in zip(sub, self.input_has_examples, strict=False)
-                if keep
-            ]
         return sub
 
     def create(self) -> None:
@@ -336,7 +342,7 @@ class Examples:
                 self.cache_event = self.load_input_event = self.dataset.click(
                     load_example_with_output,
                     inputs=[self.dataset],
-                    outputs=self.inputs_with_examples + self.outputs,  # type: ignore
+                    outputs=self.inputs + self.outputs,  # type: ignore
                     show_progress="hidden",
                     postprocess=False,
                     queue=False,
@@ -364,7 +370,7 @@ class Examples:
                 self.load_input_event = self.dataset.click(
                     load_example,
                     inputs=[self.dataset],
-                    outputs=self.inputs_with_examples,  # type: ignore
+                    outputs=self.inputs_with_examples,
                     show_progress="hidden",
                     postprocess=False,
                     queue=False,
@@ -382,8 +388,8 @@ class Examples:
                         )
                     self.load_input_event.then(
                         self.fn,
-                        inputs=self.inputs,  # type: ignore
-                        outputs=self.outputs,  # type: ignore
+                        inputs=self.inputs,
+                        outputs=self.outputs,
                         show_api=False,
                     )
         else:
@@ -550,8 +556,8 @@ class Examples:
             _, fn_index = self.root_block.default_config.set_event_trigger(
                 [EventListenerMethod(Context.root_block, "load")],
                 fn=fn,
-                inputs=self.inputs_with_examples,  # type: ignore
-                outputs=self.outputs,  # type: ignore
+                inputs=self.inputs,
+                outputs=self.outputs,
                 preprocess=self.preprocess and not self._api_mode,
                 postprocess=self.postprocess and not self._api_mode,
                 batch=self.batch,
@@ -559,11 +565,13 @@ class Examples:
 
             if self.outputs is None:
                 raise ValueError("self.outputs is missing")
-            for i, example in enumerate(self.examples):
+            for i, example in enumerate(self.non_none_examples):
                 if example_id is not None and i != example_id:
                     continue
-                print(f"Caching example {i + 1}/{len(self.examples)}")
                 processed_input = self._get_processed_example(example)
+                for index, keep in enumerate(self.input_has_examples):
+                    if not keep:
+                        processed_input.insert(index, None)
                 if self.batch:
                     processed_input = [[value] for value in processed_input]
                 with utils.MatplotlibBackendMananger():

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -311,7 +311,9 @@ class Examples:
             return self.non_none_processed_examples[example]
         with utils.set_directory(self.working_directory):
             sub = []
-            for component, sample in zip(self.inputs_with_examples, example, strict=False):
+            for component, sample in zip(
+                self.inputs_with_examples, example, strict=False
+            ):
                 prediction_value = component.postprocess(sample)
                 if isinstance(prediction_value, (GradioRootModel, GradioModel)):
                     prediction_value = prediction_value.model_dump()

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -311,7 +311,9 @@ class Examples:
                 sub.append(prediction_value)
         if len(sub) > len(self.input_has_examples):
             return [
-                ex for (ex, keep) in zip(sub, self.input_has_examples, strict=False) if keep
+                ex
+                for (ex, keep) in zip(sub, self.input_has_examples, strict=False)
+                if keep
             ]
         return sub
 

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -932,3 +932,35 @@ def test_check_event_data_in_cache():
                 },
             ),
         )
+
+
+def test_examples_no_cache_optional_inputs():
+    def foo(a, b, c, d):
+        return {"a": a, "b": b, "c": c, "d": d}
+
+    io = gr.Interface(
+        foo,
+        ["text", "text", "text", "text"],
+        "json",
+        cache_examples=False,
+        examples=[["a", "b", "c", "d"], ["a", "b", None, "de"]],
+    )
+
+    try:
+        app, _, _ = io.launch(prevent_thread_lock=True)
+
+        client = TestClient(app)
+        with client as c:
+            for i in range(2):
+                response = c.post(
+                    f"{API_PREFIX}/run/predict/",
+                    json={
+                        "data": [i],
+                        "fn_index": 6,
+                        "trigger_id": 19,
+                        "session_hash": "test",
+                    },
+                )
+                assert response.status_code == 200
+    finally:
+        io.close()

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -943,7 +943,7 @@ def test_examples_no_cache_optional_inputs():
         ["text", "text", "text", "text"],
         "json",
         cache_examples=False,
-        examples=[["a", "b", "c", "d"], ["a", "b", None, "de"]],
+        examples=[["a", "b", None, "d"], ["a", "b", None, "de"]],
     )
 
     try:


### PR DESCRIPTION
## Description

If one component does not have example values, then you get an out of index error when loading the example value because the data loaded from the dataset component has a different length than `self.input_has_examples`

See [context](https://huggingface.slack.com/archives/C02QZLG8GMN/p1732573418485419)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
