### PR TITLE
Add api_name for ChatInterface

### DIFF
--- a/.changeset/tender-seals-kiss.md
+++ b/.changeset/tender-seals-kiss.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Add api_name for ChatInterface

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -131,7 +131,7 @@ class ChatInterface(Blocks):
             show_progress: how to show the progress animation while event is running: "full" shows a spinner which covers the output component area as well as a runtime display in the upper right corner, "minimal" only shows the runtime display, "hidden" shows no progress animation at all
             fill_height: if True, the chat interface will expand to the height of window.
             fill_width: Whether to horizontally expand to fill container fully. If False, centers and constrains app to a maximum width.
-            api_name: the name of the API endpoint to use for the chat interface. Defaults to "/chat". Set to False to disable the API endpoint.
+            api_name: the name of the API endpoint to use for the chat interface. Defaults to "chat". Set to False to disable the API endpoint.
         """
         super().__init__(
             analytics_enabled=analytics_enabled,

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -97,6 +97,7 @@ class ChatInterface(Blocks):
         show_progress: Literal["full", "minimal", "hidden"] = "minimal",
         fill_height: bool = True,
         fill_width: bool = False,
+        api_name: str | Literal[False] = "chat",
     ):
         """
         Parameters:
@@ -130,6 +131,7 @@ class ChatInterface(Blocks):
             show_progress: how to show the progress animation while event is running: "full" shows a spinner which covers the output component area as well as a runtime display in the upper right corner, "minimal" only shows the runtime display, "hidden" shows no progress animation at all
             fill_height: if True, the chat interface will expand to the height of window.
             fill_width: Whether to horizontally expand to fill container fully. If False, centers and constrains app to a maximum width.
+            api_name: the name of the API endpoint to use for the chat interface. Defaults to "/chat". Set to False to disable the API endpoint.
         """
         super().__init__(
             analytics_enabled=analytics_enabled,
@@ -145,6 +147,7 @@ class ChatInterface(Blocks):
             fill_width=fill_width,
             delete_cache=delete_cache,
         )
+        self.api_name = api_name
         self.type = type
         self.multimodal = multimodal
         self.concurrency_limit = concurrency_limit
@@ -537,7 +540,7 @@ class ChatInterface(Blocks):
             api_fn,
             [self.textbox, self.chatbot_state] + self.additional_inputs,
             [self.fake_response_textbox, self.chatbot_state],
-            api_name="chat",
+            api_name=cast(Union[str, Literal[False]], self.api_name),
             concurrency_limit=cast(
                 Union[int, Literal["default"], None], self.concurrency_limit
             ),

--- a/test/test_chat_interface.py
+++ b/test/test_chat_interface.py
@@ -352,7 +352,7 @@ class TestExampleMessages:
         chat._setup_example_messages(None)
         assert chat.examples_messages == []
 
-    def test_chat_interface_disable_api(self, connect):
+    def test_chat_interface_api_name(self, connect):
         chat = gr.ChatInterface(double, api_name=False)
         assert chat.api_name is False
         with connect(chat) as client:

--- a/test/test_chat_interface.py
+++ b/test/test_chat_interface.py
@@ -351,3 +351,12 @@ class TestExampleMessages:
         chat = gr.ChatInterface(double)
         chat._setup_example_messages(None)
         assert chat.examples_messages == []
+
+    def test_chat_interface_disable_api(self, connect):
+        chat = gr.ChatInterface(double, api_name=False)
+        assert chat.api_name is False
+        with connect(chat) as client:
+            assert client.view_api(return_format="dict")["named_endpoints"] == {}
+        chat = gr.ChatInterface(double, api_name="double")
+        with connect(chat) as client:
+            assert "/double" in client.view_api(return_format="dict")["named_endpoints"]


### PR DESCRIPTION
## Description

Adds `api_name` parameter to ChatInterface to let developers set api_name=False or change the name of the api route.

Closes: #10047

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
