### PR TITLE
Use get_token instead of HfFolder.get_token

### DIFF
--- a/.changeset/itchy-facts-retire.md
+++ b/.changeset/itchy-facts-retire.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Use get_token instead of HfFolder.get_token

--- a/gradio/oauth.py
+++ b/gradio/oauth.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 
 import fastapi
 from fastapi.responses import RedirectResponse
-from huggingface_hub import HfFolder, whoami
+from huggingface_hub import get_token, whoami
 from starlette.datastructures import URL
 
 from gradio.utils import get_space
@@ -298,7 +298,7 @@ class OAuthToken:
 
 
 def _get_mocked_oauth_info() -> typing.Dict:
-    token = HfFolder.get_token()
+    token = get_token()
     if token is None:
         raise ValueError(
             "Your machine must be logged in to HF to debug a Gradio app locally. Please"


### PR DESCRIPTION
I just noticed that the oauth code is using `huggingface_hub.HfFolder.get_token` to retrieve the token from the user's machine. This is deprecated in favor of the more straightforward `huggingface_hub.get_token`. Both are doing the same thing but we're trying to get rid of the `HfFolder` abstraction. Token is retrieved from either the environment variable, the local file or the colab secret. Nothing new, just a namespace update :hugs:

(note: I've also checked and minimal version of `huggingface_hub` is 0.25.1 which is recent enough to support `get_token`. This have been in place for 11 months now.)