### PR TITLE
Fix to call bootstrap_custom_element() if the script is loaded after the DOMContentLoaded event

### DIFF
--- a/.changeset/cyan-things-rule.md
+++ b/.changeset/cyan-things-rule.md
@@ -2,4 +2,4 @@
 "@gradio/lite": minor
 ---
 
-feat:Fix to call bootstrap_custom_element() if the script is loaded after the DOContentLoaded event
+feat:Fix to call bootstrap_custom_element() if the script is loaded after the DOMContentLoaded event

--- a/.changeset/cyan-things-rule.md
+++ b/.changeset/cyan-things-rule.md
@@ -1,0 +1,5 @@
+---
+"@gradio/lite": minor
+---
+
+feat:Fix to call bootstrap_custom_element() if the script is loaded after the DOContentLoaded event

--- a/js/lite/src/index.ts
+++ b/js/lite/src/index.ts
@@ -144,9 +144,13 @@ globalThis.createGradioApp = create;
 // because the browser has not parsed the content yet.
 // Using `setTimeout()` is also a solution but it might not be the best practice as written in the article below.
 // Ref: https://dbushell.com/2024/06/15/custom-elements-unconnected-callback/
-document.addEventListener("DOMContentLoaded", () => {
+if (document.readyState === "loading") {
+	document.addEventListener("DOMContentLoaded", () => {
+		bootstrap_custom_element(create);
+	});
+} else {
 	bootstrap_custom_element(create);
-});
+}
 
 declare let BUILD_MODE: string;
 if (BUILD_MODE === "dev") {


### PR DESCRIPTION
## Description

`stlite.js` can be loaded after the DOM initialization is finished, and in that case, the custom element is never initialized.
Acutally the Lite demos embedded into the document (e.g. https://www.gradio.app/docs/gradio/interface) are broken now.
This PR fixes it.
