### PR TITLE
Add HTML support to paramviewer descriptions

### DIFF
--- a/.changeset/angry-fans-sneeze.md
+++ b/.changeset/angry-fans-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@gradio/paramviewer": minor
+"gradio": minor
+---
+
+feat:Add HTML support to paramviewer descriptions

--- a/js/paramviewer/ParamViewer.svelte
+++ b/js/paramviewer/ParamViewer.svelte
@@ -96,7 +96,7 @@
 					</div>
 				{/if}
 				{#if description}
-					<div class="description"><p>{description}</p></div>
+					<div class="description"><p>{@html description}</p></div>
 				{/if}
 			</details>
 		{/each}


### PR DESCRIPTION
Simple change to paramviewer descriptions so that you can add links, like a demo that explains a parameter. [Internal discussion](https://huggingface.slack.com/archives/C03BHNJCBC4/p1732826555853109) 