### PR TITLE
build(deps): unpin and upgrade `python-multipart`

### DIFF
--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -632,7 +632,7 @@ class GradioMultiPartParser:
             raise MultiPartException("Missing boundary in multipart.") from e
 
         # Callbacks dictionary.
-        callbacks: multipart.multipart.MultipartCallbacks = {
+        callbacks = {
             "on_part_begin": self.on_part_begin,
             "on_part_data": self.on_part_data,
             "on_part_end": self.on_part_end,
@@ -644,7 +644,7 @@ class GradioMultiPartParser:
         }
 
         # Create the parser.
-        parser = multipart.MultipartParser(boundary, callbacks)
+        parser = multipart.MultipartParser(boundary, callbacks)  # type: ignore
         try:
             # Feed the parser with data from the request.
             async for chunk in self.stream:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ packaging
 pandas>=1.0,<3.0
 pillow>=8.0,<12.0
 pydantic>=2.0
-python-multipart==0.0.12 # required for fastapi forms. pinning to avoid yanking issues with micropip.
+python-multipart>=0.0.18 # required for fastapi forms.
 pydub
 pyyaml>=5.0,<7.0
 ruff>=0.2.2; sys.platform != 'emscripten'


### PR DESCRIPTION
## Description

Commit febbed6db1c1 ("Pin multipart version to fix issues with yanking (#9834)") pinned this because of issues with `micropip` yanking versions. However, doing so blocks users of `gradio` from being able to resolve important security vulnerabilities (see [[1]] as an example).

This updates `python-multipart` to the patched version, as well as unpins it to prevent the need for `gradio` to cut new releases every time a `python-multipart` vulnerability is found.

[1]: https://github.com/advisories/GHSA-59g5-xgcq-4qw3