### PR TITLE
Fix API docs for `multimodal_textbox.py`

### DIFF
--- a/.changeset/fast-wings-wave.md
+++ b/.changeset/fast-wings-wave.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Fix API docs for `multimodal_textbox.py`
+fix:Fix API docs for `multimodal_textbox.py`

--- a/gradio/components/multimodal_textbox.py
+++ b/gradio/components/multimodal_textbox.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
 import gradio_client.utils as client_utils
-from gradio_client.documentation import document
 from gradio_client import handle_file
+from gradio_client.documentation import document
 from pydantic import Field
 from typing_extensions import NotRequired
 
@@ -212,11 +212,19 @@ class MultimodalTextbox(FormComponent):
         return MultimodalData(text=text, files=files)
 
     def example_payload(self) -> Any:
-        return {"text": "Describe this image", "files": [handle_file(
-            "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"
-        )]}
+        return {
+            "text": "Describe this image",
+            "files": [
+                handle_file(
+                    "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"
+                )
+            ],
+        }
 
     def example_value(self) -> Any:
-        return {"text": "Describe this image", "files": [
-            "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"
-        ]}
+        return {
+            "text": "Describe this image",
+            "files": [
+                "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"
+            ],
+        }

--- a/gradio/components/multimodal_textbox.py
+++ b/gradio/components/multimodal_textbox.py
@@ -118,8 +118,6 @@ class MultimodalTextbox(FormComponent):
         """
         self.file_types = file_types
         self.file_count = file_count
-        if value is None:
-            value = {"text": "", "files": []}
         if file_types is not None and not isinstance(file_types, list):
             raise ValueError(
                 f"Parameter file_types must be a list. Received {file_types.__class__.__name__}"
@@ -172,7 +170,7 @@ class MultimodalTextbox(FormComponent):
             "files": [f.path for f in payload.files],
         }
 
-    def postprocess(self, value: MultimodalValue | str | None) -> MultimodalData:
+    def postprocess(self, value: MultimodalValue | str | None) -> MultimodalData | None:
         """
         Parameters:
             value: Expects a {dict} with "text" and "files", both optional. The files array is a list of file paths or URLs.
@@ -180,7 +178,7 @@ class MultimodalTextbox(FormComponent):
             The value to display in the multimodal textbox. Files information as a list of FileData objects.
         """
         if value is None:
-            return MultimodalData(text="", files=[])
+            return None
         if not isinstance(value, (dict, str)):
             raise ValueError(
                 f"MultimodalTextbox expects a string or a dictionary with optional keys 'text' and 'files'. Received {value.__class__.__name__}"

--- a/gradio/components/multimodal_textbox.py
+++ b/gradio/components/multimodal_textbox.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
 import gradio_client.utils as client_utils
 from gradio_client.documentation import document
+from gradio_client import handle_file
 from pydantic import Field
 from typing_extensions import NotRequired
 
@@ -210,5 +211,12 @@ class MultimodalTextbox(FormComponent):
             )
         return MultimodalData(text=text, files=files)
 
-    def example_inputs(self) -> Any:
-        return {"text": "sample text", "files": []}
+    def example_payload(self) -> Any:
+        return {"text": "Describe this image", "files": [handle_file(
+            "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"
+        )]}
+
+    def example_value(self) -> Any:
+        return {"text": "Describe this image", "files": [
+            "https://raw.githubusercontent.com/gradio-app/gradio/main/test/test_files/bus.png"
+        ]}


### PR DESCRIPTION
API Snippet shows up fine now:

<img width="930" alt="image" src="https://github.com/user-attachments/assets/4f54bcfb-2def-4b75-9203-5fdcd8556d38">

with 

```py
import gradio as gr

def fn(x, y):
    print(message)

with gr.Blocks() as demo:
    t = gr.File()
    text = gr.MultimodalTextbox()
    text.submit(fn=fn, inputs=[t, text])
demo.launch()
```

Closes: https://github.com/gradio-app/gradio/issues/10104