### PR TITLE
Fixes error ERR_PNPM_UNSUPPORTED_ENGINE while creating a devcontainer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
 	},
 	"engines": {
 		"node": ">=18.0.0",
-		"pnpm": "~9.1.0"
+		"pnpm": "^9.1.0"
 	},
 	"pnpm": {
 		"patchedDependencies": {


### PR DESCRIPTION
## Description

This PR fixes the error ERR_PNPM_UNSUPPORTED_ENGINE while creating a devcontainer. The details of the error are described in https://github.com/gradio-app/gradio/issues/10141#issuecomment-2525108481.

Closes: additional errors reported in the #10141. 