### PR TITLE
Add a `.click()` event and `padding` parameter to the `HTML` component

### DIFF
--- a/.changeset/public-owls-mate.md
+++ b/.changeset/public-owls-mate.md
@@ -3,4 +3,4 @@
 "gradio": minor
 ---
 
-feat:Add a `.click()` event to the `HTML` component
+feat:Add a `.click()` event and `padding` parameter to the `HTML` component

--- a/.changeset/public-owls-mate.md
+++ b/.changeset/public-owls-mate.md
@@ -1,0 +1,6 @@
+---
+"@gradio/html": minor
+"gradio": minor
+---
+
+feat:Add a `.click()` event to the `HTML` component

--- a/gradio/components/html.py
+++ b/gradio/components/html.py
@@ -23,7 +23,7 @@ class HTML(Component):
     Guides: key-features
     """
 
-    EVENTS = [Events.change]
+    EVENTS = [Events.change, Events.click]
 
     def __init__(
         self,

--- a/gradio/components/html.py
+++ b/gradio/components/html.py
@@ -41,6 +41,7 @@ class HTML(Component):
         min_height: int | None = None,
         max_height: int | None = None,
         container: bool = False,
+        padding: bool = True,
     ):
         """
         Parameters:
@@ -57,9 +58,11 @@ class HTML(Component):
             min_height: The minimum height of the component, specified in pixels if a number is passed, or in CSS units if a string is passed. If HTML content exceeds the height, the component will expand to fit the content.
             max_height: The maximum height of the component, specified in pixels if a number is passed, or in CSS units if a string is passed. If content exceeds the height, the component will scroll.
             container: If True, the HTML component will be displayed in a container. Default is False.
+            padding: If True, the HTML component will have a certain padding (set by the `--block-padding` CSS variable) in all directions. Default is True.
         """
         self.min_height = min_height
         self.max_height = max_height
+        self.padding = padding
         super().__init__(
             label=label,
             every=every,

--- a/js/html/Index.svelte
+++ b/js/html/Index.svelte
@@ -22,6 +22,7 @@
 	export let min_height: number | undefined = undefined;
 	export let max_height: number | undefined = undefined;
 	export let container = false;
+	export let padding = true;
 
 	$: label, gradio.dispatch("change");
 </script>
@@ -40,6 +41,7 @@
 	/>
 	<div
 		class="html-container"
+		class:padding={padding}
 		class:pending={loading_status?.status === "pending"}
 		style:min-height={min_height && loading_status?.status !== "pending"
 			? css_units(min_height)
@@ -57,7 +59,7 @@
 </Block>
 
 <style>
-	.html-container {
+	.padding {
 		padding: var(--block-padding);
 	}
 

--- a/js/html/Index.svelte
+++ b/js/html/Index.svelte
@@ -15,6 +15,7 @@
 	export let loading_status: LoadingStatus;
 	export let gradio: Gradio<{
 		change: never;
+		click: never;
 		clear_status: LoadingStatus;
 	}>;
 	export let show_label = false;
@@ -50,6 +51,7 @@
 			{elem_classes}
 			{visible}
 			on:change={() => gradio.dispatch("change")}
+			on:click={() => gradio.dispatch("click")}
 		/>
 	</div>
 </Block>

--- a/js/html/Index.svelte
+++ b/js/html/Index.svelte
@@ -41,7 +41,7 @@
 	/>
 	<div
 		class="html-container"
-		class:padding={padding}
+		class:padding
 		class:pending={loading_status?.status === "pending"}
 		style:min-height={min_height && loading_status?.status !== "pending"
 			? css_units(min_height)

--- a/js/html/shared/HTML.svelte
+++ b/js/html/shared/HTML.svelte
@@ -5,13 +5,20 @@
 	export let value: string;
 	export let visible = true;
 
-	const dispatch = createEventDispatcher<{ change: undefined; click: undefined }>();
+	const dispatch = createEventDispatcher<{
+		change: undefined;
+		click: undefined;
+	}>();
 
 	$: value, dispatch("change");
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-<div class="prose {elem_classes.join(' ')}" class:hide={!visible} on:click={() => dispatch("click")}>
+<div
+	class="prose {elem_classes.join(' ')}"
+	class:hide={!visible}
+	on:click={() => dispatch("click")}
+>
 	{@html value}
 </div>
 

--- a/js/html/shared/HTML.svelte
+++ b/js/html/shared/HTML.svelte
@@ -5,12 +5,13 @@
 	export let value: string;
 	export let visible = true;
 
-	const dispatch = createEventDispatcher<{ change: undefined }>();
+	const dispatch = createEventDispatcher<{ change: undefined; click: undefined }>();
 
 	$: value, dispatch("change");
 </script>
 
-<div class="prose {elem_classes.join(' ')}" class:hide={!visible}>
+<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+<div class="prose {elem_classes.join(' ')}" class:hide={!visible} on:click={() => dispatch("click")}>
 	{@html value}
 </div>
 

--- a/test/components/test_html.py
+++ b/test/components/test_html.py
@@ -21,6 +21,7 @@ class TestHTML:
             "min_height": None,
             "max_height": None,
             "container": False,
+            "padding": True,
         }
 
     def test_in_interface(self):


### PR DESCRIPTION
Small PR that adds a `.click()` event to HTML, which is useful if you are creating very custom buttons.

Silly example of what this allows:

```py
html_button = """
<style>
    .stylish-button {
        background-color: #4CAF50;
        border: none;
        color: white;
        padding: 15px 32px !important;
        text-align: center;
        text-decoration: none;
        display: inline-block;
        font-size: 16px;
        margin: 4px 2px;
        cursor: pointer;
        border-radius: 8px;
        transition: all 0.3s ease;
        box-shadow: 0 4px 6px rgba(0,0,0,0.1);
        font-family: Arial, sans-serif;
        text-transform: uppercase;
        letter-spacing: 1px;
        font-weight: bold;
    }

    .stylish-button:hover {
        background-color: #45a049;
        transform: translateY(-2px);
        box-shadow: 0 6px 8px rgba(0,0,0,0.2);
    }

    .stylish-button:active {
        transform: translateY(1px);
        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
    }
</style>
<button class="stylish-button">Click Me</button>
"""

import gradio as gr

with gr.Blocks() as demo:
    h = gr.HTML(html_button)
    t = gr.Textbox()
    h.click(lambda :"Clicked!", None, t)

demo.launch()
```