### PR TITLE
make printing the error message from a `gr.Error` to the console configurable

### DIFF
--- a/.changeset/rotten-drinks-push.md
+++ b/.changeset/rotten-drinks-push.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:make print_exc error configurable

--- a/.changeset/rotten-drinks-push.md
+++ b/.changeset/rotten-drinks-push.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:make print_exc error configurable
+feat:make printing the error message from a `gr.Error` to the console configurable

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -81,6 +81,7 @@ class Error(Exception):
         duration: float | None = 10,
         visible: bool = True,
         title: str = "Error",
+        print_exc: bool = True
     ):
         """
         Parameters:
@@ -88,11 +89,13 @@ class Error(Exception):
             duration: The duration in seconds to display the error message. If None or 0, the error message will be displayed until the user closes it.
             visible: Whether the error message should be displayed in the UI.
             title: The title to be displayed to the user at the top of the error modal.
+            print_exc: Print traceback of the error
         """
         self.title = title
         self.message = message
         self.duration = duration
         self.visible = visible
+        self.print_exc = print_exc
         super().__init__(self.message)
 
     def __str__(self):

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -81,7 +81,7 @@ class Error(Exception):
         duration: float | None = 10,
         visible: bool = True,
         title: str = "Error",
-        print_exc: bool = True
+        print_exception: bool = True
     ):
         """
         Parameters:
@@ -89,13 +89,13 @@ class Error(Exception):
             duration: The duration in seconds to display the error message. If None or 0, the error message will be displayed until the user closes it.
             visible: Whether the error message should be displayed in the UI.
             title: The title to be displayed to the user at the top of the error modal.
-            print_exc: Print traceback of the error
+            print_exception: Whether to print traceback of the error to the console when the error is raised.
         """
         self.title = title
         self.message = message
         self.duration = duration
         self.visible = visible
-        self.print_exc = print_exc
+        self.print_exception = print_exception
         super().__init__(self.message)
 
     def __str__(self):

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -81,7 +81,7 @@ class Error(Exception):
         duration: float | None = 10,
         visible: bool = True,
         title: str = "Error",
-        print_exception: bool = True
+        print_exception: bool = True,
     ):
         """
         Parameters:

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -17,6 +17,7 @@ from gradio import route_utils, routes
 from gradio.data_classes import (
     PredictBodyInternal,
 )
+from gradio.exceptions import Error
 from gradio.helpers import TrackedIterable
 from gradio.route_utils import API_PREFIX
 from gradio.server_messages import (
@@ -637,7 +638,8 @@ class Queue:
                         response["is_generating"] = not event.is_finished
 
             except Exception as e:
-                traceback.print_exc()
+                if not isinstance(e, Error) or e.print_exception:
+                    traceback.print_exc()
                 response = None
                 err = e
                 for event in awake_events:
@@ -722,7 +724,8 @@ class Queue:
                             if event.streaming:
                                 response["is_generating"] = not event.is_finished
                     except Exception as e:
-                        traceback.print_exc()
+                        if not isinstance(e, Error) or e.print_exception:
+                            traceback.print_exc()
                         response = None
                         err = e
 
@@ -764,7 +767,8 @@ class Queue:
                 for event in events:
                     self.event_analytics[event._id]["process_time"] = duration
         except Exception as e:
-            traceback.print_exc()
+            if not isinstance(e, Error) or e.print_exception:
+                traceback.print_exc()
         finally:
             event_queue = self.event_queue_per_concurrency_id[events[0].concurrency_id]
             event_queue.current_concurrency -= 1

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -998,7 +998,7 @@ class App(FastAPI):
                 )
             except BaseException as error:
                 content = utils.error_payload(error, app.get_blocks().show_error)
-                if not isinstance(error, Error) or error.print_exc:
+                if not isinstance(error, Error) or error.print_exception:
                     traceback.print_exc()
                 return JSONResponse(
                     content=content,

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -76,7 +76,7 @@ from gradio.data_classes import (
     SimplePredictBody,
     UserProvidedPath,
 )
-from gradio.exceptions import InvalidPathError
+from gradio.exceptions import InvalidPathError, Error
 from gradio.node_server import (
     start_node_server,
 )
@@ -998,7 +998,8 @@ class App(FastAPI):
                 )
             except BaseException as error:
                 content = utils.error_payload(error, app.get_blocks().show_error)
-                traceback.print_exc()
+                if not isinstance(error, Error) or error.print_exc:
+                    traceback.print_exc()
                 return JSONResponse(
                     content=content,
                     status_code=500,

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -76,7 +76,7 @@ from gradio.data_classes import (
     SimplePredictBody,
     UserProvidedPath,
 )
-from gradio.exceptions import InvalidPathError, Error
+from gradio.exceptions import Error, InvalidPathError
 from gradio.node_server import (
     start_node_server,
 )

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -312,11 +312,12 @@ def watchfn(reloader: SourceFileReloader):
                     str(reloader.demo_file)
                 )
                 exec(changed_demo_file, module.__dict__)
-            except Exception:
+            except Exception as error:
                 print(
                     f"Reloading {reloader.watch_module_name} failed with the following exception: "
                 )
-                traceback.print_exc()
+                if not isinstance(error, Error) or error.print_exception:
+                    traceback.print_exc()
                 mtimes = {}
                 reloader.alert_change("error")
                 reloader.app.reload_error_message = traceback.format_exc()


### PR DESCRIPTION
## Description

> This would allow not printing stack traces for "expected" errors (while still using gr.Error in order to nicely display the error message in the UI). For instance in ZeroGPU, Spaces logs are full of "quota exceeded" stack traces that bring a lot of noise to the logs.
> Example usage: raise gr.Error("my error message", print_exc=False) ==> won't print the exception in the logs

Closes: #10136

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
