### PR TITLE
Add Japanese translations for login UI

### DIFF
--- a/.changeset/three-chefs-ask.md
+++ b/.changeset/three-chefs-ask.md
@@ -1,0 +1,6 @@
+---
+"@gradio/core": minor
+"gradio": minor
+---
+
+feat:Add Japanese translations for login UI

--- a/.changeset/three-chefs-ask.md
+++ b/.changeset/three-chefs-ask.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/core": minor
-"gradio": minor
+"@gradio/core": patch
+"gradio": patch
 ---
 
 feat:Add Japanese translations for login UI

--- a/js/core/src/Login.svelte
+++ b/js/core/src/Login.svelte
@@ -51,7 +51,7 @@
 			<Block>
 				<Textbox
 					{root}
-					label="username"
+					label={$_("login.username")}
 					lines={1}
 					show_label={true}
 					max_lines={1}
@@ -63,7 +63,7 @@
 			<Block>
 				<Textbox
 					{root}
-					label="password"
+					label={$_("login.password")}
 					lines={1}
 					show_label={true}
 					max_lines={1}

--- a/js/core/src/lang/en.json
+++ b/js/core/src/lang/en.json
@@ -97,6 +97,8 @@
 	"login": {
 		"enable_cookies": "If you are visiting a HuggingFace Space in Incognito mode, you must enable third party cookies.",
 		"incorrect_credentials": "Incorrect Credentials",
+		"username": "username",
+		"password": "password",
 		"login": "Login"
 	},
 	"number": {

--- a/js/core/src/lang/ja.json
+++ b/js/core/src/lang/ja.json
@@ -8,6 +8,12 @@
 	"errors": {
 		"use_via_api": "API経由で使おう"
 	},
+	"login": {
+		"incorrect_credentials": "認証情報が正しくありません",
+		"username": "ユーザ名",
+		"password": "パスワード",
+		"login": "ログイン"
+	},
 	"upload_text": {
 		"click_to_upload": "クリックしてアップロード",
 		"drop_audio": "ここに音声をドロップ",


### PR DESCRIPTION
I added Japanese translations for login UI. It will be useful for Japanese users.

<img width="1440" alt="Screenshot 2024-12-10 at 20 13 10" src="https://github.com/user-attachments/assets/8f5898e7-eee6-4b96-b287-63569e5db9d3">
