### PR TITLE
Inject the WebSocket constructor instead of polyfilling the global WebSocket

### DIFF
--- a/.changeset/honest-lions-reflect.md
+++ b/.changeset/honest-lions-reflect.md
@@ -1,0 +1,5 @@
+---
+"@gradio/client": minor
+---
+
+Inject the websocket constructor as a client option instead of polyfilling the global websocket

--- a/client/js/package.json
+++ b/client/js/package.json
@@ -15,11 +15,9 @@
 	},
 	"dependencies": {
 		"fetch-event-stream": "^0.1.5",
-		"semiver": "^1.1.0",
-		"ws": "^8.13.0"
+		"semiver": "^1.1.0"
 	},
 	"devDependencies": {
-		"@types/ws": "^8.5.10",
 		"esbuild": "^0.21.0",
 		"msw": "^2.2.1",
 		"typescript": "^5.0.0"

--- a/client/js/package.json
+++ b/client/js/package.json
@@ -14,19 +14,15 @@
 		"./package.json": "./package.json"
 	},
 	"dependencies": {
-		"@types/eventsource": "^1.1.15",
-		"bufferutil": "^4.0.7",
-		"eventsource": "^2.0.2",
 		"fetch-event-stream": "^0.1.5",
-		"msw": "^2.2.1",
 		"semiver": "^1.1.0",
-		"textlinestream": "^1.1.1",
-		"typescript": "^5.0.0",
 		"ws": "^8.13.0"
 	},
 	"devDependencies": {
 		"@types/ws": "^8.5.10",
-		"esbuild": "^0.21.0"
+		"esbuild": "^0.21.0",
+		"msw": "^2.2.1",
+		"typescript": "^5.0.0"
 	},
 	"scripts": {
 		"bundle": "vite build --ssr",

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -165,14 +165,6 @@ export class Client {
 	}
 
 	private async init(): Promise<void> {
-		if (
-			(typeof window === "undefined" || !("WebSocket" in window)) &&
-			!global.WebSocket
-		) {
-			const ws = await import("ws");
-			global.WebSocket = ws.WebSocket as unknown as typeof WebSocket;
-		}
-
 		if (this.options.auth) {
 			await this.resolve_cookies();
 		}
@@ -449,7 +441,12 @@ export class Client {
 		return new Promise((resolve, reject) => {
 			let ws;
 			try {
-				ws = new WebSocket(url);
+				const constructor = this.options.wsConstructor ?? global.WebSocket;
+				if (!constructor) {
+					console.error("WebSocket constructor not found");
+					throw new Error("WebSocket constructor not found");
+				}
+				ws = new constructor(url);
 			} catch (e) {
 				this.ws_map[url] = "failed";
 				return;

--- a/client/js/src/types.ts
+++ b/client/js/src/types.ts
@@ -300,6 +300,7 @@ export interface ClientOptions {
 	with_null_state?: boolean;
 	events?: EventType[];
 	headers?: Record<string, string>;
+	wsConstructor?: typeof WebSocket;
 }
 
 export interface FileData {

--- a/client/js/vite.config.js
+++ b/client/js/vite.config.js
@@ -33,12 +33,7 @@ export default defineConfig(({ mode }) => {
 		ssr: {
 			target: "node",
 			format: "esm",
-			noExternal: [
-				"ws",
-				"semiver",
-				"@gradio/upload",
-				"fetch-event-stream"
-			]
+			noExternal: ["semiver", "fetch-event-stream"]
 		}
 	};
 });

--- a/client/js/vite.config.js
+++ b/client/js/vite.config.js
@@ -36,7 +36,6 @@ export default defineConfig(({ mode }) => {
 			noExternal: [
 				"ws",
 				"semiver",
-				"bufferutil",
 				"@gradio/upload",
 				"fetch-event-stream"
 			]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,13 +410,7 @@ importers:
       semiver:
         specifier: ^1.1.0
         version: 1.1.0
-      ws:
-        specifier: ^8.13.0
-        version: 8.13.0(bufferutil@4.0.7)
     devDependencies:
-      '@types/ws':
-        specifier: ^8.5.10
-        version: 8.5.10
       esbuild:
         specifier: ^0.21.0
         version: 0.21.0
@@ -4569,9 +4563,6 @@ packages:
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
 
-  '@types/ws@8.5.10':
-    resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
-
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
@@ -5890,6 +5881,7 @@ packages:
   eslint@8.4.1:
     resolution: {integrity: sha512-TxU/p7LB1KxQ6+7aztTnO7K0i+h0tDi81YRY9VzB6Id71kNz+fFYnf5HD5UOQmxkzcoa0TlVZf9dpMtUv0GpWg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   eslint@9.1.1:
@@ -9015,18 +9007,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.13.0:
-    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.17.0:
     resolution: {integrity: sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==}
     engines: {node: '>=10.0.0'}
@@ -11367,10 +11347,6 @@ snapshots:
   '@types/which@3.0.0': {}
 
   '@types/wrap-ansi@3.0.0': {}
-
-  '@types/ws@8.5.10':
-    dependencies:
-      '@types/node': 20.12.8
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -16504,10 +16480,6 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
-
-  ws@8.13.0(bufferutil@4.0.7):
-    optionalDependencies:
-      bufferutil: 4.0.7
 
   ws@8.17.0(bufferutil@4.0.7):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,30 +404,12 @@ importers:
 
   client/js:
     dependencies:
-      '@types/eventsource':
-        specifier: ^1.1.15
-        version: 1.1.15
-      bufferutil:
-        specifier: ^4.0.7
-        version: 4.0.7
-      eventsource:
-        specifier: ^2.0.2
-        version: 2.0.2
       fetch-event-stream:
         specifier: ^0.1.5
         version: 0.1.5
-      msw:
-        specifier: ^2.2.1
-        version: 2.2.8(typescript@5.4.3)
       semiver:
         specifier: ^1.1.0
         version: 1.1.0
-      textlinestream:
-        specifier: ^1.1.1
-        version: 1.1.1
-      typescript:
-        specifier: ^5.0.0
-        version: 5.4.3
       ws:
         specifier: ^8.13.0
         version: 8.13.0(bufferutil@4.0.7)
@@ -438,6 +420,12 @@ importers:
       esbuild:
         specifier: ^0.21.0
         version: 0.21.0
+      msw:
+        specifier: ^2.2.1
+        version: 2.2.8(typescript@5.4.3)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.4.3
 
   client/python/gradio_client: {}
 
@@ -5968,10 +5956,6 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
-  eventsource@2.0.2:
-    resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
-    engines: {node: '>=12.0.0'}
-
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -8384,9 +8368,6 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
-
-  textlinestream@1.1.1:
-    resolution: {integrity: sha512-iBHbi7BQxrFmwZUQJsT0SjNzlLLsXhvW/kg7EyOMVMBIrlnj/qYofwo1LVLZi+3GbUEo96Iu2eqToI2+lZoAEQ==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -11828,6 +11809,7 @@ snapshots:
   bufferutil@4.0.7:
     dependencies:
       node-gyp-build: 4.6.1
+    optional: true
 
   builtin-modules@3.3.0: {}
 
@@ -12975,8 +12957,6 @@ snapshots:
       es5-ext: 0.10.62
 
   eventemitter3@4.0.7: {}
-
-  eventsource@2.0.2: {}
 
   execa@8.0.1:
     dependencies:
@@ -15668,8 +15648,6 @@ snapshots:
   term-size@2.2.1: {}
 
   text-table@0.2.0: {}
-
-  textlinestream@1.1.1: {}
 
   thenify-all@1.6.0:
     dependencies:


### PR DESCRIPTION
## Description

The JavaScript client currently implicitly polyfills the global `WebSocket` when `.init` is called (which happens automatically when `.connect` is used to construct the client). While this design simplifies setup, it has significant drawbacks:

1. **Unintended Side Effects**: Injecting a global polyfill can lead to conflicts with other libraries or applications that also use or modify the global `WebSocket`.
2. **Bundler Compatibility Issues**: Importing the `ws` package often causes issues with certain bundlers. For instance, SvelteKit with the Cloudflare adapter fails because `ws` relies on multiple Node.js built-in modules.
3. **Obsolescence**: The `ws` package is seems required for older Gradio versions and not be necessary for newer versions.

This PR introduces a `wsConstructor` option in the client configuration. This enhancement provides flexibility by allowing library users to specify their own WebSocket constructor (e.g., `ws.WebSocket`) if needed. If no constructor is provided, the client defaults to using the global `WebSocket`.

The Gradio client can now work better with a broader range of bundlers by eliminating platform-specific dependencies. Unused dependencies and development dependencies have been removed, making the package more lightweight and streamlined. The only remaining dependencies are `fetch-event-stream` and `semver`. Developers can easily adapt the client to their specific WebSocket implementation without worrying about compatibility issues.
