### PR TITLE
Fixed warning about not being able to find the app for some pattern

### DIFF
--- a/.changeset/early-wombats-bathe.md
+++ b/.changeset/early-wombats-bathe.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fixed warning about not being able to find the app for some pattern

--- a/.changeset/early-wombats-bathe.md
+++ b/.changeset/early-wombats-bathe.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Fixed warning about not being able to find the app for some pattern
+fix:Fixed warning about not being able to find the app for some pattern

--- a/gradio/cli/commands/reload.py
+++ b/gradio/cli/commands/reload.py
@@ -37,7 +37,7 @@ def _setup_config(
     app_text = original_path.read_text(encoding=encoding)
 
     patterns = [
-        f"with gr\\.Blocks\\(.*\\) as {demo_name}",
+        fr"with (?:gr\.)?Blocks\(.*\) as {demo_name}",
         f"{demo_name} = gr\\.Blocks",
         f"{demo_name} = gr\\.Interface",
         f"{demo_name} = gr\\.ChatInterface",

--- a/gradio/cli/commands/reload.py
+++ b/gradio/cli/commands/reload.py
@@ -37,7 +37,7 @@ def _setup_config(
     app_text = original_path.read_text(encoding=encoding)
 
     patterns = [
-        fr"with (?:gr\.)?Blocks\(.*\) as {demo_name}",
+        rf"with (?:gr\.)?Blocks\(.*\) as {demo_name}",
         f"{demo_name} = gr\\.Blocks",
         f"{demo_name} = gr\\.Interface",
         f"{demo_name} = gr\\.ChatInterface",


### PR DESCRIPTION
## Description

This pull request updates the regex pattern used to recognize Blocks declarations in the code. 

Certain linting tools enforce a style of import.

The previous pattern only matched gr.Blocks, which caused issues when Blocks was used directly. 
The updated pattern now supports both cases.


Closes: https://github.com/gradio-app/gradio/issues/10289
Closes: https://github.com/gradio-app/gradio/issues/6045

Following the previous patterns:

```python
patterns = [
    f"with gr\\.Blocks\\(.*\\) as {demo_name}",
    f"{demo_name} = gr\\.Blocks",
    f"{demo_name} = gr\\.Interface",
    f"{demo_name} = gr\\.ChatInterface",
    f"{demo_name} = gr\\.TabbedInterface",
]
```

It's needed this format.

```python
import gradio as gr
with gr.Blocks(...)

>> Watching: xxx
```

But certain linting tools enforce a style of import.

```python
from gradio.blocks import Blocks
with Blocks(...)

>> Warning: Cannot statically find a gradio demo called demo. Reload work may fail.
>> Watching: xxx
```
  
Now, the updated pattern now supports both cases.