### PR TITLE
ImageEditor: Trigger input event even if change event not defined

### DIFF
--- a/.changeset/long-snakes-notice.md
+++ b/.changeset/long-snakes-notice.md
@@ -1,0 +1,6 @@
+---
+"@gradio/imageeditor": patch
+"gradio": patch
+---
+
+fix:ImageEditor: Trigger input event even if change event not defined

--- a/js/imageeditor/Index.svelte
+++ b/js/imageeditor/Index.svelte
@@ -214,7 +214,8 @@
 			{brush}
 			{eraser}
 			changeable={attached_events.includes("apply")}
-			realtime={attached_events.includes("change") || attached_events.includes("input")}
+			realtime={attached_events.includes("change") ||
+				attached_events.includes("input")}
 			i18n={gradio.i18n}
 			{transforms}
 			accept_blobs={server.accept_blobs}

--- a/js/imageeditor/Index.svelte
+++ b/js/imageeditor/Index.svelte
@@ -214,7 +214,7 @@
 			{brush}
 			{eraser}
 			changeable={attached_events.includes("apply")}
-			realtime={attached_events.includes("change")}
+			realtime={attached_events.includes("change") || attached_events.includes("input")}
 			i18n={gradio.i18n}
 			{transforms}
 			accept_blobs={server.accept_blobs}


### PR DESCRIPTION
## Description

Closes: #8601 

Run the repro from the original issue to test.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
