### PR TITLE
Allow custom REST endpoints

### DIFF
--- a/.changeset/cute-toes-happen.md
+++ b/.changeset/cute-toes-happen.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Allow custom REST endpoints

--- a/gradio/__init__.py
+++ b/gradio/__init__.py
@@ -4,7 +4,7 @@ import gradio._simple_templates
 import gradio.image_utils
 import gradio.processing_utils
 import gradio.templates
-from gradio import components, layouts, themes
+from gradio import api, components, layouts, themes
 from gradio.blocks import Blocks
 from gradio.chat_interface import ChatInterface
 from gradio.components import (

--- a/gradio/api.py
+++ b/gradio/api.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from functools import wraps
+
+from gradio.context import Context
+
+
+@dataclass
+class Route:
+    path: str
+    mode: str
+    func: callable
+    route_args: tuple
+    route_kwargs: dict
+
+
+def route(path: str, mode, *route_args, **route_kwargs):
+    root_block = Context.root_block
+    if root_block is None:
+        raise ValueError("Cannot create get() route outside Block context.")
+
+    def decorator(func):
+        root_block.extra_api_routes.append(
+            Route(path, mode, func, route_args, route_kwargs)
+        )
+
+        @wraps(func)
+        def wrapper(*fn_args, **fn_kwargs):
+            return func(*fn_args, **fn_kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def get(path: str, *args, **kwargs):
+    if not path.startswith("/"):
+        path = "/" + path
+    return route(path, "GET", *args, **kwargs)
+
+
+def post(path: str, *args, **kwargs):
+    if not path.startswith("/"):
+        path = "/" + path
+    return route(path, "POST", *args, **kwargs)
+
+
+__all__ = ["get", "post"]

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -97,6 +97,7 @@ except Exception:
 
 
 if TYPE_CHECKING:  # Only import for type checking (is False at runtime).
+    from gradio.api import Route
     from gradio.components.base import Component
     from gradio.renderable import Renderable
 
@@ -1070,6 +1071,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
         self.delete_cache = delete_cache
         self.extra_startup_events: list[Callable[..., Coroutine[Any, Any, Any]]] = []
         self.css = css or ""
+        self.extra_api_routes: list[Route] = []
         css_paths = utils.none_or_singleton_to_list(css_paths)
         for css_path in css_paths or []:
             with open(css_path, encoding="utf-8") as css_file:

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1504,6 +1504,16 @@ class App(FastAPI):
             else:
                 raise HTTPException(status_code=403, detail="Invalid key.")
 
+        for route in blocks.extra_api_routes:
+            if route.mode == "GET":
+                app.get("/get" + route.path, *route.route_args, **route.route_kwargs)(
+                    route.func
+                )
+            elif route.mode == "POST":
+                app.post("/post" + route.path, *route.route_args, **route.route_kwargs)(
+                    route.func
+                )
+
         app.include_router(router)
 
         return app

--- a/guides/04_additional-features/07_sharing-your-app.md
+++ b/guides/04_additional-features/07_sharing-your-app.md
@@ -192,6 +192,32 @@ example, when examples are cached, or when the Gradio app is called via API), th
 You should handle this case explicitly to ensure that your app does not throw any errors. That is why
 we have the explicit check `if request`.
 
+## Adding Custom API Endpoints
+
+If you need to add some extra GET and POST request endpoints to you app, you can do so as such:
+
+```python
+with gr.Blocks() as demo:
+    textbox = ...
+
+    @gr.api.get("/sum")
+    def some_function(a: int, b: int):
+        return {"sum": a + b}
+```
+
+This would expose a GET endpoint at "http://localhost:7860/get/sum" that would take two arguments via query parameters. e.g. "http://localhost:7860/get/sum?a=4&b=3". Note the type-hinting of `a` and `b` so the underlying FastAPI app can cast the inputs to int. Also note the "/get" URL prefix in the request!
+
+POST requests work similarly, with URL's prefixed with `/post`. 
+
+```python
+with gr.Blocks() as demo:
+    @gr.api.post("/sum")
+    def some_function(data: dict):
+        return {"sum": data.get("a") + data.get("b")}
+```
+
+Under the hood, Gradio is simply attaching your function directly to the FastAPI app underneath, so all FastAPI features are supported.
+
 ## Mounting Within Another FastAPI App
 
 In some cases, you might have an existing FastAPI app, and you'd like to add a path for a Gradio demo.

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -813,6 +813,29 @@ class TestDevMode:
         assert not gradio_fast_api.app.blocks.dev_mode  # type: ignore
 
 
+class TestCustomRestApi:
+    def test_custom_rest_api(self, connect):
+        with gr.Blocks() as demo:
+
+            @gr.api.get("/add")
+            def add(a: int, b: int):
+                return {"sum": a + b}
+
+            @gr.api.post("/subtract")
+            def subtract(data: dict):
+                return {"difference": data["a"] - data["b"]}
+
+        with connect(demo) as client:
+            response = requests.get(f"{client.src}/get/add?a=1&b=2")
+            assert response.json() == {"sum": 3}
+
+            response = requests.post(
+                f"{client.src}/post/subtract", json={"a": 2, "b": 1}
+            )
+            print(response.json())
+            assert response.json() == {"difference": 1}
+
+
 class TestPassingRequest:
     def test_request_included_with_interface(self):
         def identity(name, request: gr.Request):


### PR DESCRIPTION
Split out the ChatAPI content from this PR because how chat api endpoints are handled are very different. Allows the ability to ad GET and POST endpoint to your gradio app.

From what I added to the guides:
---------------

If you need to add some extra GET and POST request endpoints to you app, you can do so as such:

```python
with gr.Blocks() as demo:
    textbox = ...

    @gr.api.get("/sum")
    def some_function(a: int, b: int):
        return {"sum": a + b}
```

This would expose a GET endpoint at "http://localhost:7860/get/sum" that would take two arguments via query parameters. e.g. "http://localhost:7860/get/sum?a=4&b=3". Note the type-hinting of `a` and `b` so the underlying FastAPI app can cast the inputs to int. Also note the "/get" URL prefix in the request!

POST requests work similarly, with URL's prefixed with `/post`. 

```python
with gr.Blocks() as demo:
    @gr.api.post("/sum")
    def some_function(data: dict):
        return {"sum": data.get("a") + data.get("b")}
```

Under the hood, Gradio is simply attaching your function directly to the FastAPI app underneath, so all FastAPI features are supported.