### PR TITLE
Add `show_reset_button` to `gr.slider` initialization

### DIFF
--- a/.changeset/silly-jeans-suffer.md
+++ b/.changeset/silly-jeans-suffer.md
@@ -3,4 +3,4 @@
 "gradio": minor
 ---
 
-feat:Add `show_reset_button` to Slider component initialization
+feat:Add `show_reset_button` to `gr.slider` initialization

--- a/.changeset/silly-jeans-suffer.md
+++ b/.changeset/silly-jeans-suffer.md
@@ -1,0 +1,6 @@
+---
+"@gradio/slider": minor
+"gradio": minor
+---
+
+feat:Add `show_reset_button` to Slider component initialization

--- a/gradio/components/slider.py
+++ b/gradio/components/slider.py
@@ -49,7 +49,7 @@ class Slider(FormComponent):
         render: bool = True,
         key: int | str | None = None,
         randomize: bool = False,
-        show_reset_button: bool = False,
+        show_reset_button: bool = True,
     ):
         """
         Parameters:
@@ -72,7 +72,7 @@ class Slider(FormComponent):
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             key: if assigned, will be used to assume identity across a re-render. Components that have the same key across a re-render will have their value preserved.
             randomize: If True, the value of the slider when the app loads is taken uniformly at random from the range given by the minimum and maximum.
-            show_reset_button: if True, will show button to reset slider to minimum value.
+            show_reset_button: if False, will hide button to reset slider to default value.
         """
         self.minimum = minimum
         self.maximum = maximum

--- a/gradio/components/slider.py
+++ b/gradio/components/slider.py
@@ -49,6 +49,7 @@ class Slider(FormComponent):
         render: bool = True,
         key: int | str | None = None,
         randomize: bool = False,
+        show_reset_button: bool = False,
     ):
         """
         Parameters:
@@ -71,6 +72,7 @@ class Slider(FormComponent):
             render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
             key: if assigned, will be used to assume identity across a re-render. Components that have the same key across a re-render will have their value preserved.
             randomize: If True, the value of the slider when the app loads is taken uniformly at random from the range given by the minimum and maximum.
+            show_reset_button: if True, will show button to reset slider to minimum value.
         """
         self.minimum = minimum
         self.maximum = maximum
@@ -80,6 +82,7 @@ class Slider(FormComponent):
             self.step = 10**power
         else:
             self.step = step
+        self.show_reset_button = show_reset_button
         if randomize:
             value = self.get_random_value
         super().__init__(

--- a/js/slider/Index.svelte
+++ b/js/slider/Index.svelte
@@ -34,6 +34,7 @@
 	export let loading_status: LoadingStatus;
 	export let value_is_output = false;
 	export let root: string;
+	export let show_reset_button: boolean;
 
 	let range_input: HTMLInputElement;
 	let number_input: HTMLInputElement;
@@ -124,14 +125,17 @@
 					{disabled}
 					on:pointerup={handle_release}
 				/>
-				<button
-					class="reset-button"
-					on:click={reset_value}
-					{disabled}
-					aria-label="Reset to default value"
-				>
-					↺
-				</button>
+				{#if show_reset_button}
+					<button
+						class="reset-button"
+						on:click={reset_value}
+						{disabled}
+						aria-label="Reset to default value"
+						data-testid="reset-button"
+					>
+						↺
+					</button>
+				{/if}
 			</div>
 		</div>
 

--- a/js/slider/Slider.component.spec.ts
+++ b/js/slider/Slider.component.spec.ts
@@ -60,6 +60,25 @@ test("Slider respects show_label", async ({ mount, page }) => {
 	await expect(component.getByTestId("block-title")).toBeHidden();
 });
 
+test("Slider respects show_reset_button", async ({ mount, page }) => {
+	const component = await mount(Slider, {
+		props: {
+			value: 3,
+			minimum: 0,
+			maximum: 10,
+			label: "My Slider",
+			show_reset_button: true,
+			step: 1,
+			interactive: true,
+			loading_status: loading_status,
+			gradio: {
+				dispatch() {}
+			}
+		}
+	});
+	await expect(component.getByTestId("reset-button")).toBeVisible();
+});
+
 test("Slider Maximum/Minimum values", async ({ mount, page }) => {
 	const component = await mount(Slider, {
 		props: {

--- a/js/slider/Slider.stories.svelte
+++ b/js/slider/Slider.stories.svelte
@@ -50,3 +50,13 @@
 		interactive: false
 	}}
 />
+
+<Story
+	name="Slider with reset button"
+	args={{
+		value: 50,
+		minimum: 10,
+		maximum: 100,
+		show_reset_button: true
+	}}
+/>

--- a/js/slider/Slider.stories.svelte
+++ b/js/slider/Slider.stories.svelte
@@ -52,11 +52,11 @@
 />
 
 <Story
-	name="Slider with reset button"
+	name="Slider with reset button hidden"
 	args={{
 		value: 50,
 		minimum: 10,
 		maximum: 100,
-		show_reset_button: true
+		show_reset_button: false
 	}}
 />

--- a/test/components/test_slider.py
+++ b/test/components/test_slider.py
@@ -22,7 +22,7 @@ class TestSlider:
             "value": 15,
             "name": "slider",
             "show_label": True,
-            "show_reset_button": False,
+            "show_reset_button": True,
             "label": "Slide Your Input",
             "container": True,
             "min_width": 160,

--- a/test/components/test_slider.py
+++ b/test/components/test_slider.py
@@ -22,6 +22,7 @@ class TestSlider:
             "value": 15,
             "name": "slider",
             "show_label": True,
+            "show_reset_button": False,
             "label": "Slide Your Input",
             "container": True,
             "min_width": 160,


### PR DESCRIPTION
## Description

Added an argument `show_reset_button` to `Slider` component to make reset button visible. By default `show_reset_button` is `False` to reduce visual clutter.

Test script
```
 import gradio as gr

def multiply_by_two(x):
    return x * 2

with gr.Blocks() as demo:
    gr.Markdown("## Multiply by Two")
    slider = gr.Slider(minimum=10, maximum=100, step=1, label="Input Number", show_reset_button=True)
    output = gr.Number(label="Output")
    button = gr.Button("Multiply")

    button.click(fn=multiply_by_two, inputs=slider, outputs=output)

demo.launch()
```

Closes: #9973 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
