### PR TITLE
Adds Swedish language to the lang-settings

### DIFF
--- a/js/core/src/lang/sv.json
+++ b/js/core/src/lang/sv.json
@@ -1,0 +1,130 @@
+{
+	"_name": "Svenska",
+	"3D_model": {
+		"3d_model": "3D-modell"
+	},
+	"annotated_image": {
+		"annotated_image": "Annoterad bild"
+	},
+	"audio": {
+		"allow_recording_access": "Tillåt mikrofonåtkomst för inspelning.",
+		"audio": "Ljud",
+		"record_from_microphone": "Spela in från mikrofon",
+		"stop_recording": "Stoppa inspelning",
+		"no_device_support": "Kan inte få åtkomst till medieenheter. Se till att du använder en säker källa (https) eller localhost (eller har gett ett giltigt SSL-certifikat till ssl_verify) och att du har gett webbläsaren åtkomst till din enhet.",
+		"stop": "Stopp",
+		"resume": "Fortsätt",
+		"record": "Spela in",
+		"no_microphone": "Ingen mikrofon hittades",
+		"pause": "Paus",
+		"play": "Spela upp",
+		"waiting": "Väntar"
+	},
+	"blocks": {
+		"connection_can_break": "På mobila enheter kan anslutningen brytas om fliken lämnas eller om enheten går i viloläge, och du förlorar din plats i kön.",
+		"long_requests_queue": "Det är en lång kö med väntande förfrågningar. Duplicera detta Space för att hoppa över kön.",
+		"lost_connection": "Anslutningen bröts eftersom sidan lämnades. Återgår till kön..."
+	},
+	"checkbox": {
+		"checkbox": "Kryssruta",
+		"checkbox_group": "Kryssrutgrupp"
+	},
+	"code": {
+		"code": "Kod"
+	},
+	"color_picker": {
+		"color_picker": "Färgväljare"
+	},
+	"common": {
+		"built_with": "byggt med",
+		"built_with_gradio": "Byggt med Gradio",
+		"clear": "Rensa",
+		"download": "Ladda ner",
+		"edit": "Redigera",
+		"empty": "Tom",
+		"error": "Fel",
+		"hosted_on": "värd på",
+		"loading": "Laddar",
+		"logo": "Logotyp",
+		"or": "eller",
+		"remove": "Ta bort",
+		"settings": "Inställningar",
+		"share": "Dela",
+		"submit": "Skicka",
+		"undo": "Ångra",
+		"no_devices": "Inga enheter hittades",
+		"language": "Språk",
+		"display_theme": "Visningstema",
+		"pwa": "Progressiv webbapplikation"
+	},
+	"dataframe": {
+		"incorrect_format": "Fel format, endast CSV- och TSV-filer stöds",
+		"new_column": "Lägg till kolumn",
+		"new_row": "Ny rad",
+		"add_row_above": "Lägg till rad ovanför",
+		"add_row_below": "Lägg till rad nedanför",
+		"add_column_left": "Lägg till kolumn till vänster",
+		"add_column_right": "Lägg till kolumn till höger"
+	},
+	"dropdown": {
+		"dropdown": "Rullgardinsmeny"
+	},
+	"errors": {
+		"build_error": "det finns ett byggfel",
+		"config_error": "det finns ett konfigurationsfel",
+		"contact_page_author": "Kontakta sidans författare för att informera dem.",
+		"no_app_file": "det finns ingen app-fil",
+		"runtime_error": "det finns ett körtidsfel",
+		"space_not_working": "\"Space fungerar inte eftersom\" {0}",
+		"space_paused": "space är pausat",
+		"use_via_api": "Använd via API"
+	},
+	"file": {
+		"uploading": "Laddar upp..."
+	},
+	"highlighted_text": {
+		"highlighted_text": "Markerad text"
+	},
+	"image": {
+		"allow_webcam_access": "Tillåt webbkameråtkomst för inspelning.",
+		"brush_color": "Penselfärg",
+		"brush_radius": "Penselstorlek",
+		"image": "Bild",
+		"remove_image": "Ta bort bild",
+		"select_brush_color": "Välj penselfärg",
+		"start_drawing": "Börja rita",
+		"use_brush": "Använd pensel"
+	},
+	"label": {
+		"label": "Etikett"
+	},
+	"login": {
+		"enable_cookies": "Om du besöker ett HuggingFace Space i inkognitoläge måste du aktivera tredjepartscookies.",
+		"incorrect_credentials": "Felaktiga inloggningsuppgifter",
+		"username": "användarnamn",
+		"password": "lösenord",
+		"login": "Logga in"
+	},
+	"number": {
+		"number": "Nummer"
+	},
+	"plot": {
+		"plot": "Diagram"
+	},
+	"radio": {
+		"radio": "Radio"
+	},
+	"slider": {
+		"slider": "Skjutreglage"
+	},
+	"upload_text": {
+		"click_to_upload": "Klicka för att ladda upp",
+		"drop_audio": "Släpp ljud här",
+		"drop_csv": "Släpp CSV här",
+		"drop_file": "Släpp fil här",
+		"drop_image": "Släpp bild här",
+		"drop_video": "Släpp video här",
+		"drop_gallery": "Släpp media här",
+		"paste_clipboard": "Klistra in från urklipp"
+	}
+}


### PR DESCRIPTION
This pull request adds Swedish language translations to the Gradio language settings. The translations include user-facing strings for various components, such as audio, dropdowns, sliders, and error messages.

