### PR TITLE
Tweak behavior related to the `status` of `gr.Chatbot` thought messages

### DIFF
--- a/.changeset/honest-frogs-fall.md
+++ b/.changeset/honest-frogs-fall.md
@@ -1,7 +1,7 @@
 ---
-"@gradio/chatbot": minor
-"gradio": minor
-"website": minor
+"@gradio/chatbot": patch
+"gradio": patch
+"website": patch
 ---
 
-feat:Tweak behavior related to the `status` of `gr.Chatbot` thought messages
+fix:Tweak behavior related to the `status` of `gr.Chatbot` thought messages

--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -44,7 +44,7 @@ class MetadataDict(TypedDict):
         parent_id: The ID of the parent message. Only used for nested thoughts.
         log: A string message to display next to the thought title in a subdued font.
         duration: The duration of the message in seconds. Appears next to the thought title in a subdued font inside a parentheses.
-        status: The status of the message. If "pending", the status is displayed as a spinner icon.
+        status: The status of the message. If "pending", a spinner icon appears next to the thought title. If "done", the thought accordion becomes closed. If not provided, the thought accordion is open and no spinner is displayed.
     """
 
     title: NotRequired[str]

--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -44,7 +44,7 @@ class MetadataDict(TypedDict):
         parent_id: The ID of the parent message. Only used for nested thoughts.
         log: A string message to display next to the thought title in a subdued font.
         duration: The duration of the message in seconds. Appears next to the thought title in a subdued font inside a parentheses.
-        status: The status of the message. If "pending", a spinner icon appears next to the thought title. If "done", the thought accordion becomes closed. If not provided, the thought accordion is open and no spinner is displayed.
+        status: The status of the message. If "pending", a spinner icon appears next to the thought title. If "done", the thought accordion becomes closed. If no value is provided, the thought accordion is open and no spinner is displayed.
     """
 
     title: NotRequired[str]

--- a/guides/05_chatbots/03_agents-and-tool-usage.md
+++ b/guides/05_chatbots/03_agents-and-tool-usage.md
@@ -62,7 +62,7 @@ In addition to `title`, the dictionary provided to `metadata` can take several o
 
 * `log`: an optional string value to be displayed in a subdued font next to the thought title.
 * `duration`: an optional numeric value representing the duration of the thought/tool usage, in seconds. Displayed in a subdued font next inside parentheses next to the thought title.
-* `status`: if set to `pending`, a spinner appears next to the thought title.
+* `status`: if set to `pending`, a spinner appears next to the thought title.  If "done", the thought accordion becomes closed. If not provided, the thought accordion is open and no spinner is displayed.
 * `id` and `parent_id`: if these are provided, they can be used to nest thoughts inside other thoughts.
 
 Below, we show several complete examples of using `gr.Chatbot` and `gr.ChatInterface` to display tool use or thinking UIs.

--- a/js/_website/src/lib/templates/gradio/03_components/chatbot.svx
+++ b/js/_website/src/lib/templates/gradio/03_components/chatbot.svx
@@ -57,7 +57,7 @@
         {
             "name": "status",
             "annotation": "Literal['pending', 'done']",
-            "doc": "The status of the message. If 'pending', the status is displayed as a spinner icon."
+            "doc": "The status of the message. If "pending", a spinner icon appears next to the thought title. If "done", the thought accordion becomes closed. If not provided, the thought accordion is open and no spinner is displayed."
         }
     ]
 

--- a/js/chatbot/shared/Thought.svelte
+++ b/js/chatbot/shared/Thought.svelte
@@ -71,7 +71,7 @@
 			{sanitize_html}
 			{root}
 		/>
-		{#if thought_node.metadata?.status === "pending" || (thought_node.metadata?.status !== "done" && (thought_node.content === "" || thought_node.content === null))}
+		{#if thought_node.metadata?.status === "pending"}
 			<span class="loading-spinner"></span>
 		{/if}
 		{#if thought_node?.metadata?.log || thought_node?.metadata?.duration}

--- a/js/chatbot/shared/Thought.svelte
+++ b/js/chatbot/shared/Thought.svelte
@@ -31,7 +31,6 @@
 	export let i18n: I18nFormatter;
 	export let line_breaks: boolean;
 
-	let expanded = thought_node.metadata?.status !== "done";
 
 	function is_thought_node(msg: NormalisedMessage): msg is ThoughtNode {
 		return "children" in msg;
@@ -46,6 +45,8 @@
 	function toggleExpanded(): void {
 		expanded = !expanded;
 	}
+
+	$: expanded = thought_node.metadata?.status !== "done";
 </script>
 
 <div class="thought-group">

--- a/js/chatbot/shared/Thought.svelte
+++ b/js/chatbot/shared/Thought.svelte
@@ -31,7 +31,6 @@
 	export let i18n: I18nFormatter;
 	export let line_breaks: boolean;
 
-
 	function is_thought_node(msg: NormalisedMessage): msg is ThoughtNode {
 		return "children" in msg;
 	}

--- a/js/chatbot/shared/Thought.svelte
+++ b/js/chatbot/shared/Thought.svelte
@@ -31,7 +31,7 @@
 	export let i18n: I18nFormatter;
 	export let line_breaks: boolean;
 
-	let expanded = true;
+	let expanded = thought_node.metadata?.status !== "done";
 
 	function is_thought_node(msg: NormalisedMessage): msg is ThoughtNode {
 		return "children" in msg;


### PR DESCRIPTION
Tightens up the role of the `status` key. Now the behavior is as follows:

* status: The status of the message. If "pending", a spinner icon appears next to the thought title. If "done", the thought accordion becomes closed. If no value is provided, the thought accordion is open and no spinner is displayed.

Based on discussions with @yvrjsharma I think this will be more intuitive to users.

Closes: #10401 
Closes: #10402 

Here's an example demonstrating the new behavior, adapted from @yvrjsharma's issues:

```py
import gradio as gr
import time

def stream_messages(message):
    messages = []
    messages.append(gr.ChatMessage(role="user", content=message))
    yield messages
    
    # Parent tool message with unique ID
    parent_id = "search_1"
    tool_parent = gr.ChatMessage(
        role="assistant",
        content="search('example query')",
        metadata={
            "title": "🛠️ Used tool search",
            "id": parent_id,
            "status": "pending"
        }
    )
    messages.append(tool_parent)
    yield messages

    time.sleep(1)  # Simulating search delay
  
    long_search_results = """Search Results:
    
Result 1: Lorem ipsum dolor sit amet, consectetur adipiscing elit
Result 2: Ut enim ad minim veniam, quis nostrud exercitation
Result 3: Duis aute irure dolor in reprehenderit
Result 4: Excepteur sint occaecat cupidatat non proident"""
    
    execution_logs = gr.ChatMessage(
        role="assistant",
        content=long_search_results,
        metadata={
            "title": "📝 Execution Logs",
            "parent_id": parent_id,  # trying to create nesting
            "status": "pending"
        }
    )
    messages.append(execution_logs)
    yield messages
    
    # Setting child status to done first
    execution_logs.metadata["status"] = "done"
    yield messages

    time.sleep(1)
    
    # Then setting parent status to done
    tool_parent.metadata["status"] = "done"
    yield messages

    messages.append(gr.ChatMessage(content="Final answer: 4"))
    yield messages
    

with gr.Blocks(fill_height=True) as demo:
    chatbot = gr.Chatbot(type="messages", scale=1)  # full height to better show nesting
    msg = gr.Textbox()
    msg.submit(stream_messages, msg, chatbot)

demo.launch()
```