### PR TITLE
Allow rendering javascript in `gr.HTML`

### DIFF
--- a/.changeset/thick-groups-take.md
+++ b/.changeset/thick-groups-take.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/html": patch
-"gradio": patch
+"@gradio/html": minor
+"gradio": minor
 ---
 
 fix:Allow rendering javascript in `gr.HTML`

--- a/demo/html_component/run.py
+++ b/demo/html_component/run.py
@@ -1,6 +1,12 @@
 import gradio as gr
 
+value = """
+<script>
+    alert("Hello, world!");
+</script>
+"""
+
 with gr.Blocks() as demo:
-    gr.HTML(value="<p style='margin-top: 1rem, margin-bottom: 1rem'>This <em>example</em> was <strong>written</strong> in <a href='https://en.wikipedia.org/wiki/HTML' _target='blank'>HTML</a> </p>")
+    gr.HTML(value=value, allow_js=False)
 
 demo.launch()

--- a/demo/html_component/run.py
+++ b/demo/html_component/run.py
@@ -7,6 +7,6 @@ value = """
 """
 
 with gr.Blocks() as demo:
-    gr.HTML(value=value, allow_js=False)
+    gr.HTML(value=value, as_iframe=False)
 
 demo.launch()

--- a/demo/html_component/run.py
+++ b/demo/html_component/run.py
@@ -1,12 +1,6 @@
 import gradio as gr
 
-value = """
-<script>
-    alert("Hello, world!");
-</script>
-"""
-
 with gr.Blocks() as demo:
-    gr.HTML(value=value, as_iframe=False)
+    gr.HTML(value="<p style='margin-top: 1rem, margin-bottom: 1rem'>This <em>example</em> was <strong>written</strong> in <a href='https://en.wikipedia.org/wiki/HTML' _target='blank'>HTML</a> </p>")
 
 demo.launch()

--- a/gradio/components/html.py
+++ b/gradio/components/html.py
@@ -42,11 +42,11 @@ class HTML(Component):
         max_height: int | None = None,
         container: bool = False,
         padding: bool = True,
-        allow_js: bool = False,
+        as_iframe: bool = False,
     ):
         """
         Parameters:
-            value: The HTML content to display. Only static HTML is rendered by default. Set allow_js=True to enable JavaScript execution.
+            value: The HTML content to display. Only static HTML is rendered by default. To allow JavaScript execution, set as_iframe=True.
             label: The label for this component. Is used as the header if there are a table of examples for this component. If None and used in a `gr.Interface`, the label will be the name of the parameter this component is assigned to.
             every: Continously calls `value` to recalculate it if `value` is a function (has no effect otherwise). Can provide a Timer whose tick resets `value`, or a float that provides the regular interval for the reset Timer.
             inputs: Components that are used as inputs to calculate `value` if `value` is a function (has no effect otherwise). `value` is recalculated any time the inputs change.
@@ -58,14 +58,14 @@ class HTML(Component):
             key: if assigned, will be used to assume identity across a re-render. Components that have the same key across a re-render will have their value preserved.
             min_height: The minimum height of the component, specified in pixels if a number is passed, or in CSS units if a string is passed. If HTML content exceeds the height, the component will expand to fit the content.
             max_height: The maximum height of the component, specified in pixels if a number is passed, or in CSS units if a string is passed. If content exceeds the height, the component will scroll.
-            container: If True, the HTML component will be displayed in a container. Default is False.
+            container: If True, the HTML component will be displayed in a container.
             padding: If True, the HTML component will have a certain padding (set by the `--block-padding` CSS variable) in all directions. Default is True.
-            allow_js: If True, allows JavaScript within the HTML to be executed. Note that this can be a security risk if the HTML is not trusted.
+            as_iframe: If True, the HTML component will be displayed in an iframe. Note: This allows for JavaScript execution, so it can be a security risk if the HTML is not trusted.
         """
         self.min_height = min_height
         self.max_height = max_height
         self.padding = padding
-        self.allow_js = allow_js
+        self.as_iframe = as_iframe
         super().__init__(
             label=label,
             every=every,

--- a/gradio/components/html.py
+++ b/gradio/components/html.py
@@ -42,10 +42,11 @@ class HTML(Component):
         max_height: int | None = None,
         container: bool = False,
         padding: bool = True,
+        allow_js: bool = False,
     ):
         """
         Parameters:
-            value: The HTML content to display. Only static HTML is rendered (e.g. no JavaScript. To render JavaScript, use the `js` or `head` parameters in the `Blocks` constructor). If a function is provided, the function will be called each time the app loads to set the initial value of this component.
+            value: The HTML content to display. Only static HTML is rendered by default. Set allow_js=True to enable JavaScript execution.
             label: The label for this component. Is used as the header if there are a table of examples for this component. If None and used in a `gr.Interface`, the label will be the name of the parameter this component is assigned to.
             every: Continously calls `value` to recalculate it if `value` is a function (has no effect otherwise). Can provide a Timer whose tick resets `value`, or a float that provides the regular interval for the reset Timer.
             inputs: Components that are used as inputs to calculate `value` if `value` is a function (has no effect otherwise). `value` is recalculated any time the inputs change.
@@ -59,10 +60,12 @@ class HTML(Component):
             max_height: The maximum height of the component, specified in pixels if a number is passed, or in CSS units if a string is passed. If content exceeds the height, the component will scroll.
             container: If True, the HTML component will be displayed in a container. Default is False.
             padding: If True, the HTML component will have a certain padding (set by the `--block-padding` CSS variable) in all directions. Default is True.
+            allow_js: If True, allows JavaScript within the HTML to be executed. Note that this can be a security risk if the HTML is not trusted.
         """
         self.min_height = min_height
         self.max_height = max_height
         self.padding = padding
+        self.allow_js = allow_js
         super().__init__(
             label=label,
             every=every,

--- a/gradio/components/html.py
+++ b/gradio/components/html.py
@@ -46,7 +46,7 @@ class HTML(Component):
     ):
         """
         Parameters:
-            value: The HTML content to display. Only static HTML is rendered by default. To allow JavaScript execution, set as_iframe=True.
+            value: The HTML content to display. Only static HTML is rendered by default. To allow JavaScript execution, set as_iframe=True. If a function is provided, the function will be called each time the app loads to set the initial value of this component.
             label: The label for this component. Is used as the header if there are a table of examples for this component. If None and used in a `gr.Interface`, the label will be the name of the parameter this component is assigned to.
             every: Continously calls `value` to recalculate it if `value` is a function (has no effect otherwise). Can provide a Timer whose tick resets `value`, or a float that provides the regular interval for the reset Timer.
             inputs: Components that are used as inputs to calculate `value` if `value` is a function (has no effect otherwise). `value` is recalculated any time the inputs change.

--- a/gradio/components/html.py
+++ b/gradio/components/html.py
@@ -60,7 +60,7 @@ class HTML(Component):
             max_height: The maximum height of the component, specified in pixels if a number is passed, or in CSS units if a string is passed. If content exceeds the height, the component will scroll.
             container: If True, the HTML component will be displayed in a container.
             padding: If True, the HTML component will have a certain padding (set by the `--block-padding` CSS variable) in all directions. Default is True.
-            as_iframe: If True, the HTML component will be displayed in an iframe. Note: This allows for JavaScript execution, so it can be a security risk if the HTML is not trusted.
+            as_iframe: If True, the HTML component will be displayed in an iframe and not inherit the Gradio page's styles. Note: This also allows for JavaScript execution, so it can be a security risk if the HTML is not trusted.
         """
         self.min_height = min_height
         self.max_height = max_height

--- a/js/html/Index.svelte
+++ b/js/html/Index.svelte
@@ -23,6 +23,7 @@
 	export let max_height: number | undefined = undefined;
 	export let container = false;
 	export let padding = true;
+	export let allow_js = false;
 
 	$: label, gradio.dispatch("change");
 </script>
@@ -52,6 +53,7 @@
 			{value}
 			{elem_classes}
 			{visible}
+			{allow_js}
 			on:change={() => gradio.dispatch("change")}
 			on:click={() => gradio.dispatch("click")}
 		/>

--- a/js/html/Index.svelte
+++ b/js/html/Index.svelte
@@ -23,7 +23,7 @@
 	export let max_height: number | undefined = undefined;
 	export let container = false;
 	export let padding = true;
-	export let allow_js = false;
+	export let as_iframe = false;
 
 	$: label, gradio.dispatch("change");
 </script>
@@ -53,7 +53,7 @@
 			{value}
 			{elem_classes}
 			{visible}
-			{allow_js}
+			{as_iframe}
 			on:change={() => gradio.dispatch("change")}
 			on:click={() => gradio.dispatch("click")}
 		/>

--- a/js/html/shared/HTML.svelte
+++ b/js/html/shared/HTML.svelte
@@ -18,7 +18,7 @@
 	class="prose {elem_classes.join(' ')}"
 	class:hide={!visible}
 	on:click={() => dispatch("click")}
->	
+>
 	{#if as_iframe}
 		<iframe
 			srcdoc={value}

--- a/js/html/shared/HTML.svelte
+++ b/js/html/shared/HTML.svelte
@@ -1,43 +1,25 @@
 <script lang="ts">
-	import { createEventDispatcher, onMount } from "svelte";
+	import { createEventDispatcher } from "svelte";
 
 	export let elem_classes: string[] = [];
 	export let value: string;
 	export let visible = true;
-	export let allow_js = false;
 
 	const dispatch = createEventDispatcher<{
 		change: undefined;
 		click: undefined;
 	}>();
 
-	let container: HTMLElement;
-
-	onMount(() => {
-		if (allow_js && container && value) {
-			const parser = new DOMParser();
-			const doc = parser.parseFromString(value, 'text/html');			
-			container.innerHTML = '';
-			doc.body.childNodes.forEach(node => {
-				const importedNode = document.importNode(node, true);
-				container.appendChild(importedNode);
-			});
-		}
-	});
-
 	$: value, dispatch("change");
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
 <div
-	bind:this={container}
 	class="prose {elem_classes.join(' ')}"
 	class:hide={!visible}
 	on:click={() => dispatch("click")}
 >
-	{#if !allow_js}
-		{@html value}
-	{/if}
+	{@html value}
 </div>
 
 <style>

--- a/js/html/shared/HTML.svelte
+++ b/js/html/shared/HTML.svelte
@@ -1,25 +1,43 @@
 <script lang="ts">
-	import { createEventDispatcher } from "svelte";
+	import { createEventDispatcher, onMount } from "svelte";
 
 	export let elem_classes: string[] = [];
 	export let value: string;
 	export let visible = true;
+	export let allow_js = false;
 
 	const dispatch = createEventDispatcher<{
 		change: undefined;
 		click: undefined;
 	}>();
 
+	let container: HTMLElement;
+
+	onMount(() => {
+		if (allow_js && container && value) {
+			const parser = new DOMParser();
+			const doc = parser.parseFromString(value, 'text/html');			
+			container.innerHTML = '';
+			doc.body.childNodes.forEach(node => {
+				const importedNode = document.importNode(node, true);
+				container.appendChild(importedNode);
+			});
+		}
+	});
+
 	$: value, dispatch("change");
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
 <div
+	bind:this={container}
 	class="prose {elem_classes.join(' ')}"
 	class:hide={!visible}
 	on:click={() => dispatch("click")}
 >
-	{@html value}
+	{#if !allow_js}
+		{@html value}
+	{/if}
 </div>
 
 <style>

--- a/js/html/shared/HTML.svelte
+++ b/js/html/shared/HTML.svelte
@@ -4,7 +4,7 @@
 	export let elem_classes: string[] = [];
 	export let value: string;
 	export let visible = true;
-
+	export let as_iframe = false;
 	const dispatch = createEventDispatcher<{
 		change: undefined;
 		click: undefined;
@@ -18,12 +18,25 @@
 	class="prose {elem_classes.join(' ')}"
 	class:hide={!visible}
 	on:click={() => dispatch("click")}
->
-	{@html value}
+>	
+	{#if as_iframe}
+		<iframe
+			srcdoc={value}
+			sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"
+			title="HTML content"
+		/>
+	{:else}
+		{@html value}
+	{/if}
 </div>
 
 <style>
 	.hide {
 		display: none;
+	}
+	iframe {
+		border: none;
+		width: 100%;
+		height: 100%;
 	}
 </style>

--- a/test/components/test_html.py
+++ b/test/components/test_html.py
@@ -22,6 +22,7 @@ class TestHTML:
             "max_height": None,
             "container": False,
             "padding": True,
+            "as_iframe": False,
         }
 
     def test_in_interface(self):


### PR DESCRIPTION
[We frequently get](https://github.com/gradio-app/gradio/issues/8626) [issues from users who want to dump HTML + JS ](https://github.com/gradio-app/gradio/issues/10429)into a gr.HTML component as a bypass (e.g. to display graphs using a custom js library) only to find that the HTML does not display as expected. That's because we strip out the JS and we tell people to instead use the js tags in Blocks to include the relevant js. But this requires manual parsing on the user's part. [As discussed internally](https://huggingface.slack.com/archives/C02SPHC1KD1/p1737765591525449), it would make gradio more hackable if we could support this pattern

Closes: https://github.com/gradio-app/gradio/issues/10429