### PR TITLE
Fix error with website build in chatbot.svx 

### DIFF
--- a/.changeset/shiny-walls-hear.md
+++ b/.changeset/shiny-walls-hear.md
@@ -1,0 +1,5 @@
+---
+"website": minor
+---
+
+feat:Fix error with website build in chatbot.svx 

--- a/js/_website/src/lib/templates/gradio/03_components/chatbot.svx
+++ b/js/_website/src/lib/templates/gradio/03_components/chatbot.svx
@@ -57,7 +57,7 @@
         {
             "name": "status",
             "annotation": "Literal['pending', 'done']",
-            "doc": "The status of the message. If "pending", a spinner icon appears next to the thought title. If "done", the thought accordion becomes closed. If not provided, the thought accordion is open and no spinner is displayed."
+            "doc": "The status of the message. If 'pending', a spinner icon appears next to the thought title. If 'done', the thought accordion becomes closed. If not provided, the thought accordion is open and no spinner is displayed."
         }
     ]
 


### PR DESCRIPTION
Tiny syntax error that somehow slipped and is currently blocking the website builds. 

Since it's so simple I just went ahead and also updated the s3 templates so versioned docs can be fixed too. 