### PR TITLE
Set plotly version as 5 for the outbreak_forecast demo

### DIFF
--- a/demo/outbreak_forecast/requirements.txt
+++ b/demo/outbreak_forecast/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 matplotlib
 bokeh
-plotly
+plotly==5.*
 altair


### PR DESCRIPTION
The following error occurred in Lite.
This is because plotly==6.0.0 was released and it depends on `narwhals>=1.15.0` (https://github.com/plotly/plotly.py/blob/v6.0.0/packages/python/plotly/recipe/meta.yaml#L28) but Pyodide only provides `narwhals==1.10.0` (https://pyodide.org/en/stable/usage/packages-in-pyodide.html),
and micropip doesn't resolve the plotly version as 5 even with this dependency version mismatch.

This PR proves that installing plotly v5 solves the error.

```
webworker.js:368 Python error: Traceback (most recent call last):
  File "/lib/python3.12/site-packages/gradio/queueing.py", line 625, in process_events
    response = await route_utils.call_process_api(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/gradio/route_utils.py", line 322, in call_process_api
    output = await app.get_blocks().process_api(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/gradio/blocks.py", line 2044, in process_api
    result = await self.call_function(
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/gradio/blocks.py", line 1591, in call_function
    prediction = await anyio.to_thread.run_sync(  # type: ignore
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<exec>", line 3, in mocked_anyio_to_thread_run_sync
  File "/lib/python3.12/site-packages/gradio/utils.py", line 883, in wrapper
    response = f(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^
  File "app.py", line 33, in outbreak
    fig = px.line(df, x="day", y=countries)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/plotly/express/_chart_types.py", line 270, in line
    return make_figure(args=locals(), constructor=go.Scatter)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/plotly/express/_core.py", line 2477, in make_figure
    args = build_dataframe(args, constructor)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/plotly/express/_core.py", line 1727, in build_dataframe
    df_output, wide_id_vars = process_args_into_dataframe(
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/plotly/express/_core.py", line 1343, in process_args_into_dataframe
    df_output[col_name] = to_named_series(
                          ^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/plotly/express/_core.py", line 1175, in to_named_series
    x = nw.from_native(x, series_only=True, pass_through=True)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: from_native() got an unexpected keyword argument 'pass_through'
```