### PR TITLE
Fix the wrapper function of micropip.install to throw the original error for better debug experience

### DIFF
--- a/.changeset/curly-rules-change.md
+++ b/.changeset/curly-rules-change.md
@@ -1,0 +1,6 @@
+---
+"@gradio/wasm": minor
+"gradio": minor
+---
+
+feat:Fix the wrapper function of micropip.install to throw the original error for better debug experience

--- a/.changeset/curly-rules-change.md
+++ b/.changeset/curly-rules-change.md
@@ -1,7 +1,7 @@
 ---
-"@gradio/lite": minor
-"@gradio/wasm": minor
-"gradio": minor
+"@gradio/lite": patch
+"@gradio/wasm": patch
+"gradio": patch
 ---
 
-feat:Fix the wrapper function of micropip.install to throw the original error for better debug experience
+fix:Fix the wrapper function of micropip.install to throw the original error for better debug experience

--- a/.changeset/curly-rules-change.md
+++ b/.changeset/curly-rules-change.md
@@ -1,4 +1,5 @@
 ---
+"@gradio/lite": minor
 "@gradio/wasm": minor
 "gradio": minor
 ---

--- a/js/lite/src/dev/App.svelte
+++ b/js/lite/src/dev/App.svelte
@@ -53,8 +53,8 @@ def hi(name):
 	function parse_requirements(text: string): string[] {
 		return text
 			.split("\n")
-			.map((line) => line.trim())
-			.filter((line) => line.length > 0 && !line.startsWith("#"));
+			.map((line) => line.split("#")[0].trim())
+			.filter((line) => line.length > 0);
 	}
 
 	const requirements = parse_requirements(requirements_txt);

--- a/js/wasm/src/webworker/index.ts
+++ b/js/wasm/src/webworker/index.ts
@@ -55,22 +55,29 @@ let run_script: (
 ) => Promise<void>;
 let unload_local_modules: (target_dir_path?: string) => void;
 
-function installPackages(requirements: string[], retries = 3): Promise<void> {
+async function installPackages(
+	requirements: string[],
+	retries = 3
+): Promise<void> {
 	// A wrapper function to install packages with retries and requirement patching.
 	// Ref: https://github.com/pyodide/micropip/issues/170#issuecomment-2558887851
 	// Background: https://discord.com/channels/879548962464493619/1318487777779646504/1319516137725231124
-	if (retries <= 0) {
-		throw new Error("Failed to install packages.");
-	}
 
 	const patchedRequirements = patchRequirements(pyodide, requirements);
 
-	return micropip.install
-		.callKwargs(patchedRequirements, { keep_going: true })
-		.catch((error) => {
+	for (let i = 0; i < retries; i++) {
+		const isLastTry = i === retries - 1;
+		try {
+			return micropip.install.callKwargs(patchedRequirements, {
+				keep_going: true
+			});
+		} catch (error) {
+			if (isLastTry) {
+				throw error;
+			}
 			console.error("Failed to install packages. Retrying...", error);
-			return installPackages(requirements, retries - 1);
-		});
+		}
+	}
 }
 
 async function initializeEnvironment(


### PR DESCRIPTION
## Description 

Now `installPackages()` (introduced by #10366) hides the error thrown from `micropip.install()` and it makes debugging less easy.

![CleanShot 2025-01-30 at 17 20 28@2x](https://github.com/user-attachments/assets/9a6ef27f-0755-43b0-80f1-9b04c34f42cd)

This PR fixes it so the original error is properly shown:

![CleanShot 2025-01-30 at 17 21 15@2x](https://github.com/user-attachments/assets/be24d74b-8e99-42f2-b354-00aed26f4071)
