### PR TITLE
Add sidebar to the docs 

### DIFF
--- a/.changeset/four-buttons-say.md
+++ b/.changeset/four-buttons-say.md
@@ -1,0 +1,6 @@
+---
+"gradio": minor
+"website": minor
+---
+
+feat:Add sidebar to the docs 

--- a/gradio/layouts/sidebar.py
+++ b/gradio/layouts/sidebar.py
@@ -16,6 +16,7 @@ class Sidebar(BlockContext, metaclass=ComponentMeta):
             with gr.Sidebar():
                 gr.Textbox()
                 gr.Button()
+    Guides: controlling-layout
     """
 
     EVENTS = [Events.expand, Events.collapse]

--- a/guides/03_building-with-blocks/02_controlling-layout.md
+++ b/guides/03_building-with-blocks/02_controlling-layout.md
@@ -100,7 +100,7 @@ For example:
 $code_blocks_sidebar
 $demo_blocks_sidebar
 
-Learn more about [Sidebar](https://gradio.app/docs/sidebar) in the docs.
+Learn more about [Sidebar](https://gradio.app/docs/gradio/sidebar) in the docs.
 
 ## Visibility
 

--- a/js/_website/src/lib/templates/gradio/03_components/sidebar.svx
+++ b/js/_website/src/lib/templates/gradio/03_components/sidebar.svx
@@ -1,0 +1,59 @@
+<script lang="ts">
+    import {get_object} from "../../process_json.ts";
+    import ParamTable from "$lib/components/ParamTable.svelte";
+    import ShortcutTable from "$lib/components/ShortcutTable.svelte";
+    import DemosSection from "$lib/components/DemosSection.svelte";
+    import FunctionsSection from "$lib/components/FunctionsSection.svelte";
+    import GuidesSection from "$lib/components/GuidesSection.svelte";
+    import CopyButton from "$lib/components/CopyButton.svelte";
+    import { style_formatted_text } from "$lib/text";
+
+    let obj = get_object("sidebar");
+</script>
+
+<!--- Title -->
+# {obj.name}
+
+<!--- Usage -->
+```python
+gradio.Sidebar(···)
+```
+
+<!--- Description -->
+### Description
+## {@html style_formatted_text(obj.description)}
+
+<!-- Example Usage --> 
+
+{#if obj.example}
+### Example Usage
+```python
+with gr.Blocks() as demo:
+    with gr.Sidebar():
+        gr.Textbox()
+        gr.Button()
+```
+{/if}
+
+<!--- Initialization -->
+### Initialization
+<ParamTable parameters={obj.parameters} />
+
+
+{#if obj.demos && obj.demos.length > 0}
+<!--- Demos -->
+### Demos 
+<DemosSection demos={obj.demos} />
+{/if}
+
+{#if obj.fns && obj.fns.length > 0}
+<!--- Methods -->
+### Methods 
+<FunctionsSection fns={obj.fns} event_listeners={false} />
+{/if}
+
+{#if obj.guides && obj.guides.length > 0}
+<!--- Guides -->
+### Guides
+<GuidesSection guides={obj.guides}/>
+{/if}


### PR DESCRIPTION
We forgot to create a template for sidebar when we added the component, so that's what this PR does. Also adds the guide to the docstring and fixes the link in that guide. 

I'll manually update the docs on s3 for 5.14.0 so it works there too. 