### PR TITLE
Workaround for Lite to work with multipage client API

### DIFF
--- a/.changeset/green-heads-tan.md
+++ b/.changeset/green-heads-tan.md
@@ -1,5 +1,5 @@
 ---
-"@gradio/lite": minor
+"@gradio/lite": patch
 ---
 
 feat:Workaround for Lite to work with multipage client API

--- a/.changeset/green-heads-tan.md
+++ b/.changeset/green-heads-tan.md
@@ -1,0 +1,5 @@
+---
+"@gradio/lite": minor
+---
+
+feat:Workaround for Lite to work with multipage client API

--- a/js/lite/src/LiteIndex.svelte
+++ b/js/lite/src/LiteIndex.svelte
@@ -11,7 +11,7 @@
 	import type { ThemeMode } from "@gradio/core";
 	import { WorkerProxy, type WorkerProxyOptions } from "@gradio/wasm";
 	import { FAKE_LITE_HOST } from "@gradio/wasm/network";
-	import { Client } from "@gradio/client";
+	import { Client, type Config } from "@gradio/client";
 	import { wasm_proxied_fetch } from "./fetch";
 	import { wasm_proxied_stream_factory } from "./sse";
 	import { wasm_proxied_mount_css, mount_prebuilt_css } from "./css";
@@ -135,6 +135,13 @@
 
 		stream(url: URL): EventSource {
 			return wasm_proxied_stream_factory(worker_proxy, url);
+		}
+
+		get_url_config(url: string | null = null): Config {
+			// A workaround for Lite to work with the multipage Client API.
+			// TODO: Support multiple pages on Lite
+			const page = "";
+			return this.get_page_config(page);
 		}
 	}
 


### PR DESCRIPTION
## Description

There is as error on Lite as below now, due to the new client implementation to support multipage apps.
```
client.ts:87 Uncaught (in promise) Error: Page lite.html not found
    at LiteClient.get_page_config (client.ts:87:10)
    at LiteClient.get_url_config (client.ts:79:15)
    at Index.svelte:315:16
```

This PR is a workaround for Lite just to avoid the error, not to support MPA on Lite as well.