### PR TITLE
Fix minor typo in chatbot guide

### DIFF
--- a/guides/05_chatbots/02_chatinterface-examples.md
+++ b/guides/05_chatbots/02_chatinterface-examples.md
@@ -53,7 +53,7 @@ Tip: For quick prototyping, the  <a href='https://github.com/gradio-app/sambanov
 
 ## Hyperbolic
 
-The Hyperbolic AI API provides access to many open-source models, such as the Llama family. Here's an example of how to build a Gradio app around the SambaNova API
+The Hyperbolic AI API provides access to many open-source models, such as the Llama family. Here's an example of how to build a Gradio app around the Hyperbolic
 
 $code_llm_hyperbolic
 


### PR DESCRIPTION
## Description

In Chatbot guide "Using Popular LLM libraries and APIs", there is a typo in the Hyperbolic section where "SambaNova API" is used instead of "Hyperbolic"

(This fix is very small)