### PR TITLE
Fixed wrong example usage of docs/gradio/selectdata

### DIFF
--- a/.changeset/mighty-pandas-invite.md
+++ b/.changeset/mighty-pandas-invite.md
@@ -1,0 +1,5 @@
+---
+"website": patch
+---
+
+fix:Fixed wrong example usage of docs/gradio/selectdata

--- a/js/_website/src/lib/templates/gradio/04_helpers/05_selectdata.svx
+++ b/js/_website/src/lib/templates/gradio/04_helpers/05_selectdata.svx
@@ -61,9 +61,9 @@ with gr.Blocks() as demo:
     def on_select(evt: gr.SelectData):
         return f"You selected {evt.value} at {evt.index} from {evt.target}"
 
-    table.select(on_select, table, statement)
-    gallery.select(on_select, gallery, statement)
-    textbox.select(on_select, textbox, statement)
+    table.select(on_select, None, statement)
+    gallery.select(on_select, None, statement)
+    textbox.select(on_select, None, statement)
 
 demo.launch()
 ```


### PR DESCRIPTION
## Description

Correct the **Example Usage** of **gradio.SelectData**, replaced the second arguments of `table.select`... to `None`

Closes: https://github.com/gradio-app/gradio/issues/10509

## Test of the new **Example Usage**
Now it works well.
![image](https://github.com/user-attachments/assets/f085a053-9aea-4574-bbc6-febe484c5cca)
