### PR TITLE
Plotly 6.0 Fix: Install latest plotly js version

### DIFF
--- a/.changeset/rare-donuts-draw.md
+++ b/.changeset/rare-donuts-draw.md
@@ -1,0 +1,6 @@
+---
+"@gradio/plot": patch
+"gradio": patch
+---
+
+fix:Plotly 6.0 Fix: Install latest plotly js version

--- a/js/plot/package.json
+++ b/js/plot/package.json
@@ -13,7 +13,7 @@
 		"@gradio/theme": "workspace:^",
 		"@gradio/utils": "workspace:^",
 		"@rollup/plugin-json": "^6.0.0",
-		"plotly.js-dist-min": "^2.10.1",
+		"plotly.js-dist-min": "^3.0.0",
 		"vega": "^5.23.0",
 		"vega-embed": "^6.25.0",
 		"vega-lite": "^5.12.0"

--- a/js/plot/shared/plot_types/PlotlyPlot.svelte
+++ b/js/plot/shared/plot_types/PlotlyPlot.svelte
@@ -29,6 +29,8 @@
 
 		let plotObj = JSON.parse(plot);
 
+		console.log("plotObj", plotObj);
+
 		// the docs aren't very good but this works
 		plotObj.config = plotObj.config || {};
 		plotObj.config.responsive = true;

--- a/js/plot/shared/plot_types/PlotlyPlot.svelte
+++ b/js/plot/shared/plot_types/PlotlyPlot.svelte
@@ -29,8 +29,6 @@
 
 		let plotObj = JSON.parse(plot);
 
-		console.log("plotObj", plotObj);
-
 		// the docs aren't very good but this works
 		plotObj.config = plotObj.config || {};
 		plotObj.config.responsive = true;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1954,8 +1954,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(rollup@3.28.0)
       plotly.js-dist-min:
-        specifier: ^2.10.1
-        version: 2.10.1
+        specifier: ^3.0.0
+        version: 3.0.0
       svelte:
         specifier: ^4.0.0
         version: 4.2.15
@@ -5939,6 +5939,7 @@ packages:
   eslint@8.4.1:
     resolution: {integrity: sha512-TxU/p7LB1KxQ6+7aztTnO7K0i+h0tDi81YRY9VzB6Id71kNz+fFYnf5HD5UOQmxkzcoa0TlVZf9dpMtUv0GpWg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   eslint@9.1.1:
@@ -7542,11 +7543,11 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  plotly.js-dist-min@2.10.1:
-    resolution: {integrity: sha512-H0ls1C2uu2U+qWw76djo4/zOGtUKfMILwFhu7tCOaG/wH5ypujrYGCH03N9SQVf1SXcctTfW57USf8LmagSiPQ==}
-
   plotly.js-dist-min@2.32.0:
     resolution: {integrity: sha512-UVznwUQVc7NeFih0tnIbvCpxct+Jxt6yxOGTYJF4vkKIUyujvyiTrH+XazglvcXdybFLERMu/IKt6Lhz3+BqMQ==}
+
+  plotly.js-dist-min@3.0.0:
+    resolution: {integrity: sha512-AlU1XkNRzwUI55A+kJYj0xJETp3h7aeFe4O1cmhzOryscYdw9jOywXZo+7Zy+y2kEKq12CnTzII4jV7Vgpy4xQ==}
 
   polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
@@ -14652,9 +14653,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  plotly.js-dist-min@2.10.1: {}
-
   plotly.js-dist-min@2.32.0: {}
+
+  plotly.js-dist-min@3.0.0: {}
 
   polished@4.3.1:
     dependencies:


### PR DESCRIPTION
## Description

Closes: #10475

The latest js lib is compatible with versions 5 and 6.

Test: https://huggingface.co/spaces/freddyaboulton/plotly-6.0 & https://huggingface.co/spaces/freddyaboulton/plotly-5.0

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
