### PR TITLE
quick_fix_client

### DIFF
--- a/.changeset/olive-pants-judge.md
+++ b/.changeset/olive-pants-judge.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/client": minor
-"gradio": minor
+"@gradio/client": patch
+"gradio": patch
 ---
 
-feat:quick_fix_client
+fix:quick_fix_client

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -75,7 +75,12 @@ export class Client {
 		const stripSlashes = (str: string): string => str.replace(/^\/+|\/+$/g, "");
 		let root_path = stripSlashes(new URL(this.config.root).pathname);
 		let url_path = stripSlashes(new URL(url).pathname);
-		let page = stripSlashes(url_path.substring(root_path.length));
+		let page: string;
+		if (!url_path.startsWith(root_path)) {
+			page = "";
+		} else {
+			page = stripSlashes(url_path.substring(root_path.length));
+		}
 		return this.get_page_config(page);
 	}
 	get_page_config(page: string): Config {

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -84,7 +84,7 @@ export class Client {
 		}
 		let config = this.config;
 		if (!(page in config.page)) {
-			throw new Error(`Page ${page} not found`);
+			page = "";
 		}
 		return {
 			...config,

--- a/gradio/layouts/tabs.py
+++ b/gradio/layouts/tabs.py
@@ -67,7 +67,7 @@ class Tab(BlockContext, metaclass=ComponentMeta):
         id: int | str | None = None,
         elem_id: str | None = None,
         elem_classes: list[str] | str | None = None,
-        scale: int | None = None,
+        scale: int = 0,
         render: bool = True,
     ):
         """


### PR DESCRIPTION
Quick fix for the client when can't find a page to default to the main page. Was hitting issues due to how how I'm using the url to get the path for a page, which is incorrect. I just use the pathname from the URL, remove the config.root path if its mounted on a subpath, and assume that's the final pathname. This doesn't work when embedded because for example on "http://gradio.app/guides/quickstart" it sees the pathname "guides/quickstart" from the URL and there is no page in the gradio app called "guides/quickstart", since its an embedded an HF space . The quick fix is to return the main page (whose route is "") when it can't find the "expected" page for a path.
