### PR TITLE
Add show_line_numbers option to gr.Code component

### DIFF
--- a/gradio/components/code.py
+++ b/gradio/components/code.py
@@ -108,6 +108,7 @@ class Code(Component):
         render: bool = True,
         key: int | str | None = None,
         wrap_lines: bool = False,
+        show_line_numbers: bool = True,
     ):
         """
         Parameters:
@@ -129,6 +130,7 @@ class Code(Component):
             lines: Minimum number of visible lines to show in the code editor.
             max_lines: Maximum number of visible lines to show in the code editor. Defaults to None and will fill the height of the container.
             wrap_lines: If True, will wrap lines to the width of the container when overflow occurs. Defaults to False.
+            show_line_numbers: If True, will display line numbers in the code editor. Defaults to True.
         """
         if language not in Code.languages:
             raise ValueError(f"Language {language} not supported.")
@@ -137,6 +139,7 @@ class Code(Component):
         self.lines = lines
         self.max_lines = max(lines, max_lines) if max_lines is not None else None
         self.wrap_lines = wrap_lines
+        self.show_line_numbers = show_line_numbers
         super().__init__(
             label=label,
             every=every,

--- a/js/code/Index.svelte
+++ b/js/code/Index.svelte
@@ -39,6 +39,7 @@
 	export let scale: number | null = null;
 	export let min_width: number | undefined = undefined;
 	export let wrap_lines = false;
+	export let show_line_numbers = true;
 
 	export let interactive: boolean;
 
@@ -91,6 +92,7 @@
 			{max_lines}
 			{dark_mode}
 			{wrap_lines}
+			{show_line_numbers}
 			readonly={!interactive}
 			on:blur={() => gradio.dispatch("blur")}
 			on:focus={() => gradio.dispatch("focus")}

--- a/js/code/shared/Code.svelte
+++ b/js/code/shared/Code.svelte
@@ -4,7 +4,8 @@
 		EditorView,
 		ViewUpdate,
 		keymap,
-		placeholder as placeholderExt
+		placeholder as placeholderExt,
+		lineNumbers
 	} from "@codemirror/view";
 	import { StateEffect, EditorState, type Extension } from "@codemirror/state";
 	import { indentWithTab } from "@codemirror/commands";
@@ -26,6 +27,7 @@
 	export let readonly = false;
 	export let placeholder: string | HTMLElement | null | undefined = undefined;
 	export let wrap_lines = false;
+	export let show_line_numbers = true;
 
 	const dispatch = createEventDispatcher<{
 		change: string;
@@ -131,7 +133,8 @@
 				use_tab,
 				placeholder,
 				readonly,
-				lang_extension
+				lang_extension,
+				show_line_numbers
 			),
 			FontTheme,
 			...get_theme(),
@@ -184,7 +187,8 @@
 		use_tab: boolean,
 		placeholder: string | HTMLElement | null | undefined,
 		readonly: boolean,
-		lang: Extension | null | undefined
+		lang: Extension | null | undefined,
+		show_line_numbers: boolean
 	): Extension[] {
 		const extensions: Extension[] = [
 			EditorView.editable.of(!readonly),
@@ -203,6 +207,9 @@
 		}
 		if (lang) {
 			extensions.push(lang);
+		}
+		if (show_line_numbers) {
+			extensions.push(lineNumbers());
 		}
 
 		extensions.push(EditorView.updateListener.of(handle_change));

--- a/js/code/shared/extensions.ts
+++ b/js/code/shared/extensions.ts
@@ -25,7 +25,6 @@ import {
 import { lintKeymap } from "@codemirror/lint";
 
 export const basicSetup: Extension = /*@__PURE__*/ ((): Extension[] => [
-	lineNumbers(),
 	highlightSpecialChars(),
 	history(),
 	foldGutter(),


### PR DESCRIPTION
Add an option to remove line numbers in `gradio.Code`.