### PR TITLE
Fix `Blocks.serve_static_file` and `Button.svelte` to work on Lite

### DIFF
--- a/.changeset/six-suits-fail.md
+++ b/.changeset/six-suits-fail.md
@@ -1,0 +1,6 @@
+---
+"@gradio/button": minor
+"gradio": minor
+---
+
+feat:Fix `Blocks.serve_static_file` and `Button.svelte` to work on Lite

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -389,9 +389,7 @@ class Block:
         else:
             data = {"path": url_or_file_path, "meta": {"_type": "gradio.FileData"}}
             try:
-                return client_utils.synchronize_async(
-                    processing_utils.async_move_files_to_cache, data, self
-                )
+                return processing_utils.move_files_to_cache(data, self)
             except AttributeError:  # Can be raised if this function is called before the Block is fully initialized.
                 return data
 

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -475,6 +475,14 @@ def move_files_to_cache(
         keep_in_cache: If True, the file will not be deleted from cache when the server is shut down.
     """
 
+    def _mark_svg_as_safe(payload: FileData):
+        # If the app has not launched, this path can be considered an "allowed path"
+        # This is mainly so that svg files can be displayed inline for button/chatbot icons
+        if (
+            (blocks := LocalContext.blocks.get()) is None or not blocks.is_running
+        ) and (mimetypes.guess_type(payload.path)[0] == "image/svg+xml"):
+            utils.set_static_paths([payload.path])
+
     def _move_to_cache(d: dict):
         payload = FileData(**d)
         # If the gradio app developer is returning a URL from
@@ -510,7 +518,7 @@ def move_files_to_cache(
         else:
             url = f"{url_prefix}{payload.path}"
         payload.url = url
-
+        _mark_svg_as_safe(payload)
         return payload.model_dump()
 
     if isinstance(data, (GradioRootModel, GradioModel)):

--- a/js/button/package.json
+++ b/js/button/package.json
@@ -8,6 +8,7 @@
 	"private": false,
 	"dependencies": {
 		"@gradio/client": "workspace:^",
+		"@gradio/image": "workspace:^",
 		"@gradio/upload": "workspace:^",
 		"@gradio/utils": "workspace:^"
 	},

--- a/js/button/shared/Button.svelte
+++ b/js/button/shared/Button.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { type FileData } from "@gradio/client";
+	import { Image } from "@gradio/image/shared";
 
 	export let elem_id = "";
 	export let elem_classes: string[] = [];
@@ -32,7 +33,7 @@
 		id={elem_id}
 	>
 		{#if icon}
-			<img class="button-icon" src={icon.url} alt={`${value} icon`} />
+			<Image class="button-icon" src={icon.url} alt={`${value} icon`} />
 		{/if}
 		<slot />
 	</a>
@@ -50,9 +51,8 @@
 		{disabled}
 	>
 		{#if icon}
-			<img
-				class="button-icon"
-				class:right-padded={value}
+			<Image
+				class={`button-icon ${value ? "right-padded" : ""}`}
 				src={icon.url}
 				alt={`${value} icon`}
 			/>
@@ -188,11 +188,11 @@
 		font-size: var(--button-large-text-size);
 	}
 
-	.button-icon {
+	:global(.button-icon) {
 		width: var(--text-xl);
 		height: var(--text-xl);
 	}
-	.button-icon.right-padded {
+	:global(.button-icon.right-padded) {
 		margin-right: var(--spacing-md);
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -753,6 +753,9 @@ importers:
       '@gradio/client':
         specifier: workspace:^
         version: link:../../client/js
+      '@gradio/image':
+        specifier: workspace:^
+        version: link:../image
       '@gradio/upload':
         specifier: workspace:^
         version: link:../upload


### PR DESCRIPTION
## Description

This PR fixes the following error on Lite.

The direct reason of it was that `Button(icon=...)` was added to `ChatInterface` in #10191 and the icon option [calls](https://github.com/gradio-app/gradio/blame/1299267a8a78546d3f9e13d6b3c58231cf88f2b9/gradio/components/button.py#L76) `Blocks.serve_static_file()` which doesn't work on Lite.

This PR modifies `Blocks.serve_static_file()` to use the sync version of `move_files_to_cache()` because `Blocks.serve_static_file()` itself is synchronous. The sync version works on Lite.

In addition, I fixed the `Button` component to show the icon image on Lite properly.

#### Error

```python
import time
import gradio as gr

demo = gr.ChatInterface(
    lambda x,y:x,
    type="messages",
    flagging_mode="manual",
    flagging_options=["Like", "Spam", "Inappropriate", "Other"],
    save_history=True,
)

if __name__ == "__main__":
    demo.launch()
```

```
PythonError: Traceback (most recent call last):
  File "<exec>", line 149, in _run_code
  File "<string>", line 5, in <module>
  File "/lib/python3.12/site-packages/gradio/chat_interface.py", line 264, in __init__
    self._render_history_area()
  File "/lib/python3.12/site-packages/gradio/chat_interface.py", line 286, in _render_history_area
    self.new_chat_button = Button(
                           ^^^^^^^
  File "/lib/python3.12/site-packages/gradio/component_meta.py", line 181, in wrapper
    return fn(self, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/gradio/components/button.py", line 76, in __init__
    self.icon = self.serve_static_file(icon)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/gradio/blocks.py", line 392, in serve_static_file
    return client_utils.synchronize_async(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/gradio_client/utils.py", line 890, in synchronize_async
    return fsspec.asyn.sync(fsspec.asyn.get_loop(), func, *args, **kwargs)  # type: ignore
                            ^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/fsspec/asyn.py", line 149, in get_loop
    th.start()
  File "/lib/python312.zip/threading.py", line 994, in start
    _start_new_thread(self._bootstrap, ())
RuntimeError: can't start new thread
```