### PR TITLE
Fix subroutine in Windows batch scripts

### DIFF
--- a/scripts/build_frontend.bat
+++ b/scripts/build_frontend.bat
@@ -4,11 +4,8 @@ setlocal EnableDelayedExpansion
 :: Change to parent directory of script location
 cd /d "%~dp0.."
 
-:: Source the helpers script
-call scripts\helpers.bat
-
 :: Check for pnpm
-call :pnpm_required
+call scripts\helpers.bat pnpm_required
 
 :: Generate theme using Python script
 python scripts\generate_theme.py

--- a/scripts/build_lite.bat
+++ b/scripts/build_lite.bat
@@ -4,11 +4,8 @@ setlocal EnableDelayedExpansion
 :: Change to parent directory of script location
 cd /d "%~dp0.."
 
-:: Source the helpers script
-call scripts\helpers.bat
-
 :: Check for pnpm
-call :pnpm_required
+call scripts\helpers.bat pnpm_required
 
 :: Generate theme using Python script
 python scripts\generate_theme.py

--- a/scripts/create_test_requirements.bat
+++ b/scripts/create_test_requirements.bat
@@ -4,11 +4,8 @@ setlocal EnableDelayedExpansion
 :: Change to parent directory of script location
 cd /d "%~dp0.."
 
-:: Source the helpers script
-call scripts\helpers.bat
-
 :: Check for pip
-call :pip_required
+call scripts\helpers.bat pip_required
 
 echo Creating test requirements...
 echo To match the CI environment, this script should be run from a Unix-like system in Python 3.9.

--- a/scripts/format_frontend.bat
+++ b/scripts/format_frontend.bat
@@ -4,11 +4,8 @@ setlocal EnableDelayedExpansion
 :: Change to parent directory of script location
 cd /d "%~dp0.."
 
-:: Source the helpers script
-call scripts\helpers.bat
-
 :: Check for pnpm
-call :pnpm_required
+call scripts\helpers.bat pnpm_required
 
 echo Formatting the frontend... Also we'll do type checking with TypeScript.
 pnpm i

--- a/scripts/helpers.bat
+++ b/scripts/helpers.bat
@@ -1,6 +1,12 @@
 @echo off
 setlocal EnableDelayedExpansion
 
+:: A collection of helper functions to check for required programs.
+:: Helper functions can be called using `call scripts\helpers.bat function_name`.
+
+:: Jump to MAIN to avoid running subroutines by default
+goto :MAIN
+
 :: Tell the user what programs to install for a specific task.
 :: Arguments:
 ::   %1 - Name of the program or actual command, a string.
@@ -52,3 +58,10 @@ exit /b %ERRORLEVEL%
 :foo_required
 call :program_required "foo" "https://jqlang.github.io/jq/"
 exit /b %ERRORLEVEL%
+
+:MAIN
+:: Handle command-line arguments to call specific subroutines
+if not "%~1"=="" (
+    call :%~1
+    exit /b %ERRORLEVEL%
+)

--- a/scripts/install_gradio.bat
+++ b/scripts/install_gradio.bat
@@ -4,11 +4,8 @@ setlocal EnableDelayedExpansion
 :: Change to parent directory of script location
 cd /d "%~dp0.."
 
-:: Source the helpers script
-call scripts\helpers.bat
-
 :: Check for pip
-call :pip_required
+call scripts\helpers.bat pip_required
 
 echo Installing Gradio...
 pip install -e .

--- a/scripts/install_test_requirements.bat
+++ b/scripts/install_test_requirements.bat
@@ -4,11 +4,8 @@ setlocal EnableDelayedExpansion
 :: Change to parent directory of script location
 cd /d "%~dp0.."
 
-:: Source the helpers script
-call scripts\helpers.bat
-
 :: Check for pip
-call :pip_required
+call scripts\helpers.bat pip_required
 
 echo Installing requirements before running tests...
 pip install --upgrade pip

--- a/scripts/launch_website.bat
+++ b/scripts/launch_website.bat
@@ -4,11 +4,8 @@ setlocal EnableDelayedExpansion
 :: Change to parent directory of script location
 cd /d "%~dp0.."
 
-:: Source the helpers script
-call scripts\helpers.bat
-
 :: Check for pnpm
-call :pnpm_required
+call scripts\helpers.bat pnpm_required
 
 echo Building the website...
 cd js/_website

--- a/scripts/run_frontend.bat
+++ b/scripts/run_frontend.bat
@@ -4,11 +4,8 @@ setlocal EnableDelayedExpansion
 :: Change to parent directory of script location
 cd /d "%~dp0.."
 
-:: Source the helpers script
-call scripts\helpers.bat
-
 :: Check for pnpm
-call :pnpm_required
+call scripts\helpers.bat pnpm_required
 
 echo Running the frontend...
 pnpm i

--- a/scripts/run_lite.bat
+++ b/scripts/run_lite.bat
@@ -6,12 +6,9 @@ set "SCRIPT_DIR=%~dp0"
 set "ROOTDIR=%SCRIPT_DIR%.."
 cd /d "%ROOTDIR%"
 
-:: Source helpers (assuming helpers.bat exists)
-call scripts\helpers.bat
-
-:: Check requirements (assuming these functions exist in helpers.bat)
-call :pnpm_required
-call :jq_required
+:: Check requirements: pnpm and jq
+call scripts\helpers.bat pnpm_required
+call scripts\helpers.bat jq_required
 
 :: Get versions using jq
 for /f "tokens=* usebackq" %%a in (`jq -r .version gradio/package.json`) do (

--- a/scripts/type_check_backend.bat
+++ b/scripts/type_check_backend.bat
@@ -4,11 +4,8 @@ setlocal
 :: Change to parent directory of script location
 cd /d "%~dp0.."
 
-:: Source helpers
-call scripts\helpers.bat
-
 :: Check pip requirement
-call :pip_required
+call scripts\helpers.bat pip_required
 
 echo Adding py.typed file to gradio.
 type nul > gradio\py.typed


### PR DESCRIPTION
Scripts fail to run on Windows because Batch does not allow calling subroutines from another script.

To get around this, `scripts/helpers.bat` needs to accept a parameter and run the corresponding subroutine.

To fix this:
I replaced subroutine calls in batch scripts from:
```
call scripts/helpers.bat
cal :[SUBROUTINE_NAME]
```
to
```
call scripts/helpers.bat [SUBROUTINE_NAME]
```

I added logic to call the corresponding subroutine in 'helpers.bat'

Closes: #10609

