### PR TITLE
Fix fill_width

### DIFF
--- a/.changeset/salty-toes-kneel.md
+++ b/.changeset/salty-toes-kneel.md
@@ -1,0 +1,6 @@
+---
+"@gradio/core": patch
+"gradio": patch
+---
+
+fix:Fix fill_width

--- a/js/core/src/Embed.svelte
+++ b/js/core/src/Embed.svelte
@@ -40,7 +40,7 @@
 			</nav>
 		</div>
 	{/if}
-	<main class="fillable" class:app={!display && !is_embed}>
+	<main class="fillable" class:fill_width class:app={!display && !is_embed}>
 		<slot />
 		<div>
 			{#if display && space && info}


### PR DESCRIPTION
Got broken. Fixes: #10602

Test with:
```python
import gradio as gr

demo = gr.Interface(
    fn=None,
    inputs=["textbox"],
    outputs=None,
    fill_width=True
)

demo.launch()
```