### PR TITLE
Pass kwargs into `gr.ChatInterface` created by `gr.load()`

### DIFF
--- a/.changeset/fast-mammals-hide.md
+++ b/.changeset/fast-mammals-hide.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Pass kwargs into `gr.ChatInterface` created by `gr.load()`

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -308,7 +308,11 @@ def from_model(
                 "Explain gravity to a 5-year-old.",
                 "What were the main causes of World War I?",
             ]
-            return ChatInterface(fn, type="messages", examples=examples)
+            chat_interface_kwargs = {
+                "examples": examples,
+            }
+            kwargs = dict(chat_interface_kwargs, **kwargs)
+            return ChatInterface(fn, type="messages", **kwargs)  # type: ignore
         inputs = components.Textbox(label="Text")
         outputs = inputs
         examples = ["Once upon a time"]


### PR DESCRIPTION
Fixes: https://github.com/gradio-app/gradio/issues/10617

e.g. this works now:

```py
import gradio as gr

gr.load(name="deepseek-ai/DeepSeek-R1", src="models", provider="together", examples=[["abc"], ["def"]]).launch()
```

Treating this as a bug since this should have always been the behavior according to the docstring for `gr.load()`