### PR TITLE
Fix chatbot share button payload too large

### DIFF
--- a/.changeset/rotten-states-see.md
+++ b/.changeset/rotten-states-see.md
@@ -1,0 +1,6 @@
+---
+"@gradio/chatbot": patch
+"gradio": patch
+---
+
+fix:Fix chatbot share button payload too large

--- a/js/chatbot/shared/ChatBot.svelte
+++ b/js/chatbot/shared/ChatBot.svelte
@@ -252,25 +252,8 @@
 				Icon={Community}
 				on:click={async () => {
 					try {
-						const CLOUDFRONT_LIMIT = 20 * 1024; // 20KB limit
-						let messages_to_share = value;
 						// @ts-ignore
-						let formatted = await format_chat_for_sharing(messages_to_share);
-
-						while (
-							new Blob([formatted]).size > CLOUDFRONT_LIMIT &&
-							messages_to_share.length > 1
-						) {
-							messages_to_share = value.slice(1);
-							formatted = await format_chat_for_sharing(messages_to_share);
-						}
-
-						if (new Blob([formatted]).size > CLOUDFRONT_LIMIT) {
-							throw new ShareError(
-								"Chat content too large to share, even with a single message."
-							);
-						}
-
+						const formatted = await format_chat_for_sharing(value);
 						dispatch("share", {
 							description: formatted
 						});

--- a/js/chatbot/shared/utils.ts
+++ b/js/chatbot/shared/utils.ts
@@ -21,7 +21,6 @@ export const format_chat_for_sharing = async (
 	let messages_to_share = [...chat];
 	let formatted = await format_messages(messages_to_share);
 
-	// Use only first and last message if the conversation is too large
 	if (formatted.length > url_length_limit && messages_to_share.length > 2) {
 		const first_message = messages_to_share[0];
 		const last_message = messages_to_share[messages_to_share.length - 1];
@@ -29,7 +28,6 @@ export const format_chat_for_sharing = async (
 		formatted = await format_messages(messages_to_share);
 	}
 
-	// Truncate messages if still too large
 	if (formatted.length > url_length_limit && messages_to_share.length > 0) {
 		const truncated_messages = messages_to_share.map((msg) => {
 			if (msg.type === "text") {


### PR DESCRIPTION
## Description
The messages are being passed through the url, so this shortens the URL to be max 1800 characters to ensure there is no error.

Closes: #10606

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
