### PR TITLE
Change `gr.load` chatinterface behavior to streaming

### DIFF
--- a/.changeset/clear-boxes-dance.md
+++ b/.changeset/clear-boxes-dance.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:Change `gr.load` chatinterface behavior to streaming

--- a/gradio/external_utils.py
+++ b/gradio/external_utils.py
@@ -135,8 +135,10 @@ def conversational_wrapper(client: InferenceClient):
             history = []
         history.append({"role": "user", "content": message})
         try:
-            result = client.chat_completion(history)
-            return result.choices[0].message.content
+            out = ""
+            for chunk in client.chat_completion(messages=history, stream=True):
+                out += chunk.choices[0].delta.content or ""
+                yield out
         except Exception as e:
             handle_hf_error(e)
 


### PR DESCRIPTION
Closes: https://github.com/gradio-app/gradio/issues/10680
Closes: https://github.com/gradio-app/gradio/issues/10682

Test with, e.g.:

```py
import gradio as gr

gr.load(
    "models/meta-llama/Llama-3.2-3B-Instruct",
    provider="sambanova",
    chatbot=gr.Chatbot(type="messages", allow_tags=["think"], scale=1),
).launch()
```