### PR TITLE
chore: bump Pyodide version to 0.27.3

### DIFF
--- a/.changeset/shaggy-llamas-shake.md
+++ b/.changeset/shaggy-llamas-shake.md
@@ -1,0 +1,6 @@
+---
+"@gradio/wasm": patch
+"gradio": patch
+---
+
+fix:chore: bump Pyodide version to 0.27.3

--- a/js/wasm/package.json
+++ b/js/wasm/package.json
@@ -40,7 +40,7 @@
 	"dependencies": {
 		"@types/path-browserify": "^1.0.0",
 		"path-browserify": "^1.0.1",
-		"pyodide": "0.27.2"
+		"pyodide": "0.27.3"
 	},
 	"peerDependencies": {
 		"svelte": "^4.0.0"

--- a/js/wasm/src/webworker/index.ts
+++ b/js/wasm/src/webworker/index.ts
@@ -27,7 +27,7 @@ import { generateRandomString } from "./random";
 import scriptRunnerPySource from "./py/script_runner.py?raw";
 import unloadModulesPySource from "./py/unload_modules.py?raw";
 
-importScripts("https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js");
+importScripts("https://cdn.jsdelivr.net/pyodide/v0.27.3/full/pyodide.js");
 
 type MessageTransceiver = DedicatedWorkerGlobalScope | MessagePort;
 

--- a/package.json
+++ b/package.json
@@ -178,6 +178,5 @@
 		"overrides": {
 			"svelte-preprocess": "^6.0.3"
 		}
-	},
-	"packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -178,5 +178,6 @@
 		"overrides": {
 			"svelte-preprocess": "^6.0.3"
 		}
-	}
+	},
+	"packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2515,8 +2515,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       pyodide:
-        specifier: 0.27.2
-        version: 0.27.2(bufferutil@4.0.7)
+        specifier: 0.27.3
+        version: 0.27.3(bufferutil@4.0.7)
       svelte:
         specifier: ^4.0.0
         version: 4.2.15
@@ -7812,8 +7812,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  pyodide@0.27.2:
-    resolution: {integrity: sha512-sfA2kiUuQVRpWI4BYnU3sX5PaTTt/xrcVEmRzRcId8DzZXGGtPgCBC0gCqjUTUYSa8ofPaSjXmzESc86yvvCHg==}
+  pyodide@0.27.3:
+    resolution: {integrity: sha512-6NwKEbPk0M3Wic2T1TCZijgZH9VE4RkHp1VGljS1sou0NjGdsmY2R/fG5oLmdDkjTRMI1iW7WYaY9pofX8gg1g==}
     engines: {node: '>=18.0.0'}
 
   qs@6.11.0:
@@ -14943,7 +14943,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  pyodide@0.27.2(bufferutil@4.0.7):
+  pyodide@0.27.3(bufferutil@4.0.7):
     dependencies:
       ws: 8.18.0(bufferutil@4.0.7)
     transitivePeerDependencies:


### PR DESCRIPTION
## Description

Leverages all the new features released by Pyodide, notably fixes broken Gradio Lite apps on iOS/webkit browser.

Closes: #10705
