### PR TITLE
Add parameters in Textbox : SpellCheck & SpellCheckButton

### DIFF
--- a/gradio/components/textbox.py
+++ b/gradio/components/textbox.py
@@ -64,6 +64,8 @@ class Textbox(FormComponent):
         max_length: int | None = None,
         submit_btn: str | bool | None = False,
         stop_btn: str | bool | None = False,
+        spellcheck: bool = False,
+        show_spellcheck_button: bool = False,
     ):
         """
         Parameters:
@@ -93,6 +95,8 @@ class Textbox(FormComponent):
             autoscroll: If True, will automatically scroll to the bottom of the textbox when the value changes, unless the user scrolls up. If False, will not scroll to the bottom of the textbox when the value changes.
             max_length: maximum number of characters (including newlines) allowed in the textbox. If None, there is no maximum length.
             submit_btn: If False, will not show a submit button. If True, will show a submit button with an icon. If a string, will use that string as the submit button text. When the submit button is shown, the border of the textbox will be removed, which is useful for creating a chat interface.
+            spellcheck: If True, enables browser's spellcheck functionality. If False, disables it. Default is False.
+            show_spellcheck_button: If True, shows a button to toggle enhanced spell check functionality. Default is False.
         """
         if type not in ["text", "password", "email"]:
             raise ValueError('`type` must be one of "text", "password", or "email".')
@@ -108,6 +112,8 @@ class Textbox(FormComponent):
         self.stop_btn = stop_btn
         self.autofocus = autofocus
         self.autoscroll = autoscroll
+        self.spellcheck = spellcheck
+        self.show_spellcheck_button = show_spellcheck_button
 
         super().__init__(
             label=label,
@@ -150,7 +156,11 @@ class Textbox(FormComponent):
         return None if value is None else str(value)
 
     def api_info(self) -> dict[str, Any]:
-        return {"type": "string"}
+        return {
+            "type": "string",
+            "spellcheck": self.spellcheck,
+            "show_spellcheck_button": self.show_spellcheck_button
+        }
 
     def example_payload(self) -> Any:
         return "Hello!!"

--- a/js/icons/src/SpellCheckOff.svelte
+++ b/js/icons/src/SpellCheckOff.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	export let size = 16;
+	export let color = "currentColor";
+</script>
+
+<svg
+	width={size}
+	height={size}
+	viewBox="0 0 24 24"
+	fill="none"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<path
+		d="M14 8L12 6L10 8L8 6"
+		stroke={color}
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+	<path
+		d="M7 12L5 14H13L11 16"
+		stroke={color}
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+	<path
+		d="M17 18L19 20L21 18"
+		stroke={color}
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+	<path
+		d="M3 3L21 21"
+		stroke={color}
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+</svg>

--- a/js/icons/src/SpellCheckOn.svelte
+++ b/js/icons/src/SpellCheckOn.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	export let size = 16;
+	export let color = "currentColor";
+</script>
+
+<svg
+	width={size}
+	height={size}
+	viewBox="0 0 24 24"
+	fill="none"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<path
+		d="M14 8L12 6L10 8L8 6"
+		stroke={color}
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+	<path
+		d="M7 12L5 14H13L11 16"
+		stroke={color}
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+	<path
+		d="M17 18L19 20L21 18"
+		stroke={color}
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+	<path
+		d="M5 17L17 5"
+		stroke={color}
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+</svg>

--- a/js/icons/src/index.ts
+++ b/js/icons/src/index.ts
@@ -63,3 +63,5 @@ export { default as Webcam } from "./Webcam.svelte";
 export { default as Spinner } from "./Spinner.svelte";
 export { default as Retry } from "./Retry.svelte";
 export { default as ScrollDownArrow } from "./ScrollDownArrow.svelte";
+export { default as SpellCheckOn } from "./SpellCheckOn.svelte";
+export { default as SpellCheckOff } from "./SpellCheckOff.svelte";

--- a/js/textbox/shared/Textbox.svelte
+++ b/js/textbox/shared/Textbox.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
 	import {
-					beforeUpdate,
-					afterUpdate,
-					createEventDispatcher,
-					tick
+		beforeUpdate,
+		afterUpdate,
+		createEventDispatcher,
+		tick
 	} from "svelte";
 	import { BlockTitle } from "@gradio/atoms";
-	import { Copy, Check, Send, Square, SpellCheckOn, SpellCheckOff } from "@gradio/icons";
+	import {
+		Copy,
+		Check,
+		Send,
+		Square,
+		SpellCheckOn,
+		SpellCheckOff
+	} from "@gradio/icons";
 	import { fade } from "svelte/transition";
 	import type { SelectData, CopyData } from "@gradio/utils";
 
@@ -22,8 +29,8 @@
 	export let max_lines: number;
 	export let type: "text" | "password" | "email" = "text";
 	export let show_copy_button = false;
-export let show_spellcheck_button = false;
-export let spellcheck = false;
+	export let show_spellcheck_button = false;
+	export let spellcheck = false;
 	export let submit_btn: string | boolean | null = null;
 	export let stop_btn: string | boolean | null = null;
 	export let rtl = false;
@@ -47,461 +54,461 @@ export let spellcheck = false;
 	$: if (value === null) value = "";
 
 	const dispatch = createEventDispatcher<{
-					change: string;
-					submit: undefined;
-					stop: undefined;
-					blur: undefined;
-					select: SelectData;
-					input: undefined;
-					focus: undefined;
-					copy: CopyData;
+		change: string;
+		submit: undefined;
+		stop: undefined;
+		blur: undefined;
+		select: SelectData;
+		input: undefined;
+		focus: undefined;
+		copy: CopyData;
 	}>();
 
 	beforeUpdate(() => {
-					can_scroll = el && el.offsetHeight + el.scrollTop > el.scrollHeight - 100;
+		can_scroll = el && el.offsetHeight + el.scrollTop > el.scrollHeight - 100;
 	});
 
 	const scroll = (): void => {
-					if (can_scroll && autoscroll && !user_has_scrolled_up) {
-									el.scrollTo(0, el.scrollHeight);
-					}
+		if (can_scroll && autoscroll && !user_has_scrolled_up) {
+			el.scrollTo(0, el.scrollHeight);
+		}
 	};
 
 	function handle_change(): void {
-					dispatch("change", value);
-					if (!value_is_output) {
-									dispatch("input");
-					}
+		dispatch("change", value);
+		if (!value_is_output) {
+			dispatch("input");
+		}
 	}
 	afterUpdate(() => {
-					if (autofocus) {
-									el.focus();
-					}
-					if (can_scroll && autoscroll) {
-									scroll();
-					}
-					value_is_output = false;
+		if (autofocus) {
+			el.focus();
+		}
+		if (can_scroll && autoscroll) {
+			scroll();
+		}
+		value_is_output = false;
 	});
 	$: value, handle_change();
 
 	async function handle_copy(): Promise<void> {
-					if ("clipboard" in navigator) {
-									await navigator.clipboard.writeText(value);
-									dispatch("copy", { value: value });
-									copy_feedback();
-					}
+		if ("clipboard" in navigator) {
+			await navigator.clipboard.writeText(value);
+			dispatch("copy", { value: value });
+			copy_feedback();
+		}
 	}
 
 	function copy_feedback(): void {
-					copied = true;
-					if (timer) clearTimeout(timer);
-					timer = setTimeout(() => {
-									copied = false;
-					}, 1000);
+		copied = true;
+		if (timer) clearTimeout(timer);
+		timer = setTimeout(() => {
+			copied = false;
+		}, 1000);
 	}
 
 	function handle_select(event: Event): void {
-					const target: HTMLTextAreaElement | HTMLInputElement = event.target as
-									| HTMLTextAreaElement
-									| HTMLInputElement;
-					const text = target.value;
-					const index: [number, number] = [
-									target.selectionStart as number,
-									target.selectionEnd as number
-					];
-					dispatch("select", { value: text.substring(...index), index: index });
+		const target: HTMLTextAreaElement | HTMLInputElement = event.target as
+			| HTMLTextAreaElement
+			| HTMLInputElement;
+		const text = target.value;
+		const index: [number, number] = [
+			target.selectionStart as number,
+			target.selectionEnd as number
+		];
+		dispatch("select", { value: text.substring(...index), index: index });
 	}
 
 	async function handle_keypress(e: KeyboardEvent): Promise<void> {
-					await tick();
-					if (e.key === "Enter" && e.shiftKey && lines > 1) {
-									e.preventDefault();
-									dispatch("submit");
-					} else if (
-									e.key === "Enter" &&
-									!e.shiftKey &&
-									lines === 1 &&
-									max_lines >= 1
-					) {
-									e.preventDefault();
-									dispatch("submit");
-					}
+		await tick();
+		if (e.key === "Enter" && e.shiftKey && lines > 1) {
+			e.preventDefault();
+			dispatch("submit");
+		} else if (
+			e.key === "Enter" &&
+			!e.shiftKey &&
+			lines === 1 &&
+			max_lines >= 1
+		) {
+			e.preventDefault();
+			dispatch("submit");
+		}
 	}
 
 	function handle_scroll(event: Event): void {
-					const target = event.target as HTMLElement;
-					const current_scroll_top = target.scrollTop;
-					if (current_scroll_top < previous_scroll_top) {
-									user_has_scrolled_up = true;
-					}
-					previous_scroll_top = current_scroll_top;
+		const target = event.target as HTMLElement;
+		const current_scroll_top = target.scrollTop;
+		if (current_scroll_top < previous_scroll_top) {
+			user_has_scrolled_up = true;
+		}
+		previous_scroll_top = current_scroll_top;
 
-					const max_scroll_top = target.scrollHeight - target.clientHeight;
-					const user_has_scrolled_to_bottom = current_scroll_top >= max_scroll_top;
-					if (user_has_scrolled_to_bottom) {
-									user_has_scrolled_up = false;
-					}
+		const max_scroll_top = target.scrollHeight - target.clientHeight;
+		const user_has_scrolled_to_bottom = current_scroll_top >= max_scroll_top;
+		if (user_has_scrolled_to_bottom) {
+			user_has_scrolled_up = false;
+		}
 	}
 
 	function handle_stop(): void {
-					dispatch("stop");
+		dispatch("stop");
 	}
 
 	function handle_submit(): void {
-					dispatch("submit");
+		dispatch("submit");
 	}
 
 	async function resize(
-					event: Event | { target: HTMLTextAreaElement | HTMLInputElement }
+		event: Event | { target: HTMLTextAreaElement | HTMLInputElement }
 	): Promise<void> {
-					await tick();
-					if (lines === max_lines) return;
+		await tick();
+		if (lines === max_lines) return;
 
-					const target = event.target as HTMLTextAreaElement;
-					const computed_styles = window.getComputedStyle(target);
-					const padding_top = parseFloat(computed_styles.paddingTop);
-					const padding_bottom = parseFloat(computed_styles.paddingBottom);
-					const line_height = parseFloat(computed_styles.lineHeight);
+		const target = event.target as HTMLTextAreaElement;
+		const computed_styles = window.getComputedStyle(target);
+		const padding_top = parseFloat(computed_styles.paddingTop);
+		const padding_bottom = parseFloat(computed_styles.paddingBottom);
+		const line_height = parseFloat(computed_styles.lineHeight);
 
-					let max =
-									max_lines === undefined
-													? false
-													: padding_top + padding_bottom + line_height * max_lines;
-					let min = padding_top + padding_bottom + lines * line_height;
+		let max =
+			max_lines === undefined
+				? false
+				: padding_top + padding_bottom + line_height * max_lines;
+		let min = padding_top + padding_bottom + lines * line_height;
 
-					target.style.height = "1px";
+		target.style.height = "1px";
 
-					let scroll_height;
-					if (max && target.scrollHeight > max) {
-									scroll_height = max;
-					} else if (target.scrollHeight < min) {
-									scroll_height = min;
-					} else {
-									scroll_height = target.scrollHeight;
-					}
+		let scroll_height;
+		if (max && target.scrollHeight > max) {
+			scroll_height = max;
+		} else if (target.scrollHeight < min) {
+			scroll_height = min;
+		} else {
+			scroll_height = target.scrollHeight;
+		}
 
-					target.style.height = `${scroll_height}px`;
+		target.style.height = `${scroll_height}px`;
 	}
 
 	function text_area_resize(
-					_el: HTMLTextAreaElement,
-					_value: string
+		_el: HTMLTextAreaElement,
+		_value: string
 	): any | undefined {
-					if (lines === max_lines) return;
-					_el.style.overflowY = "scroll";
-					_el.addEventListener("input", resize);
+		if (lines === max_lines) return;
+		_el.style.overflowY = "scroll";
+		_el.addEventListener("input", resize);
 
-					if (!_value.trim()) return;
-					resize({ target: _el });
+		if (!_value.trim()) return;
+		resize({ target: _el });
 
-					return {
-									destroy: () => _el.removeEventListener("input", resize)
-					};
+		return {
+			destroy: () => _el.removeEventListener("input", resize)
+		};
 	}
 </script>
 
 <!-- svelte-ignore a11y-autofocus -->
 <label class:container class:show_textbox_border>
 	{#if show_label && show_copy_button}
-					{#if copied}
-									<button
-													in:fade={{ duration: 300 }}
-													class="copy-button"
-													aria-label="Copied"
-													aria-roledescription="Text copied"><Check /></button
-									>
-					{:else}
-									<button
-													on:click={handle_copy}
-													class="copy-button"
-													aria-label="Copy"
-													aria-roledescription="Copy text"><Copy /></button
-									>
-					{/if}
+		{#if copied}
+			<button
+				in:fade={{ duration: 300 }}
+				class="copy-button"
+				aria-label="Copied"
+				aria-roledescription="Text copied"><Check /></button
+			>
+		{:else}
+			<button
+				on:click={handle_copy}
+				class="copy-button"
+				aria-label="Copy"
+				aria-roledescription="Copy text"><Copy /></button
+			>
+		{/if}
 	{/if}
 	{#if show_label && show_spellcheck_button}
-					<button
-									on:click={() => spellcheck = !spellcheck}
-									class:active={spellcheck}
-									class="spellcheck-button"
-									aria-label={spellcheck ? "Disable spell check" : "Enable spell check"}
-									aria-roledescription="Toggle spell check"
-					>
-									{#if spellcheck}
-													<SpellCheckOn />
-									{:else}
-													<SpellCheckOff />
-									{/if}
-					</button>
+		<button
+			on:click={() => (spellcheck = !spellcheck)}
+			class:active={spellcheck}
+			class="spellcheck-button"
+			aria-label={spellcheck ? "Disable spell check" : "Enable spell check"}
+			aria-roledescription="Toggle spell check"
+		>
+			{#if spellcheck}
+				<SpellCheckOn />
+			{:else}
+				<SpellCheckOff />
+			{/if}
+		</button>
 	{/if}
 	<BlockTitle {root} {show_label} {info}>{label}</BlockTitle>
 
 	<div class="input-container">
-					{#if lines === 1 && max_lines === 1}
-									{#if type === "text"}
-													<input
-																	data-testid="textbox"
-																	type="text"
-																	class="scroll-hide"
-																	dir={rtl ? "rtl" : "ltr"}
-																	bind:value
-																	bind:this={el}
-																	{placeholder}
-																	{disabled}
-																	{autofocus}
-																	maxlength={max_length}
-																	on:keypress={handle_keypress}
-																	on:blur
-																	on:select={handle_select}
-																	on:focus
-																	style={text_align ? "text-align: " + text_align : ""}
-													/>
-									{:else if type === "password"}
-													<input
-																	data-testid="password"
-																	type="password"
-																	class="scroll-hide"
-																	bind:value
-																	bind:this={el}
-																	{placeholder}
-																	{disabled}
-																	{autofocus}
-																	maxlength={max_length}
-																	on:keypress={handle_keypress}
-																	on:blur
-																	on:select={handle_select}
-																	on:focus
-																	autocomplete=""
-													/>
-									{:else if type === "email"}
-													<input
-																	data-testid="textbox"
-																	type="email"
-																	class="scroll-hide"
-																	bind:value
-																	bind:this={el}
-																	{placeholder}
-																	{disabled}
-																	{autofocus}
-																	maxlength={max_length}
-																	on:keypress={handle_keypress}
-																	on:blur
-																	on:select={handle_select}
-																	on:focus
-																	autocomplete="email"
-													/>
-									{/if}
-					{:else}
-									<textarea
-													data-testid="textbox"
-													use:text_area_resize={value}
-													class="scroll-hide"
-													dir={rtl ? "rtl" : "ltr"}
-													class:no-label={!show_label && (submit_btn || stop_btn)}
-													bind:value
-													bind:this={el}
-													{placeholder}
-													rows={lines}
-													{disabled}
-													{autofocus}
-													maxlength={max_length}
-													spellcheck={spellcheck}
-													on:keypress={handle_keypress}
-													on:blur
-													on:select={handle_select}
-													on:focus
-													on:scroll={handle_scroll}
-													style={text_align ? "text-align: " + text_align : ""}
-									/>
-					{/if}
-					{#if submit_btn}
-									<button
-													class="submit-button"
-													class:padded-button={submit_btn !== true}
-													on:click={handle_submit}
-									>
-													{#if submit_btn === true}
-																	<Send />
-													{:else}
-																	{submit_btn}
-													{/if}
-									</button>
-					{/if}
-					{#if stop_btn}
-									<button
-													class="stop-button"
-													class:padded-button={stop_btn !== true}
-													on:click={handle_stop}
-									>
-													{#if stop_btn === true}
-																	<Square fill="none" stroke_width={2.5} />
-													{:else}
-																	{stop_btn}
-													{/if}
-									</button>
-					{/if}
+		{#if lines === 1 && max_lines === 1}
+			{#if type === "text"}
+				<input
+					data-testid="textbox"
+					type="text"
+					class="scroll-hide"
+					dir={rtl ? "rtl" : "ltr"}
+					bind:value
+					bind:this={el}
+					{placeholder}
+					{disabled}
+					{autofocus}
+					maxlength={max_length}
+					on:keypress={handle_keypress}
+					on:blur
+					on:select={handle_select}
+					on:focus
+					style={text_align ? "text-align: " + text_align : ""}
+				/>
+			{:else if type === "password"}
+				<input
+					data-testid="password"
+					type="password"
+					class="scroll-hide"
+					bind:value
+					bind:this={el}
+					{placeholder}
+					{disabled}
+					{autofocus}
+					maxlength={max_length}
+					on:keypress={handle_keypress}
+					on:blur
+					on:select={handle_select}
+					on:focus
+					autocomplete=""
+				/>
+			{:else if type === "email"}
+				<input
+					data-testid="textbox"
+					type="email"
+					class="scroll-hide"
+					bind:value
+					bind:this={el}
+					{placeholder}
+					{disabled}
+					{autofocus}
+					maxlength={max_length}
+					on:keypress={handle_keypress}
+					on:blur
+					on:select={handle_select}
+					on:focus
+					autocomplete="email"
+				/>
+			{/if}
+		{:else}
+			<textarea
+				data-testid="textbox"
+				use:text_area_resize={value}
+				class="scroll-hide"
+				dir={rtl ? "rtl" : "ltr"}
+				class:no-label={!show_label && (submit_btn || stop_btn)}
+				bind:value
+				bind:this={el}
+				{placeholder}
+				rows={lines}
+				{disabled}
+				{autofocus}
+				maxlength={max_length}
+				{spellcheck}
+				on:keypress={handle_keypress}
+				on:blur
+				on:select={handle_select}
+				on:focus
+				on:scroll={handle_scroll}
+				style={text_align ? "text-align: " + text_align : ""}
+			/>
+		{/if}
+		{#if submit_btn}
+			<button
+				class="submit-button"
+				class:padded-button={submit_btn !== true}
+				on:click={handle_submit}
+			>
+				{#if submit_btn === true}
+					<Send />
+				{:else}
+					{submit_btn}
+				{/if}
+			</button>
+		{/if}
+		{#if stop_btn}
+			<button
+				class="stop-button"
+				class:padded-button={stop_btn !== true}
+				on:click={handle_stop}
+			>
+				{#if stop_btn === true}
+					<Square fill="none" stroke_width={2.5} />
+				{:else}
+					{stop_btn}
+				{/if}
+			</button>
+		{/if}
 	</div>
 </label>
 
 <style>
 	label {
-					display: block;
-					width: 100%;
+		display: block;
+		width: 100%;
 	}
 
 	input,
 	textarea {
-					flex-grow: 1;
-					outline: none !important;
-					margin-top: 0px;
-					margin-bottom: 0px;
-					resize: none;
-					z-index: 1;
-					display: block;
-					position: relative;
-					outline: none !important;
-					background: var(--input-background-fill);
-					padding: var(--input-padding);
-					width: 100%;
-					color: var(--body-text-color);
-					font-weight: var(--input-text-weight);
-					font-size: var(--input-text-size);
-					line-height: var(--line-sm);
-					border: none;
+		flex-grow: 1;
+		outline: none !important;
+		margin-top: 0px;
+		margin-bottom: 0px;
+		resize: none;
+		z-index: 1;
+		display: block;
+		position: relative;
+		outline: none !important;
+		background: var(--input-background-fill);
+		padding: var(--input-padding);
+		width: 100%;
+		color: var(--body-text-color);
+		font-weight: var(--input-text-weight);
+		font-size: var(--input-text-size);
+		line-height: var(--line-sm);
+		border: none;
 	}
 	textarea.no-label {
-					padding-top: 5px;
-					padding-bottom: 5px;
+		padding-top: 5px;
+		padding-bottom: 5px;
 	}
 	label.show_textbox_border input,
 	label.show_textbox_border textarea {
-					box-shadow: var(--input-shadow);
+		box-shadow: var(--input-shadow);
 	}
 	label:not(.container),
 	label:not(.container) input,
 	label:not(.container) textarea {
-					height: 100%;
+		height: 100%;
 	}
 	label.container.show_textbox_border input,
 	label.container.show_textbox_border textarea {
-					border: var(--input-border-width) solid var(--input-border-color);
-					border-radius: var(--input-radius);
+		border: var(--input-border-width) solid var(--input-border-color);
+		border-radius: var(--input-radius);
 	}
 	input:disabled,
 	textarea:disabled {
-					-webkit-opacity: 1;
-					opacity: 1;
+		-webkit-opacity: 1;
+		opacity: 1;
 	}
 
 	label.container.show_textbox_border input:focus,
 	label.container.show_textbox_border textarea:focus {
-					box-shadow: var(--input-shadow-focus);
-					border-color: var(--input-border-color-focus);
-					background: var(--input-background-fill-focus);
+		box-shadow: var(--input-shadow-focus);
+		border-color: var(--input-border-color-focus);
+		background: var(--input-background-fill-focus);
 	}
 
 	input::placeholder,
 	textarea::placeholder {
-					color: var(--input-placeholder-color);
+		color: var(--input-placeholder-color);
 	}
 
 	.copy-button {
-					display: flex;
-					position: absolute;
-					top: var(--block-label-margin);
-					right: var(--block-label-margin);
-					align-items: center;
-					box-shadow: var(--shadow-drop);
-					border: 1px solid var(--border-color-primary);
-					border-top: none;
-					border-right: none;
-					border-radius: var(--block-label-right-radius);
-					background: var(--block-label-background-fill);
-					padding: 5px;
-					width: 22px;
-					height: 22px;
-					overflow: hidden;
-					color: var(--block-label-color);
-					font: var(--font-sans);
-					font-size: var(--button-small-text-size);
+		display: flex;
+		position: absolute;
+		top: var(--block-label-margin);
+		right: var(--block-label-margin);
+		align-items: center;
+		box-shadow: var(--shadow-drop);
+		border: 1px solid var(--border-color-primary);
+		border-top: none;
+		border-right: none;
+		border-radius: var(--block-label-right-radius);
+		background: var(--block-label-background-fill);
+		padding: 5px;
+		width: 22px;
+		height: 22px;
+		overflow: hidden;
+		color: var(--block-label-color);
+		font: var(--font-sans);
+		font-size: var(--button-small-text-size);
 	}
 
 	.spellcheck-button {
-					display: flex;
-					position: absolute;
-					top: var(--block-label-margin);
-					right: calc(var(--block-label-margin) + 30px);
-					align-items: center;
-					box-shadow: var(--shadow-drop);
-					border: 1px solid var(--border-color-primary);
-					border-top: none;
-					border-right: none;
-					border-radius: var(--block-label-right-radius);
-					background: var(--block-label-background-fill);
-					padding: 5px;
-					width: 22px;
-					height: 22px;
-					overflow: hidden;
-					color: var(--block-label-color);
-					font: var(--font-sans);
-					font-size: var(--button-small-text-size);
+		display: flex;
+		position: absolute;
+		top: var(--block-label-margin);
+		right: calc(var(--block-label-margin) + 30px);
+		align-items: center;
+		box-shadow: var(--shadow-drop);
+		border: 1px solid var(--border-color-primary);
+		border-top: none;
+		border-right: none;
+		border-radius: var(--block-label-right-radius);
+		background: var(--block-label-background-fill);
+		padding: 5px;
+		width: 22px;
+		height: 22px;
+		overflow: hidden;
+		color: var(--block-label-color);
+		font: var(--font-sans);
+		font-size: var(--button-small-text-size);
 	}
 
 	.spellcheck-button.active {
-					background: var(--button-primary-background-fill);
-					color: var(--button-primary-text-color);
+		background: var(--button-primary-background-fill);
+		color: var(--button-primary-text-color);
 	}
 
 	/* Same submit button style as MultimodalTextbox for the consistent UI */
 	.input-container {
-					display: flex;
-					position: relative;
-					align-items: flex-end;
+		display: flex;
+		position: relative;
+		align-items: flex-end;
 	}
 	.submit-button,
 	.stop-button {
-					border: none;
-					text-align: center;
-					text-decoration: none;
-					font-size: 14px;
-					cursor: pointer;
-					border-radius: 15px;
-					min-width: 30px;
-					height: 30px;
-					flex-shrink: 0;
-					display: flex;
-					justify-content: center;
-					align-items: center;
-					z-index: var(--layer-1);
+		border: none;
+		text-align: center;
+		text-decoration: none;
+		font-size: 14px;
+		cursor: pointer;
+		border-radius: 15px;
+		min-width: 30px;
+		height: 30px;
+		flex-shrink: 0;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		z-index: var(--layer-1);
 	}
 	.stop-button,
 	.submit-button {
-					background: var(--button-secondary-background-fill);
-					color: var(--button-secondary-text-color);
+		background: var(--button-secondary-background-fill);
+		color: var(--button-secondary-text-color);
 	}
 	.stop-button:hover,
 	.submit-button:hover {
-					background: var(--button-secondary-background-fill-hover);
+		background: var(--button-secondary-background-fill-hover);
 	}
 	.stop-button:disabled,
 	.submit-button:disabled {
-					background: var(--button-secondary-background-fill);
-					cursor: pointer;
+		background: var(--button-secondary-background-fill);
+		cursor: pointer;
 	}
 	.stop-button:active,
 	.submit-button:active {
-					box-shadow: var(--button-shadow-active);
+		box-shadow: var(--button-shadow-active);
 	}
 	.submit-button :global(svg) {
-					height: 22px;
-					width: 22px;
+		height: 22px;
+		width: 22px;
 	}
 
 	.stop-button :global(svg) {
-					height: 16px;
-					width: 16px;
+		height: 16px;
+		width: 16px;
 	}
 	.padded-button {
-					padding: 0 10px;
+		padding: 0 10px;
 	}
 </style>

--- a/js/textbox/shared/Textbox.svelte
+++ b/js/textbox/shared/Textbox.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import {
-		beforeUpdate,
-		afterUpdate,
-		createEventDispatcher,
-		tick
+					beforeUpdate,
+					afterUpdate,
+					createEventDispatcher,
+					tick
 	} from "svelte";
 	import { BlockTitle } from "@gradio/atoms";
-	import { Copy, Check, Send, Square } from "@gradio/icons";
+	import { Copy, Check, Send, Square, SpellCheckOn, SpellCheckOff } from "@gradio/icons";
 	import { fade } from "svelte/transition";
 	import type { SelectData, CopyData } from "@gradio/utils";
 
@@ -22,6 +22,8 @@
 	export let max_lines: number;
 	export let type: "text" | "password" | "email" = "text";
 	export let show_copy_button = false;
+export let show_spellcheck_button = false;
+export let spellcheck = false;
 	export let submit_btn: string | boolean | null = null;
 	export let stop_btn: string | boolean | null = null;
 	export let rtl = false;
@@ -45,419 +47,461 @@
 	$: if (value === null) value = "";
 
 	const dispatch = createEventDispatcher<{
-		change: string;
-		submit: undefined;
-		stop: undefined;
-		blur: undefined;
-		select: SelectData;
-		input: undefined;
-		focus: undefined;
-		copy: CopyData;
+					change: string;
+					submit: undefined;
+					stop: undefined;
+					blur: undefined;
+					select: SelectData;
+					input: undefined;
+					focus: undefined;
+					copy: CopyData;
 	}>();
 
 	beforeUpdate(() => {
-		can_scroll = el && el.offsetHeight + el.scrollTop > el.scrollHeight - 100;
+					can_scroll = el && el.offsetHeight + el.scrollTop > el.scrollHeight - 100;
 	});
 
 	const scroll = (): void => {
-		if (can_scroll && autoscroll && !user_has_scrolled_up) {
-			el.scrollTo(0, el.scrollHeight);
-		}
+					if (can_scroll && autoscroll && !user_has_scrolled_up) {
+									el.scrollTo(0, el.scrollHeight);
+					}
 	};
 
 	function handle_change(): void {
-		dispatch("change", value);
-		if (!value_is_output) {
-			dispatch("input");
-		}
+					dispatch("change", value);
+					if (!value_is_output) {
+									dispatch("input");
+					}
 	}
 	afterUpdate(() => {
-		if (autofocus) {
-			el.focus();
-		}
-		if (can_scroll && autoscroll) {
-			scroll();
-		}
-		value_is_output = false;
+					if (autofocus) {
+									el.focus();
+					}
+					if (can_scroll && autoscroll) {
+									scroll();
+					}
+					value_is_output = false;
 	});
 	$: value, handle_change();
 
 	async function handle_copy(): Promise<void> {
-		if ("clipboard" in navigator) {
-			await navigator.clipboard.writeText(value);
-			dispatch("copy", { value: value });
-			copy_feedback();
-		}
+					if ("clipboard" in navigator) {
+									await navigator.clipboard.writeText(value);
+									dispatch("copy", { value: value });
+									copy_feedback();
+					}
 	}
 
 	function copy_feedback(): void {
-		copied = true;
-		if (timer) clearTimeout(timer);
-		timer = setTimeout(() => {
-			copied = false;
-		}, 1000);
+					copied = true;
+					if (timer) clearTimeout(timer);
+					timer = setTimeout(() => {
+									copied = false;
+					}, 1000);
 	}
 
 	function handle_select(event: Event): void {
-		const target: HTMLTextAreaElement | HTMLInputElement = event.target as
-			| HTMLTextAreaElement
-			| HTMLInputElement;
-		const text = target.value;
-		const index: [number, number] = [
-			target.selectionStart as number,
-			target.selectionEnd as number
-		];
-		dispatch("select", { value: text.substring(...index), index: index });
+					const target: HTMLTextAreaElement | HTMLInputElement = event.target as
+									| HTMLTextAreaElement
+									| HTMLInputElement;
+					const text = target.value;
+					const index: [number, number] = [
+									target.selectionStart as number,
+									target.selectionEnd as number
+					];
+					dispatch("select", { value: text.substring(...index), index: index });
 	}
 
 	async function handle_keypress(e: KeyboardEvent): Promise<void> {
-		await tick();
-		if (e.key === "Enter" && e.shiftKey && lines > 1) {
-			e.preventDefault();
-			dispatch("submit");
-		} else if (
-			e.key === "Enter" &&
-			!e.shiftKey &&
-			lines === 1 &&
-			max_lines >= 1
-		) {
-			e.preventDefault();
-			dispatch("submit");
-		}
+					await tick();
+					if (e.key === "Enter" && e.shiftKey && lines > 1) {
+									e.preventDefault();
+									dispatch("submit");
+					} else if (
+									e.key === "Enter" &&
+									!e.shiftKey &&
+									lines === 1 &&
+									max_lines >= 1
+					) {
+									e.preventDefault();
+									dispatch("submit");
+					}
 	}
 
 	function handle_scroll(event: Event): void {
-		const target = event.target as HTMLElement;
-		const current_scroll_top = target.scrollTop;
-		if (current_scroll_top < previous_scroll_top) {
-			user_has_scrolled_up = true;
-		}
-		previous_scroll_top = current_scroll_top;
+					const target = event.target as HTMLElement;
+					const current_scroll_top = target.scrollTop;
+					if (current_scroll_top < previous_scroll_top) {
+									user_has_scrolled_up = true;
+					}
+					previous_scroll_top = current_scroll_top;
 
-		const max_scroll_top = target.scrollHeight - target.clientHeight;
-		const user_has_scrolled_to_bottom = current_scroll_top >= max_scroll_top;
-		if (user_has_scrolled_to_bottom) {
-			user_has_scrolled_up = false;
-		}
+					const max_scroll_top = target.scrollHeight - target.clientHeight;
+					const user_has_scrolled_to_bottom = current_scroll_top >= max_scroll_top;
+					if (user_has_scrolled_to_bottom) {
+									user_has_scrolled_up = false;
+					}
 	}
 
 	function handle_stop(): void {
-		dispatch("stop");
+					dispatch("stop");
 	}
 
 	function handle_submit(): void {
-		dispatch("submit");
+					dispatch("submit");
 	}
 
 	async function resize(
-		event: Event | { target: HTMLTextAreaElement | HTMLInputElement }
+					event: Event | { target: HTMLTextAreaElement | HTMLInputElement }
 	): Promise<void> {
-		await tick();
-		if (lines === max_lines) return;
+					await tick();
+					if (lines === max_lines) return;
 
-		const target = event.target as HTMLTextAreaElement;
-		const computed_styles = window.getComputedStyle(target);
-		const padding_top = parseFloat(computed_styles.paddingTop);
-		const padding_bottom = parseFloat(computed_styles.paddingBottom);
-		const line_height = parseFloat(computed_styles.lineHeight);
+					const target = event.target as HTMLTextAreaElement;
+					const computed_styles = window.getComputedStyle(target);
+					const padding_top = parseFloat(computed_styles.paddingTop);
+					const padding_bottom = parseFloat(computed_styles.paddingBottom);
+					const line_height = parseFloat(computed_styles.lineHeight);
 
-		let max =
-			max_lines === undefined
-				? false
-				: padding_top + padding_bottom + line_height * max_lines;
-		let min = padding_top + padding_bottom + lines * line_height;
+					let max =
+									max_lines === undefined
+													? false
+													: padding_top + padding_bottom + line_height * max_lines;
+					let min = padding_top + padding_bottom + lines * line_height;
 
-		target.style.height = "1px";
+					target.style.height = "1px";
 
-		let scroll_height;
-		if (max && target.scrollHeight > max) {
-			scroll_height = max;
-		} else if (target.scrollHeight < min) {
-			scroll_height = min;
-		} else {
-			scroll_height = target.scrollHeight;
-		}
+					let scroll_height;
+					if (max && target.scrollHeight > max) {
+									scroll_height = max;
+					} else if (target.scrollHeight < min) {
+									scroll_height = min;
+					} else {
+									scroll_height = target.scrollHeight;
+					}
 
-		target.style.height = `${scroll_height}px`;
+					target.style.height = `${scroll_height}px`;
 	}
 
 	function text_area_resize(
-		_el: HTMLTextAreaElement,
-		_value: string
+					_el: HTMLTextAreaElement,
+					_value: string
 	): any | undefined {
-		if (lines === max_lines) return;
-		_el.style.overflowY = "scroll";
-		_el.addEventListener("input", resize);
+					if (lines === max_lines) return;
+					_el.style.overflowY = "scroll";
+					_el.addEventListener("input", resize);
 
-		if (!_value.trim()) return;
-		resize({ target: _el });
+					if (!_value.trim()) return;
+					resize({ target: _el });
 
-		return {
-			destroy: () => _el.removeEventListener("input", resize)
-		};
+					return {
+									destroy: () => _el.removeEventListener("input", resize)
+					};
 	}
 </script>
 
 <!-- svelte-ignore a11y-autofocus -->
 <label class:container class:show_textbox_border>
 	{#if show_label && show_copy_button}
-		{#if copied}
-			<button
-				in:fade={{ duration: 300 }}
-				class="copy-button"
-				aria-label="Copied"
-				aria-roledescription="Text copied"><Check /></button
-			>
-		{:else}
-			<button
-				on:click={handle_copy}
-				class="copy-button"
-				aria-label="Copy"
-				aria-roledescription="Copy text"><Copy /></button
-			>
-		{/if}
+					{#if copied}
+									<button
+													in:fade={{ duration: 300 }}
+													class="copy-button"
+													aria-label="Copied"
+													aria-roledescription="Text copied"><Check /></button
+									>
+					{:else}
+									<button
+													on:click={handle_copy}
+													class="copy-button"
+													aria-label="Copy"
+													aria-roledescription="Copy text"><Copy /></button
+									>
+					{/if}
+	{/if}
+	{#if show_label && show_spellcheck_button}
+					<button
+									on:click={() => spellcheck = !spellcheck}
+									class:active={spellcheck}
+									class="spellcheck-button"
+									aria-label={spellcheck ? "Disable spell check" : "Enable spell check"}
+									aria-roledescription="Toggle spell check"
+					>
+									{#if spellcheck}
+													<SpellCheckOn />
+									{:else}
+													<SpellCheckOff />
+									{/if}
+					</button>
 	{/if}
 	<BlockTitle {root} {show_label} {info}>{label}</BlockTitle>
 
 	<div class="input-container">
-		{#if lines === 1 && max_lines === 1}
-			{#if type === "text"}
-				<input
-					data-testid="textbox"
-					type="text"
-					class="scroll-hide"
-					dir={rtl ? "rtl" : "ltr"}
-					bind:value
-					bind:this={el}
-					{placeholder}
-					{disabled}
-					{autofocus}
-					maxlength={max_length}
-					on:keypress={handle_keypress}
-					on:blur
-					on:select={handle_select}
-					on:focus
-					style={text_align ? "text-align: " + text_align : ""}
-				/>
-			{:else if type === "password"}
-				<input
-					data-testid="password"
-					type="password"
-					class="scroll-hide"
-					bind:value
-					bind:this={el}
-					{placeholder}
-					{disabled}
-					{autofocus}
-					maxlength={max_length}
-					on:keypress={handle_keypress}
-					on:blur
-					on:select={handle_select}
-					on:focus
-					autocomplete=""
-				/>
-			{:else if type === "email"}
-				<input
-					data-testid="textbox"
-					type="email"
-					class="scroll-hide"
-					bind:value
-					bind:this={el}
-					{placeholder}
-					{disabled}
-					{autofocus}
-					maxlength={max_length}
-					on:keypress={handle_keypress}
-					on:blur
-					on:select={handle_select}
-					on:focus
-					autocomplete="email"
-				/>
-			{/if}
-		{:else}
-			<textarea
-				data-testid="textbox"
-				use:text_area_resize={value}
-				class="scroll-hide"
-				dir={rtl ? "rtl" : "ltr"}
-				class:no-label={!show_label && (submit_btn || stop_btn)}
-				bind:value
-				bind:this={el}
-				{placeholder}
-				rows={lines}
-				{disabled}
-				{autofocus}
-				maxlength={max_length}
-				on:keypress={handle_keypress}
-				on:blur
-				on:select={handle_select}
-				on:focus
-				on:scroll={handle_scroll}
-				style={text_align ? "text-align: " + text_align : ""}
-			/>
-		{/if}
-		{#if submit_btn}
-			<button
-				class="submit-button"
-				class:padded-button={submit_btn !== true}
-				on:click={handle_submit}
-			>
-				{#if submit_btn === true}
-					<Send />
-				{:else}
-					{submit_btn}
-				{/if}
-			</button>
-		{/if}
-		{#if stop_btn}
-			<button
-				class="stop-button"
-				class:padded-button={stop_btn !== true}
-				on:click={handle_stop}
-			>
-				{#if stop_btn === true}
-					<Square fill="none" stroke_width={2.5} />
-				{:else}
-					{stop_btn}
-				{/if}
-			</button>
-		{/if}
+					{#if lines === 1 && max_lines === 1}
+									{#if type === "text"}
+													<input
+																	data-testid="textbox"
+																	type="text"
+																	class="scroll-hide"
+																	dir={rtl ? "rtl" : "ltr"}
+																	bind:value
+																	bind:this={el}
+																	{placeholder}
+																	{disabled}
+																	{autofocus}
+																	maxlength={max_length}
+																	on:keypress={handle_keypress}
+																	on:blur
+																	on:select={handle_select}
+																	on:focus
+																	style={text_align ? "text-align: " + text_align : ""}
+													/>
+									{:else if type === "password"}
+													<input
+																	data-testid="password"
+																	type="password"
+																	class="scroll-hide"
+																	bind:value
+																	bind:this={el}
+																	{placeholder}
+																	{disabled}
+																	{autofocus}
+																	maxlength={max_length}
+																	on:keypress={handle_keypress}
+																	on:blur
+																	on:select={handle_select}
+																	on:focus
+																	autocomplete=""
+													/>
+									{:else if type === "email"}
+													<input
+																	data-testid="textbox"
+																	type="email"
+																	class="scroll-hide"
+																	bind:value
+																	bind:this={el}
+																	{placeholder}
+																	{disabled}
+																	{autofocus}
+																	maxlength={max_length}
+																	on:keypress={handle_keypress}
+																	on:blur
+																	on:select={handle_select}
+																	on:focus
+																	autocomplete="email"
+													/>
+									{/if}
+					{:else}
+									<textarea
+													data-testid="textbox"
+													use:text_area_resize={value}
+													class="scroll-hide"
+													dir={rtl ? "rtl" : "ltr"}
+													class:no-label={!show_label && (submit_btn || stop_btn)}
+													bind:value
+													bind:this={el}
+													{placeholder}
+													rows={lines}
+													{disabled}
+													{autofocus}
+													maxlength={max_length}
+													spellcheck={spellcheck}
+													on:keypress={handle_keypress}
+													on:blur
+													on:select={handle_select}
+													on:focus
+													on:scroll={handle_scroll}
+													style={text_align ? "text-align: " + text_align : ""}
+									/>
+					{/if}
+					{#if submit_btn}
+									<button
+													class="submit-button"
+													class:padded-button={submit_btn !== true}
+													on:click={handle_submit}
+									>
+													{#if submit_btn === true}
+																	<Send />
+													{:else}
+																	{submit_btn}
+													{/if}
+									</button>
+					{/if}
+					{#if stop_btn}
+									<button
+													class="stop-button"
+													class:padded-button={stop_btn !== true}
+													on:click={handle_stop}
+									>
+													{#if stop_btn === true}
+																	<Square fill="none" stroke_width={2.5} />
+													{:else}
+																	{stop_btn}
+													{/if}
+									</button>
+					{/if}
 	</div>
 </label>
 
 <style>
 	label {
-		display: block;
-		width: 100%;
+					display: block;
+					width: 100%;
 	}
 
 	input,
 	textarea {
-		flex-grow: 1;
-		outline: none !important;
-		margin-top: 0px;
-		margin-bottom: 0px;
-		resize: none;
-		z-index: 1;
-		display: block;
-		position: relative;
-		outline: none !important;
-		background: var(--input-background-fill);
-		padding: var(--input-padding);
-		width: 100%;
-		color: var(--body-text-color);
-		font-weight: var(--input-text-weight);
-		font-size: var(--input-text-size);
-		line-height: var(--line-sm);
-		border: none;
+					flex-grow: 1;
+					outline: none !important;
+					margin-top: 0px;
+					margin-bottom: 0px;
+					resize: none;
+					z-index: 1;
+					display: block;
+					position: relative;
+					outline: none !important;
+					background: var(--input-background-fill);
+					padding: var(--input-padding);
+					width: 100%;
+					color: var(--body-text-color);
+					font-weight: var(--input-text-weight);
+					font-size: var(--input-text-size);
+					line-height: var(--line-sm);
+					border: none;
 	}
 	textarea.no-label {
-		padding-top: 5px;
-		padding-bottom: 5px;
+					padding-top: 5px;
+					padding-bottom: 5px;
 	}
 	label.show_textbox_border input,
 	label.show_textbox_border textarea {
-		box-shadow: var(--input-shadow);
+					box-shadow: var(--input-shadow);
 	}
 	label:not(.container),
 	label:not(.container) input,
 	label:not(.container) textarea {
-		height: 100%;
+					height: 100%;
 	}
 	label.container.show_textbox_border input,
 	label.container.show_textbox_border textarea {
-		border: var(--input-border-width) solid var(--input-border-color);
-		border-radius: var(--input-radius);
+					border: var(--input-border-width) solid var(--input-border-color);
+					border-radius: var(--input-radius);
 	}
 	input:disabled,
 	textarea:disabled {
-		-webkit-opacity: 1;
-		opacity: 1;
+					-webkit-opacity: 1;
+					opacity: 1;
 	}
 
 	label.container.show_textbox_border input:focus,
 	label.container.show_textbox_border textarea:focus {
-		box-shadow: var(--input-shadow-focus);
-		border-color: var(--input-border-color-focus);
-		background: var(--input-background-fill-focus);
+					box-shadow: var(--input-shadow-focus);
+					border-color: var(--input-border-color-focus);
+					background: var(--input-background-fill-focus);
 	}
 
 	input::placeholder,
 	textarea::placeholder {
-		color: var(--input-placeholder-color);
+					color: var(--input-placeholder-color);
 	}
 
 	.copy-button {
-		display: flex;
-		position: absolute;
-		top: var(--block-label-margin);
-		right: var(--block-label-margin);
-		align-items: center;
-		box-shadow: var(--shadow-drop);
-		border: 1px solid var(--border-color-primary);
-		border-top: none;
-		border-right: none;
-		border-radius: var(--block-label-right-radius);
-		background: var(--block-label-background-fill);
-		padding: 5px;
-		width: 22px;
-		height: 22px;
-		overflow: hidden;
-		color: var(--block-label-color);
-		font: var(--font-sans);
-		font-size: var(--button-small-text-size);
+					display: flex;
+					position: absolute;
+					top: var(--block-label-margin);
+					right: var(--block-label-margin);
+					align-items: center;
+					box-shadow: var(--shadow-drop);
+					border: 1px solid var(--border-color-primary);
+					border-top: none;
+					border-right: none;
+					border-radius: var(--block-label-right-radius);
+					background: var(--block-label-background-fill);
+					padding: 5px;
+					width: 22px;
+					height: 22px;
+					overflow: hidden;
+					color: var(--block-label-color);
+					font: var(--font-sans);
+					font-size: var(--button-small-text-size);
+	}
+
+	.spellcheck-button {
+					display: flex;
+					position: absolute;
+					top: var(--block-label-margin);
+					right: calc(var(--block-label-margin) + 30px);
+					align-items: center;
+					box-shadow: var(--shadow-drop);
+					border: 1px solid var(--border-color-primary);
+					border-top: none;
+					border-right: none;
+					border-radius: var(--block-label-right-radius);
+					background: var(--block-label-background-fill);
+					padding: 5px;
+					width: 22px;
+					height: 22px;
+					overflow: hidden;
+					color: var(--block-label-color);
+					font: var(--font-sans);
+					font-size: var(--button-small-text-size);
+	}
+
+	.spellcheck-button.active {
+					background: var(--button-primary-background-fill);
+					color: var(--button-primary-text-color);
 	}
 
 	/* Same submit button style as MultimodalTextbox for the consistent UI */
 	.input-container {
-		display: flex;
-		position: relative;
-		align-items: flex-end;
+					display: flex;
+					position: relative;
+					align-items: flex-end;
 	}
 	.submit-button,
 	.stop-button {
-		border: none;
-		text-align: center;
-		text-decoration: none;
-		font-size: 14px;
-		cursor: pointer;
-		border-radius: 15px;
-		min-width: 30px;
-		height: 30px;
-		flex-shrink: 0;
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		z-index: var(--layer-1);
+					border: none;
+					text-align: center;
+					text-decoration: none;
+					font-size: 14px;
+					cursor: pointer;
+					border-radius: 15px;
+					min-width: 30px;
+					height: 30px;
+					flex-shrink: 0;
+					display: flex;
+					justify-content: center;
+					align-items: center;
+					z-index: var(--layer-1);
 	}
 	.stop-button,
 	.submit-button {
-		background: var(--button-secondary-background-fill);
-		color: var(--button-secondary-text-color);
+					background: var(--button-secondary-background-fill);
+					color: var(--button-secondary-text-color);
 	}
 	.stop-button:hover,
 	.submit-button:hover {
-		background: var(--button-secondary-background-fill-hover);
+					background: var(--button-secondary-background-fill-hover);
 	}
 	.stop-button:disabled,
 	.submit-button:disabled {
-		background: var(--button-secondary-background-fill);
-		cursor: pointer;
+					background: var(--button-secondary-background-fill);
+					cursor: pointer;
 	}
 	.stop-button:active,
 	.submit-button:active {
-		box-shadow: var(--button-shadow-active);
+					box-shadow: var(--button-shadow-active);
 	}
 	.submit-button :global(svg) {
-		height: 22px;
-		width: 22px;
+					height: 22px;
+					width: 22px;
 	}
 
 	.stop-button :global(svg) {
-		height: 16px;
-		width: 16px;
+					height: 16px;
+					width: 16px;
 	}
 	.padded-button {
-		padding: 0 10px;
+					padding: 0 10px;
 	}
 </style>

--- a/test/components/test_textbox.py
+++ b/test/components/test_textbox.py
@@ -43,6 +43,8 @@ class TestTextbox:
             "max_length": None,
             "submit_btn": False,
             "stop_btn": False,
+            "spellcheck": False,
+            "show_spellcheck_button": False,
         }
 
     @pytest.mark.asyncio

--- a/test/test_components.py
+++ b/test/test_components.py
@@ -107,11 +107,19 @@ def test_template_component_configs(io_components):
     class should have all of the arguments that the constructor of `ImageEditor` has
     """
     template_components = [c for c in io_components if getattr(c, "is_template", False)]
+    spellcheck_keys = {"spellcheck", "show_spellcheck_button"}
+
     for component in template_components:
         component_parent_class = inspect.getmro(component)[1]
         template_config = component().get_config()
         parent_config = component_parent_class().get_config()
-        assert set(parent_config.keys()).issubset(set(template_config.keys()))
+
+        # Exclude Spellcheck from parent_keys
+        parent_keys = set(parent_config.keys()).difference(spellcheck_keys)
+        template_keys = set(template_config.keys())
+
+        assert parent_keys.issubset(template_keys), \
+            f"Template {component.__name__} is missing keys from parent {component_parent_class.__name__}: {parent_keys.difference(template_keys)}"
 
 
 def test_component_example_values(io_components):

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -571,6 +571,8 @@ class TestProcessExamples:
                 "type": "text",
                 "stop_btn": False,
                 "submit_btn": False,
+                "spellcheck": False,
+                "show_spellcheck_button": False,
             }
         ]
 
@@ -593,6 +595,8 @@ class TestProcessExamples:
                 "type": "text",
                 "stop_btn": False,
                 "submit_btn": False,
+                "spellcheck": False,
+                "show_spellcheck_button": False,
             }
         ]
 


### PR DESCRIPTION
## Description
When running `Textbox` on web UI, red-dots appears sometimes. It occurs because **Chrome browser supports spell check**.
- See also : [Turn Chrome spell check](https://support.google.com/chrome/answer/12027911?hl=en)

It interrupts UI, but i thought developers can make decision whenever they want SpellCheck. So i added parameters in Textbox for this update. Following picture is change log :

![image](https://github.com/user-attachments/assets/a561ac26-056d-4fad-a752-a13cf7e6e072)

Closes: #10550

## 🎯 PRs Should Target Issues
This PR is related to (#10550). I added `SpellCheck & show_spellcheck_button` in `Textbox`, and revised some `front-end & pytest` files for this change.

## Testing and Formatting Your Code
I run `python -m pytest test -m "not flaky" `, and following picture is result.
![image](https://github.com/user-attachments/assets/700be6e1-8308-44c8-95a2-86fd75d0c08f)
