### PR TITLE
Fix error display

### DIFF
--- a/.changeset/orange-dragons-rescue.md
+++ b/.changeset/orange-dragons-rescue.md
@@ -1,0 +1,7 @@
+---
+"@gradio/client": patch
+"@gradio/core": patch
+"gradio": patch
+---
+
+fix:Fix error display

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -55,7 +55,7 @@ export class Client {
 
 	// streaming
 	stream_status = { open: false };
-	closed = false
+	closed = false;
 	pending_stream_messages: Record<string, any[][]> = {};
 	pending_diff_streams: Record<string, any[][]> = {};
 	event_callbacks: Record<string, (data?: unknown) => Promise<void>> = {};

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -55,6 +55,7 @@ export class Client {
 
 	// streaming
 	stream_status = { open: false };
+	closed = false
 	pending_stream_messages: Record<string, any[][]> = {};
 	pending_diff_streams: Record<string, any[][]> = {};
 	event_callbacks: Record<string, (data?: unknown) => Promise<void>> = {};
@@ -274,6 +275,7 @@ export class Client {
 	}
 
 	close(): void {
+		this.closed = true;
 		close_stream(this.stream_status, this.abort_controller);
 	}
 

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -387,7 +387,7 @@
 				);
 			} catch (e) {
 				const fn_index = 0; // Mock value for fn_index
-				if (!app.stream_status.open) return; // when a user navigates away in multipage app.
+				if (app.closed) return; // when a user navigates away in multipage app.
 				messages = [
 					new_message("Error", String(e), fn_index, "error"),
 					...messages
@@ -719,7 +719,7 @@
 			value: LoadingStatus;
 		}[] = [];
 		Object.entries(statuses).forEach(([id, loading_status]) => {
-			if (!app.stream_status.open && loading_status.status === "error") {
+			if (app.closed && loading_status.status === "error") {
 				// when a user navigates away in multipage app.
 				return;
 			}


### PR DESCRIPTION
Fixes: #10713

Issue was introduced when I tried to prevent the error message from popping up when a user clicked to a new page in multipage while a request was pending. The way it was implemented, all error messages stopped displaying.

Fixed now. 

Test multipage navigation with below (no errors should propogate on switching links while request pending):
```python
import gradio as gr
import random
import time

with gr.Blocks() as demo:
    name = gr.Textbox(label="Name")
    output = gr.Textbox(label="Output Box")
    greet_btn = gr.Button("Greet")
    @gr.on([greet_btn.click, name.submit, demo.load], inputs=name, outputs=output)
    def greet(name):
        time.sleep(10)
        return "Hello " + name + "!"
    
with demo.route("Up") as incrementer_demo:
    num = gr.Number()

demo.launch()
```

Test regular errors propogate with
```python
import gradio as gr

def submit(input_value):
    raise gr.Error("test")

with gr.Blocks() as demo:
    chatbot = gr.Chatbot()
    input = gr.Textbox()
    input.submit(submit, inputs=input, outputs=[input, chatbot])

demo.launch()
```