### PR TITLE
Add `pwa` and `enable_monitoring` parameters to `mount_gradio_app`

### DIFF
--- a/.changeset/pink-snails-arrive.md
+++ b/.changeset/pink-snails-arrive.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Add `pwa` and `enable_monitoring` parameters to `mount_gradio_app`

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1646,6 +1646,8 @@ def mount_gradio_app(
     ssr_mode: bool | None = None,
     node_server_name: str | None = None,
     node_port: int | None = None,
+    enable_monitoring: bool | None = None,
+    pwa: bool | None = None,
 ) -> fastapi.FastAPI:
     """Mount a gradio.Blocks to an existing FastAPI application.
 
@@ -1695,6 +1697,9 @@ def mount_gradio_app(
     blocks.custom_mount_path = path
     blocks.server_port = server_port
     blocks.server_name = server_name
+    blocks.enable_monitoring = enable_monitoring
+    if pwa is not None:
+        blocks.pwa = pwa
 
     if auth is not None and auth_dependency is not None:
         raise ValueError(

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1,6 +1,7 @@
 """Contains tests for networking.py and app.py"""
 
 import functools
+import inspect
 import json
 import os
 import pickle
@@ -1675,11 +1676,9 @@ def test_file_without_meta_key_not_moved():
 
 def test_mount_gradio_app_args_match_launch_args():
     """Test that all arguments in Blocks.launch() are also valid in mount_gradio_app()."""
-    import inspect
-
     # Get the parameters from both functions
     launch_params = inspect.signature(gr.Blocks.launch).parameters
-    mount_params = inspect.signature(gr.routes.mount_gradio_app).parameters
+    mount_params = inspect.signature(routes.mount_gradio_app).parameters
 
     # Parameters that are intentionally not included in mount_gradio_app
     exception_list = {

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1671,3 +1671,44 @@ def test_file_without_meta_key_not_moved():
             assert req.status_code == 500
     finally:
         demo.close()
+
+
+def test_mount_gradio_app_args_match_launch_args():
+    """Test that all arguments in Blocks.launch() are also valid in mount_gradio_app()."""
+    import inspect
+
+    # Get the parameters from both functions
+    launch_params = inspect.signature(gr.Blocks.launch).parameters
+    mount_params = inspect.signature(gr.routes.mount_gradio_app).parameters
+
+    # Parameters that are intentionally not included in mount_gradio_app
+    exception_list = {
+        "inline",
+        "inbrowser",
+        "prevent_thread_lock",
+        "debug",
+        "quiet",
+        "height",
+        "width",
+        "ssl_keyfile",
+        "ssl_certfile",
+        "ssl_keyfile_password",
+        "ssl_verify",
+        "share",
+        "share_server_address",
+        "share_server_protocol",
+        "state_session_capacity",
+        "_frontend",
+        "self",
+        "strict_cors",
+        "max_threads",
+    }
+
+    missing_params = []
+    for param_name in launch_params:
+        if param_name not in exception_list and param_name not in mount_params:
+            missing_params.append(param_name)
+
+    assert not missing_params, (
+        f"Parameters in launch() but missing in mount_gradio_app(): {missing_params}"
+    )


### PR DESCRIPTION
Adds a couple of missing parameters to `mount_gradio_app` and because this is a common issue, adds a test to make sure we don't miss adding new parameters in the future.

Closes: https://github.com/gradio-app/gradio/issues/10716