### PR TITLE
fix: Check for Node.js path only if SSR mode is true.

### DIFF
--- a/.changeset/common-nails-divide.md
+++ b/.changeset/common-nails-divide.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:fix: Check for Node.js path only if SSR mode is true.

--- a/.changeset/common-nails-divide.md
+++ b/.changeset/common-nails-divide.md
@@ -2,4 +2,4 @@
 "gradio": patch
 ---
 
-fix:fix: Check for Node.js path only if SSR mode is true.
+fix: Check for Node.js path only if SSR mode is true.

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -391,9 +391,7 @@ class Block:
             data = {"path": url_or_file_path, "meta": {"_type": "gradio.FileData"}}
             try:
                 return processing_utils.move_files_to_cache(data, self)
-            except (
-                AttributeError
-            ):  # Can be raised if this function is called before the Block is fully initialized.
+            except AttributeError:  # Can be raised if this function is called before the Block is fully initialized.
                 return data
 
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -609,11 +609,9 @@ class BlockFunction:
             "api_name": self.api_name,
             "scroll_to_output": self.scroll_to_output,
             "show_progress": self.show_progress,
-            "show_progress_on": (
-                None
-                if self.show_progress_on is None
-                else [block._id for block in self.show_progress_on]
-            ),
+            "show_progress_on": None
+            if self.show_progress_on is None
+            else [block._id for block in self.show_progress_on],
             "batch": self.batch,
             "max_batch_size": self.max_batch_size,
             "cancels": self.cancels,

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -391,7 +391,9 @@ class Block:
             data = {"path": url_or_file_path, "meta": {"_type": "gradio.FileData"}}
             try:
                 return processing_utils.move_files_to_cache(data, self)
-            except AttributeError:  # Can be raised if this function is called before the Block is fully initialized.
+            except (
+                AttributeError
+            ):  # Can be raised if this function is called before the Block is fully initialized.
                 return data
 
 
@@ -609,9 +611,11 @@ class BlockFunction:
             "api_name": self.api_name,
             "scroll_to_output": self.scroll_to_output,
             "show_progress": self.show_progress,
-            "show_progress_on": None
-            if self.show_progress_on is None
-            else [block._id for block in self.show_progress_on],
+            "show_progress_on": (
+                None
+                if self.show_progress_on is None
+                else [block._id for block in self.show_progress_on]
+            ),
             "batch": self.batch,
             "max_batch_size": self.max_batch_size,
             "cancels": self.cancels,
@@ -2556,10 +2560,10 @@ Received inputs:
                 else os.getenv("GRADIO_SSR_MODE", "False").lower() == "true"
             )
         )
-        self.node_path = os.environ.get(
-            "GRADIO_NODE_PATH", "" if wasm_utils.IS_WASM else get_node_path()
-        )
         if self.ssr_mode:
+            self.node_path = os.environ.get(
+                "GRADIO_NODE_PATH", "" if wasm_utils.IS_WASM else get_node_path()
+            )
             self.node_server_name, self.node_process, self.node_port = (
                 start_node_server(
                     server_name=node_server_name,

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -459,9 +459,7 @@ class App(FastAPI):
                 not callable(app.auth)
                 and username in app.auth
                 and compare_passwords_securely(password, app.auth[username])  # type: ignore
-            ) or (
-                callable(app.auth) and app.auth.__call__(username, password)
-            ):  # type: ignore
+            ) or (callable(app.auth) and app.auth.__call__(username, password)):  # type: ignore
                 token = secrets.token_urlsafe(16)
                 app.tokens[token] = username
                 response = JSONResponse(content={"success": True})

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -459,7 +459,9 @@ class App(FastAPI):
                 not callable(app.auth)
                 and username in app.auth
                 and compare_passwords_securely(password, app.auth[username])  # type: ignore
-            ) or (callable(app.auth) and app.auth.__call__(username, password)):  # type: ignore
+            ) or (
+                callable(app.auth) and app.auth.__call__(username, password)
+            ):  # type: ignore
                 token = secrets.token_urlsafe(16)
                 app.tokens[token] = username
                 response = JSONResponse(content={"success": True})
@@ -1733,14 +1735,13 @@ def mount_gradio_app(
         )
     )
 
-    blocks.node_path = os.environ.get(
-        "GRADIO_NODE_PATH", "" if wasm_utils.IS_WASM else get_node_path()
-    )
-
-    blocks.node_server_name = node_server_name
-    blocks.node_port = node_port
-
     if blocks.ssr_mode:
+        blocks.node_path = os.environ.get(
+            "GRADIO_NODE_PATH", "" if wasm_utils.IS_WASM else get_node_path()
+        )
+
+        blocks.node_server_name = node_server_name
+        blocks.node_port = node_port
         blocks.node_server_name, blocks.node_process, blocks.node_port = (
             start_node_server(
                 server_name=blocks.node_server_name,


### PR DESCRIPTION
## Description

When running inside a trusted platform module, such as the Intel SGX, with a library operating system (e.g., Gramine), it is not possible to fork out new processes. Thus, a call to spawn a subprocess to invoke `which` in an attempt to check the Node.js path will fail.

However, this scenario is unlikely to happen when SSR mode is disabled. Hence, the check for Node.js path should also not happen unless SSR mode is enabled.

Note that SSR mode may work with Gramine but it will require additional configuration, but these are outside the merits of this PR and the related issue.

Closes: #10711   
