### PR TITLE
fix FileExplorer InvalidPathError #9918

### DIFF
--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -1519,23 +1519,16 @@ class UnhashableKeyDict(MutableMapping):
 
 
 def safe_join(directory: DeveloperPath, path: UserProvidedPath) -> str:
-    """Safely path to a base directory to avoid escaping the base directory.
-    Borrowed from: werkzeug.security.safe_join"""
-    _os_alt_seps: list[str] = [
-        sep for sep in [os.path.sep, os.path.altsep] if sep is not None and sep != "/"
-    ]
-
-    filename = posixpath.normpath(path)
-    fullpath = os.path.join(directory, filename)
-    if (
-        any(sep in filename for sep in _os_alt_seps)
-        or os.path.isabs(filename)
-        or filename == ".."
-        or filename.startswith("../")
-    ):
+    """Safely path to a base directory to avoid escaping the base directory."""
+    normalized = posixpath.normpath(path)
+    if posixpath.isabs(normalized):
         raise InvalidPathError()
-
-    return fullpath
+    if normalized.startswith('..'):
+        raise InvalidPathError()
+    full_path = os.path.join(directory, normalized)
+    if not full_path.startswith(directory):
+        raise InvalidPathError()
+    return full_path
 
 
 def is_allowed_file(

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -1525,10 +1525,10 @@ def safe_join(directory: DeveloperPath, path: UserProvidedPath) -> str:
         raise InvalidPathError()
     if normalized.startswith('..'):
         raise InvalidPathError()
-    full_path = os.path.join(directory, normalized)
-    if not full_path.startswith(directory):
+    fullpath = os.path.join(directory, normalized)
+    if not fullpath.startswith(directory):
         raise InvalidPathError()
-    return full_path
+    return fullpath
 
 
 def is_allowed_file(


### PR DESCRIPTION
## Description
In
```
      line 1531      any(sep in filename for sep in _os_alt_seps)
```
,the original code mistakenly treats the system's separator ('\\\\' or '/' ) as an illegal character, resulting in a legal path being rejected. 

Closes: #9918
Closes: #9715

## 🎯 Target Issues
Gradio FileExplorer InvalidPathError #9918
gr.FileExplorer raises InvalidPathError() gradio.exceptions.InvalidPathError on Windows #9715
