### PR TITLE
Update `gradio/utils.py` to properly handle the case when the `which` command is missing.

### DIFF
--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -1577,14 +1577,17 @@ def get_node_path():
                 .strip()
                 .split("\r\n")[0]
             )
-            # Verify the path exists
             if os.path.exists(windows_path):
                 return windows_path
-        # Try using the 'which' command on Unix-like systems
-        else:
-            return subprocess.check_output(["which", "node"]).decode().strip()
-
     except subprocess.CalledProcessError:
+        # Command failed, fall back to checking common install locations
+        pass
+
+    try:
+        # On Unix-like systems, try using 'which' command
+        if sys.platform != "win32":
+            return subprocess.check_output(["which", "node"]).decode().strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
         # Command failed, fall back to checking common install locations
         pass
 


### PR DESCRIPTION
### Description

This pull request updates the `get_node_path` function in the `gradio/utils.py` file to handle scenarios where the `which` command is missing. The function has been improved by splitting the error handling into two separate `try` blocks for better granularity and robustness.

### Changes Made

- Split the `try` block into two separate `try` blocks for handling Windows and Unix-like systems.
- Added error handling for `FileNotFoundError` in addition to `subprocess.CalledProcessError`.

### Rationale

The original implementation did not properly handle the case when the `which` command is missing. This update ensures the function gracefully handles such scenarios and continues to check other possible locations for the `node` executable.
