### PR TITLE
Fix cell selection when using shift + arrow keys

### DIFF
--- a/.changeset/yellow-paws-grin.md
+++ b/.changeset/yellow-paws-grin.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/dataframe": minor
-"gradio": minor
+"@gradio/dataframe": patch
+"gradio": patch
 ---
 
 feat:Fix cell selection when using shift + arrow keys

--- a/.changeset/yellow-paws-grin.md
+++ b/.changeset/yellow-paws-grin.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": minor
+"gradio": minor
+---
+
+feat:Fix cell selection when using shift + arrow keys

--- a/js/dataframe/shared/selection_utils.ts
+++ b/js/dataframe/shared/selection_utils.ts
@@ -56,7 +56,14 @@ export function handle_selection(
 	selected_cells: CellCoordinate[],
 	event: { shiftKey: boolean; metaKey: boolean; ctrlKey: boolean }
 ): CellCoordinate[] {
-	console.log("current", current, "selected_cells", selected_cells, "event", event);
+	console.log(
+		"current",
+		current,
+		"selected_cells",
+		selected_cells,
+		"event",
+		event
+	);
 	if (event.shiftKey && selected_cells.length > 0) {
 		return get_range_selection(
 			selected_cells[selected_cells.length - 1],

--- a/js/dataframe/shared/selection_utils.ts
+++ b/js/dataframe/shared/selection_utils.ts
@@ -37,8 +37,14 @@ export function get_range_selection(
 	const max_col = Math.max(start_col, end_col);
 
 	const cells: CellCoordinate[] = [];
+	// Add the start cell as the "anchor" cell so that when
+	// we press shift+arrow keys, the selection will always
+	// include the anchor cell.
+	cells.push(start);
+
 	for (let i = min_row; i <= max_row; i++) {
 		for (let j = min_col; j <= max_col; j++) {
+			if (i === start_row && j === start_col) continue;
 			cells.push([i, j]);
 		}
 	}
@@ -50,6 +56,7 @@ export function handle_selection(
 	selected_cells: CellCoordinate[],
 	event: { shiftKey: boolean; metaKey: boolean; ctrlKey: boolean }
 ): CellCoordinate[] {
+	console.log("current", current, "selected_cells", selected_cells, "event", event);
 	if (event.shiftKey && selected_cells.length > 0) {
 		return get_range_selection(
 			selected_cells[selected_cells.length - 1],

--- a/js/dataframe/shared/selection_utils.ts
+++ b/js/dataframe/shared/selection_utils.ts
@@ -56,14 +56,6 @@ export function handle_selection(
 	selected_cells: CellCoordinate[],
 	event: { shiftKey: boolean; metaKey: boolean; ctrlKey: boolean }
 ): CellCoordinate[] {
-	console.log(
-		"current",
-		current,
-		"selected_cells",
-		selected_cells,
-		"event",
-		event
-	);
 	if (event.shiftKey && selected_cells.length > 0) {
 		return get_range_selection(
 			selected_cells[selected_cells.length - 1],


### PR DESCRIPTION
Previously, we would treat the cell that was farthest to the left and top as the "anchor" cell, which would lead to interesting behavior when using shift+arrow keys. For example, here, I'm pressing on a cell, and then doing shift + up/left. 


https://github.com/user-attachments/assets/60ce5f16-6710-4658-bc2c-99a518942cb9



In this PR:


https://github.com/user-attachments/assets/18e2ad2f-028a-4fae-812d-c9dfb3b44fd5

