### PR TITLE
Allow navigating down from header cells

### DIFF
--- a/js/dataframe/shared/utils/keyboard_utils.ts
+++ b/js/dataframe/shared/utils/keyboard_utils.ts
@@ -9,12 +9,11 @@ function handle_header_navigation(
 	ctx: KeyboardContext
 ): boolean {
 	if (ctx.selected_header === false || ctx.header_edit !== false) return false;
-
 	switch (event.key) {
 		case "ArrowDown":
-			ctx.df_actions.set_selected([0, ctx.selected_header]);
-			ctx.df_actions.set_selected_cells([[0, ctx.selected_header]]);
 			ctx.df_actions.set_selected_header(false);
+			ctx.df_actions.set_selected([0, ctx.selected_header])
+			ctx.df_actions.set_selected_cells([[0, ctx.selected_header]]);
 			return true;
 		case "ArrowLeft":
 			ctx.df_actions.set_selected_header(
@@ -195,7 +194,6 @@ async function handle_cell_navigation(
 	ctx: KeyboardContext
 ): Promise<boolean> {
 	if (!ctx.selected) return false;
-
 	if (event.key === "c" && (event.metaKey || event.ctrlKey)) {
 		event.preventDefault();
 		if (ctx.selected_cells.length > 0) {


### PR DESCRIPTION
There was a small issue: if you used the keyboard to navigate to the header cell, you couldn't navigate down to the regular table cells. 

Before:


https://github.com/user-attachments/assets/71a91a1b-5d56-4b73-a02a-3e30adbdb6fc

Fixed:


https://github.com/user-attachments/assets/02af6aa5-1499-472e-8560-90cf2a49c0e8


