### PR TITLE
Add parent focus for drag selection

### DIFF
--- a/.changeset/ready-donuts-switch.md
+++ b/.changeset/ready-donuts-switch.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": minor
+"gradio": minor
+---
+
+feat:Add parent focus for drag selection

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -43,7 +43,11 @@
 	} from "./utils/table_utils";
 	import { make_headers, process_data } from "./utils/data_processing";
 	import { handle_keydown } from "./utils/keyboard_utils";
-	import { create_drag_handlers, type DragState } from "./utils/drag_utils";
+	import {
+		create_drag_handlers,
+		type DragState,
+		type DragHandlers
+	} from "./utils/drag_utils";
 
 	export let datatype: Datatype | Datatype[];
 	export let label: string | null = null;
@@ -691,19 +695,26 @@
 		mouse_down_pos = drag_state.mouse_down_pos;
 	}
 
-	const drag_handlers = create_drag_handlers(
-		drag_state,
-		(value) => (is_dragging = value),
-		(cells) => df_actions.set_selected_cells(cells),
-		(cell) => df_actions.set_selected(cell),
-		(event, row, col) =>
-			selection_ctx.actions.handle_cell_click(event, row, col),
-		show_row_numbers
-	);
+	let drag_handlers: DragHandlers;
 
-	const handle_mouse_down = drag_handlers.handle_mouse_down;
-	const handle_mouse_move = drag_handlers.handle_mouse_move;
-	const handle_mouse_up = drag_handlers.handle_mouse_up;
+	function init_drag_handlers(): void {
+		drag_handlers = create_drag_handlers(
+			drag_state,
+			(value) => (is_dragging = value),
+			(cells) => df_actions.set_selected_cells(cells),
+			(cell) => df_actions.set_selected(cell),
+			(event, row, col) =>
+				selection_ctx.actions.handle_cell_click(event, row, col),
+			show_row_numbers,
+			parent
+		);
+	}
+
+	$: if (parent) init_drag_handlers();
+
+	$: handle_mouse_down = drag_handlers?.handle_mouse_down || (() => {});
+	$: handle_mouse_move = drag_handlers?.handle_mouse_move || (() => {});
+	$: handle_mouse_up = drag_handlers?.handle_mouse_up || (() => {});
 </script>
 
 <svelte:window on:resize={() => set_cell_widths()} />

--- a/js/dataframe/shared/utils/drag_utils.ts
+++ b/js/dataframe/shared/utils/drag_utils.ts
@@ -19,7 +19,8 @@ export function create_drag_handlers(
 	set_selected_cells: (cells: CellCoordinate[]) => void,
 	set_selected: (cell: CellCoordinate | false) => void,
 	handle_cell_click: (event: MouseEvent, row: number, col: number) => void,
-	show_row_numbers: boolean
+	show_row_numbers: boolean,
+	parent_element?: HTMLElement
 ): DragHandlers {
 	const start_drag = (event: MouseEvent, row: number, col: number): void => {
 		if (
@@ -57,6 +58,8 @@ export function create_drag_handlers(
 	const end_drag = (event: MouseEvent): void => {
 		if (!state.is_dragging && state.drag_start) {
 			handle_cell_click(event, state.drag_start[0], state.drag_start[1]);
+		} else if (state.is_dragging && parent_element) {
+			parent_element.focus();
 		}
 
 		state.is_dragging = false;


### PR DESCRIPTION
## Description

This is a super niche bug fix. Drag selection and then copying didn't work on mount unless you had selected a cell already because we needed to add focus to the parent. 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
