### PR TITLE
Fix max characters in non-editable dataframes

### DIFF
--- a/.changeset/four-tips-pump.md
+++ b/.changeset/four-tips-pump.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": minor
+"gradio": minor
+---
+
+feat:Fix max characters in non-editable dataframes

--- a/js/dataframe/shared/EditableCell.svelte
+++ b/js/dataframe/shared/EditableCell.svelte
@@ -53,14 +53,23 @@
 	): string {
 		if (is_image) return String(text);
 		const str = String(text);
-		if (!max_length || str.length <= max_length) return str;
+		if (!max_length || max_length <= 0) return str;
+		if (str.length <= max_length) return str;
 		return str.slice(0, max_length) + "...";
 	}
 
-	$: display_text =
-		edit || is_expanded
-			? value
-			: truncate_text(display_value || value, max_chars, datatype === "image");
+	$: should_truncate =
+		!edit && !is_expanded && max_chars !== null && max_chars > 0;
+
+	$: display_content = editable
+		? value
+		: display_value !== null
+			? display_value
+			: value;
+
+	$: display_text = should_truncate
+		? truncate_text(display_content, max_chars, datatype === "image")
+		: display_content;
 
 	function use_focus(node: HTMLInputElement): any {
 		if (clear_on_focus) {
@@ -135,6 +144,8 @@
 	on:focus|preventDefault
 	style={styling}
 	data-editable={editable}
+	data-max-chars={max_chars}
+	data-expanded={is_expanded}
 	placeholder=" "
 	class:text={datatype === "str"}
 >
@@ -159,7 +170,7 @@
 			{root}
 		/>
 	{:else}
-		{editable ? display_text : display_value || display_text}
+		{display_text}
 	{/if}
 </span>
 {#if show_selection_buttons && coords && on_select_column && on_select_row}
@@ -202,6 +213,12 @@
 		cursor: text;
 		width: 100%;
 		height: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	span.text:not(.expanded) {
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;


### PR DESCRIPTION
## Description

Max characters was working as expected in editable dataframes but not in non-editable dataframes. This fixes that.

Note, this has flagged an issue that I notice that we should really be calculating the column widths based on the truncated values, not the original values. A viable workaround for now is just setting the column width manually which isn't ideal but there is a bit of time needed to rejig the native dataframe to calculate the column widths based on the truncated value. I think. 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
