### PR TITLE
Fix #9599: Preserve preview mode when selected_index exceeds the number of images in the gallery.

### DIFF
--- a/js/gallery/shared/Gallery.svelte
+++ b/js/gallery/shared/Gallery.svelte
@@ -144,6 +144,12 @@
 		if (selected_index !== old_selected_index) {
 			old_selected_index = selected_index;
 			if (selected_index !== null) {
+				if (resolved_value != null) {
+					selected_index = Math.max(
+						0,
+						Math.min(selected_index, resolved_value.length - 1)
+					);
+				}
 				dispatch("select", {
 					index: selected_index,
 					value: resolved_value?.[selected_index]

--- a/js/gallery/shared/Gallery.svelte
+++ b/js/gallery/shared/Gallery.svelte
@@ -90,10 +90,14 @@
 			// Otherwise we keep the selected_index the same if the
 			// gallery has at least as many elements as it did before
 		} else {
-			selected_index =
-				selected_index != null && value != null && selected_index < value.length
-					? selected_index
-					: null;
+			if (selected_index !== null && value !== null) {
+				selected_index = Math.max(
+					0,
+					Math.min(selected_index, value.length - 1)
+				);
+			} else {
+				selected_index = null;
+			}
 		}
 		dispatch("change");
 		prev_value = value;


### PR DESCRIPTION
Fixed preview mode unexpected exit when selected_index is greater than the number of images in the gallery.

## Description

To maintain a smooth user experience, I introduced an additional edge case:

If selection_index exceeds the number of available images, it now selects the highest valid index instead of defaulting to null.
This ensures that when images are removed from the gallery, the preview remains active, selecting the last available image instead of forcefully exiting.
The gallery now only exits preview mode when the user explicitly selects the exit button.

Closes: #9599

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
