### PR TITLE
fix typing on load event listener

### DIFF
--- a/.changeset/flat-memes-sort.md
+++ b/.changeset/flat-memes-sort.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:fix typing on load event listener

--- a/gradio/component_meta.py
+++ b/gradio/component_meta.py
@@ -18,6 +18,7 @@ INTERFACE_TEMPLATE = '''
     from gradio.blocks import Block
     if TYPE_CHECKING:
         from gradio.components import Timer
+        from gradio.components.base import Component
 
     {% for event in events %}
     def {{ event.event_name }}(self,


### PR DESCRIPTION
## Description

This PR fixes an issue with insufficient typing of the `load` event listener due to not having imported the `Component` class.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
