### PR TITLE
bug fix logout if there is root_path in launch

### DIFF
--- a/.changeset/olive-sites-ask.md
+++ b/.changeset/olive-sites-ask.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:bug fix logout if there is root_path in launch

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -451,7 +451,9 @@ class App(FastAPI):
 
         @app.post("/login")
         @app.post("/login/")
-        def login(request: fastapi.Request, form_data: OAuth2PasswordRequestForm = Depends()):
+        def login(
+            request: fastapi.Request, form_data: OAuth2PasswordRequestForm = Depends()
+        ):
             username, password = form_data.username.strip(), form_data.password
             if app.auth is None:
                 root = route_utils.get_root_url(

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -492,7 +492,7 @@ class App(FastAPI):
 
             @app.get("/logout")
             def logout(user: str = Depends(get_current_user)):
-                response = RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
+                response = RedirectResponse(url=app.root_path or "/", status_code=status.HTTP_302_FOUND)
                 response.delete_cookie(key=f"access-token-{app.cookie_id}", path="/")
                 response.delete_cookie(
                     key=f"access-token-unsecure-{app.cookie_id}", path="/"

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -451,10 +451,15 @@ class App(FastAPI):
 
         @app.post("/login")
         @app.post("/login/")
-        def login(form_data: OAuth2PasswordRequestForm = Depends()):
+        def login(request: fastapi.Request, form_data: OAuth2PasswordRequestForm = Depends()):
             username, password = form_data.username.strip(), form_data.password
             if app.auth is None:
-                return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
+                root = route_utils.get_root_url(
+                    request=request,
+                    route_path="/login",
+                    root_path=app.root_path,
+                )
+                return RedirectResponse(url=root, status_code=status.HTTP_302_FOUND)
             if (
                 not callable(app.auth)
                 and username in app.auth
@@ -491,8 +496,13 @@ class App(FastAPI):
         else:
 
             @app.get("/logout")
-            def logout(user: str = Depends(get_current_user)):
-                response = RedirectResponse(url=app.root_path or "/", status_code=status.HTTP_302_FOUND)
+            def logout(request: fastapi.Request, user: str = Depends(get_current_user)):
+                root = route_utils.get_root_url(
+                    request=request,
+                    route_path="/logout",
+                    root_path=app.root_path,
+                )
+                response = RedirectResponse(url=root, status_code=status.HTTP_302_FOUND)
                 response.delete_cookie(key=f"access-token-{app.cookie_id}", path="/")
                 response.delete_cookie(
                     key=f"access-token-unsecure-{app.cookie_id}", path="/"


### PR DESCRIPTION
## Description

Fixing if in the launch there is root_path assigned and it return back to "/" not the root path (especially when doing this in kubernetes). This bug is already tested with dev container vscode. Thank you

Closes: #10291

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
