### PR TITLE
fix typing of gr.on event listener

### DIFF
--- a/gradio/events.py
+++ b/gradio/events.py
@@ -468,7 +468,7 @@ class EventListenerMethod:
 if TYPE_CHECKING:
     EventListenerCallable = Callable[
         [
-            Union[Callable, None],
+            Union[Callable[..., Any], None],
             Union[Component, Sequence[Component], None],
             Union[Block, Sequence[Block], Sequence[Component], Component, None],
             Union[str, None, Literal[False]],
@@ -728,7 +728,7 @@ class EventListener(str):
 @document()
 def on(
     triggers: Sequence[EventListenerCallable] | EventListenerCallable | None = None,
-    fn: Callable | None | Literal["decorator"] = "decorator",
+    fn: Callable[..., Any] | None | Literal["decorator"] = "decorator",
     inputs: Component
     | BlockContext
     | Sequence[Component | BlockContext]


### PR DESCRIPTION
## Description

The `gr.on` event listener is insufficiently typed due to instances of `Callable` not being qualified. This PR fixes that. 

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
