### PR TITLE
Improve UI for lazy caching

### DIFF
--- a/.changeset/puny-jokes-clap.md
+++ b/.changeset/puny-jokes-clap.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Improve UI for lazy caching

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -365,7 +365,6 @@ class Examples:
                     show_progress="hidden",
                     postprocess=False,
                     queue=False,
-                    api_name=self.api_name,
                     show_api=False,
                 ).then(
                     load_example_output,

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -350,9 +350,7 @@ class Examples:
 
                 def load_example_input(example_tuple):
                     _, example_value = example_tuple
-                    processed_example = self._get_processed_example(
-                        example_value
-                    )
+                    processed_example = self._get_processed_example(example_value)
                     return utils.resolve_singleton(processed_example)
 
                 def load_example_output(example_tuple):

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -362,6 +362,7 @@ class Examples:
                     load_example_input,
                     inputs=[self.dataset],
                     outputs=self.inputs,
+                    show_progress="hidden",
                     postprocess=False,
                     queue=False,
                     api_name=self.api_name,

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -348,20 +348,31 @@ class Examples:
 
             if self.cache_examples:
 
-                def load_example_with_output(example_tuple):
-                    example_id, example_value = example_tuple
+                def load_example_input(example_tuple):
+                    _, example_value = example_tuple
                     processed_example = self._get_processed_example(
                         example_value
-                    ) + self.load_from_cache(example_id)
+                    )
                     return utils.resolve_singleton(processed_example)
 
+                def load_example_output(example_tuple):
+                    example_id, _ = example_tuple
+                    cached_outputs = self.load_from_cache(example_id)
+                    return utils.resolve_singleton(cached_outputs)
+
                 self.cache_event = self.load_input_event = self.dataset.click(
-                    load_example_with_output,
+                    load_example_input,
                     inputs=[self.dataset],
-                    outputs=self.inputs + self.outputs,  # type: ignore
-                    show_progress="hidden",
+                    outputs=self.inputs,
                     postprocess=False,
                     queue=False,
+                    api_name=self.api_name,
+                    show_api=False,
+                ).then(
+                    load_example_output,
+                    inputs=[self.dataset],
+                    outputs=self.outputs,
+                    postprocess=False,
                     api_name=self.api_name,
                     show_api=False,
                 )

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -213,21 +213,13 @@ def test_example_caching_relaunch(connect):
         )
 
     with connect(demo) as client:
-        assert client.predict(1, api_name="/examples") == (
-            "hello",
-            "Eve",
-            "hello Eve",
-        )
+        assert client.predict(1, api_name="/examples") == "hello Eve"
 
     # Let the server shut down
     time.sleep(1)
 
     with connect(demo) as client:
-        assert client.predict(1, api_name="/examples") == (
-            "hello",
-            "Eve",
-            "hello Eve",
-        )
+        assert client.predict(1, api_name="/examples") == "hello Eve"
 
 
 @patch("gradio.utils.get_cache_folder", return_value=Path(tempfile.mkdtemp()))
@@ -264,18 +256,10 @@ class TestProcessExamples:
             )
 
         with connect(demo) as client:
-            assert client.predict(1, api_name="/examples") == (
-                "hello",
-                "Eve",
-                "hello Eve",
-            )
+            assert client.predict(1, api_name="/examples") == "hello Eve"
 
         with connect(demo) as client:
-            assert client.predict(1, api_name="/examples") == (
-                "hello",
-                "Eve",
-                "hello Eve",
-            )
+            assert client.predict(1, api_name="/examples") == "hello Eve"
 
     def test_caching_image(self, patched_cache_folder, connect):
         io = gr.Interface(
@@ -616,10 +600,10 @@ class TestProcessExamples:
         client = TestClient(app)
 
         response = client.post(f"{API_PREFIX}/api/load_example/", json={"data": [0]})
-        assert response.json()["data"] == ["Hello,", "World", "Hello, World"]
+        assert response.json()["data"] == ["Hello, World"]
 
         response = client.post(f"{API_PREFIX}/api/load_example/", json={"data": [1]})
-        assert response.json()["data"] == ["Michael", "Jordan", "Michael Jordan"]
+        assert response.json()["data"] == ["Michael Jordan"]
 
     def test_end_to_end_lazy_cache_examples(self, patched_cache_folder):
         def image_identity(image, string):
@@ -648,13 +632,11 @@ class TestProcessExamples:
 
         response = client.post(f"{API_PREFIX}/api/load_example/", json={"data": [0]})
         data = response.json()["data"]
-        assert data[0]["path"].endswith("cheetah1.jpg")
-        assert data[1] == "cheetah"
+        assert data[0]["path"].endswith("image.webp")
 
         response = client.post(f"{API_PREFIX}/api/load_example/", json={"data": [1]})
         data = response.json()["data"]
-        assert data[0]["path"].endswith("bus.png")
-        assert data[1] == "bus"
+        assert data[0]["path"].endswith("image.webp")
 
 
 def test_multiple_file_flagging(tmp_path, connect):


### PR DESCRIPTION
When examples were cached, we previously combined two events together: loading the input value and loading the output value. For eager caching, this makes sense, but for lazy caching, we should first load the input value (since that's instantaneous) and _then_ load the output value, which can be time-consuming. 

Closes: https://github.com/gradio-app/gradio/issues/10866