### PR TITLE
Fix `root_url` assignment issue in `get_request_url()` when `X_Forwarded_Host` is set

### DIFF
--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -361,14 +361,13 @@ def get_first_header_value(request: fastapi.Request, header_name: str):
 
 
 def get_request_url(request: fastapi.Request) -> str:
-    x_forwarded_host = get_first_header_value(request, "x-forwarded-host")
-    root_url = f"http://{x_forwarded_host}" if x_forwarded_host else str(request.url)
-    root_url = httpx.URL(root_url)
-    root_url = root_url.copy_with(query=None)
-    root_url = str(root_url).rstrip("/")
+    request_url = str(request.url)
+    request_url = httpx.URL(request_url)
+    request_url = request_url.copy_with(query=None)
     if get_first_header_value(request, "x-forwarded-proto") == "https":
-        root_url = root_url.replace("http://", "https://")
-    return root_url
+        request_url = request_url.copy_with(scheme="https")
+    request_url = str(request_url).rstrip("/")
+    return request_url
 
 
 def get_api_call_path(request: fastapi.Request) -> str:


### PR DESCRIPTION
## Description
In #10841, the `get_request_url()` function was introduced to help calculating the correct path of the request. Ideally, this function should return the **full URL string** (i.e. scheme+domain+path) to allow further calculation and adjustment in the following function. However, notice that `X_Forwarded_Host` will be assigned to `root_url` when it is set. In the following `get_api_call_path()` function, path included in the URL string obtained by the `get_request_url()` function will be checked, and a ValueError will be raised if neither `queue_api_url` nor `generic_api_url` was matched. That is to say, if the request contains `X_Forwarded_Host`, this function will always raise an error as there is no path in this parameter.

## Changes
This PR change the following things in function get_request_url() in file `gradio/route_utils.py`:  
- Assign `request.url` to `root_url` directly
- Use `copy_with` method to adjust scheme when required
- Rename variable `root_url` to `request_url` to avoid confusion