### PR TITLE
Switch from `root_url` to `request.url` in `get_api_call_path()`

### DIFF
--- a/.changeset/public-zoos-obey.md
+++ b/.changeset/public-zoos-obey.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Switch from `root_url` to `request.url` in `get_api_call_path()`

--- a/.changeset/public-zoos-obey.md
+++ b/.changeset/public-zoos-obey.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Switch from `root_url` to `request.url` in `get_api_call_path()`

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -384,17 +384,16 @@ def get_api_call_path(request: fastapi.Request) -> str:
     """
     queue_api_url = f"{API_PREFIX}/queue/join"
     generic_api_url = f"{API_PREFIX}/call"
+    request_url = str(request.url)
 
-    root_url = get_request_url(request)
-
-    if root_url.endswith(queue_api_url):
+    if request_url.endswith(queue_api_url):
         return queue_api_url
 
-    start_index = root_url.rfind(generic_api_url)
+    start_index = request_url.rfind(generic_api_url)
     if start_index >= 0:
-        return root_url[start_index : len(root_url)]
+        return request_url[start_index : len(request_url)]
 
-    raise ValueError(f"Request url '{root_url}' has an unkown api call pattern.")
+    raise ValueError(f"Request url '{request_url}' has an unkown api call pattern.")
 
 
 def get_root_url(


### PR DESCRIPTION
A regression was introduced in https://github.com/gradio-app/gradio/pull/10841. This PR fixes it. Basically, we shouldn't be using the forwarded url header here since it's not going to include the full url with the full path. However, `request.url` should be fine to use.

See: https://github.com/gradio-app/gradio/pull/10841#issuecomment-2750507289 and https://github.com/gradio-app/gradio/pull/10875

cc @Kenxu2022, @tqbl, @cansik 

