### PR TITLE
Fix request url

### DIFF
--- a/.changeset/some-masks-stay.md
+++ b/.changeset/some-masks-stay.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:Fix request url

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -384,7 +384,7 @@ def get_api_call_path(request: fastapi.Request) -> str:
     """
     queue_api_url = f"{API_PREFIX}/queue/join"
     generic_api_url = f"{API_PREFIX}/call"
-    request_url = str(request.url)
+    request_url = str(httpx.URL(str(request.url)).copy_with(query=None)).strip("/")
 
     if request_url.endswith(queue_api_url):
         return queue_api_url

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -38,6 +38,7 @@ from gradio.route_utils import (
     API_PREFIX,
     FnIndexInferError,
     compare_passwords_securely,
+    get_api_call_path,
     get_root_url,
     starts_with_protocol,
 )
@@ -1712,3 +1713,28 @@ def test_mount_gradio_app_args_match_launch_args():
     assert not missing_params, (
         f"Parameters in launch() but missing in mount_gradio_app(): {missing_params}"
     )
+
+
+def test_get_api_call_path_queue_join():
+    queue_url = f"http://localhost:7860{API_PREFIX}/queue/join?__theme=dark"
+    scope = {"type": "http", "headers": [], "path": queue_url}
+    request = Request(scope)
+
+    path = get_api_call_path(request)
+    assert path == f"{API_PREFIX}/queue/join"
+
+
+def test_get_api_call_path_generic_call():
+    call_url = f"http://localhost:7860{API_PREFIX}/call/predict?__theme=light"
+    scope = {"type": "http", "headers": [], "path": call_url}
+    request = Request(scope)
+    path = get_api_call_path(request)
+    assert path == f"{API_PREFIX}/call/predict"
+
+    complex_call_url = (
+        f"http://localhost:7860{API_PREFIX}/call/custom_function/with/extra/parts"
+    )
+    scope = {"type": "http", "headers": [], "path": complex_call_url}
+    request = Request(scope)
+    path = get_api_call_path(request)
+    assert path == f"{API_PREFIX}/call/custom_function/with/extra/parts"


### PR DESCRIPTION
I made a mistake in https://github.com/gradio-app/gradio/pull/10877, which was causing all demos on Spaces to hang. The mistake was that I was not stripping out query parameters when looking at the `request.url`. So on Spaces, we'd see an error like this:

```
ValueError: Request url 'http://gradio-pr-deploys-pr-10877-all-demos.hf.space/demo/calculator/gradio_api/queue/join?logs=container&__theme=dark' has an unkown api call pattern.
```

This fixes that.