### PR TITLE
Fix minor heartbeat memory leak

### DIFF
--- a/.changeset/clear-vans-push.md
+++ b/.changeset/clear-vans-push.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Fix minor heartbeat memory leak
+fix:Fix minor heartbeat memory leak

--- a/.changeset/clear-vans-push.md
+++ b/.changeset/clear-vans-push.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix minor heartbeat memory leak

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1006,13 +1006,13 @@ class App(FastAPI):
                 return "stop"
 
             async def iterator():
+                stop_stream_task = asyncio.create_task(stop_stream())
                 while True:
                     try:
                         yield "data: ALIVE\n\n"
                         # We need to close the heartbeat connections as soon as the server stops
                         # otherwise the server can take forever to close
                         wait_task = asyncio.create_task(wait())
-                        stop_stream_task = asyncio.create_task(stop_stream())
                         done, _ = await asyncio.wait(
                             [wait_task, stop_stream_task],
                             return_when=asyncio.FIRST_COMPLETED,
@@ -1021,10 +1021,13 @@ class App(FastAPI):
                         if "stop" in done:
                             raise asyncio.CancelledError()
                     except asyncio.CancelledError:
+                        if not stop_stream_task.done():
+                            stop_stream_task.cancel()
+
                         req = Request(request, username, session_hash=session_hash)
                         root_path = route_utils.get_root_url(
                             request=request,
-                            route_path=f"{API_PREFIX}/hearbeat/{session_hash}",
+                            route_path=f"{API_PREFIX}/heartbeat/{session_hash}",
                             root_path=app.root_path,
                         )
                         body = PredictBodyInternal(
@@ -1036,7 +1039,7 @@ class App(FastAPI):
                             if any(t for t in dep.targets if t[1] == "unload")
                         ]
                         for fn_index in unload_fn_indices:
-                            # The task runnning this loop has been cancelled
+                            # The task running this loop has been cancelled
                             # so we add tasks in the background
                             background_tasks.add_task(
                                 route_utils.call_process_api,


### PR DESCRIPTION
Hello!!

I was reading through the Gradio code today and noticed:
- A `stop_stream()` task was being created on every heartbeat, in an infinite loop. Past tasks were never cancelled. I guess this is not an issue in practice, but it will slowly leak memory.
- Some typos. A route here was spelled as `hearbeat` instead of `heartbeat`. I don't know what this impacts.

As a fix I:
- Made the code reuse the same `stop_stream()` task.
- Simplified slightly.
- Fixed typos.