### PR TITLE
Switch to HF Inference Providers on Playground

### DIFF
--- a/js/_website/src/lib/components/DemosLite/DemosLite.svelte
+++ b/js/_website/src/lib/components/DemosLite/DemosLite.svelte
@@ -137,7 +137,8 @@
 	system_prompt = prompt_rules[0] + system_prompt + prompt_rules[1];
 	fallback_prompt = prompt_rules[0] + fallback_prompt + prompt_rules[1];
 
-	const workerUrl = "https://playground-worker.pages.dev/api/generate";
+	const workerUrl = "https://inference-providers.playground-worker.pages.dev/api/generate";
+	// const workerUrl = "https://playground-worker.pages.dev/api/generate";
 	// const workerUrl = "http://localhost:5173/api/generate";
 
 	let abortController: AbortController | null = null;


### PR DESCRIPTION
This PR doesn't actually include any changes, just replaces the url for testing. All the changes are [here](https://github.com/gradio-app/playground-worker/pull/3). Doesn't need to be merged, once [this](https://github.com/gradio-app/playground-worker/pull/3) is merged changes will take effect. 