### PR TITLE
Fix route_utils.get_api_call_path()

### DIFF
--- a/.changeset/crazy-melons-exist.md
+++ b/.changeset/crazy-melons-exist.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:Fix get_api_call_path
+feat:Fix route_utils.get_api_call_path()

--- a/.changeset/crazy-melons-exist.md
+++ b/.changeset/crazy-melons-exist.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix get_api_call_path

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -393,7 +393,7 @@ def get_api_call_path(request: fastapi.Request) -> str:
     if start_index >= 0:
         return request_url[start_index : len(request_url)]
 
-    raise ValueError(f"Request url '{request_url}' has an unkown api call pattern.")
+    raise ValueError(f"Request url '{request_url}' has an unknown api call pattern.")
 
 
 def get_root_url(

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -384,7 +384,7 @@ def get_api_call_path(request: fastapi.Request) -> str:
     """
     queue_api_url = f"{API_PREFIX}/queue/join"
     generic_api_url = f"{API_PREFIX}/call"
-    request_url = str(httpx.URL(str(request.url)).copy_with(query=None)).rstrip("/")
+    request_url = str(request.url.replace(query=None)).rstrip("/")
 
     if request_url.endswith(queue_api_url):
         return queue_api_url

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -384,16 +384,18 @@ def get_api_call_path(request: fastapi.Request) -> str:
     """
     queue_api_url = f"{API_PREFIX}/queue/join"
     generic_api_url = f"{API_PREFIX}/call"
-    request_url = str(request.url.replace(query=None)).rstrip("/")
+    request_path = request.url.path.rstrip("/")
 
-    if request_url.endswith(queue_api_url):
+    if request_path.endswith(queue_api_url):
         return queue_api_url
 
-    start_index = request_url.rfind(generic_api_url)
+    start_index = request_path.rfind(generic_api_url)
     if start_index >= 0:
-        return request_url[start_index : len(request_url)]
+        return request_path[start_index : len(request_path)]
 
-    raise ValueError(f"Request url '{request_url}' has an unknown api call pattern.")
+    raise ValueError(
+        f"Request url '{str(request.url)}' has an unknown api call pattern."
+    )
 
 
 def get_root_url(

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -384,7 +384,7 @@ def get_api_call_path(request: fastapi.Request) -> str:
     """
     queue_api_url = f"{API_PREFIX}/queue/join"
     generic_api_url = f"{API_PREFIX}/call"
-    request_url = str(httpx.URL(str(request.url)).copy_with(query=None)).strip("/")
+    request_url = str(httpx.URL(str(request.url)).copy_with(query=None)).rstrip("/")
 
     if request_url.endswith(queue_api_url):
         return queue_api_url

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1746,17 +1746,43 @@ def test_get_api_call_path_queue_join(server, path):
     assert path == f"{API_PREFIX}/queue/join"
 
 
-def test_get_api_call_path_generic_call():
-    call_url = f"http://localhost:7860{API_PREFIX}/call/predict?__theme=light"
-    scope = {"type": "http", "headers": [], "path": call_url}
+@pytest.mark.parametrize(
+    "server, path, expected",
+    [
+        (
+            ("localhost", 7860),
+            f"{API_PREFIX}/call/predict",
+            f"{API_PREFIX}/call/predict",
+        ),
+        (
+            None,
+            f"http://localhost:7860{API_PREFIX}/call/predict",
+            f"{API_PREFIX}/call/predict",
+        ),
+        (
+            ("localhost", 7860),
+            f"{API_PREFIX}/call/custom_function/with/extra/parts",
+            f"{API_PREFIX}/call/custom_function/with/extra/parts",
+        ),
+        (
+            None,
+            f"http://localhost:7860{API_PREFIX}/call/custom_function/with/extra/parts",
+            f"{API_PREFIX}/call/custom_function/with/extra/parts",
+        ),
+        (  # Query params are ignored.
+            ("localhost", 7860),
+            f"{API_PREFIX}/call/custom_function/with/extra/parts?__theme=light",
+            f"{API_PREFIX}/call/custom_function/with/extra/parts",
+        ),
+        (  # Query params are ignored.
+            None,
+            f"http://localhost:7860{API_PREFIX}/call/custom_function/with/extra/parts?__theme=light",
+            f"{API_PREFIX}/call/custom_function/with/extra/parts",
+        ),
+    ],
+)
+def test_get_api_call_path_generic_call(server, path, expected):
+    scope = {"type": "http", "headers": [], "server": server, "path": path}
     request = Request(scope)
     path = get_api_call_path(request)
-    assert path == f"{API_PREFIX}/call/predict"
-
-    complex_call_url = (
-        f"http://localhost:7860{API_PREFIX}/call/custom_function/with/extra/parts"
-    )
-    scope = {"type": "http", "headers": [], "path": complex_call_url}
-    request = Request(scope)
-    path = get_api_call_path(request)
-    assert path == f"{API_PREFIX}/call/custom_function/with/extra/parts"
+    assert path == expected

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1715,9 +1715,15 @@ def test_mount_gradio_app_args_match_launch_args():
     )
 
 
-def test_get_api_call_path_queue_join():
-    queue_url = f"http://localhost:7860{API_PREFIX}/queue/join?__theme=dark"
-    scope = {"type": "http", "headers": [], "path": queue_url}
+@pytest.mark.parametrize(
+    "path",
+    [
+        f"http://localhost:7860{API_PREFIX}/queue/join?__theme=dark",
+        f"{API_PREFIX}/queue/join",
+    ],
+)
+def test_get_api_call_path_queue_join(path):
+    scope = {"type": "http", "headers": [], "path": path}
     request = Request(scope)
 
     path = get_api_call_path(request)

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1718,7 +1718,7 @@ def test_mount_gradio_app_args_match_launch_args():
 @pytest.mark.parametrize(
     "server, path",
     [
-        # ASGI HTTP Connection Scope. Spec: https://asgi.readthedocs.io/en/latest/specs/www.html#http-connection-scope
+        # ASGI HTTP Connection Scope. Ref: https://asgi.readthedocs.io/en/latest/specs/www.html#http-connection-scopeg
         (
             None,  # 'server' is optional. Requests from Gradio-Lite will be this case.
             f"{API_PREFIX}/queue/join",

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1716,14 +1716,30 @@ def test_mount_gradio_app_args_match_launch_args():
 
 
 @pytest.mark.parametrize(
-    "path",
+    "server, path",
     [
-        f"http://localhost:7860{API_PREFIX}/queue/join?__theme=dark",
-        f"{API_PREFIX}/queue/join",
+        # ASGI HTTP Connection Scope. Spec: https://asgi.readthedocs.io/en/latest/specs/www.html#http-connection-scope
+        (
+            None,  # 'server' is optional. Requests from Gradio-Lite will be this case.
+            f"{API_PREFIX}/queue/join",
+        ),
+        (("localhost", 7860), f"{API_PREFIX}/queue/join"),
+        (
+            ("localhost", 7860),
+            f"{API_PREFIX}/queue/join?__theme=dark",  # With query params.
+        ),
+        (
+            ("localhost", 7860),
+            f"{API_PREFIX}/queue/join?foo=bar&__theme=dark",  # With multiple query params.
+        ),
+        (
+            None,
+            f"http://localhost:7860{API_PREFIX}/queue/join?__theme=dark",  # Putting the server in the path may be invalid but we test it anyway.
+        ),
     ],
 )
-def test_get_api_call_path_queue_join(path):
-    scope = {"type": "http", "headers": [], "path": path}
+def test_get_api_call_path_queue_join(server, path):
+    scope = {"type": "http", "headers": [], "server": server, "path": path}
     request = Request(scope)
 
     path = get_api_call_path(request)


### PR DESCRIPTION
## Description

Lite is broken in the main branch and this PR fixes it.

This replacement of `.strip("/")` to `.rstrip("/")` is the core of the fix.
https://github.com/gradio-app/gradio/pull/10897/files#diff-7b70c24a1e3baea4acc4ef7072c619340363fe1e5f9f3860183da99be7463213R387
And this test case covers it.
https://github.com/gradio-app/gradio/pull/10897/files#diff-c96cc0d0cdce3ed40a62b12fe1138e01a135dc3825cade2fb3642d0794142a3cR1722-R1725

Other parts in this PR are all refactoring.

The problem was, `request.url` can be `"/gradio_api/call/predict"` that doesn't have a host name in the case of Lite, and in that case, `.strip("/")` deletes the leading slash and returns `"gradio_api/call/predict"` then it doesn't match in `if request_url.endswith(queue_api_url)` and leads to the error raised at the bottom.
Using `.rstrip("/")` fixes it.