### PR TITLE
Fix EventData scaling when `gr.Image` is in fullscreen mode

### DIFF
--- a/js/image/shared/ImagePreview.svelte
+++ b/js/image/shared/ImagePreview.svelte
@@ -103,13 +103,6 @@
 		justify-content: center;
 	}
 
-	.image-frame {
-		width: auto;
-		height: 100%;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
 	.image-frame :global(img) {
 		width: var(--size-full);
 		height: var(--size-full);

--- a/js/image/shared/ImageUploader.svelte
+++ b/js/image/shared/ImageUploader.svelte
@@ -225,12 +225,6 @@
 		object-fit: scale-down;
 	}
 
-	.image-frame {
-		object-fit: cover;
-		width: 100%;
-		height: 100%;
-	}
-
 	.upload-container {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
## Description

Previously, when an image smaller than the screen size was displayed in `gr.Image` and the fullscreen button was pressed, the image remained at its original size, to prevent it from becoming blurry or low-resolution. However, the `div` container that surrounds the image scaled as though the image had expanded to fullscreen. This caused the EventData to detect clicks outside the image but within the expanded container (since it's actually detecting clicks on the container rather than the image).

To fix this, I removed the image container styles, to ensure that the container always matches the image size, whether scaled or not. This guarantees that EventData accurately detects clicks within the correct boundaries.

This fix was applied to not only `ImageUploader` (as mentioned in #10268) but also to `ImagePreview` to ensure consistent behavior across the `gr.Image` component.

I tried to create a Playwright test for this issue but wasn't able to expand `gr.Image` to fullscreen, as I think Playwright does not support fullscreen mode by default. However, I manually tested with different image sizes and browser dimensions and found no issues.

## Reproduction Code
This code detects clicks on both `ImageUploader` and `ImagePreview` with a small image. 

```python
import gradio as gr

def handle_click(image, event_data: gr.SelectData):
    x, y = event_data.index
    return f"Clicked at coordinates: ({x}, {y})"

with gr.Blocks() as demo:
    with gr.Row():
        with gr.Column():
            image_uploader = gr.Image(label="Upload Image")
            coordinates1_output = gr.Textbox(label="Coordinates for ImageUploader")
            
        with gr.Column():
            image_preview = gr.Image(label="Image Preview", value="https://www.gradio.app/_app/immutable/assets/gradio.CHB5adID.svg", sources=[])
            coordinates2_output = gr.Textbox(label="Coordinates for ImagePreview")
    
    image_uploader.select(handle_click, [image_uploader], coordinates1_output)
    image_preview.select(handle_click, [image_preview], coordinates2_output)

if __name__ == "__main__":
    demo.launch(show_error=True)
```


Closes: #10268 
