### PR TITLE
Fix disabling buttons in `MultimodalTextbox` when `interactive=False`

### DIFF
--- a/.changeset/plain-moments-cover.md
+++ b/.changeset/plain-moments-cover.md
@@ -1,0 +1,6 @@
+---
+"@gradio/multimodaltextbox": patch
+"gradio": patch
+---
+
+fix:Fix disabling buttons in `MultimodalTextbox` when `interactive=False`

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -355,7 +355,7 @@
 			{/if}
 		</div>
 	{/if}
-	{#if sources && sources.includes("microphone") && active_source === "microphone"}
+	{#if sources && sources.includes("microphone") && active_source === "microphone" && !disabled}
 		<InteractiveAudio
 			on:change={({ detail }) => {
 				if (detail !== null) {
@@ -412,7 +412,7 @@
 				on:click={handle_upload_click}><Paperclip /></button
 			>
 		{/if}
-		{#if sources && sources.includes("microphone")}
+		{#if sources && sources.includes("microphone") && !disabled}
 			<button
 				data-testid="microphone-button"
 				class="microphone-button"
@@ -449,7 +449,7 @@
 			on:paste={handle_paste}
 			style={text_align ? "text-align: " + text_align : ""}
 		/>
-		{#if submit_btn}
+		{#if submit_btn && !disabled}
 			<button
 				class="submit-button"
 				class:padded-button={submit_btn !== true}

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -355,7 +355,7 @@
 			{/if}
 		</div>
 	{/if}
-	{#if sources && sources.includes("microphone") && active_source === "microphone" && !disabled}
+	{#if sources && sources.includes("microphone") && active_source === "microphone"}
 		<InteractiveAudio
 			on:change={({ detail }) => {
 				if (detail !== null) {
@@ -388,7 +388,7 @@
 		/>
 	{/if}
 	<div class="input-container">
-		{#if sources && sources.includes("upload") && !disabled && !(file_count === "single" && value.files.length > 0)}
+		{#if sources && sources.includes("upload") && !(file_count === "single" && value.files.length > 0)}
 			<Upload
 				bind:this={upload_component}
 				on:load={handle_upload}
@@ -409,17 +409,23 @@
 			<button
 				data-testid="upload-button"
 				class="upload-button"
-				on:click={handle_upload_click}><Paperclip /></button
+				{disabled}
+				on:click={disabled ? undefined : handle_upload_click}
+				><Paperclip /></button
 			>
 		{/if}
-		{#if sources && sources.includes("microphone") && !disabled}
+		{#if sources && sources.includes("microphone")}
 			<button
 				data-testid="microphone-button"
 				class="microphone-button"
 				class:recording
-				on:click={() => {
-					active_source = active_source !== "microphone" ? "microphone" : null;
-				}}
+				{disabled}
+				on:click={disabled
+					? undefined
+					: () => {
+							active_source =
+								active_source !== "microphone" ? "microphone" : null;
+						}}
 			>
 				<Microphone />
 			</button>
@@ -449,11 +455,12 @@
 			on:paste={handle_paste}
 			style={text_align ? "text-align: " + text_align : ""}
 		/>
-		{#if submit_btn && !disabled}
+		{#if submit_btn}
 			<button
 				class="submit-button"
 				class:padded-button={submit_btn !== true}
-				on:click={handle_submit}
+				{disabled}
+				on:click={disabled ? undefined : handle_submit}
 			>
 				{#if submit_btn === true}
 					<Send />
@@ -567,10 +574,10 @@
 		background: var(--button-secondary-background-fill);
 	}
 
-	.microphone-button:hover,
-	.stop-button:hover,
-	.upload-button:hover,
-	.submit-button:hover {
+	.microphone-button:hover:not(:disabled),
+	.stop-button:hover:not(:disabled),
+	.upload-button:hover:not(:disabled),
+	.submit-button:hover:not(:disabled) {
 		background: var(--button-secondary-background-fill-hover);
 	}
 
@@ -579,7 +586,7 @@
 	.upload-button:disabled,
 	.submit-button:disabled {
 		background: var(--button-secondary-background-fill);
-		cursor: initial;
+		cursor: not-allowed;
 	}
 	.microphone-button:active,
 	.stop-button:active,


### PR DESCRIPTION
## Description

In the `MultimodalTextbox` component, when `interactive=False`, the submit and microphone buttons remained active allowing users to submit inputs without being able to edit them. To fix this issue, I added restrictions to disable these buttons when the component is set to non-interactive. This ensures that users cannot submit inputs or use the microphone when `interactive=False`, maintaining consistency in the component’s behavior and preventing unintended interactions.


## Reproduction Code

Initially, the component `MultimodalTextbox` is set to `interactive=True`, allowing input submissions. After the first submission, it changes to `interactive=False`, disabling the submit and microphone buttons.

```
import gradio as gr

def greet(a, c):
    return gr.MultimodalTextbox(interactive=False), a, c+1

with gr.Blocks() as demo:
    a = gr.MultimodalTextbox(interactive=True, show_label=False, sources="microphone") 
    b = gr.Textbox(interactive=False, show_label=False)
    c = gr.Number(interactive=False, show_label=False)
    a.submit(fn=greet, inputs=[a, c], outputs=[a, b, c])

if __name__ == "__main__":
    demo.launch()
```


Closes: #9967 