### PR TITLE
Reverse order of conversations in chat history and render correctly with custom chatbot

### DIFF
--- a/.changeset/tough-pots-shake.md
+++ b/.changeset/tough-pots-shake.md
@@ -2,4 +2,4 @@
 "gradio": patch
 ---
 
-fix:Reverse order of conversations in chat history
+fix:Reverse order of conversations in chat history and render correctly with custom chatbot

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -468,8 +468,8 @@ class ChatInterface(Blocks):
                 saved_conversations[index] = conversation
             else:
                 saved_conversations = saved_conversations or []
-                saved_conversations.append(conversation)
-                index = len(saved_conversations) - 1
+                saved_conversations.insert(0, conversation)
+                index = 0
         return index, saved_conversations
 
     def _delete_conversation(

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -248,6 +248,8 @@ class ChatInterface(Blocks):
             )
         self.flagging_options = flagging_options
         self.flagging_dir = flagging_dir
+        if isinstance(chatbot, Chatbot):
+            chatbot.unrender()
 
         with self:
             self.saved_conversations = BrowserState(


### PR DESCRIPTION
Puts the latest conversations at the top, which is more standard and makes more sense especially if you have a large number of conversations in history.

Closes: https://github.com/gradio-app/gradio/issues/10896

Also fixes a separate issue related to custom chatbot component. Closes: https://github.com/gradio-app/gradio/issues/10645