### PR TITLE
Fix gr.NativePlot sorting of labels as default behaviour

### DIFF
--- a/.changeset/funny-cows-draw.md
+++ b/.changeset/funny-cows-draw.md
@@ -1,0 +1,6 @@
+---
+"@gradio/nativeplot": patch
+"gradio": patch
+---
+
+fix:Fix gr.NativePlot sorting of labels as default behaviour

--- a/js/nativeplot/Index.svelte
+++ b/js/nativeplot/Index.svelte
@@ -56,6 +56,7 @@
 		| "descending"
 		| { field: string; order: "ascending" | "descending" }
 		| string[]
+		| null
 		| undefined {
 		if (_sort === "x") {
 			return "ascending";
@@ -66,7 +67,7 @@
 		} else if (_sort === "-y") {
 			return { field: y, order: "descending" };
 		} else if (_sort === null) {
-			return undefined;
+			return null;
 		} else if (Array.isArray(_sort)) {
 			return _sort;
 		}


### PR DESCRIPTION
## Description

Previously, when a gr.NativePlot component was created with a DataFrame and the sort argument was omitted (i.e., set to null), the x-axis labels were automatically sorted alphabetically. Initially, the bug appeared to be isolated to gr.BarPlot, but I later discovered that it affected all gr.NativePlot components (gr.BarPlot, gr.LinePlot, and gr.ScatterPlot).

Although the data did not appear sorted during the program's execution, it became sorted when the rendered Svelte file was interpreted by the browser. This issue occurred because the reformat_sort function in index.svelte of NativePlot returned undefined when sort was not specified, and after compilation, undefined was treated as void 0, which implicitly triggered default sorting.

To fix this, I changed undefined to null, ensuring that the compiled code handles it as null. This change ensures that the data is displayed in the browser in the order defined initially.

I tried to create a Playwright test for this issue but was unable to retrieve the data from the browser because I couldn't select the component that contained the information. However, I manually tested the gr.NativePlot components with different values for the sort argument, and everything worked as expected.

## Reproduction Code
This code creates a tab for each gr.NativePlot component, with the inserted data unordered alphabetically.
```python
import gradio as gr
import pandas as pd
import numpy as np

# Generate random data for the plot
data = {
    'Category': ['F', 'A', 'D', 'C', 'B'],
    'Value': np.random.randint(1, 100, 5)
}

df = pd.DataFrame(data)

# Define the function to create the plot
def create_plot():
    return df

with gr.Blocks() as bar_plot:
    # Create a BarPlot component
    bar_plot = gr.BarPlot(
        value=create_plot,
        x="Category",
        y="Value",
    )

with gr.Blocks() as line_plot:
    # Create a LinePlot component
    line_plot = gr.LinePlot(
        value=create_plot,
        x="Category",
        y="Value",
    )

with gr.Blocks() as scatter_plot:
    # Create a ScatterPlot component
    scatter_plot = gr.ScatterPlot(
        value=create_plot,
        x="Category",
        y="Value",
    )

with gr.Blocks() as demo:
    with gr.Tabs():
        with gr.TabItem("Line Plot"):
            line_plot.render()
        with gr.TabItem("Scatter Plot"):
            scatter_plot.render()
        with gr.TabItem("Bar Plot"):
            bar_plot.render()

if __name__ == "__main__":
    demo.launch()
```
 
Closes: #10764