### PR TITLE
Unrender user-provided textbox in `gr.ChatInterface` so that it is rendered in the right place as part of a `gr.Blocks` app

### DIFF
--- a/.changeset/tangy-parts-arrive.md
+++ b/.changeset/tangy-parts-arrive.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Unrender user-provided textbox in `gr.ChatInterface` so that it is rendered in the right place as part of a `gr.Blocks` app

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -248,6 +248,8 @@ class ChatInterface(Blocks):
             )
         self.flagging_options = flagging_options
         self.flagging_dir = flagging_dir
+        if isinstance(textbox, (Textbox, MultimodalTextbox)):
+            textbox.unrender()
         if isinstance(chatbot, Chatbot):
             chatbot.unrender()
 


### PR DESCRIPTION
Analogous change to https://github.com/gradio-app/gradio/pull/10928.

Closes: https://github.com/gradio-app/gradio/issues/10958