### PR TITLE
Load lite js correctly in playground

### DIFF
--- a/.changeset/petite-grapes-wear.md
+++ b/.changeset/petite-grapes-wear.md
@@ -1,5 +1,5 @@
 ---
-"website": minor
+"website": patch
 ---
 
 feat:Load lite js correctly in playground

--- a/.changeset/petite-grapes-wear.md
+++ b/.changeset/petite-grapes-wear.md
@@ -1,0 +1,5 @@
+---
+"website": minor
+---
+
+feat:Load lite js correctly in playground

--- a/js/_website/src/routes/playground/+page.svelte
+++ b/js/_website/src/routes/playground/+page.svelte
@@ -43,10 +43,22 @@
 	let show_preview = false;
 
 	let on_desktop = false;
-	afterNavigate(() => {
+
+	function loadScript(src: string) {
+		return new Promise((resolve, reject) => {
+			const script = document.createElement("script");
+			script.src = src;
+			script.onload = () => resolve(script);
+			script.onerror = () => reject(new Error(`Script load error for ${src}`));
+			document.head.appendChild(script);
+		});
+	}
+
+	afterNavigate(async () => {
 		if (window.innerWidth > 768) {
 			on_desktop = true;
 		}
+		await loadScript(WHEEL.gradio_lite_url + "/dist/lite.js");
 	});
 
 	const mobile_click = (demo_name: string) => {


### PR DESCRIPTION
Annoying issue where the lite js sometimes doesn't load if you directly access the link to the playground, which for a first time user looks like the preview is just empty. 

eg: https://www.gradio.app/playground vs https://www.gradio.app and then clicking on playground 
vs
https://b18250ab.gradio-website.pages.dev/playground