### PR TITLE
fix: accept signed URLs in gr.Audio

### DIFF
--- a/.changeset/silver-nights-jump.md
+++ b/.changeset/silver-nights-jump.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:fix: accept signed URLs in gr.Audio

--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -309,9 +309,8 @@ class Audio(
             )
             orig_name = Path(file_path).name
         elif isinstance(value, (str, Path)):
-            if isinstance(value, str) and value.startswith("http"):
-                # remove any trailing parts of a URL like signed token
-                original_suffix = Path(value.split("?")[0]).suffix.lower()
+            if client_utils.is_http_url_like(value):
+                original_suffix = Path(httpx.URL(str(value)).path).suffix.lower()
             else:
                 original_suffix = Path(value).suffix.lower()
             if self.format is not None and original_suffix != f".{self.format}":

--- a/gradio/components/audio.py
+++ b/gradio/components/audio.py
@@ -309,7 +309,11 @@ class Audio(
             )
             orig_name = Path(file_path).name
         elif isinstance(value, (str, Path)):
-            original_suffix = Path(value).suffix.lower()
+            if isinstance(value, str) and value.startswith("http"):
+                # remove any trailing parts of a URL like signed token
+                original_suffix = Path(value.split("?")[0]).suffix.lower()
+            else:
+                original_suffix = Path(value).suffix.lower()
             if self.format is not None and original_suffix != f".{self.format}":
                 sample_rate, data = processing_utils.audio_from_file(str(value))
                 file_path = processing_utils.save_audio_to_cache(

--- a/test/components/test_audio.py
+++ b/test/components/test_audio.py
@@ -183,6 +183,13 @@ class TestAudio:
         ).model_dump()  # type: ignore
         assert output["path"].endswith("mp3")
 
+    def test_postprocess_http_url_like(self):
+        audio = gr.Audio()
+        output = audio.postprocess("https://test.com/test.mp3?token=123")
+        assert isinstance(output, FileData) and output.path.endswith(
+            "test.mp3?token=123"
+        )
+
     @pytest.mark.asyncio
     async def test_combine_stream_audio(self, gradio_temp_dir):
         x_wav = FileData(


### PR DESCRIPTION
## Description

In the `gr.Audio` component, it accepts URLs, however, to check if the suffix is valid, it simply assumes that the url ends with e.g. `.mp3`. However, if a URL is signed with a token (let's say coming from a database), the check fails, and the audio module tries to load it like a regular file, which crashs the app

Closes: #(issue) See issue #10969 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
