### PR TITLE
ensure images uploaded to the ImageEditor correctly initialise the canvas dimensions

### DIFF
--- a/js/imageeditor/shared/image/image.ts
+++ b/js/imageeditor/shared/image/image.ts
@@ -52,8 +52,7 @@ export class ImageTool implements Tool {
 			border_region
 		);
 
-		await image_command.start();
-		this.context.execute_command(image_command);
+		await this.context.execute_command(image_command);
 	}
 
 	set_tool(tool: ToolbarTool, subtool: Subtool): void {
@@ -162,7 +161,7 @@ export class AddImageCommand implements BgImageCommand {
 		const [width, height] = await this.start();
 
 		// Update image properties with the original dimensions and center in viewport
-		this.context.set_image_properties({
+		await this.context.set_image_properties({
 			scale: 1, // Start at 1:1 scale
 			position: {
 				x: this.context.app.screen.width / 2,
@@ -196,7 +195,6 @@ export class AddImageCommand implements BgImageCommand {
 		if (this.sprite) {
 			this.sprite.destroy();
 		}
-		// The background layer will be automatically cleaned up when a new image is added
 	}
 }
 

--- a/js/imageeditor/shared/zoom/zoom.ts
+++ b/js/imageeditor/shared/zoom/zoom.ts
@@ -142,7 +142,7 @@ export class ZoomTool implements Tool {
 		this.setup_event_listeners();
 
 		// Update context with initial values
-		this.image_editor_context.set_image_properties({
+		await this.image_editor_context.set_image_properties({
 			scale: min_zoom,
 			position: { x: initial_x, y: initial_y }
 		});


### PR DESCRIPTION
## Description

When `fixed_canvas=False`, the uploaded image determines the canvas dimensions and then automatically switches to the brush tool after uploading the image. The brush uses the canvas dimensions stored in state to create textures of the correct size.

There was a race condition that was allowing the brush to initialise its textures before the image dimensions were fully set, causing the draw texture to be the previous canvas dimensions (typically 800x800). This PR resolves that by ensuring we wait for the necessary step to occur, before returning the `add_image` promise.

Closes: #10986.
