### PR TITLE
disable flaky tests

### DIFF
--- a/.config/playwright.config.js
+++ b/.config/playwright.config.js
@@ -48,7 +48,7 @@ const lite = defineConfig(base, {
 		reuseExistingServer: !process.env.CI
 	},
 	testMatch: [
-		"**/file_component_events.spec.ts",
+		// "**/file_component_events.spec.ts",
 		"**/kitchen_sink.spec.ts",
 		"**/gallery_component_events.spec.ts",
 		"**/image_remote_url.spec.ts" // To detect the bugs on Lite fixed in https://github.com/gradio-app/gradio/pull/8011 and https://github.com/gradio-app/gradio/pull/8026

--- a/js/spa/test/video_component_events.spec.ts
+++ b/js/spa/test/video_component_events.spec.ts
@@ -32,7 +32,7 @@ test("Video click-to-upload uploads video successfuly. Clear, play, and pause bu
 	await expect(download.suggestedFilename()).toBe("av1-video.mp4");
 });
 
-test("Video play, pause events work correctly.", async ({ page }) => {
+test.skip("Video play, pause events work correctly.", async ({ page }) => {
 	const [fileChooser] = await Promise.all([
 		page.waitForEvent("filechooser"),
 		page.getByLabel("Drop a video file here to upload").first().click()


### PR DESCRIPTION
## Description

These tests are failing consistently in PRs now but in a confusing and inconsistent way. They are not high enough value to warrant the disruption. Disabling until we can figure it out.