### PR TITLE
Use xvfb to run Playwright in the headed mode to avoid FireFox crash

### DIFF
--- a/.github/workflows/test-functional-lite.yml
+++ b/.github/workflows/test-functional-lite.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run Lite E2E tests
         run: |
           . venv/bin/activate
-          pnpm --filter @gradio/lite test:browser
+          xvfb-run pnpm --filter @gradio/lite test:browser
       - name: Get the performance result
         run: |
           export LITE_APP_LOAD_TIME=$(jq -r '.app_load_time' .lite-perf.json)


### PR DESCRIPTION
## Description

Workaround for Firefox crashes in CI.
Debug note is https://github.com/gradio-app/gradio/pull/10973#issuecomment-2797207911

We still don't know why the problem started happen recently though.