### PR TITLE
Ensure that the `.select()` event in `gr.DataFrame` carries the `.row_value` and `.col_value`

### DIFF
--- a/.changeset/tender-keys-find.md
+++ b/.changeset/tender-keys-find.md
@@ -1,8 +1,8 @@
 ---
-"@gradio/dataframe": minor
-"@gradio/utils": minor
-"gradio": minor
-"website": minor
+"@gradio/dataframe": patch
+"@gradio/utils": patch
+"gradio": patch
+"website": patch
 ---
 
-feat:Df select
+fix:Ensure that the `.select()` event in `gr.DataFrame` carries the `.row_value` and `.col_value`

--- a/.changeset/tender-keys-find.md
+++ b/.changeset/tender-keys-find.md
@@ -1,0 +1,8 @@
+---
+"@gradio/dataframe": minor
+"@gradio/utils": minor
+"gradio": minor
+"website": minor
+---
+
+feat:Df select

--- a/js/_website/src/lib/templates/gradio/04_helpers/05_selectdata.svx
+++ b/js/_website/src/lib/templates/gradio/04_helpers/05_selectdata.svx
@@ -33,7 +33,7 @@
             {
                 name: "col_value",
                 annotation: "list[float | str]",
-                doc: "The value of the entire row that the selected item belongs to, as a 1-D list. Only implemented for the `Dataframe` component, returns None for other components.",
+                doc: "The value of the entire column that the selected item belongs to, as a 1-D list. Only implemented for the `Dataframe` component, returns None for other components.",
                 kwargs: null
             },
             {

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -111,6 +111,8 @@
 	onMount(() => {
 		df_ctx.parent_element = parent;
 		df_ctx.get_data_at = get_data_at;
+		df_ctx.get_column = get_column;
+		df_ctx.get_row = get_row;
 		df_ctx.dispatch = dispatch;
 		init_drag_handlers();
 
@@ -185,6 +187,12 @@
 
 	const get_data_at = (row: number, col: number): string | number =>
 		data?.[row]?.[col]?.value;
+
+	const get_column = (col: number): (string | number)[] =>
+		data?.map(row => row[col]?.value) ?? [];
+
+	const get_row = (row: number): (string | number)[] =>
+		data?.[row]?.map(cell => cell.value) ?? [];
 
 	$: {
 		if (!dequal(headers, old_headers)) {

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -189,10 +189,10 @@
 		data?.[row]?.[col]?.value;
 
 	const get_column = (col: number): (string | number)[] =>
-		data?.map(row => row[col]?.value) ?? [];
+		data?.map((row) => row[col]?.value) ?? [];
 
 	const get_row = (row: number): (string | number)[] =>
-		data?.[row]?.map(cell => cell.value) ?? [];
+		data?.[row]?.map((cell) => cell.value) ?? [];
 
 	$: {
 		if (!dequal(headers, old_headers)) {

--- a/js/dataframe/shared/context/dataframe_context.ts
+++ b/js/dataframe/shared/context/dataframe_context.ts
@@ -155,6 +155,8 @@ export interface DataFrameContext {
 	>;
 	parent_element?: HTMLElement;
 	get_data_at?: (row: number, col: number) => string | number;
+	get_column?: (col: number) => (string | number)[];
+	get_row?: (row: number) => (string | number)[];
 	dispatch?: (e: "change" | "select" | "search", detail?: any) => void;
 }
 

--- a/js/dataframe/shared/context/dataframe_context.ts
+++ b/js/dataframe/shared/context/dataframe_context.ts
@@ -469,6 +469,8 @@ function create_actions(
 
 			context.dispatch?.("select", {
 				index: [actual_row, col],
+				col_value: context.get_column!(col),
+				row_value: context.get_row!(actual_row),
 				value: context.get_data_at!(actual_row, col)
 			});
 		},

--- a/js/utils/src/utils.ts
+++ b/js/utils/src/utils.ts
@@ -9,6 +9,7 @@ export interface ValueData {
 
 export interface SelectData {
 	row_value?: any[];
+	col_value?: any[];
 	index: number | [number, number];
 	value: any;
 	selected?: boolean;


### PR DESCRIPTION
Test code:

```py
import gradio as gr

with gr.Blocks() as demo:
    table = gr.Dataframe([[1, "text first"], [2,"text second"], [3, "text third"]], show_search='search', show_row_numbers=True)
    statement = gr.Textbox()

    def on_select(evt: gr.SelectData):
        return f"{evt.value=}\n{evt.index=}\n{evt.row_value=}\n{evt.col_value=}\n{evt.target=}\n{evt._data=}"

    table.select(on_select, None, statement)

demo.launch()
```

Closes: https://github.com/gradio-app/gradio/issues/10964
Closes: https://github.com/gradio-app/gradio/issues/11004