### PR TITLE
Disable Lite E2E tests on Firefox

### DIFF
--- a/.config/playwright.config.js
+++ b/.config/playwright.config.js
@@ -61,6 +61,10 @@ const lite = defineConfig(base, {
 		{
 			name: "chromium",
 			use: { ...devices["Desktop Chrome"] }
+		},
+		{
+			use: { ...devices["Desktop Firefox"] },
+			testMatch: ["**/kitchen_sink.spec.ts"] // Only run one test on Firefox to check the issue fixed in https://github.com/gradio-app/gradio/pull/9528
 		}
 	]
 });

--- a/.config/playwright.config.js
+++ b/.config/playwright.config.js
@@ -61,7 +61,7 @@ const lite = defineConfig(base, {
 		{
 			name: "chromium",
 			use: { ...devices["Desktop Chrome"] }
-		},
+		}
 	]
 });
 

--- a/.config/playwright.config.js
+++ b/.config/playwright.config.js
@@ -62,10 +62,13 @@ const lite = defineConfig(base, {
 			name: "chromium",
 			use: { ...devices["Desktop Chrome"] }
 		},
-		{
-			use: { ...devices["Desktop Firefox"] },
-			testMatch: ["**/kitchen_sink.spec.ts"] // Only run one test on Firefox to check the issue fixed in https://github.com/gradio-app/gradio/pull/9528
-		}
+		process.env.CI
+			? undefined // There are Firefox-specific issues such as https://github.com/gradio-app/gradio/pull/9528 so we want to run the tests on Firefox, but Firefox sometimes fails to start in the GitHub Actions environment so we disable it on CI.
+			: {
+					name: "firefox",
+					use: { ...devices["Desktop Firefox"] },
+					testIgnore: "**/kitchen_sink.*" // This test requires the camera permission but it's not supported on FireFox: https://github.com/microsoft/playwright/issues/11714
+				}
 	]
 });
 

--- a/.config/playwright.config.js
+++ b/.config/playwright.config.js
@@ -69,7 +69,7 @@ const lite = defineConfig(base, {
 					use: { ...devices["Desktop Firefox"] },
 					testIgnore: "**/kitchen_sink.*" // This test requires the camera permission but it's not supported on FireFox: https://github.com/microsoft/playwright/issues/11714
 				}
-	]
+	].filter(Boolean)
 });
 
 export default !!process.env.GRADIO_E2E_TEST_LITE ? lite : normal;

--- a/.config/playwright.config.js
+++ b/.config/playwright.config.js
@@ -62,11 +62,6 @@ const lite = defineConfig(base, {
 			name: "chromium",
 			use: { ...devices["Desktop Chrome"] }
 		},
-		{
-			name: "firefox",
-			use: { ...devices["Desktop Firefox"] },
-			testIgnore: "**/kitchen_sink.*" // This test requires the camera permission but it's not supported on FireFox: https://github.com/microsoft/playwright/issues/11714
-		}
 	]
 });
 


### PR DESCRIPTION
## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
