### PR TITLE
Fix `ssr_mode` parameter name in notice message

### DIFF
--- a/.changeset/floppy-pianos-dance.md
+++ b/.changeset/floppy-pianos-dance.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Fix `ssr_mode` parameter name in notice message
+fix:Fix `ssr_mode` parameter name in notice message

--- a/.changeset/floppy-pianos-dance.md
+++ b/.changeset/floppy-pianos-dance.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix `ssr_mode` parameter name in notice message

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2664,7 +2664,7 @@ Received inputs:
             )
             if not wasm_utils.IS_WASM and not self.is_colab and not quiet:
                 s = (
-                    "* Running on local URL:  {}://{}:{}, with SSR ⚡ (experimental, to disable set `ssr=False` in `launch()`)"
+                    "* Running on local URL:  {}://{}:{}, with SSR ⚡ (experimental, to disable set `ssr_mode=False` in `launch()`)"
                     if self.ssr_mode
                     else "* Running on local URL:  {}://{}:{}"
                 )


### PR DESCRIPTION
## Description

Fixes the SSR notice message to correctly reference the `ssr_mode` parameter instead of `ssr` so users know the right parameter to use when disabling SSR.
