### PR TITLE
Attach cookies to client after first request (to support multiple-replica setups with cookie-based affinity)

### DIFF
--- a/.changeset/easy-doodles-sip.md
+++ b/.changeset/easy-doodles-sip.md
@@ -1,0 +1,6 @@
+---
+"gradio": patch
+"gradio_client": patch
+---
+
+fix:Attach cookies to client after first request (to support multiple-replica setups with cookie-based affinity)

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -887,6 +887,15 @@ class Client:
             **self.httpx_kwargs,
         )
         if r.is_success:
+            # Cookies are sometimes needed to correctly route requests using
+            # multiple replicas e.g. using cookie session-affinity in Kubernetes.
+            # This approach attaches cookies to subsequent requests (without overriding existing cookies)
+            new_cookies = {
+                name: value
+                for name, value in r.cookies.items()
+                if value is not None and name not in self.cookies
+            }
+            self.cookies.update(new_cookies)
             return r.json()
         elif r.status_code == 401:
             raise AuthenticationError(

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -887,9 +887,10 @@ class Client:
             **self.httpx_kwargs,
         )
         if r.is_success:
-            # Cookies are sometimes needed to correctly route requests using
-            # multiple replicas e.g. using cookie session-affinity in Kubernetes.
-            # This approach attaches cookies to subsequent requests (without overriding existing cookies)
+            # Cookies are sometimes needed to correctly route requests if the Gradio app is
+            # running on multiple replicas e.g. using cookie session-affinity in Kubernetes.
+            # This approach attaches cookies from the first response to subsequent requests
+            # without overriding existing cookies.
             new_cookies = {
                 name: value
                 for name, value in r.cookies.items()


### PR DESCRIPTION
Closes: https://github.com/gradio-app/gradio/issues/10164 (not sure if we have a way to test this yet, @aliabid94?)