### PR TITLE
Update using-flagging.md

### DIFF
--- a/guides/10_other-tutorials/using-flagging.md
+++ b/guides/10_other-tutorials/using-flagging.md
@@ -54,7 +54,7 @@ iface = gr.Interface(
     calculator,
     ["number", gr.Radio(["add", "subtract", "multiply", "divide"]), "number"],
     "number",
-    allow_flagging="manual"
+    flagging_mode="manual"
 )
 
 iface.launch()


### PR DESCRIPTION
## Description

Update "Using Flagging" docs (https://www.gradio.app/guides/using-flagging) to use non-deprecated argument:

```
UserWarning: The `allow_flagging` parameter in `Interface` is deprecated.Use `flagging_mode` instead.
```
  
