### PR TITLE
chore: log tested Python version

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -41,12 +41,13 @@ jobs:
   test:
     permissions:
       contents: read
-    name: "test-${{ matrix.os }}-${{ matrix.test-type == 'flaky' && 'flaky' || 'not-flaky'}}"
+    name: "test-python${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.test-type == 'flaky' && 'flaky' || 'not-flaky'}}"
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         test-type: ["not flaky", "flaky"]
         exclude:
           - os: ${{ github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'windows-tests') && 'dummy' || 'windows-latest' }}
@@ -59,7 +60,7 @@ jobs:
         id: install_deps
         uses: "gradio-app/gradio/.github/actions/install-all-deps@main"
         with:
-          python_version: "3.10"
+          python_version: ${{ matrix.python-version }}
           os: ${{ matrix.os }}
           test: true
       - name: Lint

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10"] # Only test one version because tests are too slow
         test-type: ["not flaky", "flaky"]
         exclude:
           - os: ${{ github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'windows-tests') && 'dummy' || 'windows-latest' }}

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -41,13 +41,12 @@ jobs:
   test:
     permissions:
       contents: read
-    name: "test-python${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.test-type == 'flaky' && 'flaky' || 'not-flaky'}}"
+    name: "test-${{ matrix.os }}-${{ matrix.test-type == 'flaky' && 'flaky' || 'not-flaky'}}"
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.10"] # Only test one version because tests are too slow
         test-type: ["not flaky", "flaky"]
         exclude:
           - os: ${{ github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'windows-tests') && 'dummy' || 'windows-latest' }}
@@ -60,7 +59,7 @@ jobs:
         id: install_deps
         uses: "gradio-app/gradio/.github/actions/install-all-deps@main"
         with:
-          python_version: ${{ matrix.python-version }}
+          python_version: "3.10"
           os: ${{ matrix.os }}
           test: true
       - name: Lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,13 @@ keywords = ["machine learning", "reproducibility", "visualization"]
 
 classifiers = [
   'Development Status :: 5 - Production/Stable',
-  'License :: OSI Approved :: Apache Software License',
   'Operating System :: OS Independent',
   'Programming Language :: Python :: 3',
   'Programming Language :: Python :: 3 :: Only',
-  'Programming Language :: Python :: 3.8',
-  'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
+  'Programming Language :: Python :: 3.12',
+  'Programming Language :: Python :: 3.13',
   'Topic :: Scientific/Engineering',
   'Topic :: Scientific/Engineering :: Artificial Intelligence',
   'Topic :: Scientific/Engineering :: Visualization',


### PR DESCRIPTION
## Description

- Log Python version used for testing (tests are too slow for all supported Python versions)
- Sync pyproject.toml (remove 3.8 3.9 add 3.11 3.12 3.13)
- Remove incorrect license classifier
