### PR TITLE
Ensure it is possible to draw after uploading an image to the ImageEditor

### DIFF
--- a/.changeset/dull-breads-rest.md
+++ b/.changeset/dull-breads-rest.md
@@ -1,0 +1,6 @@
+---
+"@gradio/imageeditor": patch
+"gradio": patch
+---
+
+fix:Ensure it is possible to draw after uploading an image to the ImageEditor

--- a/js/imageeditor/shared/core/editor.ts
+++ b/js/imageeditor/shared/core/editor.ts
@@ -900,6 +900,11 @@ export class LayerManager {
 		if (!persist) {
 			this.active_layer = this.layers[0].container;
 			this.active_layer_id = this.layers[0].id;
+		} else {
+			// the id is the same but the layer is new, we need to find the new layer
+			this.active_layer =
+				this.layers.find((l) => l.id === this.active_layer_id)?.container ||
+				this.layers[0].container;
 		}
 
 		this.layer_store.update((state) => ({


### PR DESCRIPTION
## Description

Due to previous changes by a reckless penguin, uploading a new image would persist layer ids but the layer still needed to be recreated and there was no check to ensure the layer object (that we draw on) actually exists. The `id` was persisted and correct but the layer object was not set to the newly created layer with the same `id`. 

This PR fixes that.

Closes: #11024.
