### PR TITLE
Update client.py to always send file data, even for files without extensions

### DIFF
--- a/.changeset/hip-games-double.md
+++ b/.changeset/hip-games-double.md
@@ -1,0 +1,6 @@
+---
+"gradio": patch
+"gradio_client": patch
+---
+
+fix:Update client.py to always send file data, even for files without extensions

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -1395,7 +1395,7 @@ class Endpoint:
         return {
             "path": file_path,
             "orig_name": utils.strip_invalid_filename_characters(orig_name.name),
-            "meta": {"_type": "gradio.FileData"} if orig_name.suffix else None,
+            "meta": {"_type": "gradio.FileData"},
         }
 
     def _download_file(self, x: dict) -> str:


### PR DESCRIPTION
## Description

Update client.py to always send file data, even for files without extensions

Closes: #10775 

