### PR TITLE
Make video trimming faster

### DIFF
--- a/.changeset/tasty-clocks-kick.md
+++ b/.changeset/tasty-clocks-kick.md
@@ -1,0 +1,6 @@
+---
+"@gradio/video": patch
+"gradio": patch
+---
+
+fix:Make video trimming faster

--- a/js/video/shared/utils.ts
+++ b/js/video/shared/utils.ts
@@ -90,7 +90,7 @@ export async function trimVideo(
 			inputName,
 			...(startTime !== 0 ? ["-ss", startTime.toString()] : []),
 			...(endTime !== 0 ? ["-to", endTime.toString()] : []),
-			"-c:a",
+			"-c",
 			"copy",
 			outputName
 		];


### PR DESCRIPTION
## Description

Closes #6664 

Copy the video and audio codec as opposed to just the audio. Since we're just trimming, we can keep the same video codec.

![video_trimming](https://github.com/user-attachments/assets/f00dd957-e4c9-4f55-a1d8-d3bdf9cd0bd1)


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
