### PR TITLE
Fix gradio cc environment

### DIFF
--- a/.changeset/open-dragons-melt.md
+++ b/.changeset/open-dragons-melt.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix gradio cc environment

--- a/gradio/cli/commands/cli_env_info.py
+++ b/gradio/cli/commands/cli_env_info.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import platform
 from importlib import metadata
 
+from packaging.requirements import Requirement
 from rich import print
 
 
@@ -28,17 +29,11 @@ def print_environment_info():
             print(f"{package_name} dependencies in your environment:\n")
             if dist.requires is not None:
                 for req in dist.requires:
-                    req_base_name = (
-                        req.split(">")[0]
-                        .split("<")[0]
-                        .split("~")[0]
-                        .split("[")[0]
-                        .split("!")[0]
-                    )
+                    req_obj = Requirement(req)
                     try:
-                        print(f"{req_base_name}: {metadata.version(req_base_name)}")
+                        print(f"{req_obj.name}: {metadata.version(req_obj.name)}")
                     except metadata.PackageNotFoundError:
-                        print(f"{req_base_name} is not installed.")
+                        print(f"{req_obj.name} is not installed.")
                 print("\n")
         except metadata.PackageNotFoundError:
             print(f"{package_name} package is not installed.")


### PR DESCRIPTION
## Description

We were not parsing requirements with `==` version pins correctly.

```bash
Gradio Environment Information:
------------------------------
Operating System: Darwin
gradio version: 5.20.1
gradio_client version: 1.7.2

------------------------------------------------
gradio dependencies in your environment:

aiofiles: 23.2.1
anyio: 4.9.0
audioop-lts is not installed.
fastapi: 0.115.7
ffmpy: 0.3.2
gradio-client: 1.7.2
groovy: 0.1.1
httpx: 0.28.1
huggingface-hub: 0.29.3
jinja2: 3.1.2
markupsafe: 2.1.1
numpy: 1.24.4
orjson: 3.9.14
packaging: 24.2
pandas: 1.5.3
pillow: 11.1.0
pydantic: 2.11.3
pydub: 0.25.1
python-multipart: 0.0.20
pyyaml: 6.0.2
ruff: 0.9.3
safehttpx: 0.1.6
semantic-version: 2.10.0
starlette: 0.46.2
tomlkit: 0.12.0
typer: 0.15.1
typing-extensions: 4.13.2
urllib3: 2.3.0
uvicorn: 0.34.2
authlib: 1.4.1
itsdangerous: 2.2.0


gradio_client dependencies in your environment:

fsspec: 2024.12.0
httpx: 0.28.1
huggingface-hub: 0.29.3
packaging: 24.2
typing-extensions: 4.13.2
websockets: 11.0.3
```


Closes: #8890

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
