### PR TITLE
update STDIO instructions to specify sse-only transport

### DIFF
--- a/.changeset/ninety-bears-tickle.md
+++ b/.changeset/ninety-bears-tickle.md
@@ -1,0 +1,6 @@
+---
+"@gradio/core": patch
+"gradio": patch
+---
+
+fix:update STDIO instructions to specify sse-only transport

--- a/js/core/src/api_docs/ApiDocs.svelte
+++ b/js/core/src/api_docs/ApiDocs.svelte
@@ -37,7 +37,7 @@
 	const spaces_docs_suffix = "#connecting-to-a-hugging-face-space";
 
 	let api_count = dependencies.filter(
-		(dependency) => dependency.show_api
+		(dependency) => dependency.show_api,
 	).length;
 
 	if (root === "") {
@@ -54,7 +54,7 @@
 		["python", "Python", python],
 		["javascript", "JavaScript", javascript],
 		["bash", "cURL", bash],
-		["mcp", "MCP", mcp]
+		["mcp", "MCP", mcp],
 	] as const;
 
 	let is_running = false;
@@ -65,7 +65,7 @@
 		unnamed_endpoints: any;
 	}> {
 		let response = await fetch(
-			root.replace(/\/$/, "") + app.api_prefix + "/info"
+			root.replace(/\/$/, "") + app.api_prefix + "/info",
 		);
 		let data = await response.json();
 		return data;
@@ -119,7 +119,7 @@
 				name: `${name}`,
 				description: tool.description || "",
 				parameters: tool.properties || {},
-				expanded: false
+				expanded: false,
 			}));
 		} catch (error) {
 			console.error("Failed to fetch MCP tools:", error);
@@ -303,12 +303,12 @@
 													{
 														mcpServers: {
 															gradio: {
-																url: mcp_server_url
-															}
-														}
+																url: mcp_server_url,
+															},
+														},
 													},
 													null,
-													2
+													2,
 												)}
 											/>
 										</div>
@@ -317,12 +317,12 @@
 													{
 														mcpServers: {
 															gradio: {
-																url: mcp_server_url
-															}
-														}
+																url: mcp_server_url,
+															},
+														},
 													},
 													null,
-													2
+													2,
 												)}</pre>
 										</div>
 									</code>
@@ -343,12 +343,17 @@
 														mcpServers: {
 															gradio: {
 																command: "npx",
-																args: ["mcp-remote", mcp_server_url]
-															}
-														}
+																args: [
+																	"mcp-remote",
+																	mcp_server_url,
+																	"--transport",
+																	"sse-only",
+																],
+															},
+														},
 													},
 													null,
-													2
+													2,
 												)}
 											/>
 										</div>
@@ -358,12 +363,17 @@
 														mcpServers: {
 															gradio: {
 																command: "npx",
-																arguments: ["mcp-remote", mcp_server_url]
-															}
-														}
+																arguments: [
+																	"mcp-remote",
+																	mcp_server_url,
+																	"--transport",
+																	"sse-only",
+																],
+															},
+														},
 													},
 													null,
-													2
+													2,
 												)}</pre>
 										</div>
 									</code>

--- a/js/core/src/api_docs/ApiDocs.svelte
+++ b/js/core/src/api_docs/ApiDocs.svelte
@@ -37,7 +37,7 @@
 	const spaces_docs_suffix = "#connecting-to-a-hugging-face-space";
 
 	let api_count = dependencies.filter(
-		(dependency) => dependency.show_api,
+		(dependency) => dependency.show_api
 	).length;
 
 	if (root === "") {
@@ -54,7 +54,7 @@
 		["python", "Python", python],
 		["javascript", "JavaScript", javascript],
 		["bash", "cURL", bash],
-		["mcp", "MCP", mcp],
+		["mcp", "MCP", mcp]
 	] as const;
 
 	let is_running = false;
@@ -65,7 +65,7 @@
 		unnamed_endpoints: any;
 	}> {
 		let response = await fetch(
-			root.replace(/\/$/, "") + app.api_prefix + "/info",
+			root.replace(/\/$/, "") + app.api_prefix + "/info"
 		);
 		let data = await response.json();
 		return data;
@@ -119,7 +119,7 @@
 				name: `${name}`,
 				description: tool.description || "",
 				parameters: tool.properties || {},
-				expanded: false,
+				expanded: false
 			}));
 		} catch (error) {
 			console.error("Failed to fetch MCP tools:", error);
@@ -303,12 +303,12 @@
 													{
 														mcpServers: {
 															gradio: {
-																url: mcp_server_url,
-															},
-														},
+																url: mcp_server_url
+															}
+														}
 													},
 													null,
-													2,
+													2
 												)}
 											/>
 										</div>
@@ -317,12 +317,12 @@
 													{
 														mcpServers: {
 															gradio: {
-																url: mcp_server_url,
-															},
-														},
+																url: mcp_server_url
+															}
+														}
 													},
 													null,
-													2,
+													2
 												)}</pre>
 										</div>
 									</code>
@@ -347,13 +347,13 @@
 																	"mcp-remote",
 																	mcp_server_url,
 																	"--transport",
-																	"sse-only",
-																],
-															},
-														},
+																	"sse-only"
+																]
+															}
+														}
 													},
 													null,
-													2,
+													2
 												)}
 											/>
 										</div>
@@ -367,13 +367,13 @@
 																	"mcp-remote",
 																	mcp_server_url,
 																	"--transport",
-																	"sse-only",
-																],
-															},
-														},
+																	"sse-only"
+																]
+															}
+														}
 													},
 													null,
-													2,
+													2
 												)}</pre>
 										</div>
 									</code>

--- a/js/core/src/api_docs/ApiDocs.svelte
+++ b/js/core/src/api_docs/ApiDocs.svelte
@@ -363,7 +363,7 @@
 														mcpServers: {
 															gradio: {
 																command: "npx",
-																arguments: [
+																args: [
 																	"mcp-remote",
 																	mcp_server_url,
 																	"--transport",


### PR DESCRIPTION
## Description

This changes the instructions displayed for using an MCP Server with STDIO. It adds the "--transport sse-only" options after specifying the remote MCP endpoint. 

By default, 
Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #11114

## 🎯 PRs Should Target Issues

Solves issue #11114

## Testing and Formatting Your Code

  