### PR TITLE
Option of a custom landing-page added to routes.py

### DIFF
--- a/.changeset/curly-suits-beam.md
+++ b/.changeset/curly-suits-beam.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Option of a custom landing-page added to routes.py

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -401,6 +401,8 @@ class App(FastAPI):
         def login_check(user: str = Depends(get_current_user)):
             if (app.auth is None and app.auth_dependency is None) or user is not None:
                 return
+            if landing_page_path:
+                return RedirectResponse(url=landing_page_path, status_code=status.HTTP_302_FOUND)
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
             )
@@ -612,6 +614,8 @@ class App(FastAPI):
                 config["layout"] = config["page"][page]["layout"]
                 config["current_page"] = page
             elif app.auth_dependency:
+                if landing_page_path:
+                    return RedirectResponse(url=landing_page_path, status_code=status.HTTP_302_FOUND)
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
                 )
@@ -1823,6 +1827,7 @@ def mount_gradio_app(
     node_port: int | None = None,
     enable_monitoring: bool | None = None,
     pwa: bool | None = None,
+    landing_page_path: str | None = None,
 ) -> fastapi.FastAPI:
     """Mount a gradio.Blocks to an existing FastAPI application.
 


### PR DESCRIPTION
Instead to raise HTTPException for the unauthorized requests, an option as landing_page_path is added to mount_gradio_app by which the unauthorized requests are redirected to a custom landing page.

## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
