### PR TITLE
Lazy import pandas in native_plot.py

### DIFF
--- a/.changeset/smooth-parents-sink.md
+++ b/.changeset/smooth-parents-sink.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Lazy import pandas in native_plot.py

--- a/.changeset/smooth-parents-sink.md
+++ b/.changeset/smooth-parents-sink.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Lazy import pandas in native_plot.py

--- a/gradio/components/native_plot.py
+++ b/gradio/components/native_plot.py
@@ -9,7 +9,6 @@ from typing import (
     Literal,
 )
 
-import pandas as pd
 from gradio_client.documentation import document
 
 from gradio.components.base import Component
@@ -17,6 +16,8 @@ from gradio.data_classes import GradioModel
 from gradio.events import Events
 
 if TYPE_CHECKING:
+    import pandas as pd
+
     from gradio.components import Timer
 
 
@@ -191,6 +192,8 @@ class NativePlot(Component):
             return value
 
         def get_simplified_type(dtype):
+            import pandas as pd
+
             if pd.api.types.is_numeric_dtype(dtype):
                 return "quantitative"
             elif pd.api.types.is_string_dtype(


### PR DESCRIPTION
## Description

To make the initial `import gradio` faster, importing packages that are not necessarily used every time should be deferred.
This PR does it for `pandas`.  #7851 did it already but the same problem appeared again since then.

The following charts are the import time inspection during `import gradio` obtained by the following commands:
```
find . -name "__pycache__" -type d -exec rm -r {} +  # Remove the cache
python -X importtime -c 'import gradio' &> import_time.txt
tuna import_time.txt
```

These results show that this PR eliminates the `pandas` import from the execution of `import gradio`.

| `main` | This PR|
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/d9cd964e-7c83-4c73-804a-cbbd207827de) | ![image](https://github.com/user-attachments/assets/d633aecb-8740-4d77-b13d-8db09480538f) |

While these results were measured in normal Gradio, this fix should contribute to reducing the initial loading time of Gradio-Lite too.