### PR TITLE
gr.Chatbot: Style fixes to remove multiple scrollbars

### DIFF
--- a/.changeset/tasty-bees-stick.md
+++ b/.changeset/tasty-bees-stick.md
@@ -1,0 +1,6 @@
+---
+"@gradio/chatbot": patch
+"gradio": patch
+---
+
+fix:gr.Chatbot: Style fixes to remove multiple scrollbars

--- a/js/chatbot/shared/ChatBot.svelte
+++ b/js/chatbot/shared/ChatBot.svelte
@@ -411,10 +411,6 @@
 		padding-top: var(--spacing-xxl);
 	}
 
-	.role {
-		max-width: 95%;
-	}
-
 	@media (prefers-color-scheme: dark) {
 		.bubble-wrap {
 			background: var(--background-fill-secondary);

--- a/js/chatbot/shared/ChatBot.svelte
+++ b/js/chatbot/shared/ChatBot.svelte
@@ -406,9 +406,13 @@
 
 	.bubble-wrap {
 		width: 100%;
-		overflow-y: auto;
+		overflow-y: visible;
 		height: 100%;
 		padding-top: var(--spacing-xxl);
+	}
+
+	.role {
+		max-width: 95%;
 	}
 
 	@media (prefers-color-scheme: dark) {


### PR DESCRIPTION
I was experiencing multiple scrollbars in the `gr.Chatbot` component, cf screenshot below:

![image](https://github.com/user-attachments/assets/70a0afd7-9c26-4fb4-ab23-1fa1c9299738)

 As seen with @freddyaboulton , I've done these changes in the style of my `gradio` demo under `app.py`:

```
#chatbot .role {
  max-width:95%
}
#chatbot .bubble-wrap {
  overflow-y: visible;
}
```
So this PR hopes to integrate these changes in the main code:  however maybe I've done mistakes since I'm not sure how svelte works!

Closes: https://github.com/gradio-app/gradio/issues/10934