### PR TITLE
chore: Support Path type for the favicon

### DIFF
--- a/.changeset/famous-cougars-bake.md
+++ b/.changeset/famous-cougars-bake.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:chore: Support Path type for the favicon

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2418,7 +2418,7 @@ Received inputs:
         *,
         height: int = 500,
         width: int | str = "100%",
-        favicon_path: str | None = None,
+        favicon_path: str | Path | None = None,
         ssl_keyfile: str | None = None,
         ssl_certfile: str | None = None,
         ssl_keyfile_password: str | None = None,

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1674,6 +1674,8 @@ class App(FastAPI):
                 raise HTTPException(status_code=404)
 
             favicon_path = blocks.favicon_path
+            if isinstance(favicon_path, Path):
+                favicon_path = str(favicon_path)
             if favicon_path is None:
                 icons = [
                     {


### PR DESCRIPTION
## Description

Type checkers currently highlight a type mismatch when we are trying to use `Path` for the `favicon_path`. This change aims to remove the "error" raised by the type checkers by hinting that we can also use `Path`.

## 🎯 PRs Should Target Issues

The change is very small, I don't think it requires an issue.
  
