### PR TITLE
Fix python client SSE decoding issue

### DIFF
--- a/.changeset/weak-chicken-stop.md
+++ b/.changeset/weak-chicken-stop.md
@@ -1,0 +1,6 @@
+---
+"gradio": patch
+"gradio_client": patch
+---
+
+fix:Fix python client SSE decoding issue

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -268,7 +268,8 @@ class Client:
                                 if resp["msg"] == ServerMessage.heartbeat:
                                     continue
                                 elif (
-                                    resp.get("message", "") == ServerMessage.server_stopped
+                                    resp.get("message", "")
+                                    == ServerMessage.server_stopped
                                 ):
                                     for (
                                         pending_messages

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -255,39 +255,43 @@ class Client:
                     headers=self.headers,
                     cookies=self.cookies,
                 ) as response:
-                    for line in response.iter_lines():
-                        line = line.rstrip("\n")
-                        if not len(line):
-                            continue
-                        if line.startswith("data:"):
-                            resp = json.loads(line[5:])
-                            if resp["msg"] == ServerMessage.heartbeat:
+                    buffer = b""
+                    for chunk in response.iter_bytes():
+                        buffer += chunk
+                        while b"\n\n" in buffer:
+                            line, buffer = buffer.split(b"\n\n", 1)
+                            line = line.decode("utf-8").rstrip("\n")
+                            if not len(line):
                                 continue
-                            elif (
-                                resp.get("message", "") == ServerMessage.server_stopped
-                            ):
-                                for (
-                                    pending_messages
-                                ) in self.pending_messages_per_event.values():
-                                    pending_messages.append(resp)
-                                return
-                            elif resp["msg"] == ServerMessage.close_stream:
-                                self.stream_open = False
-                                return
-                            event_id = resp["event_id"]
-                            if event_id not in self.pending_messages_per_event:
-                                self.pending_messages_per_event[event_id] = []
-                            self.pending_messages_per_event[event_id].append(resp)
-                            if resp["msg"] == ServerMessage.process_completed:
-                                self.pending_event_ids.remove(event_id)
-                            if (
-                                len(self.pending_event_ids) == 0
-                                and protocol != "sse_v3"
-                            ):
-                                self.stream_open = False
-                                return
-                        else:
-                            raise ValueError(f"Unexpected SSE line: '{line}'")
+                            if line.startswith("data:"):
+                                resp = json.loads(line[5:])
+                                if resp["msg"] == ServerMessage.heartbeat:
+                                    continue
+                                elif (
+                                    resp.get("message", "") == ServerMessage.server_stopped
+                                ):
+                                    for (
+                                        pending_messages
+                                    ) in self.pending_messages_per_event.values():
+                                        pending_messages.append(resp)
+                                    return
+                                elif resp["msg"] == ServerMessage.close_stream:
+                                    self.stream_open = False
+                                    return
+                                event_id = resp["event_id"]
+                                if event_id not in self.pending_messages_per_event:
+                                    self.pending_messages_per_event[event_id] = []
+                                self.pending_messages_per_event[event_id].append(resp)
+                                if resp["msg"] == ServerMessage.process_completed:
+                                    self.pending_event_ids.remove(event_id)
+                                if (
+                                    len(self.pending_event_ids) == 0
+                                    and protocol != "sse_v3"
+                                ):
+                                    self.stream_open = False
+                                    return
+                            else:
+                                raise ValueError(f"Unexpected SSE line: '{line}'")
         except BaseException as e:
             # If the job is cancelled the stream will close so we
             # should not raise this httpx exception that comes from the
@@ -1480,8 +1484,8 @@ class Job(Future):
     submitted by the Gradio client. This class is not meant to be instantiated directly, but rather
     is created by the Client.submit() method.
 
-    A Job object includes methods to get the status of the prediction call, as well to get the outputs of
-    the prediction call. Job objects are also iterable, and can be used in a loop to get the outputs
+    A Job object includes methods to get the status of the prediction call, as well to get the outputs
+    of the prediction call. Job objects are also iterable, and can be used in a loop to get the outputs
     of prediction calls as they become available for generator endpoints.
     """
 

--- a/client/python/test/test_client.py
+++ b/client/python/test/test_client.py
@@ -648,6 +648,15 @@ class TestClientPredictions:
         new_headers = client.add_zero_gpu_headers(headers)
         assert new_headers == {"existing": "header", "x-ip-token": "test-token"}
 
+    def test_multiple_newlines_in_output(self):
+        def test():
+            return """before\x85after"""
+
+        demo = gr.Interface(fn=test, inputs=[], outputs=["text"])
+        with connect(demo) as client:
+            result = client.predict(api_name="/predict")
+            assert result == "before\x85after"
+
 
 class TestClientPredictionsWithKwargs:
     def test_no_default_params(self, calculator_demo):


### PR DESCRIPTION
## Description

The issue right now is that `iter_lines` uses an internal list of newline characters that include `\x85` and we can't control that list. So in those cases where one of those newline characters is returned, the line is shorter than expected and json.loads fails.

Closes: #10133

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
