### PR TITLE
Remove warning from gr.File about specifying file_types when file_count is directory

### DIFF
--- a/.changeset/angry-years-flow.md
+++ b/.changeset/angry-years-flow.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Remove warning from gr.File about specifying file_types when file_count is directory

--- a/gradio/components/file.py
+++ b/gradio/components/file.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import tempfile
-import warnings
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -108,10 +107,6 @@ class File(Component):
         if type not in valid_types:
             raise ValueError(
                 f"Invalid value for parameter `type`: {type}. Please choose from one of: {valid_types}"
-            )
-        if file_count == "directory" and file_types is not None:
-            warnings.warn(
-                "The `file_types` parameter is ignored when `file_count` is 'directory'."
             )
         super().__init__(
             label=label,


### PR DESCRIPTION
## Description

Closes: #10382

When file_count="directory", the frontend does respect the "file_type" parameter. So I just removed the warning.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
