### PR TITLE
Fix `.unrender()`

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -195,6 +195,7 @@ class Block:
             if root_context:
                 self.page = root_context.root_block.current_page
             render_context.add(self)
+            self.parent = render_context
         if root_context is not None:
             root_context.blocks[self._id] = self
             self.is_rendered = True
@@ -211,6 +212,7 @@ class Block:
         if self.parent is not None:
             try:
                 self.parent.children.remove(self)
+                self.parent = None
             except ValueError:
                 pass
         if root_context is not None:

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -208,10 +208,9 @@ class Block:
         Removes self from the layout and collection of blocks, but does not delete any event triggers.
         """
         root_context = get_blocks_context()
-        render_context = get_render_context()
-        if render_context is not None:
+        if self.parent is not None:
             try:
-                render_context.children.remove(self)
+                self.parent.children.remove(self)
             except ValueError:
                 pass
         if root_context is not None:

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1360,6 +1360,35 @@ class TestRender:
             ["Ask question", "Show question"],
         )
 
+    def test_unrender_in_different_blocks_context(self):
+        def count_key_value(obj, key, value):
+            """
+            Recursively count how many times `obj[key] == value` appears in a nested structure.
+            """
+            count = 0
+            if isinstance(obj, dict):
+                if obj.get(key) == value:
+                    count += 1
+                for v in obj.values():
+                    count += count_key_value(v, key, value)
+            elif isinstance(obj, list):
+                for item in obj:
+                    count += count_key_value(item, key, value)
+            return count
+
+        with gr.Blocks() as demo:
+            with gr.Row():
+                textbox = gr.Textbox()
+            with gr.Row():
+                textbox.unrender()
+            with gr.Row():
+                textbox.render()
+
+        # The textbox should be rendered only once
+        config = demo.get_config_file()
+        assert config and "layout" in config
+        assert count_key_value(config["layout"], "id", textbox._id) == 1
+
 
 class TestCancel:
     @pytest.mark.asyncio

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1377,12 +1377,15 @@ class TestRender:
             return count
 
         with gr.Blocks() as demo:
-            with gr.Row():
+            with gr.Row() as row1:
                 textbox = gr.Textbox()
-            with gr.Row():
+                assert textbox.parent == row1
+            with gr.Row() as row2:  # noqa: F841
                 textbox.unrender()
-            with gr.Row():
+                assert textbox.parent is None
+            with gr.Row() as row3:
                 textbox.render()
+                assert textbox.parent == row3
 
         # The textbox should be rendered only once
         config = demo.get_config_file()


### PR DESCRIPTION
The logic in `Block.unrender()` was incorrect: when we would unrender a `Block`, we were previously trying to remove it from the layout where `.unrender()` was called instead of its original parent layout. This was fine if the `Block` was rendered and unrendered within the same layout, but if it was unrendered in a different layout than it was originally rendered, then it would appear twice in the Gradio app.

Closes: https://github.com/gradio-app/gradio/issues/11122