### PR TITLE
Refactor `gr.State`, `gr.BrowserState`, and `gr.Timer` to inherit from `FormComponent`

### DIFF
--- a/.changeset/flat-otters-admire.md
+++ b/.changeset/flat-otters-admire.md
@@ -2,4 +2,4 @@
 "gradio": patch
 ---
 
-fix:Treat `gr.State` as a `FormComponent`
+fix:Refactor `gr.State`, `gr.BrowserState`, and `gr.Timer` to inherit from `FormComponent`

--- a/gradio/components/base.py
+++ b/gradio/components/base.py
@@ -370,6 +370,13 @@ class Component(ComponentBase, Block):
 
 
 class FormComponent(Component):
+    """
+    A base class for components that are typically used in forms (e.g. Textbox, Dropdown). These
+    components will be grouped together in the UI to provide a more condensed layout. Components
+    that are not rendered in the UI (e.g. State) should also inherit from this class, as it will
+    prevent them from breaking the grouping, see: https://github.com/gradio-app/gradio/issues/10330
+    """
+
     def get_expected_parent(self) -> type[Form] | None:
         if getattr(self, "container", None) is False:
             return None

--- a/gradio/components/browser_state.py
+++ b/gradio/components/browser_state.py
@@ -8,12 +8,12 @@ from typing import Any
 
 from gradio_client.documentation import document
 
-from gradio.components.base import Component
+from gradio.components.base import FormComponent
 from gradio.events import Events
 
 
 @document()
-class BrowserState(Component):
+class BrowserState(FormComponent):
     EVENTS = [Events.change]
     """
     Special component that stores state in the browser's localStorage in an encrypted format.

--- a/gradio/components/state.py
+++ b/gradio/components/state.py
@@ -14,7 +14,7 @@ from gradio.events import Events
 
 
 @document()
-class State(FormComponent):  # We subclass FormComponent to prevent it from breaking the grouping of form components, see: https://github.com/gradio-app/gradio/issues/10330
+class State(FormComponent):
     EVENTS = [Events.change]
     """
     Special hidden component that stores session state across runs of the demo by the

--- a/gradio/components/state.py
+++ b/gradio/components/state.py
@@ -9,12 +9,12 @@ from typing import Any
 
 from gradio_client.documentation import document
 
-from gradio.components.base import Component
+from gradio.components.base import FormComponent
 from gradio.events import Events
 
 
 @document()
-class State(Component):
+class State(FormComponent):  # We subclass FormComponent to prevent it from breaking the grouping of form components, see: https://github.com/gradio-app/gradio/issues/10330
     EVENTS = [Events.change]
     """
     Special hidden component that stores session state across runs of the demo by the

--- a/gradio/components/timer.py
+++ b/gradio/components/timer.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from gradio_client.documentation import document
 
-from gradio.components.base import Component
+from gradio.components.base import FormComponent
 from gradio.events import Events
 
 if TYPE_CHECKING:
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 @document()
-class Timer(Component):
+class Timer(FormComponent):
     """
     Special component that ticks at regular intervals when active. It is not visible, and only used to trigger events at a regular interval through the `tick` event listener.
     """


### PR DESCRIPTION
Small PR, fixes: https://github.com/gradio-app/gradio/issues/10330