### PR TITLE
Parallelize pytests

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -72,7 +72,12 @@ jobs:
         run: |
           . venv/bin/activate
           ./scripts/type_check_backend.sh
-      - name: Run tests
+      - name: Run parallel tests
         run: |
           . ${{steps.install_deps.outputs.venv_activate}}
-          python -m pytest -n auto -m "${{ matrix.test-type }}"
+          python -m pytest -n auto -m "${{ matrix.test-type }} and not serial"
+      - name: Run serial tests
+        run: |
+          . ${{steps.install_deps.outputs.venv_activate}}
+          python -m pytest -m "${{ matrix.test-type }} and serial"
+  

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -80,4 +80,3 @@ jobs:
         run: |
           . ${{steps.install_deps.outputs.venv_activate}}
           python -m pytest -m "${{ matrix.test-type }} and serial"
-  

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -75,4 +75,4 @@ jobs:
       - name: Run tests
         run: |
           . ${{steps.install_deps.outputs.venv_activate}}
-          python -m pytest -m "${{ matrix.test-type }}"
+          python -m pytest -n auto -m "${{ matrix.test-type }}"

--- a/client/python/test/requirements.txt
+++ b/client/python/test/requirements.txt
@@ -1,5 +1,6 @@
 pytest-asyncio
 pytest==7.1.2
+pytest-xdist
 ruff==0.4.1
 pyright==1.1.372
 gradio

--- a/client/python/test/test_client.py
+++ b/client/python/test/test_client.py
@@ -70,6 +70,7 @@ class TestClientInitialization:
         )
         assert {"authorization": "Bearer abcde"}.items() <= client.headers.items()
 
+    @pytest.mark.serial
     def test_many_endpoint_demo_loads_quickly(self, many_endpoint_demo):
         import datetime
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -249,6 +249,8 @@ pytest-cov==6.0.0
     # via -r test/requirements.in
 pytest-rerunfailures==15.0
     # via -r test/requirements.in
+pytest-xdist==3.6.1
+    # via -r test/requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   botocore

--- a/test/test_docker/test_reverse_proxy/test_reverse_proxy.py
+++ b/test/test_docker/test_reverse_proxy/test_reverse_proxy.py
@@ -15,6 +15,7 @@ def launch_services(launch_services_fn):
     yield from launch_services_fn(TEST_NAME, folder)
 
 
+@pytest.mark.serial
 def test_endpoint_status(launch_services):
     for endpoint in launch_services:
         response = requests.get(endpoint)
@@ -28,6 +29,7 @@ def test_endpoint_status(launch_services):
         assert response.status_code == 404
 
 
+@pytest.mark.serial
 def test_api_response(launch_services):
     for endpoint in launch_services:
         client = gradio_client.Client(endpoint)
@@ -35,6 +37,7 @@ def test_api_response(launch_services):
         assert result == "Hi John"
 
 
+@pytest.mark.serial
 def test_load_assets(launch_services):
     for endpoint in launch_services:
         asset_regex = '"\\.\\/([A-Za-z0-9-_\\/.]+\\.(?:js|css))"'

--- a/test/test_docker/test_reverse_proxy_fastapi_mount/test_reverse_proxy_fastapi_mount.py
+++ b/test/test_docker/test_reverse_proxy_fastapi_mount/test_reverse_proxy_fastapi_mount.py
@@ -15,6 +15,7 @@ def launch_services(launch_services_fn):
     yield from launch_services_fn(TEST_NAME, folder, "/mount", "/mount")
 
 
+@pytest.mark.serial
 def test_endpoint_status(launch_services):
     for endpoint in launch_services:
         response = requests.get(endpoint)
@@ -28,6 +29,7 @@ def test_endpoint_status(launch_services):
         assert response.status_code == 404
 
 
+@pytest.mark.serial
 def test_api_response(launch_services):
     for endpoint in launch_services:
         client = gradio_client.Client(endpoint)
@@ -35,6 +37,7 @@ def test_api_response(launch_services):
         assert result == "Hi John"
 
 
+@pytest.mark.serial
 def test_load_assets(launch_services):
     for endpoint in launch_services:
         asset_regex = '"\\.\\/([A-Za-z0-9-_\\/.]+\\.(?:js|css))"'

--- a/test/test_docker/test_reverse_proxy_root_path/test_reverse_proxy_root_path.py
+++ b/test/test_docker/test_reverse_proxy_root_path/test_reverse_proxy_root_path.py
@@ -15,6 +15,7 @@ def launch_services(launch_services_fn):
     yield from launch_services_fn(TEST_NAME, folder, "/gradio/demo", "/gradio/demo")
 
 
+@pytest.mark.serial
 def test_endpoint_status(launch_services):
     for endpoint in launch_services:
         response = requests.get(endpoint)
@@ -28,6 +29,7 @@ def test_endpoint_status(launch_services):
         assert response.status_code == 404
 
 
+@pytest.mark.serial
 def test_api_response(launch_services):
     for endpoint in launch_services:
         client = gradio_client.Client(endpoint)
@@ -35,6 +37,7 @@ def test_api_response(launch_services):
         assert result == "Hi John"
 
 
+@pytest.mark.serial
 def test_load_assets(launch_services):
     for endpoint in launch_services:
         asset_regex = '"\\.\\/([A-Za-z0-9-_\\/.]+\\.(?:js|css))"'

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -91,6 +91,7 @@ class TestInterface:
         assert dataset_check
 
     @patch("time.sleep")
+    @pytest.mark.serial
     def test_block_thread(self, mock_sleep):
         with pytest.raises(KeyboardInterrupt):
             with captured_output() as (out, _):

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -28,6 +28,7 @@ def captured_output():
 
 
 class TestInterface:
+    @pytest.mark.serial
     def test_close(self):
         io = Interface(lambda input: None, "textbox", "label")
         _, local_url, _ = io.launch(prevent_thread_lock=True)


### PR DESCRIPTION
Nice idea @pngwn to parallelize the python unit tests. It looks like we have 4 workers on CI so parallelization helps quite a bit (even though certain tests that cannot be parallelized or they fail, hence the `serial` marker. This is something we should keep in mind for the future -- if a test is passing locally but not on CI, and we're not sure why, it might be because of parallelization). Also the handful of docker unit tests we have take almost 2 minutes to run by themselves, fyi @aliabid94. If runtime is an issue, we could optimize, but I don't think it's too urgent right now.

Net result of this PR: time for the `test-python` GH action goes from ~11 min to ~6 minutes.