### PR TITLE
#11056 Avoid unchecked pop from `blob_storage` cache in `ImageEditor::preprocess`

### DIFF
--- a/.changeset/loose-feet-stick.md
+++ b/.changeset/loose-feet-stick.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:#11181 Avoid unchecked pop from `blob_storage` cache in `ImageEditor::preprocess`

--- a/.changeset/loose-feet-stick.md
+++ b/.changeset/loose-feet-stick.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:#11181 Avoid unchecked pop from `blob_storage` cache in `ImageEditor::preprocess`
+fix:#11056 Avoid unchecked pop from `blob_storage` cache in `ImageEditor::preprocess`

--- a/gradio/components/image_editor.py
+++ b/gradio/components/image_editor.py
@@ -383,9 +383,10 @@ class ImageEditor(Component):
         Returns:
             Passes the uploaded images as an instance of EditorValue, which is just a `dict` with keys: 'background', 'layers', and 'composite'. The values corresponding to 'background' and 'composite' are images, while 'layers' is a `list` of images. The images are of type `PIL.Image`, `np.array`, or `str` filepath, depending on the `type` parameter.
         """
-        _payload = payload
+        if payload is None:
+            return payload
 
-        if payload is not None and payload.id is not None:
+        if payload.id is not None:
             cached = self.blob_storage.get(payload.id)
             _payload = (
                 EditorDataBlobs(
@@ -396,9 +397,6 @@ class ImageEditor(Component):
                 if cached
                 else None
             )
-
-        elif _payload is None:
-            return _payload
         else:
             _payload = payload
 
@@ -415,7 +413,7 @@ class ImageEditor(Component):
             )
             composite = self.convert_and_format_image(_payload.composite)
 
-        if payload is not None and payload.id is not None:
+        if payload.id is not None and payload.id in self.blob_storage:
             self.blob_storage.pop(payload.id)
 
         return {


### PR DESCRIPTION
## Description

This PR refactors the cache logic in `ImageEditor.preprocess()` and adds a check to ensure an entry exists in `blob_storage` before attempting to remove it. While there is probably room for further refinement, the current changes are intentionally minimal to reduce risk.

Closes: #11056

  
