### PR TITLE
Fix bug where returning components in a dictionary would not work in reload mode

### DIFF
--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -283,6 +283,10 @@ def watchfn(reloader: SourceFileReloader):
     # module is available in the namespace of this thread
     module = reloader.watch_module
     no_reload_source_code = _remove_if_name_main_codeblock(str(reloader.demo_file))
+    # Reset the context to id 0 so that the loaded module is the same as the original
+    # See https://github.com/gradio-app/gradio/issues/10253
+    from gradio.context import Context
+    Context.id = 0
     exec(no_reload_source_code, module.__dict__)
     sys.modules[reloader.watch_module_name] = module
 


### PR DESCRIPTION
## Description

Closes: #10253

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
