### PR TITLE
Edit guide - use .unload instead of .close to clean up

### DIFF
--- a/guides/03_building-with-blocks/03_state-in-blocks.md
+++ b/guides/03_building-with-blocks/03_state-in-blocks.md
@@ -102,7 +102,7 @@ with gr.Blocks() as demo:
     # Initialize instance when page loads
     demo.load(initialize_instance, inputs=None, outputs=output)    
     # Clean up instance when page is closed/refreshed
-    demo.close(cleanup_instance)    
+    demo.unload(cleanup_instance)    
 
 demo.launch()
 ```


### PR DESCRIPTION
## Description

Fix States guide where .close instead of .unload is used to clean up instances.

Closes: #11190 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
