### PR TITLE
Fix ValueError in Controlling the Reload demo

### DIFF
--- a/guides/10_other-tutorials/developing-faster-with-reload-mode.md
+++ b/guides/10_other-tutorials/developing-faster-with-reload-mode.md
@@ -119,7 +119,7 @@ if gr.NO_RELOAD:
 	from transformers import pipeline
 	pipe = pipeline("text-classification", model="cardiffnlp/twitter-roberta-base-sentiment-latest")
 
-demo = gr.Interface(lambda s: pipe(s), gr.Textbox(), gr.Label())
+demo = gr.Interface(lambda s: {d["label"]: d["score"] for d in pipe(s)}, gr.Textbox(), gr.Label())
 
 if __name__ == "__main__":
     demo.launch()


### PR DESCRIPTION
## Description

This PR changes the lambda function in the demo to return a value whose type is compatible with the `gr.Label()` output component.

The changed code uses dictionary comprehension to convert the [list of dict with label and score keys](https://huggingface.co/docs/transformers/v4.51.3/en/main_classes/pipelines#transformers.TextClassificationPipeline.__call__) returned by `pipe()`  to a [{Dict[str, float]} of classes and confidences](https://www.gradio.app/docs/gradio/label#param-label-value) used by `gr.Label()` to show classes and confidence bars.

Example of the value before this change. The list was the immediate cause of the ValueError: 

```python
s = "hooray"
pipe(s)
# [{'label': 'positive', 'score': 0.9420903325080872}]
```

Example of the value after this change. The dict has the class as key and confidence score as value:

```python
s = "hooray"
{d["label"]: d["score"] for d in pipe(s)}
# {'positive': 0.9420903325080872}
```

Closes: #11170
