### PR TITLE
Ensure Clear sort works as expected

### DIFF
--- a/.changeset/smooth-adults-draw.md
+++ b/.changeset/smooth-adults-draw.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": patch
+"gradio": patch
+---
+
+fix:Ensure Clear sort works as expected

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -140,10 +140,14 @@
 		};
 	});
 
-	$: if (data || _headers || els) {
-		df_ctx.data = data;
-		df_ctx.headers = _headers;
-		df_ctx.els = els;
+	$: {
+		if (data || _headers || els) {
+			df_ctx.data = data;
+			df_ctx.headers = _headers;
+			df_ctx.els = els;
+			df_ctx.display_value = display_value;
+			df_ctx.styling = styling;
+		}
 	}
 
 	const dispatch = createEventDispatcher<{
@@ -248,6 +252,9 @@
 			df_actions.reset_sort_state();
 		} else if ($df_state.sort_state.sort_columns.length > 0) {
 			sort_data(data, display_value, styling);
+		} else {
+			df_actions.handle_sort(-1, "asc");
+			df_actions.reset_sort_state();
 		}
 
 		if ($df_state.current_search_query) {
@@ -329,7 +336,6 @@
 
 	function clear_sort(): void {
 		df_actions.reset_sort_state();
-		sort_data(data, display_value, styling);
 	}
 
 	$: if ($df_state.sort_state.sort_columns.length > 0) {


### PR DESCRIPTION
## Description

We weren't storing the initial data's order. The fix stores a snapshot of the dataframe's data before the first sort is applied and restores it when clearing the sort.

- added an initial_data property to store the original data, display values, and styling
- restore all arrays from snapshot when `clear sort` is clicked
- ensured new data is properly stored when values change without sorting

Closes: #10929

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
