### PR TITLE
Fix re-rendering with key when setting a value to None

### DIFF
--- a/.changeset/dirty-donkeys-fly.md
+++ b/.changeset/dirty-donkeys-fly.md
@@ -1,0 +1,6 @@
+---
+"@gradio/core": minor
+"gradio": minor
+---
+
+feat:Fix re-rendering with key when setting a value to None

--- a/.changeset/dirty-donkeys-fly.md
+++ b/.changeset/dirty-donkeys-fly.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/core": minor
-"gradio": minor
+"@gradio/core": patch
+"gradio": patch
 ---
 
 feat:Fix re-rendering with key when setting a value to None

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -946,10 +946,20 @@ class BlocksConfig:
         if renderable and _id not in rendered_ids:
             return {}
         props = block.get_config() if hasattr(block, "get_config") else {}
+
+        skip_none_deletion = []
+        if (
+            renderable and block.key
+        ):  # Nones are important for replacing a value in a keyed component
+            skip_none_deletion = [
+                prop for prop, val in block.constructor_args.items() if val is None
+            ]
+        utils.delete_none(props, skip_props=skip_none_deletion)
+
         block_config = {
             "id": _id,
             "type": block.get_block_name(),
-            "props": utils.delete_none(props),
+            "props": props,
             "skip_api": block.skip_api,
             "component_class_id": getattr(block, "component_class_id", None),
             "key": block.unique_key(),

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -593,11 +593,16 @@ def assert_configs_are_equivalent_besides_ids(
     return True
 
 
-def delete_none(_dict: dict, skip_value: bool = False) -> dict:
+def delete_none(
+    _dict: dict, skip_value: bool = False, skip_props: list[str] | None = None
+) -> dict:
     """
     Delete keys whose values are None from a dictionary
     """
+    skip_props = [] if skip_props is None else skip_props
     for key, value in list(_dict.items()):
+        if key in skip_props:
+            continue
         if skip_value and key == "value":
             continue
         elif value is None:

--- a/js/core/src/init.ts
+++ b/js/core/src/init.ts
@@ -179,6 +179,13 @@ export function create_components(initial_layout: ComponentMeta | undefined): {
 		root: string;
 		dependencies: Dependency[];
 	}): void {
+		components.forEach((c) => {
+			for (const prop in c.props) {
+				if (c.props[prop] === null) {
+					c.props[prop] = undefined;
+				}
+			}
+		});
 		let replacement_components: ComponentMeta[] = [];
 		let new_components: ComponentMeta[] = [];
 		components.forEach((c) => {
@@ -188,7 +195,6 @@ export function create_components(initial_layout: ComponentMeta | undefined): {
 				replacement_components.push(c);
 			}
 		});
-		console.log(new_components.length, replacement_components.length);
 		let _constructor_map = preload_all_components(new_components, root);
 		_constructor_map.forEach((v, k) => {
 			constructor_map.set(k, v);

--- a/js/core/src/init.ts
+++ b/js/core/src/init.ts
@@ -181,11 +181,6 @@ export function create_components(initial_layout: ComponentMeta | undefined): {
 	}): void {
 		let replacement_components: ComponentMeta[] = [];
 		let new_components: ComponentMeta[] = [];
-		console.log("old_keys", keys_per_render_id[render_id]);
-		console.log(
-			"new_keys",
-			components.map((c) => c.key)
-		);
 		components.forEach((c) => {
 			if (c.key == null || !keys_per_render_id[render_id]?.includes(c.key)) {
 				new_components.push(c);


### PR DESCRIPTION
If you re-render with a key, the new values should replace the existing values. However, we do a utils.delete_none to remove Nones from updates. So in a re-render previously, anything set to None was not passed as an update. Fixed now:

test with below (clearing with button wont work on main):

```python
import gradio as gr

with gr.Blocks() as demo:
  tb1 = gr.Textbox()
  clear = gr.Button()
  state = gr.State()

  tb1.change(lambda x:x, tb1, state)
  clear.click(lambda: None, outputs=state)


  @gr.render(inputs=state)
  def render(state_val):
    gr.Textbox(label=state_val, key="box", preserved_by_key=None)

demo.launch()
```