### PR TITLE
Chatbot autoscroll fix

### DIFF
--- a/.changeset/afraid-donuts-teach.md
+++ b/.changeset/afraid-donuts-teach.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/chatbot": minor
-"gradio": minor
+"@gradio/chatbot": patch
+"gradio": patch
 ---
 
 feat:Chatbot autoscroll fix

--- a/.changeset/afraid-donuts-teach.md
+++ b/.changeset/afraid-donuts-teach.md
@@ -1,0 +1,6 @@
+---
+"@gradio/chatbot": minor
+"gradio": minor
+---
+
+feat:Chatbot autoscroll fix

--- a/js/chatbot/shared/ChatBot.svelte
+++ b/js/chatbot/shared/ChatBot.svelte
@@ -134,12 +134,10 @@
 
 	async function scroll_on_value_update(): Promise<void> {
 		if (!autoscroll) return;
-
 		if (is_at_bottom()) {
 			// Child components may be loaded asynchronously,
 			// so trigger the scroll again after they load.
 			scroll_after_component_load = true;
-
 			await tick(); // Wait for the DOM to update so that the scrollHeight is correct
 			scroll_to_bottom();
 		} else {
@@ -147,6 +145,9 @@
 		}
 	}
 	onMount(() => {
+		if (autoscroll) {
+			scroll_to_bottom();
+		}
 		scroll_on_value_update();
 	});
 	$: if (value || pending_message || _components) {
@@ -406,7 +407,7 @@
 
 	.bubble-wrap {
 		width: 100%;
-		overflow-y: visible;
+		overflow-y: auto;
 		height: 100%;
 		padding-top: var(--spacing-xxl);
 	}


### PR DESCRIPTION
## Description

- Fixes autoscroll, since it was broken
- When chatbot is loaded with default value and autoscroll is True, the chatbot will already be scrolled to the bottom when first loaded



https://github.com/user-attachments/assets/ea216951-722e-434a-9cc0-4916053fc288



Closes: #11109

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
