### PR TITLE
Fix MCP server mounted path

### DIFF
--- a/.changeset/shiny-zebras-swim.md
+++ b/.changeset/shiny-zebras-swim.md
@@ -2,4 +2,4 @@
 "gradio": patch
 ---
 
-fix:Fix MCP server
+fix:Fix MCP server mounted path

--- a/.changeset/shiny-zebras-swim.md
+++ b/.changeset/shiny-zebras-swim.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix MCP server

--- a/gradio/mcp.py
+++ b/gradio/mcp.py
@@ -12,7 +12,7 @@ from mcp.server import Server
 from mcp.server.sse import SseServerTransport
 from PIL import Image
 from starlette.applications import Starlette
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
 from starlette.routing import Mount, Route
 
 from gradio import processing_utils, route_utils, utils
@@ -138,7 +138,7 @@ class GradioMCPServer:
             app: The Gradio app to mount the MCP server on.
             subpath: The subpath to mount the MCP server on. E.g. "/gradio_api/mcp"
         """
-        messages_path = f"{subpath}/messages/"
+        messages_path = "/messages/"
         sse = SseServerTransport(messages_path)
 
         async def handle_sse(request):
@@ -157,6 +157,7 @@ class GradioMCPServer:
                         streams[1],
                         self.mcp_server.create_initialization_options(),
                     )
+                return Response()
             except Exception as e:
                 print(f"MCP SSE connection error: {str(e)}")
                 raise

--- a/requirements-mcp.txt
+++ b/requirements-mcp.txt
@@ -1,2 +1,2 @@
-mcp>=1.6.0,<2.0.0
+mcp>=1.9.0,<2.0.0
 pydantic>=2.11; sys.platform != 'emscripten'


### PR DESCRIPTION
`mcp==1.9.0` introduced a breaking change in how paths are mounted (the new approach is actually the correct one, see https://github.com/modelcontextprotocol/python-sdk/pull/659)

This PR makes the corresponding change in Gradio's MCP server to account for this change and adds a test. 

Closes: https://github.com/gradio-app/gradio/issues/11225
Closes: https://github.com/gradio-app/gradio/issues/11219