### PR TITLE
Add padding param to gr.Markdown

### DIFF
--- a/.changeset/afraid-cycles-post.md
+++ b/.changeset/afraid-cycles-post.md
@@ -1,0 +1,6 @@
+---
+"@gradio/markdown": patch
+"gradio": patch
+---
+
+fix:Add padding param to gr.Markdown

--- a/gradio/components/markdown.py
+++ b/gradio/components/markdown.py
@@ -55,6 +55,7 @@ class Markdown(Component):
         min_height: int | str | None = None,
         show_copy_button: bool = False,
         container: bool = False,
+        padding: bool = True,
     ):
         """
         Parameters:
@@ -79,6 +80,7 @@ class Markdown(Component):
             min_height: The minimum height of the component, specified in pixels if a number is passed, or in CSS units if a string is passed. If markdown content exceeds the height, the component will expand to fit the content. Will not have any effect if `height` is set and is larger than `min_height`.
             show_copy_button: If True, includes a copy button to copy the text in the Markdown component. Default is False.
             container: If True, the Markdown component will be displayed in a container. Default is False.
+            padding: If True, the Markdown component will have a certain padding (set by the `--block-padding` CSS variable) in all directions. Default is True.
         """
         self.rtl = rtl
         if latex_delimiters is None:
@@ -91,6 +93,7 @@ class Markdown(Component):
         self.max_height = max_height
         self.min_height = min_height
         self.show_copy_button = show_copy_button
+        self.padding = padding
 
         super().__init__(
             label=label,

--- a/gradio/components/markdown.py
+++ b/gradio/components/markdown.py
@@ -55,7 +55,7 @@ class Markdown(Component):
         min_height: int | str | None = None,
         show_copy_button: bool = False,
         container: bool = False,
-        padding: bool = True,
+        padding: bool = False,
     ):
         """
         Parameters:
@@ -80,7 +80,7 @@ class Markdown(Component):
             min_height: The minimum height of the component, specified in pixels if a number is passed, or in CSS units if a string is passed. If markdown content exceeds the height, the component will expand to fit the content. Will not have any effect if `height` is set and is larger than `min_height`.
             show_copy_button: If True, includes a copy button to copy the text in the Markdown component. Default is False.
             container: If True, the Markdown component will be displayed in a container. Default is False.
-            padding: If True, the Markdown component will have a certain padding (set by the `--block-padding` CSS variable) in all directions. Default is True.
+            padding: If True, the Markdown component will have a certain padding (set by the `--block-padding` CSS variable) in all directions. Default is False.
         """
         self.rtl = rtl
         if latex_delimiters is None:

--- a/js/markdown/Index.svelte
+++ b/js/markdown/Index.svelte
@@ -37,7 +37,7 @@
 	export let show_copy_button = false;
 	export let container = false;
 	export let theme_mode: ThemeMode;
-	export let padding = true;
+	export let padding = false;
 </script>
 
 <Block

--- a/js/markdown/Index.svelte
+++ b/js/markdown/Index.svelte
@@ -11,6 +11,7 @@
 	import { StatusTracker } from "@gradio/statustracker";
 	import type { LoadingStatus } from "@gradio/statustracker";
 	import { Block } from "@gradio/atoms";
+	import { css_units } from "@gradio/utils";
 
 	export let elem_id = "";
 	export let elem_classes: string[] = [];
@@ -37,6 +38,7 @@
 	export let show_copy_button = false;
 	export let container = false;
 	export let theme_mode: ThemeMode;
+	export let padding = true;
 </script>
 
 <Block
@@ -57,7 +59,7 @@
 		variant="center"
 		on:clear_status={() => gradio.dispatch("clear_status", loading_status)}
 	/>
-	<div class:pending={loading_status?.status === "pending"}>
+	<div class:padding class:pending={loading_status?.status === "pending"}>
 		<Markdown
 			{value}
 			{elem_classes}
@@ -84,5 +86,9 @@
 
 	.pending {
 		opacity: 0.2;
+	}
+
+	.padding {
+		padding: var(--block-padding);
 	}
 </style>

--- a/js/markdown/Index.svelte
+++ b/js/markdown/Index.svelte
@@ -11,7 +11,6 @@
 	import { StatusTracker } from "@gradio/statustracker";
 	import type { LoadingStatus } from "@gradio/statustracker";
 	import { Block } from "@gradio/atoms";
-	import { css_units } from "@gradio/utils";
 
 	export let elem_id = "";
 	export let elem_classes: string[] = [];


### PR DESCRIPTION
## Description

Makes padding consistent across HTML and Markdown by adding a padding param to gr.Markdown. 

Should this actually be False to prevent unwarranted breaking changes? 

Closes: #11234

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
