### PR TITLE
Attempt to add bool_input property to Dataframe

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,119 @@
+from enum import Enum
+import json
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel
+import gradio as gr
+import pandas as pd
+
+
+# Function to update the state with the new dataframe
+def update_dataframe(new_df, state):
+    state = new_df  # Update the state with the new dataframe
+    return state, new_df  # Return both the updated state and the dataframe to re-render
+
+
+class BusProvider(Enum):
+    EGED = "EGED"
+    DAN = "DAN"
+
+
+BusIdsByProvider = Dict[BusProvider, List[int]]
+
+
+class BusRules(BaseModel):
+    disabled_buses: BusIdsByProvider = {}
+    express_buses: BusIdsByProvider = {}
+    accessible_buses: BusIdsByProvider = {}
+
+
+css = """
+ .dataframe {
+        overflow-x: hidden; /* Hide vertical scrollbar */
+    }
+
+.generating {
+    border: none;
+}
+"""
+with gr.Blocks(css=css) as demo:
+    config_state = gr.State(
+        BusRules(
+            disabled_buses={
+                BusProvider.DAN: [1, 2, 3],
+            },
+        )
+    )
+
+    gr.Button()
+
+    BUS_COUNTS_BY_PROVIDER = {
+        BusProvider.DAN: 10,
+        BusProvider.EGED: 23,
+    }
+
+    selected_bus_provider_state = gr.State(BusProvider.EGED)
+
+    def create_bus_ids_list(
+        bus_provider: BusProvider
+    ) -> List[str]:
+        return [
+            f"{id + 1}" for id in range(BUS_COUNTS_BY_PROVIDER[bus_provider])
+        ]
+    def create_bool_list(
+        bus_provider: BusProvider, bus_ids: Optional[List[int]]
+    ) -> List[bool]:
+        return [
+            id + 1 in (bus_ids or []) for id in range(BUS_COUNTS_BY_PROVIDER[bus_provider])
+        ]
+
+    def update_selected_mode(new_value: pd.DataFrame, bus_provider: BusProvider, config_value: BusRules):
+        print(new_value)
+        print(config_value)
+        next_config_value = config_value.model_copy()
+        next_config_value.disabled_buses[bus_provider] = [i + 1 for i, val in enumerate(new_value.to_numpy()) if str(val[1]).lower() == "true"]
+        next_config_value.express_buses[bus_provider] = [i + 1 for i, val in enumerate(new_value.to_numpy()) if str(val[2]).lower() == "true"]
+        next_config_value.accessible_buses[bus_provider] = [i + 1 for i, val in enumerate(new_value.to_numpy()) if str(val[3]).lower() == "true"]
+        return next_config_value
+
+    @gr.render(inputs=[config_state, selected_bus_provider_state])
+    def render_dataframe(config_value: BusRules, selected_bus_provider: BusProvider):
+        frame = pd.DataFrame(
+            data={
+                "Bus ID": create_bus_ids_list(bus_provider=selected_bus_provider),
+                "Is disabled?": create_bool_list(
+                    bus_provider=selected_bus_provider,
+                    bus_ids=config_value.disabled_buses.get(selected_bus_provider),
+                ),
+                "Is express?": create_bool_list(
+                    bus_provider=selected_bus_provider,
+                    bus_ids=config_value.express_buses.get(selected_bus_provider),
+                ),
+                "Is accessible?": create_bool_list(
+                    bus_provider=selected_bus_provider,
+                    bus_ids=config_value.accessible_buses.get(selected_bus_provider),
+                ),
+            },
+        )
+        df = gr.Dataframe(
+            bool_input="checkbox",
+            datatype=["str", "bool", "bool", "bool"],
+            static_columns=[0],
+            value=frame,
+            interactive=True,
+            max_height=5000
+        )
+        df.input(update_selected_mode, inputs=[df, selected_bus_provider_state, config_state], outputs=[config_state])
+
+    # def render_data_frame(data_frame_value):
+    #    df.select(lambda x: update_dataframe(x, data_frame_state), inputs=df, outputs=[data_frame_state])
+    # @df.change(inputs=[df, data_frame_state], outputs=[data_frame_state])
+    # def handle_change(dataframe_value, data_frame_value):
+    #    print(dataframe_value, data_frame_value)
+    #    return data_frame_value
+
+    @gr.render(inputs=[config_state])
+    def generate_data(config_value: BusRules):
+       gr.JSON(config_value.model_dump_json(), show_indices=False)
+
+if __name__ == "__main__":
+    demo.launch()

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -86,7 +86,7 @@ class Dataframe(Component):
         every: Timer | float | None = None,
         inputs: Component | Sequence[Component] | set[Component] | None = None,
         max_height: int | str = 500,
-        bool_input: Literal["text", "checkbox"] = "text",
+        bool_input: Literal["text", "checkbox"] = "checkbox",
         scale: int | None = None,
         min_width: int = 160,
         interactive: bool | None = None,

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -86,6 +86,7 @@ class Dataframe(Component):
         every: Timer | float | None = None,
         inputs: Component | Sequence[Component] | set[Component] | None = None,
         max_height: int | str = 500,
+        bool_input: Literal["text", "checkbox"] = "text",
         scale: int | None = None,
         min_width: int = 160,
         interactive: bool | None = None,
@@ -119,6 +120,7 @@ class Dataframe(Component):
             label: the label for this component. Appears above the component and is also used as the header if there are a table of examples for this component. If None and used in a `gr.Interface`, the label will be the name of the parameter this component is assigned to.
             show_label: if True, will display label.
             every: Continously calls `value` to recalculate it if `value` is a function (has no effect otherwise). Can provide a Timer whose tick resets `value`, or a float that provides the regular interval for the reset Timer.
+            bool_input: Determines which component is used for columns of type `bool`, as defined in `datatype`
             inputs: Components that are used as inputs to calculate `value` if `value` is a function (has no effect otherwise). `value` is recalculated any time the inputs change.
             max_height: The maximum height of the dataframe, specified in pixels if a number is passed, or in CSS units if a string is passed. If more rows are created than can fit in the height, a scrollbar will appear.
             scale: relative size compared to adjacent Components. For example if Components A and B are in a Row, and A has scale=2, and B has scale=1, A will be twice as wide as B. Should be an integer. scale applies in Rows, and to top-level Components in Blocks where fill_height=True.
@@ -183,6 +185,8 @@ class Dataframe(Component):
             else f"{w}px"
             for w in (column_widths or [])
         ]
+        self.bool_input = bool_input
+        print(f"bool_input {bool_input}")
         self.show_fullscreen_button = show_fullscreen_button
         self.show_copy_button = show_copy_button
         self.show_row_numbers = show_row_numbers

--- a/js/dataframe/Index.svelte
+++ b/js/dataframe/Index.svelte
@@ -59,6 +59,7 @@
 	export let pinned_columns = 0;
 	export let static_columns: (string | number)[] = [];
 	export let fullscreen = false;
+	export let bool_input: "text" | "checkbox";
 
 	$: _headers = [...(value.headers || headers)];
 	$: display_value = value?.metadata?.display_value
@@ -127,5 +128,6 @@
 		{pinned_columns}
 		components={{ image: Image }}
 		{static_columns}
+		{bool_input}
 	/>
 </Block>

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -36,7 +36,7 @@
 		handle_file_upload
 	} from "./utils/table_utils";
 	import { make_headers, process_data } from "./utils/data_processing";
-	import { handle_keydown, handle_cell_blur } from "./utils/keyboard_utils";
+	import { handle_keydown, handle_cell_blur, handle_cell_checked_change } from "./utils/keyboard_utils";
 	import {
 		create_drag_handlers,
 		type DragState,
@@ -77,6 +77,7 @@
 	export let pinned_columns = 0;
 	export let static_columns: (string | number)[] = [];
 	export let fullscreen = false;
+	export let bool_input: "text" | "checkbox";
 
 	const df_ctx = create_dataframe_context({
 		show_fullscreen_button,
@@ -526,6 +527,30 @@
 		handle_cell_blur(blur_event, df_ctx, coords);
 	}
 
+	function handle_checked_change(
+		event: CustomEvent<{
+			current_checked: boolean;
+			coords: [number, number]
+		}>
+	): void {
+		const { current_checked, coords } = event.detail;
+		handle_cell_checked_change(current_checked, df_ctx, coords);
+	}
+
+	function toggle_fullscreen(): void {
+		if (!document.fullscreenElement) {
+			parent.requestFullscreen();
+			is_fullscreen = true;
+		} else {
+			document.exitFullscreen();
+			is_fullscreen = false;
+		}
+	}
+
+	function handle_fullscreen_change(): void {
+		is_fullscreen = !!document.fullscreenElement;
+	}
+
 	function toggle_header_menu(event: MouseEvent, col: number): void {
 		event.stopPropagation();
 		if (active_header_menu && active_header_menu.col === col) {
@@ -793,6 +818,7 @@
 							{i18n}
 							bind:el={els[id].input}
 							{col_count}
+							{bool_input}
 						/>
 					{/each}
 				</tr>
@@ -822,7 +848,9 @@
 									on_select_column={df_actions.handle_select_column}
 									on_select_row={df_actions.handle_select_row}
 									{is_dragging}
+									{bool_input}
 									on:blur={handle_blur}
+
 								/>
 							</div>
 						</td>
@@ -899,6 +927,7 @@
 								{i18n}
 								bind:el={els[id].input}
 								{col_count}
+								{bool_input}
 							/>
 						{/each}
 					</tr>
@@ -941,6 +970,8 @@
 								bind:el={els[id]}
 								{is_dragging}
 								{wrap}
+								{bool_input}
+								{handle_checked_change}
 							/>
 						{/each}
 					</tr>

--- a/js/dataframe/shared/TableCell.svelte
+++ b/js/dataframe/shared/TableCell.svelte
@@ -21,6 +21,12 @@
 			coords: [number, number];
 		}>
 	) => void;
+	export let handle_checked_change: (
+		event: CustomEvent<{
+			current_checked: boolean;
+			coords: [number, number];
+		}>
+	) => void;
 	export let toggle_cell_menu: (
 		event: MouseEvent,
 		row: number,
@@ -67,6 +73,7 @@
 	export let is_dragging: boolean;
 	export let display_value: string | undefined;
 	export let wrap = false;
+	export let bool_input: "text" | "checkbox";
 
 	function get_cell_position(col_index: number): string {
 		if (col_index >= actual_pinned_columns) {
@@ -139,6 +146,7 @@
 				}
 			}}
 			on:blur={handle_blur}
+			on:checked_change={handle_checked_change}
 			{root}
 			{max_chars}
 			{i18n}
@@ -151,6 +159,7 @@
 			on_select_row={handle_select_row}
 			{is_dragging}
 			wrap_text={wrap}
+			{bool_input}
 		/>
 		{#if editable && should_show_cell_menu([index, j], selected_cells, editable)}
 			<CellMenuButton on_click={(event) => toggle_cell_menu(event, index, j)} />

--- a/js/dataframe/shared/TableHeader.svelte
+++ b/js/dataframe/shared/TableHeader.svelte
@@ -31,6 +31,7 @@
 	export let i18n: I18nFormatter;
 	export let el: HTMLInputElement | null;
 	export let is_static: boolean;
+	export let bool_input: "text" | "checkbox";
 	export let col_count: [number, "fixed" | "dynamic"];
 
 	$: can_add_columns = col_count && col_count[1] === "dynamic";
@@ -110,6 +111,7 @@
 					{is_static}
 					{i18n}
 					coords={[i, 0]}
+					{bool_input}
 				/>
 				{#if sort_index !== -1}
 					<div class="sort-indicators">

--- a/js/dataframe/shared/utils/keyboard_utils.ts
+++ b/js/dataframe/shared/utils/keyboard_utils.ts
@@ -6,13 +6,13 @@ import { get } from "svelte/store";
 import { copy_table_data } from "./table_utils";
 
 async function save_cell_value(
-	input_value: string,
+	input_value: string | boolean,
 	ctx: DataFrameContext,
 	row: number,
 	col: number
 ): Promise<void> {
 	if (!ctx.data || !ctx.data[row] || !ctx.data[row][col]) return;
-
+	
 	const old_value = ctx.data[row][col].value;
 	ctx.data[row][col].value = input_value;
 
@@ -36,8 +36,26 @@ export async function handle_cell_blur(
 
 	const input_el = event.target as HTMLInputElement;
 	if (!input_el || input_el.value === undefined) return;
+	
+	await save_cell_value(
+		input_el.value,
+		ctx, 
+		coords[0], 
+		coords[1]);
+}
 
-	await save_cell_value(input_el.value, ctx, coords[0], coords[1]);
+export async function handle_cell_checked_change(
+	current_checked: boolean,
+	ctx: DataFrameContext,
+	coords: [number, number]
+): Promise<void> {
+	if (!ctx.data || !ctx.headers || !ctx.els) return;
+
+	await save_cell_value(
+		current_checked,
+		ctx, 
+		coords[0], 
+		coords[1]);
 }
 
 function handle_header_navigation(
@@ -174,7 +192,7 @@ async function handle_enter_key(
 
 	const state = get(ctx.state);
 	if (!state.config.editable) return false;
-
+	
 	event.preventDefault();
 
 	const editing = state.ui_state.editing;


### PR DESCRIPTION
## Description

- Added `bool_input` property to `Dataframe` which affects how inputs of type `bool` are rendered in table cells
- The default is `"checkbox"` which displays a checkbox, but it can be set to `"text"` to preserve existing  behavior 

![image](https://github.com/user-attachments/assets/0fef0afa-4996-4f2b-ad22-81974d78558c)

Closes: #11191 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
