### PR TITLE
Fixes gr.Error

### DIFF
--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -86,13 +86,12 @@ class Error(AppError):
             title: The title to be displayed to the user at the top of the error modal.
             print_exception: Whether to print traceback of the error to the console when the error is raised.
         """
-        super().__init__(
-            message=message,
-            duration=duration,
-            visible=visible,
-            title=title,
-            print_exception=print_exception,
-        )
+        self.message = message
+        self.duration = duration
+        self.visible = visible
+        self.title = title
+        self.print_exception = print_exception
+        super().__init__(message)
 
     def __str__(self):
         return repr(self.message)

--- a/js/spa/test/blocks_chained_events.spec.ts
+++ b/js/spa/test/blocks_chained_events.spec.ts
@@ -32,6 +32,7 @@ test("gr.Error makes the toast show up", async ({ page }) => {
 
 	const toast = page.getByTestId("toast-body");
 	expect(toast).toContainText("Error");
+	expect(toast).toContainText("This should fail");
 	const close = page.getByTestId("toast-close");
 	await close.click();
 	await expect(page.getByTestId("toast-body")).toHaveCount(0);


### PR DESCRIPTION
gr.Error was not working correctly, wouldn't surface the error to the frontend either. Fixed now.

Test:
```python
import gradio as gr


def greet(name):
    raise gr.Error("Hello")


with gr.Blocks() as demo:
    name = gr.Textbox(label="Name")
    output = gr.Textbox(label="Output Box")
    greet_btn = gr.Button("Greet")
    greet_btn.click(fn=greet, inputs=name, outputs=output, api_name="greet")

if __name__ == "__main__":
    demo.launch()
```