### PR TITLE
Add missing blur event to gr.Number

### DIFF
--- a/gradio/components/number.py
+++ b/gradio/components/number.py
@@ -24,7 +24,7 @@ class Number(FormComponent):
     Demos: tax_calculator, blocks_simple_squares
     """
 
-    EVENTS = [Events.change, Events.input, Events.submit, Events.focus]
+    EVENTS = [Events.change, Events.input, Events.submit, Events.focus, Events.blur]
 
     def __init__(
         self,


### PR DESCRIPTION
## Description

- Added `blur` attribute to `gr.Number` instances. It was already supported in the HTML, but it didn't expose a `blur` attribute in Python

Closes: #11261 

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
