### PR TITLE
Fix bug where streaming one chunk of audio or video would not play

### DIFF
--- a/.changeset/fresh-vans-bow.md
+++ b/.changeset/fresh-vans-bow.md
@@ -1,0 +1,7 @@
+---
+"@gradio/audio": patch
+"@gradio/video": patch
+"gradio": patch
+---
+
+fix:Fix bug where streaming one chunk of audio or video would not play

--- a/js/audio/player/AudioPlayer.svelte
+++ b/js/audio/player/AudioPlayer.svelte
@@ -150,20 +150,8 @@
 
 	$: url && load_audio(url);
 
-	async function load_stream(value: FileData | null): Promise<void> {
+	function load_stream(value: FileData | null): void {
 		if (!value || !value.is_stream || !value.url) return;
-
-		// Wait for audio_player to be available
-		if (!audio_player) {
-			await new Promise<void>((resolve) => {
-				const checkAudioPlayer = setInterval(() => {
-					if (audio_player) {
-						clearInterval(checkAudioPlayer);
-						resolve();
-					}
-				}, 100);
-			});
-		}
 
 		if (Hls.isSupported() && !stream_active) {
 			// Set config to start playback after 1 second of data received
@@ -206,7 +194,9 @@
 		}
 	}
 
-	$: load_stream(value);
+	$: if (audio_player && value?.is_stream) {
+		load_stream(value);
+	}
 
 	onMount(() => {
 		window.addEventListener("keydown", (e) => {

--- a/js/audio/player/AudioPlayer.svelte
+++ b/js/audio/player/AudioPlayer.svelte
@@ -150,9 +150,21 @@
 
 	$: url && load_audio(url);
 
-	function load_stream(value: FileData | null): void {
+	async function load_stream(value: FileData | null): Promise<void> {
 		if (!value || !value.is_stream || !value.url) return;
-		if (!audio_player) return;
+
+		// Wait for audio_player to be available
+		if (!audio_player) {
+			await new Promise<void>((resolve) => {
+				const checkAudioPlayer = setInterval(() => {
+					if (audio_player) {
+						clearInterval(checkAudioPlayer);
+						resolve();
+					}
+				}, 100);
+			});
+		}
+
 		if (Hls.isSupported() && !stream_active) {
 			// Set config to start playback after 1 second of data received
 			const hls = new Hls({

--- a/js/video/shared/Video.svelte
+++ b/js/video/shared/Video.svelte
@@ -51,23 +51,12 @@
 
 	const dispatch = createEventDispatcher();
 
-	async function load_stream(
+	function load_stream(
 		src: string | null | undefined,
 		is_stream: boolean,
-		node: HTMLVideoElement | undefined
-	): Promise<void> {
+		node: HTMLVideoElement
+	): void {
 		if (!src || !is_stream) return;
-
-		if (!node) {
-			await new Promise<void>((resolve) => {
-				const checkNode = setInterval(() => {
-					if (node) {
-						clearInterval(checkNode);
-						resolve();
-					}
-				}, 100);
-			});
-		}
 
 		if (Hls.isSupported() && !stream_active) {
 			const hls = new Hls({
@@ -76,7 +65,6 @@
 				lowLatencyMode: true // Enable low latency mode
 			});
 			hls.loadSource(src);
-			// @ts-ignore
 			hls.attachMedia(node);
 			hls.on(Hls.Events.MANIFEST_PARSED, function () {
 				(node as HTMLVideoElement).play();
@@ -108,7 +96,9 @@
 
 	$: src, (stream_active = false);
 
-	$: load_stream(src, is_stream, node);
+	$: if (node && src && is_stream) {
+		load_stream(src, is_stream, node);
+	}
 </script>
 
 <!--

--- a/js/video/shared/Video.svelte
+++ b/js/video/shared/Video.svelte
@@ -51,13 +51,24 @@
 
 	const dispatch = createEventDispatcher();
 
-	function load_stream(
+	async function load_stream(
 		src: string | null | undefined,
 		is_stream: boolean,
 		node: HTMLVideoElement | undefined
-	): void {
+	): Promise<void> {
 		if (!src || !is_stream) return;
-		if (!node) return;
+
+		if (!node) {
+			await new Promise<void>((resolve) => {
+				const checkNode = setInterval(() => {
+					if (node) {
+						clearInterval(checkNode);
+						resolve();
+					}
+				}, 100);
+			});
+		}
+
 		if (Hls.isSupported() && !stream_active) {
 			const hls = new Hls({
 				maxBufferLength: 1, // 0.5 seconds (500 ms)
@@ -65,6 +76,7 @@
 				lowLatencyMode: true // Enable low latency mode
 			});
 			hls.loadSource(src);
+			// @ts-ignore
 			hls.attachMedia(node);
 			hls.on(Hls.Events.MANIFEST_PARSED, function () {
 				(node as HTMLVideoElement).play();


### PR DESCRIPTION
## Description
Closes: #10878

The issue is that the media player was not loaded on the page


Test:

```python
import gradio as gr
from time import sleep

def keep_repeating(audio_file):
    for _ in range(1):
        sleep(0.5)
        yield audio_file

gr.Interface(keep_repeating,
             gr.Audio(sources=["upload"], type="filepath"),
             gr.Audio(streaming=True, autoplay=True)
).launch()
```


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
