### PR TITLE
Fix bug where only the first chunk of a video stream played audio

### DIFF
--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1032,7 +1032,7 @@ class App(FastAPI):
                 playlist += f"{segment['id']}{segment['extension']}\n"  # type: ignore
                 # HLS expects the start time of the video segments to be continuous
                 # Instead of re-encoding the user video chunks, we add a discontinuity tag
-                if segment["extension"] == "ts":
+                if segment["extension"] == ".ts":
                     playlist += "#EXT-X-DISCONTINUITY\n"
 
             if stream.ended:

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1030,6 +1030,10 @@ class App(FastAPI):
             for segment in stream.segments:
                 playlist += f"#EXTINF:{segment['duration']:.3f},\n"
                 playlist += f"{segment['id']}{segment['extension']}\n"  # type: ignore
+                # HLS expects the start time of the video segments to be continuous
+                # Instead of re-encoding the user video chunks, we add a discontinuity tag
+                if segment["extension"] == "ts":
+                    playlist += "#EXT-X-DISCONTINUITY\n"
 
             if stream.ended:
                 playlist += "#EXT-X-ENDLIST\n"


### PR DESCRIPTION
## Description

Closes: #11064

```python
import gradio as gr
from time import sleep

def keep_repeating(video_file):
    for _ in range(2):
        sleep(0.5)
        yield video_file

gr.Interface(keep_repeating,
             gr.Video(sources=["upload"], format="mp4"),
             gr.Video(streaming=True, autoplay=True)
).launch()
```

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
