### PR TITLE
Fix DataFrame Group Flicker

### DIFF
--- a/.changeset/wise-paws-sing.md
+++ b/.changeset/wise-paws-sing.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": patch
+"gradio": patch
+---
+
+fix:Fix DataFrame Group Flicker

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,9 @@
 	// See https://containers.dev/features
 	"features": {
 		"ghcr.io/devcontainers/features/git:1": {},
-		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/devcontainers/features/node:1": {
+			"pnpmVersion": "9"
+		},
 		"ghcr.io/devcontainers-contrib/features/ffmpeg-apt-get:1": {}
 	},
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,7 +254,19 @@ scripts\run_backend_tests.bat
 pnpm test
 ```
 
-- Browser tests are located in `js/spa/test` and are defined as `*spec.ts` files. To run browser tests:
+- Browser tests are located in `js/spa/test` and are defined as `*spec.ts` files.
+
+To install browser test dependencies:
+
+```
+pip install -r demo/outbreak_forecast/requirements.txt
+pip install -r demo/stream_video_out/requirements.txt
+pnpm exec playwright install chromium firefox
+pnpm exec playwright install-deps chromium firefox
+pnpm --filter @gradio/utils --filter @gradio/theme package
+```
+
+To run browser tests:
 
 ```
 pnpm test:browser

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ More than 300 awesome developers have contributed to the `gradio` library, and w
 
 - [Python 3.10+](https://www.python.org/downloads/)
 - [Node.js v16.14+](https://nodejs.dev/en/download/package-manager/) (only needed if you are making changes to the frontend)
-- [pnpm 8.1+](https://pnpm.io/8.x/installation) (only needed if you are making changes to the frontend)
+- [pnpm 9.x](https://pnpm.io/9.x/installation) (only needed if you are making changes to the frontend)
 
 **Steps to Contribute**:
 

--- a/js/README.md
+++ b/js/README.md
@@ -102,7 +102,9 @@ Currently the following checks are run in CI:
 
 ```
 pip install -r demo/outbreak_forecast/requirements.txt
-pnpm exec playwright install chromium
-pnpm exec playwright install-deps chromium
+pip install -r demo/stream_video_out/requirements.txt
+pnpm exec playwright install chromium firefox
+pnpm exec playwright install-deps chromium firefox
+pnpm --filter @gradio/utils --filter @gradio/theme package
 pnpm test:browser:full
 ```

--- a/js/dataframe/shared/RowNumber.svelte
+++ b/js/dataframe/shared/RowNumber.svelte
@@ -27,15 +27,6 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		font-weight: var(--weight-semibold);
-		background: var(--table-even-background-fill);
 		border-right: 1px solid var(--border-color-primary);
-	}
-
-	:global(tr:nth-child(odd)) .row-number {
-		background: var(--table-odd-background-fill);
-	}
-
-	:global(tr:nth-child(even)) .row-number {
-		background: var(--table-even-background-fill);
 	}
 </style>

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -1092,7 +1092,11 @@
 		overflow-x: hidden;
 	}
 
-	.row-odd {
+	tr {
+		background: var(--table-even-background-fill);
+	}
+
+	tr.row-odd {
 		background: var(--table-odd-background-fill);
 	}
 

--- a/js/dataframe/shared/VirtualTable.svelte
+++ b/js/dataframe/shared/VirtualTable.svelte
@@ -396,10 +396,6 @@
 		scroll-snap-align: start;
 	}
 
-	tbody > :global(tr:nth-child(even)) {
-		background: var(--table-even-background-fill);
-	}
-
 	tbody :global(td.pinned-column) {
 		position: sticky;
 		z-index: 3;

--- a/js/spa/test/dataframe_colorful.spec.ts
+++ b/js/spa/test/dataframe_colorful.spec.ts
@@ -1,11 +1,9 @@
 import { test, expect } from "@self/tootils";
 
-test("first couple of cells in table are highlighted correctly", async ({
-	page
-}) => {
-	const first_td = await page.locator("tbody tr.row-odd td").first();
-	await expect(first_td).not.toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+test("table rows are highlighted correctly", async ({ page }) => {
+	const first_tr = await page.locator("tbody tr").first();
+	await expect(first_tr).toHaveCSS("background-color", "rgb(255, 255, 255)");
 
-	const second_td = await page.locator("tbody tr.row-odd td").nth(1);
-	await expect(second_td).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+	const second_tr = await page.locator("tbody tr").nth(1);
+	await expect(second_tr).toHaveCSS("background-color", "rgb(250, 250, 250)");
 });


### PR DESCRIPTION
## Description

Fix `tr:nth-child(even)` breaking virtual rows on scroll using explicit base `tr` rules and a `tr.row-odd` override.

Closes: #11281
Closes: #11308
Closes: #11309