### PR TITLE
Allow `gr.Progress` to take fractional steps and fractional total # of steps

### DIFF
--- a/.changeset/spicy-meals-shave.md
+++ b/.changeset/spicy-meals-shave.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Allow `gr.Progress` to take fractional steps and fractional total # of steps

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -624,8 +624,8 @@ class TrackedIterable:
     def __init__(
         self,
         iterable: Iterable | None,
-        index: int | None,
-        length: int | None,
+        index: int | float | None,
+        length: int | float | None,
         desc: str | None,
         unit: str | None,
         _tqdm=None,
@@ -706,7 +706,7 @@ class Progress(Iterable):
         self,
         progress: float | tuple[int, int | None] | None,
         desc: str | None = None,
-        total: int | None = None,
+        total: int | float | None = None,
         unit: str = "steps",
         _tqdm=None,
     ):
@@ -736,7 +736,7 @@ class Progress(Iterable):
         self,
         iterable: Iterable | None,
         desc: str | None = None,
-        total: int | None = None,
+        total: int | float | None = None,
         unit: str = "steps",
         _tqdm=None,
     ):
@@ -761,7 +761,7 @@ class Progress(Iterable):
             )
         return self
 
-    def update(self, n=1):
+    def update(self, n: int | float = 1):
         """
         Increases latest iterable with specified number of steps.
         Parameters:

--- a/gradio/server_messages.py
+++ b/gradio/server_messages.py
@@ -10,8 +10,8 @@ class BaseMessage(BaseModel):
 
 
 class ProgressUnit(BaseModel):
-    index: Optional[int] = None
-    length: Optional[int] = None
+    index: Optional[int | float] = None
+    length: Optional[int | float] = None
     unit: Optional[str] = None
     progress: Optional[float] = None
     desc: Optional[str] = None


### PR DESCRIPTION
Closes: https://github.com/gradio-app/gradio/issues/10040

Run this demo adapted from the original issue to verify:

```py
import gradio as gr
import time
from tqdm import tqdm
from ast import literal_eval

def custom_function(number, progress=gr.Progress(track_tqdm=True)):
    number = literal_eval(number) # cast str to int/float
    progress(0, desc="Starting")
    time.sleep(0.5)
    pbar = tqdm(total=number, desc='Numbers..')
    while pbar.n < pbar.total + 0.5:
        time.sleep(1)
        pbar.update(0.5)

with gr.Blocks() as demo:
    gr.Markdown("### Passive Progress Bar Example")
    number_inp = gr.Textbox(3.5, label="Enter Number")
    output_text = gr.Textbox(label="Output")

    with gr.Row():
        process_button = gr.Button("Run Function")

    process_button.click(custom_function, inputs=[number_inp], outputs=[output_text])

demo.launch()
```