### PR TITLE
Add `show_label` property to `gr.Sidebar` and fix toggle button rotate transition

### DIFF
--- a/.changeset/nice-buckets-nail.md
+++ b/.changeset/nice-buckets-nail.md
@@ -1,0 +1,6 @@
+---
+"@gradio/sidebar": minor
+"gradio": minor
+---
+
+feat:Add `show_label` property to `gr.Sidebar` and fix toggle button rotate transition

--- a/app.py
+++ b/app.py
@@ -1,0 +1,9 @@
+import gradio as gr
+
+with gr.Blocks() as demo:
+    with gr.Sidebar(label="Errors (2)", open=True, width=300, show_label=True):
+        gr.Markdown("## Sidebar")
+        gr.Textbox(label="Input", placeholder="Type something here...")
+        gr.Button("Submit")
+
+demo.launch()

--- a/gradio/layouts/sidebar.py
+++ b/gradio/layouts/sidebar.py
@@ -27,6 +27,7 @@ class Sidebar(BlockContext, metaclass=ComponentMeta):
     def __init__(
         self,
         label: str | I18nData | None = None,
+        show_label: bool = False,
         *,
         open: bool = True,
         visible: bool = True,
@@ -40,7 +41,8 @@ class Sidebar(BlockContext, metaclass=ComponentMeta):
     ):
         """
         Parameters:
-            label: name of the sidebar. Not displayed to the user.
+            label: name of the sidebar. Not displayed to the user (unless `show_label` is `True`).
+            show_label: if `True`, the label will be displayed in the sidebar toggle button next to the arrow. Defaults to `False`.
             open: if True, sidebar is open by default.
             elem_id: An optional string that is assigned as the id of this component in the HTML DOM. Can be used for targeting CSS styles.
             elem_classes: An optional string or list of strings that are assigned as the class of this component in the HTML DOM. Can be used for targeting CSS styles.
@@ -54,6 +56,7 @@ class Sidebar(BlockContext, metaclass=ComponentMeta):
         self.open = open
         self.width = width
         self.position = position
+        self.show_label = show_label
         BlockContext.__init__(
             self,
             visible=visible,

--- a/js/sidebar/Index.svelte
+++ b/js/sidebar/Index.svelte
@@ -13,6 +13,8 @@
 	}>;
 	export let width: number | string;
 	export let visible = true;
+	export let label: string | undefined;
+	export let show_label = false;
 </script>
 
 <StatusTracker
@@ -28,6 +30,8 @@
 		{width}
 		on:expand={() => gradio.dispatch("expand")}
 		on:collapse={() => gradio.dispatch("collapse")}
+		{label}
+		{show_label}
 	>
 		<Column>
 			<slot />

--- a/js/sidebar/shared/Sidebar.svelte
+++ b/js/sidebar/shared/Sidebar.svelte
@@ -8,6 +8,8 @@
 	export let open = true;
 	export let width: number | string;
 	export let position: "left" | "right" = "left";
+	export let label: string | undefined;
+	export let show_label = false;
 
 	// Using a temporary variable to animate the sidebar opening at the start
 	let mounted = false;
@@ -82,6 +84,9 @@
 		aria-label="Toggle Sidebar"
 	>
 		<div class="chevron">
+			{#if show_label && label && !_open}
+				<span class="toggle-button-label">{label}</span>
+			{/if}
 			<span class="chevron-left"></span>
 		</div>
 	</button>
@@ -178,7 +183,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: var(--size-7);
+		min-width: var(--size-7);
 		height: var(--size-8);
 		z-index: 1001;
 		border-radius: 0;
@@ -186,6 +191,14 @@
 
 	.toggle-button:not(.reduce-motion) {
 		transition: all 0.3s ease-in-out;
+	}
+
+	.toggle-button-label {
+		display: inline-block;
+		margin-inline-end: var(--size-2);
+		font-size: var(--font-size-1);
+		text-wrap: nowrap;
+		color: var(--body-text-color);
 	}
 
 	.sidebar:not(.right) .toggle-button {

--- a/js/sidebar/shared/Sidebar.svelte
+++ b/js/sidebar/shared/Sidebar.svelte
@@ -177,7 +177,6 @@
 		position: absolute;
 		top: var(--size-4);
 		background: var(--background-fill-secondary);
-		border: 1px solid var(--border-color-primary);
 		cursor: pointer;
 		padding: var(--size-2);
 		display: flex;
@@ -186,11 +185,8 @@
 		min-width: var(--size-7);
 		height: var(--size-8);
 		z-index: 1001;
+		border: 1px solid var(--border-color-primary);
 		border-radius: 0;
-	}
-
-	.toggle-button:not(.reduce-motion) {
-		transition: all 0.3s ease-in-out;
 	}
 
 	.toggle-button-label {
@@ -203,33 +199,35 @@
 
 	.sidebar:not(.right) .toggle-button {
 		left: 100%;
+		border-left-width: 0;
+		border-right-width: 1px;
 		border-radius: 0 var(--size-8) var(--size-8) 0;
-		border-left: none;
 	}
 
 	.sidebar.right .toggle-button {
 		right: 100%;
-		transform: rotate(180deg);
-		border-radius: 0 var(--size-8) var(--size-8) 0;
-		border-left: none;
+		border-left-width: 1px;
+		border-right-width: 0;
+		border-radius: var(--size-8) 0 0 var(--size-8);
 	}
 
 	.open:not(.right) .toggle-button {
 		right: 0;
 		left: auto;
-		transform: rotate(180deg);
-		border-radius: 0 var(--size-8) var(--size-8) 0;
-		border-left: none;
-		border-right: 1px solid var(--border-color-primary);
+		border-left-width: 1px;
+		border-right-width: 0;
+		border-radius: var(--size-8) 0 0 var(--size-8);
+		/* border-left: 1px solid var(--border-color-primary); */
 	}
 
 	.open.right .toggle-button {
 		left: 0;
 		right: auto;
-		transform: rotate(0deg);
+		/* transform: rotate(0deg); */
+		border-left-width: 0;
+		border-right-width: 1px;
 		border-radius: 0 var(--size-8) var(--size-8) 0;
-		border-left: none;
-		border-right: 1px solid var(--border-color-primary);
+		/* border-right: 1px solid var(--border-color-primary); */
 	}
 
 	.chevron {
@@ -237,7 +235,22 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		
+	}
+
+	:not(.right) .chevron {
+		padding-left: 0;
 		padding-right: 8px;
+	}
+
+	.right .chevron {
+		padding-left: 8px;
+		padding-right: 0;
+	}
+
+	.open:not(.right) .chevron {
+		padding-left: 8px;
+		padding-right: 0;
 	}
 
 	.chevron-left {
@@ -247,7 +260,28 @@
 		border-top: var(--size-0-5) solid var(--body-text-color);
 		border-right: var(--size-0-5) solid var(--body-text-color);
 		transform: rotate(45deg);
+		transition: transform 0.3s ease-in-out;
 	}
+
+	.right .chevron-left {
+		border-top: 0;
+		border-right: 0;
+		border-bottom: var(--size-0-5) solid var(--body-text-color);
+		border-left: var(--size-0-5) solid var(--body-text-color);
+	}
+
+	.open .chevron-left {
+		transform: rotate(-135deg);
+	}
+
+	.open.right .chevron {
+		padding-left: 0;
+		padding-right: 8px;
+	}
+
+	/* .open.right .toggle-button .chevron-left {
+		transform: rotate(-135deg);
+	} */
 
 	.sidebar-content {
 		padding: var(--size-5);


### PR DESCRIPTION
## Description

This is built on top of latest `main` (As of 2025-05-29) with the changes of #11270 merged - that include UI fixes to `gr.Sidebar`

- Adds a `show_label` property to `gr.Sidebar` to toggle visibility of label in the sidebar toggle button. Defaults to `False` to preserve current behavior.
- Supports both `position="right` and `position="left"`
- Fixed wonky animation where the container of the chevron (in the toggle button) was rotated as well, now only the chevron itself is rotated (Introduced by #11270)

## Screenshots

### `position="left"`:

Collapsed

![image](https://github.com/user-attachments/assets/78312ade-847f-4e91-9316-ac082141593e)

Expanded

![image](https://github.com/user-attachments/assets/0b25362b-01b2-445e-9cf3-3c0bc756df93)

### `position="right"`:

Collapsed

![image](https://github.com/user-attachments/assets/2f59f7e5-f173-4b42-b57c-a6fa2b5ed3d7)

Expanded

![image](https://github.com/user-attachments/assets/9f191dac-4858-41a3-a2d2-55730236bd12)


Closes: #11295 
