### PR TITLE
Streamable HTTP Transport for MCP server

### DIFF
--- a/.changeset/free-coins-care.md
+++ b/.changeset/free-coins-care.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Streamable HTTP Transport for MCP server

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2665,7 +2665,7 @@ Received inputs:
             )
         else:
             self.node_server_name = self.node_port = self.node_process = None
-        
+
         self.i18n_instance = i18n
 
         if app_kwargs is None:

--- a/gradio/mcp.py
+++ b/gradio/mcp.py
@@ -79,11 +79,10 @@ class GradioMCPServer:
         async def lifespan(app: Starlette) -> AsyncIterator[None]:  # noqa: ARG001
             """Context manager for managing session manager lifecycle."""
             async with manager.run():
-                print("Application started with StreamableHTTP session manager!")
                 try:
                     yield
                 finally:
-                    print("Application shutting down...")
+                    pass
 
         self.lifespan = lifespan
         self.manager = manager

--- a/gradio/mcp.py
+++ b/gradio/mcp.py
@@ -1,9 +1,10 @@
 import base64
+import contextlib
 import os
 import re
 import tempfile
 import warnings
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
 from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -12,10 +13,13 @@ import gradio_client.utils as client_utils
 from mcp import types
 from mcp.server import Server
 from mcp.server.sse import SseServerTransport
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from PIL import Image
 from starlette.applications import Starlette
+from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Mount, Route
+from starlette.types import Receive, Scope, Send
 
 from gradio import processing_utils, route_utils, utils
 from gradio.blocks import BlockFunction
@@ -40,7 +44,7 @@ class GradioMCPServer:
         blocks: The Blocks app to create the MCP server for.
     """
 
-    def __init__(self, blocks: "Blocks"):
+    def __init__(self, blocks: "Blocks", root_path: str):
         self.blocks = blocks
         self.api_info = self.blocks.get_api_info()
         self.mcp_server = self.create_mcp_server()
@@ -54,6 +58,36 @@ class GradioMCPServer:
             self.tool_prefix = ""
         self.tool_to_endpoint = self.get_tool_to_endpoint()
         self.warn_about_state_inputs()
+
+        manager = StreamableHTTPSessionManager(
+            app=self.mcp_server, json_response=False, stateless=True
+        )
+
+        async def handle_streamable_http(
+            scope: Scope, receive: Receive, send: Send
+        ) -> None:
+            request = Request(scope, receive)
+            self.request = request
+            self.root_url = route_utils.get_root_url(
+                request=request,
+                route_path="/gradio_api/mcp/http",
+                root_path=root_path,
+            )
+            await manager.handle_request(scope, receive, send)
+
+        @contextlib.asynccontextmanager
+        async def lifespan(app: Starlette) -> AsyncIterator[None]:  # noqa: ARG001
+            """Context manager for managing session manager lifecycle."""
+            async with manager.run():
+                print("Application started with StreamableHTTP session manager!")
+                try:
+                    yield
+                finally:
+                    print("Application shutting down...")
+
+        self.lifespan = lifespan
+        self.manager = manager
+        self.handle_streamable_http = handle_streamable_http
 
     def get_tool_to_endpoint(self) -> dict[str, str]:
         """
@@ -211,6 +245,7 @@ class GradioMCPServer:
                     ),
                     Route("/sse", endpoint=handle_sse),
                     Mount("/messages/", app=sse.handle_post_message),
+                    Mount("/http/", app=self.handle_streamable_http),
                 ],
             ),
         )

--- a/test/test_mcp.py
+++ b/test/test_mcp.py
@@ -16,13 +16,13 @@ with gr.Blocks() as app:
 
 
 def test_gradio_mcp_server_initialization():
-    server = GradioMCPServer(app)
+    server = GradioMCPServer(app, root_path="")
     assert server.blocks == app
     assert server.mcp_server is not None
 
 
 def test_get_block_fn_from_tool_name():
-    server = GradioMCPServer(app)
+    server = GradioMCPServer(app, root_path="")
     result = server.get_block_fn_from_endpoint_name("test_tool")
     assert result == app.fns[0]
     result = server.get_block_fn_from_endpoint_name("nonexistent_tool")
@@ -45,7 +45,7 @@ def test_generate_tool_names_correctly_for_interfaces():
             gr.Interface(MyCallable(), "text", "text"),
         ]
     )
-    server = GradioMCPServer(app)
+    server = GradioMCPServer(app, root_path="")
     assert list(server.tool_to_endpoint.keys()) == [
         "echo",
         "echo_",
@@ -55,7 +55,7 @@ def test_generate_tool_names_correctly_for_interfaces():
 
 
 def test_convert_strings_to_filedata():
-    server = GradioMCPServer(app)
+    server = GradioMCPServer(app, root_path="")
 
     test_data = {
         "text": "test text",
@@ -72,7 +72,7 @@ def test_convert_strings_to_filedata():
 
 
 def test_postprocess_output_data():
-    server = GradioMCPServer(app)
+    server = GradioMCPServer(app, root_path="")
 
     with tempfile.NamedTemporaryFile(suffix=".png") as temp_file:
         img = Image.new("RGB", (10, 10), color="red")
@@ -96,7 +96,7 @@ def test_postprocess_output_data():
 
 
 def test_simplify_filedata_schema():
-    server = GradioMCPServer(app)
+    server = GradioMCPServer(app, root_path="")
 
     test_schema = {
         "type": "object",
@@ -129,7 +129,7 @@ def test_tool_prefix_character_replacement():
         os.environ["SYSTEM"] = "spaces"
         for input_prefix, expected_prefix in test_cases:
             os.environ["SPACE_ID"] = input_prefix
-            server = GradioMCPServer(app)
+            server = GradioMCPServer(app, root_path="")
             assert server.tool_prefix == expected_prefix
     finally:
         if original_system is not None:


### PR DESCRIPTION
## Description

Closes #11200 

Adds a streamable http transport at `/gradio_api/mcp/http`. Let's add to the docs later when more clients switch to the http protocol

In the meantime, you can test with mcp inspector:

### calculator
![mcp_calculator_example](https://github.com/user-attachments/assets/3a7175b8-06cd-496a-9cea-eef0a09faa29)

### Image input/output
![mcp_image_mod_example](https://github.com/user-attachments/assets/624484d1-5d5a-46dd-9156-7a93d2a5371b)


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
