### PR TITLE
Fix custom components build and dev mode with certain base components (Image and Audio at least)

### DIFF
--- a/.changeset/angry-bushes-sip.md
+++ b/.changeset/angry-bushes-sip.md
@@ -1,4 +1,5 @@
 ---
+"@gradio/image": patch
 "@gradio/preview": patch
 "gradio": patch
 ---

--- a/.changeset/angry-bushes-sip.md
+++ b/.changeset/angry-bushes-sip.md
@@ -1,0 +1,6 @@
+---
+"@gradio/preview": patch
+"gradio": patch
+---
+
+fix:Fix custom components build and dev mode with certain base components (Image and Audio at least)

--- a/gradio/cli/commands/components/_create_utils.py
+++ b/gradio/cli/commands/components/_create_utils.py
@@ -299,6 +299,10 @@ def _create_frontend(
         str(Path(__file__).parent / "files" / "gradio.config.js"),
         frontend / "gradio.config.js",
     )
+    shutil.copy(
+        str(Path(__file__).parent / "files" / "tsconfig.json"),
+        frontend / "tsconfig.json",
+    )
 
 
 def _replace_old_class_name(old_class_name: str, new_class_name: str, content: str):

--- a/gradio/cli/commands/components/files/tsconfig.json
+++ b/gradio/cli/commands/components/files/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"verbatimModuleSyntax": true
+	},
+	"exclude": ["node_modules", "dist", "./gradio.config.js"]
+}

--- a/js/image/shared/ImagePreview.svelte
+++ b/js/image/shared/ImagePreview.svelte
@@ -12,7 +12,7 @@
 	} from "@gradio/atoms";
 	import { Download, Image as ImageIcon } from "@gradio/icons";
 	import { get_coordinates_of_clicked_image } from "./utils";
-	import { Image } from "@gradio/image/shared";
+	import Image from "./Image.svelte";
 	import { DownloadLink } from "@gradio/wasm/svelte";
 
 	import type { I18nFormatter } from "@gradio/utils";

--- a/js/preview/src/_deepmerge_internal.ts
+++ b/js/preview/src/_deepmerge_internal.ts
@@ -1,0 +1,133 @@
+// this is a copy of the deepemerge source code but with an esm interface rather than commonjs
+
+export const deepmerge = `
+function isMergeableObject(value) {
+	return isNonNullObject(value)
+		&& !isSpecial(value)
+}
+
+function isNonNullObject(value) {
+	return !!value && typeof value === 'object'
+}
+
+function isSpecial(value) {
+	var stringValue = Object.prototype.toString.call(value)
+
+	return stringValue === '[object RegExp]'
+		|| stringValue === '[object Date]'
+		|| isReactElement(value)
+}
+
+var canUseSymbol = typeof Symbol === 'function' && Symbol.for
+var REACT_ELEMENT_TYPE = canUseSymbol ? Symbol.for('react.element') : 0xeac7
+
+function isReactElement(value) {
+	return value.$$typeof === REACT_ELEMENT_TYPE
+}
+
+var defaultIsMergeableObject = isMergeableObject;
+
+function emptyTarget(val) {
+	return Array.isArray(val) ? [] : {}
+}
+
+function cloneUnlessOtherwiseSpecified(value, options) {
+	return (options.clone !== false && options.isMergeableObject(value))
+		? deepmerge(emptyTarget(value), value, options)
+		: value
+}
+
+function defaultArrayMerge(target, source, options) {
+	return target.concat(source).map(function(element) {
+		return cloneUnlessOtherwiseSpecified(element, options)
+	})
+}
+
+function getMergeFunction(key, options) {
+	if (!options.customMerge) {
+		return deepmerge
+	}
+	var customMerge = options.customMerge(key)
+	return typeof customMerge === 'function' ? customMerge : deepmerge
+}
+
+function getEnumerableOwnPropertySymbols(target) {
+	return Object.getOwnPropertySymbols
+		? Object.getOwnPropertySymbols(target).filter(function(symbol) {
+			return Object.propertyIsEnumerable.call(target, symbol)
+		})
+		: []
+}
+
+function getKeys(target) {
+	return Object.keys(target).concat(getEnumerableOwnPropertySymbols(target))
+}
+
+function propertyIsOnObject(object, property) {
+	try {
+		return property in object
+	} catch(_) {
+		return false
+	}
+}
+
+// Protects from prototype poisoning and unexpected merging up the prototype chain.
+function propertyIsUnsafe(target, key) {
+	return propertyIsOnObject(target, key) // Properties are safe to merge if they don't exist in the target yet,
+		&& !(Object.hasOwnProperty.call(target, key) // unsafe if they exist up the prototype chain,
+			&& Object.propertyIsEnumerable.call(target, key)) // and also unsafe if they're nonenumerable.
+}
+
+function mergeObject(target, source, options) {
+	var destination = {}
+	if (options.isMergeableObject(target)) {
+		getKeys(target).forEach(function(key) {
+			destination[key] = cloneUnlessOtherwiseSpecified(target[key], options)
+		})
+	}
+	getKeys(source).forEach(function(key) {
+		if (propertyIsUnsafe(target, key)) {
+			return
+		}
+
+		if (propertyIsOnObject(target, key) && options.isMergeableObject(source[key])) {
+			destination[key] = getMergeFunction(key, options)(target[key], source[key], options)
+		} else {
+			destination[key] = cloneUnlessOtherwiseSpecified(source[key], options)
+		}
+	})
+	return destination
+}
+
+function deepmerge(target, source, options) {
+	options = options || {}
+	options.arrayMerge = options.arrayMerge || defaultArrayMerge
+	options.isMergeableObject = options.isMergeableObject || defaultIsMergeableObject
+	
+	options.cloneUnlessOtherwiseSpecified = cloneUnlessOtherwiseSpecified
+
+	var sourceIsArray = Array.isArray(source)
+	var targetIsArray = Array.isArray(target)
+	var sourceAndTargetTypesMatch = sourceIsArray === targetIsArray
+
+	if (!sourceAndTargetTypesMatch) {
+		return cloneUnlessOtherwiseSpecified(source, options)
+	} else if (sourceIsArray) {
+		return options.arrayMerge(target, source, options)
+	} else {
+		return mergeObject(target, source, options)
+	}
+}
+
+deepmerge.all = function deepmergeAll(array, options) {
+	if (!Array.isArray(array)) {
+		throw new Error('first argument should be an array')
+	}
+
+	return array.reduce(function(prev, next) {
+		return deepmerge(prev, next, options)
+	}, {})
+}
+
+export default deepmerge;
+`;

--- a/js/preview/src/build.ts
+++ b/js/preview/src/build.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import { join } from "path";
 import { build } from "vite";
-import { plugins, make_gradio_plugin } from "./plugins";
+import { plugins, make_gradio_plugin, deepmerge_plugin } from "./plugins";
 import type { PreRenderedChunk } from "rollup";
 import { examine_module } from "./index";
 
@@ -70,7 +70,8 @@ export async function make_build({
 						configFile: false,
 						plugins: [
 							...plugins(component_config),
-							make_gradio_plugin({ mode: "build", svelte_dir })
+							make_gradio_plugin({ mode: "build", svelte_dir }),
+							deepmerge_plugin
 						],
 						resolve: {
 							conditions: ["gradio"]

--- a/js/preview/src/dev.ts
+++ b/js/preview/src/dev.ts
@@ -1,7 +1,7 @@
 import { join } from "path";
 import * as fs from "fs";
 import { createServer, createLogger } from "vite";
-import { plugins, make_gradio_plugin } from "./plugins";
+import { plugins, make_gradio_plugin, deepmerge_plugin } from "./plugins";
 import { examine_module } from "./index";
 import type { PreprocessorGroup } from "svelte/compiler";
 
@@ -71,7 +71,8 @@ export async function create_server({
 					backend_port,
 					svelte_dir,
 					imports
-				})
+				}),
+				deepmerge_plugin
 			]
 		});
 

--- a/js/preview/src/plugins.ts
+++ b/js/preview/src/plugins.ts
@@ -4,6 +4,7 @@ import preprocess from "svelte-preprocess";
 import { join } from "path";
 import { type ComponentConfig } from "./dev";
 import type { Preprocessor, PreprocessorGroup } from "svelte/compiler";
+import { deepmerge } from "./_deepmerge_internal";
 
 const svelte_codes_to_ignore: Record<string, string> = {
 	"reactive-component": "Icon"
@@ -131,3 +132,18 @@ export function make_gradio_plugin({
 		}
 	};
 }
+
+export const deepmerge_plugin: Plugin = {
+	name: "deepmerge",
+	enforce: "pre",
+	resolveId(id) {
+		if (id === "deepmerge") {
+			return "deepmerge_internal";
+		}
+	},
+	load(id) {
+		if (id === "deepmerge_internal") {
+			return deepmerge;
+		}
+	}
+};


### PR DESCRIPTION
## Description

For reasons that aren't clear to me, vite was refusing to correctly transform a commonjs module to esm. I was unable to convince it to do so, and so i went nuclear and replaced the module for the exact same module but converted to common js.

Another issue is that a recent version of svelte requires specific typescript compiler options or it won't work, so I have added a good default tsconfig when generating the custom component.

With this change it is now possible to do the following, which was not previously possible:

- create a new custom component using the Image or Audio as the template
- Run the dev mode
- Run the build

Everything still works as expected after this change.

Closes: #9879

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
