### PR TITLE
Fix textbox autoscroll in tabs

### DIFF
--- a/.changeset/cute-zebras-repair.md
+++ b/.changeset/cute-zebras-repair.md
@@ -1,0 +1,6 @@
+---
+"@gradio/textbox": patch
+"gradio": patch
+---
+
+fix:Fix textbox autoscroll in tabs

--- a/js/textbox/shared/Textbox.svelte
+++ b/js/textbox/shared/Textbox.svelte
@@ -67,7 +67,13 @@
 	}>();
 
 	beforeUpdate(() => {
-		can_scroll = el && el.offsetHeight + el.scrollTop > el.scrollHeight - 100;
+		if (
+			!user_has_scrolled_up &&
+			el &&
+			el.offsetHeight + el.scrollTop > el.scrollHeight - 100
+		) {
+			can_scroll = true;
+		}
 	});
 
 	const scroll = (): void => {


### PR DESCRIPTION
## Description
Fixes issue where textbox autoscroll was not working when switching between tabs.

Simple Repro:

```
import gradio as gr
import time

def greet(name):
    for i in range(200):
        name = name + f"{i}\n\n\n\n\n"
        time.sleep(0.1)
        yield name


with gr.Blocks() as demo:
    with gr.Tab():
        name = gr.Textbox()
    with gr.Tab():
        output = gr.Textbox(lines=20,label="Output Box", autoscroll=True)
    test_btn = gr.Button("Test")
    test_btn.click(fn=greet, inputs=name, outputs=output)

if __name__ == "__main__":
    demo.launch()
```

Closes: #10545

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
