### PR TITLE
PyPi is required  to publish to hugging face spaces

### DIFF
--- a/guides/08_custom-components/01_custom-components-in-five-minutes.md
+++ b/guides/08_custom-components/01_custom-components-in-five-minutes.md
@@ -104,7 +104,7 @@ gradio cc publish
 
 This will guide you through the following process:
 
-1. Upload your distribution files to PyPi. This is needed if you want to upload the demo to hugging face. You will need a PyPI username and password. You can get one [here](https://pypi.org/account/register/).
+1. Upload your distribution files to PyPi. This makes it easier to upload the demo to Hugging Face spaces. Otherwise your package must be at a publicly available url. If you decide to upload to PyPi, you will need a PyPI username and password. You can get one [here](https://pypi.org/account/register/).
 2. Upload a demo of your component to hugging face spaces. This is also optional.
 
 


### PR DESCRIPTION
## Description

I just changed the documentation because you need to have your component published to PyPi otherwise the hugging face demo can not install the component.

See https://discord.com/channels/879548962464493619/1379499716831739924

Closes: #11319 
  
