### PR TITLE
Fix image streaming - wait for ws to open

### DIFF
--- a/.changeset/dull-llamas-divide.md
+++ b/.changeset/dull-llamas-divide.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/client": minor
-"gradio": minor
+"@gradio/client": patch
+"gradio": patch
 ---
 
-feat:Fix image streaming - wait for ws to open
+fix:Fix image streaming - wait for ws to open

--- a/.changeset/dull-llamas-divide.md
+++ b/.changeset/dull-llamas-divide.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": minor
+"gradio": minor
+---
+
+feat:Fix image streaming - wait for ws to open

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -504,6 +504,7 @@ export class Client {
 			}
 
 			ws.onopen = () => {
+				this.ws_map[url] = ws;
 				resolve();
 			};
 
@@ -520,7 +521,6 @@ export class Client {
 			};
 
 			ws.onmessage = (event) => {};
-			this.ws_map[url] = ws;
 		});
 	}
 


### PR DESCRIPTION
## Description

Closes: #11263

You can repro the original issue by adding some delay to the ws route. There was a race condition where we tried to send a ws message before the connection resolved. The fix is to only add `ws_map` when the connection is open.

```python
        @router.websocket("/stream/{event_id}")
        async def websocket_endpoint(websocket: WebSocket, event_id: str):
            await asyncio.sleep(3)
            await websocket.accept()
            try:
                while True:
                    data = await websocket.receive_json()
                    body = PredictBody(**data)
                    event = app.get_blocks()._queue.event_ids_to_events[event_id]
                    body_internal = PredictBodyInternal(
                        **body.model_dump(), request=None
                    )
                    event.data = body_internal
                    event.signal.set()
                    await websocket.send_json({"msg": "success"})
            except WebSocketDisconnect:
                pass
```

https://github.com/user-attachments/assets/6b86d529-5eec-4eba-a59f-3612b4db133f


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
