### PR TITLE
Fix streaming chatbot diff logic

### DIFF
--- a/.changeset/pink-shrimps-accept.md
+++ b/.changeset/pink-shrimps-accept.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix streaming chatbot diff logic

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -1291,7 +1291,7 @@ def diff(old, new):
             # So subtract 1 since deleting one element will shift all the indices
             deletes_seen = 0
             for edit in edits:
-                if edit[0] == "delete":
+                if edit[0] == "delete" and isinstance(edit[1][-1], int):
                     edit[1] = [edit[1][-1] - deletes_seen]
                     deletes_seen += 1
             return edits

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -496,6 +496,40 @@ def test_get_extension_from_file_path_or_url(path_or_url, extension):
         ({}, {"a": 1, "b": 2}, [["add", ["a"], 1], ["add", ["b"], 2]]),
         (["a", "b"], {"a": 1, "b": 2}, [["replace", [], {"a": 1, "b": 2}]]),
         ("abc", "abcdef", [["append", [], "def"]]),
+        (
+            [
+                {"role": "user", "content": "Hello!", "metadata": {"id": 1}},
+                {"role": "assistant", "content": "b"},
+            ],
+            [
+                {
+                    "role": "assistant",
+                    "content": "Thinking...",
+                    "metadata": {"title": "Thinking..."},
+                },
+                {"role": "assistant", "content": "b"},
+            ],
+            [
+                ["replace", [0, "role"], "assistant"],
+                ["replace", [0, "content"], "Thinking..."],
+                ["delete", [0, "metadata", "id"], None],
+                ["add", [0, "metadata", "title"], "Thinking..."],
+            ],
+        ),
+        (
+            [
+                {"role": "user", "content": "Hello!", "metadata": {"id": 1}},
+                {"role": "assistant", "content": "b"},
+            ],
+            [
+                {"role": "user", "content": "No metadata", "metadata": {}},
+                {"role": "assistant", "content": "b"},
+            ],
+            [
+                ["replace", [0, "content"], "No metadata"],
+                ["delete", [0, "metadata", "id"], None],
+            ],
+        ),
     ],
 )
 def test_diff(old, new, expected_diff):


### PR DESCRIPTION
## Description

Closes: #11239 

This app shows the original error, basically deleting keys in a dictionary that's in a list. Added unit tests for this case.

```python
import gradio as gr
import time

def response():
    yield [{'role': 'user', 'content': 'Hello!', "metadata": {"id": 1}}, {'role': 'assistant', 'content': 'b'}]
    time.sleep(3)
    yield [{'role': 'assistant', 'content': 'Thinking...', "metadata": {"title": "Thinking..."}}]
    time.sleep(3)
    yield [{'role': 'assistant', 'content': 'No Metadata', "metadata": {}}]
    time.sleep(3)
    yield [{"role": "user", "content": "finished!"}]

gr.Interface(fn=response, inputs=[], outputs=[gr.Chatbot(type="messages")]).launch()
```



## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
