### PR TITLE
Fix Reload Mode when using gr.render

### DIFF
--- a/.changeset/lazy-spoons-fail.md
+++ b/.changeset/lazy-spoons-fail.md
@@ -1,0 +1,7 @@
+---
+"@gradio/core": patch
+"@self/spa": patch
+"gradio": patch
+---
+
+fix:Fix Reload Mode when using gr.render

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -320,7 +320,6 @@ def watchfn(reloader: SourceFileReloader):
                 changed_demo_file = _remove_if_name_main_codeblock(
                     str(reloader.demo_file)
                 )
-                Context.id = 0
                 exec(changed_demo_file, module.__dict__)
             except Exception as error:
                 print(

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -320,6 +320,7 @@ def watchfn(reloader: SourceFileReloader):
                 changed_demo_file = _remove_if_name_main_codeblock(
                     str(reloader.demo_file)
                 )
+                Context.id = 0
                 exec(changed_demo_file, module.__dict__)
             except Exception as error:
                 print(

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -81,6 +81,7 @@
 	}
 
 	async function run(): Promise<void> {
+		layout_creating = true;
 		await create_layout({
 			components,
 			layout,
@@ -91,6 +92,7 @@
 				fill_height
 			}
 		});
+		layout_creating = false;
 	}
 
 	export let search_params: URLSearchParams;
@@ -126,7 +128,10 @@
 
 	let api_calls: Payload[] = [];
 
+	let layout_creating = false;
 	export let render_complete = false;
+	$: render_complete = render_complete && !layout_creating;
+
 	async function handle_update(data: any, fn_index: number): Promise<void> {
 		const dep = dependencies.find((dep) => dep.id === fn_index);
 		const input_type = components.find(
@@ -671,7 +676,6 @@
 			if (is_external_url(_link) && _target !== "_blank")
 				a[i].setAttribute("target", "_blank");
 		}
-
 		handle_load_triggers();
 
 		if (!target || render_complete) return;

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -74,7 +74,11 @@
 	}
 
 	let old_dependencies = dependencies;
-	$: if (dependencies !== old_dependencies && render_complete) {
+	$: if (
+		dependencies !== old_dependencies &&
+		render_complete &&
+		!layout_creating
+	) {
 		// re-run load triggers in SSR mode when page changes
 		handle_load_triggers();
 		old_dependencies = dependencies;
@@ -130,7 +134,6 @@
 
 	let layout_creating = false;
 	export let render_complete = false;
-	$: render_complete = render_complete && !layout_creating;
 
 	async function handle_update(data: any, fn_index: number): Promise<void> {
 		const dep = dependencies.find((dep) => dep.id === fn_index);

--- a/js/core/src/init.ts
+++ b/js/core/src/init.ts
@@ -256,7 +256,11 @@ export function create_components(initial_layout: ComponentMeta | undefined): {
 			}
 		});
 
-		new_components.forEach((c) => {
+		const components_to_add = new_components.concat(
+			replacement_components.filter((c) => !instance_map[c.id])
+		);
+
+		components_to_add.forEach((c) => {
 			instance_map[c.id] = c;
 			_component_map.set(c.id, c);
 		});
@@ -288,7 +292,6 @@ export function create_components(initial_layout: ComponentMeta | undefined): {
 		parent?: ComponentMeta
 	): Promise<ComponentMeta> {
 		const instance = instance_map[node.id];
-
 		if (!instance.component) {
 			instance.component = (await constructor_map.get(
 				instance.component_class_id || instance.type

--- a/js/spa/src/Index.svelte
+++ b/js/spa/src/Index.svelte
@@ -325,7 +325,6 @@
 		if (deep_link) {
 			query_params.deep_link = deep_link;
 		}
-
 		app = await Client.connect(api_url, {
 			status_callback: handle_status,
 			with_null_state: true,


### PR DESCRIPTION
## Description

Closes: #10199 . You can run repro in issue.

gr.render + reload mode was not working at all. 
Two reasons:
1. When the python file changed and the app re-rendered, the Form component that's the parent of the Column where the `@gr.render` output gets placed was not in the `instance_map`.
2. When the python file changed and the app re-rerenderdd, the load event corresponding to `@gr.render` would fire with `undefined` for the component value since the load event was triggering before the components were added to the `_component_map`. 

When the page re-renders based on file changes, the `gr.render` event still triggers. We could fix this in a separate PR.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

3. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
