### PR TITLE
Fixes default tab label

### DIFF
--- a/.changeset/chatty-flowers-slide.md
+++ b/.changeset/chatty-flowers-slide.md
@@ -1,0 +1,6 @@
+---
+"@gradio/tabs": patch
+"gradio": patch
+---
+
+fix:Fixes default tab label

--- a/js/tabs/shared/Tabs.svelte
+++ b/js/tabs/shared/Tabs.svelte
@@ -201,7 +201,7 @@
 								}
 							}}
 						>
-							{t.label}
+							{t?.label !== undefined ? t?.label : "Tab " + (i + 1)}
 						</button>
 					{/if}
 				{/each}


### PR DESCRIPTION
## Description
Fixes default tab label.

<img width="608" alt="Screenshot 2025-06-05 at 11 15 03 AM" src="https://github.com/user-attachments/assets/8959aa66-f94c-4025-943f-535567e9b690" />


Closes: #11333

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
