### PR TITLE
fix(mcp): package SVG outputs as proper ImageContent for MCP clients

### DIFF
--- a/.changeset/cool-pianos-report.md
+++ b/.changeset/cool-pianos-report.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:fix(mcp): package SVG outputs as proper ImageContent for MCP clients

--- a/gradio/mcp.py
+++ b/gradio/mcp.py
@@ -591,12 +591,10 @@ class GradioMCPServer:
         """
         return_values: list[types.TextContent | types.ImageContent] = []
 
-        # Add root_url to FileData/ImageData structures before processing
         if self.root_url:
             data = processing_utils.add_root_url(data, self.root_url, None)
 
         for output in data:
-            # Check if output looks like FileData/ImageData
             if isinstance(output, dict) and ("path" in output or "url" in output):
                 path: str | None = output.get("path")
                 url: str | None = output.get("url")

--- a/gradio/mcp.py
+++ b/gradio/mcp.py
@@ -25,7 +25,7 @@ from starlette.types import Receive, Scope, Send
 from gradio import processing_utils, route_utils, utils
 from gradio.blocks import BlockFunction
 from gradio.components import State
-from gradio.data_classes import FileData, FileDataDict
+from gradio.data_classes import FileData
 
 if TYPE_CHECKING:
     from gradio.blocks import BlockContext, Blocks
@@ -546,12 +546,12 @@ class GradioMCPServer:
             return None
 
     @staticmethod
-    def get_svg(file_data: FileDataDict) -> bytes | None:
+    def get_svg(file_data: Any) -> bytes | None:
         """
-        If a file_data is a valid svg, returns bytes of the svg. Otherwise returns None.
+        If a file_data is a valid FileDataDict with a url that is a data:image/svg+xml, returns bytes of the svg. Otherwise returns None.
         """
-        if url := file_data.get("url"):
-            if url.startswith("data:image/svg"):
+        if isinstance(file_data, dict) and (url := file_data.get("url")):
+            if isinstance(url, str) and url.startswith("data:image/svg"):
                 return unquote(url.split(",", 1)[1]).encode()
             else:
                 return None

--- a/gradio/mcp.py
+++ b/gradio/mcp.py
@@ -606,8 +606,7 @@ class GradioMCPServer:
                     fmt = (image.format or "PNG").lower()
                     base64_data = self.get_base64_data(image, fmt)
                     img_url = (
-                        url
-                        or f"{self.root_url}/gradio_api/file={quote(path)}"
+                        url or f"{self.root_url}/gradio_api/file={quote(path)}"
                         if self.root_url
                         else path
                     )
@@ -618,7 +617,9 @@ class GradioMCPServer:
                                 data=base64_data,
                                 mimeType=f"image/{fmt}",
                             ),
-                            types.TextContent(type="text", text=f"Image URL: {img_url}"),
+                            types.TextContent(
+                                type="text", text=f"Image URL: {img_url}"
+                            ),
                         ]
                     )
                     continue
@@ -651,7 +652,9 @@ class GradioMCPServer:
                                 data=base64_data,
                                 mimeType="image/svg+xml",
                             ),
-                            types.TextContent(type="text", text=f"Image URL: {img_url}"),
+                            types.TextContent(
+                                type="text", text=f"Image URL: {img_url}"
+                            ),
                         ]
                     )
                     continue
@@ -662,8 +665,6 @@ class GradioMCPServer:
                 )
 
             else:  # Primitive values: str, int, dict, etc.
-                return_values.append(
-                    types.TextContent(type="text", text=str(output))
-                )
+                return_values.append(types.TextContent(type="text", text=str(output)))
 
         return return_values

--- a/gradio/mcp.py
+++ b/gradio/mcp.py
@@ -1,6 +1,5 @@
 import base64
 import contextlib
-import hashlib
 import os
 import re
 import tempfile
@@ -9,7 +8,6 @@ from collections.abc import AsyncIterator, Sequence
 from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote, unquote
 
 import gradio_client.utils as client_utils
 from mcp import types
@@ -26,7 +24,7 @@ from starlette.types import Receive, Scope, Send
 from gradio import processing_utils, route_utils, utils
 from gradio.blocks import BlockFunction
 from gradio.components import State
-from gradio.data_classes import FileData
+from gradio.data_classes import FileData, FileDataDict
 
 if TYPE_CHECKING:
     from gradio.blocks import BlockContext, Blocks
@@ -547,6 +545,21 @@ class GradioMCPServer:
             return None
 
     @staticmethod
+    def get_svg(file_path: str) -> bytes | None:
+        """
+        If a filepath is a valid svg, returns bytes of the svg. Otherwise returns None.
+        """
+        if not os.path.exists(file_path):
+            return None
+        ext = os.path.splitext(file_path.lower())[1]
+        if ext != ".svg":
+            return None
+        try:
+            return Path(file_path).read_bytes()
+        except Exception:
+            return None
+
+    @staticmethod
     def get_base64_data(image: Image.Image, format: str) -> str:
         """
         Returns a base64 encoded string of the image.
@@ -555,114 +568,54 @@ class GradioMCPServer:
         image.save(buffer, format=format)
         return base64.b64encode(buffer.getvalue()).decode("utf-8")
 
-    def _save_svg_to_temp(self, raw_svg: bytes) -> str:
-        """
-        Save SVG content to a temporary file and return the file path.
-
-        Parameters:
-            raw_svg: The raw SVG content as bytes.
-
-        Returns:
-            The path to the temporary SVG file.
-        """
-        hex_hash = hashlib.md5(raw_svg).hexdigest()[:10]
-        tmp_dir = Path(DEFAULT_TEMP_DIR)
-        tmp_dir.mkdir(parents=True, exist_ok=True)
-        tmp_path = tmp_dir / f"gradio_svg_{hex_hash}.svg"
-        tmp_path.write_bytes(raw_svg)
-        return str(tmp_path)
-
     def postprocess_output_data(
         self, data: Any
     ) -> list[types.TextContent | types.ImageContent]:
         """
-        Convert the list returned by `Blocks.process_api()` into MCP-compatible
-        payloads.
-
-        Handles PNG/JPEG images through PIL, and SVG files (both data URIs and
-        file paths) by saving them to temporary files when needed and encoding
-        them as base64.
+        Postprocess the output data from the Gradio app to convert FileData objects back to base64 encoded strings.
 
         Parameters:
             data: The output data to postprocess.
-
-        Returns:
-            List of MCP-compatible TextContent and ImageContent objects.
         """
-        return_values: list[types.TextContent | types.ImageContent] = []
-
+        return_values = []
         if self.root_url:
             data = processing_utils.add_root_url(data, self.root_url, None)
-
         for output in data:
-            if isinstance(output, dict) and ("path" in output or "url" in output):
-                path: str | None = output.get("path")
-                url: str | None = output.get("url")
-
-                # Handle raster images (PIL can open them)
-                if path and (image := self.get_image(path)):
-                    fmt = (image.format or "PNG").lower()
-                    base64_data = self.get_base64_data(image, fmt)
-                    img_url = (
-                        url or f"{self.root_url}/gradio_api/file={quote(path)}"
-                        if self.root_url
-                        else path
-                    )
-                    return_values.extend(
-                        [
-                            types.ImageContent(
-                                type="image",
-                                data=base64_data,
-                                mimeType=f"image/{fmt}",
-                            ),
-                            types.TextContent(
-                                type="text", text=f"Image URL: {img_url}"
-                            ),
-                        ]
-                    )
-                    continue
-
-                # Handle SVG files (data URI or *.svg file)
-                is_svg_file = path and path.lower().endswith(".svg")
-                is_svg_data_uri = url and url.startswith("data:image/svg+xml")
-
-                if is_svg_file or is_svg_data_uri:
-                    # Get SVG bytes
-                    if is_svg_file:
-                        raw_svg = Path(path).read_bytes()
-                    else:  # data:image/svg+xml,<content>
-                        raw_svg = unquote(url.split(",", 1)[1]).encode()
-                        path = self._save_svg_to_temp(raw_svg)
-
-                    # Build servable URL
-                    img_url = (
-                        f"{self.root_url}/gradio_api/file={quote(path)}"
-                        if self.root_url
-                        else path
-                    )
-
-                    # Encode as base64 and create payloads
-                    base64_data = base64.b64encode(raw_svg).decode()
-                    return_values.extend(
-                        [
-                            types.ImageContent(
-                                type="image",
-                                data=base64_data,
-                                mimeType="image/svg+xml",
-                            ),
-                            types.TextContent(
-                                type="text", text=f"Image URL: {img_url}"
-                            ),
-                        ]
-                    )
-                    continue
-
-                # Other files → plain link
-                return_values.append(
-                    types.TextContent(type="text", text=str(url or path))
-                )
-
-            else:  # Primitive values: str, int, dict, etc.
-                return_values.append(types.TextContent(type="text", text=str(output)))
-
+            if client_utils.is_file_obj_with_meta(output):
+                print("output", output)
+                if svg_bytes := self.get_svg(output["path"]):
+                    print("svg_bytes", svg_bytes)
+                    base64_data = base64.b64encode(svg_bytes).decode("utf-8")
+                    mimetype = "image/svg+xml"
+                    return_value = [
+                        types.ImageContent(
+                            type="image", data=base64_data, mimeType=mimetype
+                        ),
+                        types.TextContent(
+                            type="text",
+                            text=f"Image URL: {output['url'] or output['path']}",
+                        ),
+                    ]
+                elif image := self.get_image(output["path"]):
+                    image_format = image.format or "png"
+                    base64_data = self.get_base64_data(image, image_format)
+                    mimetype = f"image/{image_format.lower()}"
+                    return_value = [
+                        types.ImageContent(
+                            type="image", data=base64_data, mimeType=mimetype
+                        ),
+                        types.TextContent(
+                            type="text",
+                            text=f"Image URL: {output['url'] or output['path']}",
+                        ),
+                    ]
+                else:
+                    return_value = [
+                        types.TextContent(
+                            type="text", text=str(output["url"] or output["path"])
+                        )
+                    ]
+            else:
+                return_value = [types.TextContent(type="text", text=str(output))]
+            return_values.extend(return_value)
         return return_values

--- a/gradio/mcp.py
+++ b/gradio/mcp.py
@@ -24,7 +24,7 @@ from starlette.types import Receive, Scope, Send
 from gradio import processing_utils, route_utils, utils
 from gradio.blocks import BlockFunction
 from gradio.components import State
-from gradio.data_classes import FileData, FileDataDict
+from gradio.data_classes import FileData
 
 if TYPE_CHECKING:
     from gradio.blocks import BlockContext, Blocks

--- a/gradio/mcp.py
+++ b/gradio/mcp.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncIterator, Sequence
 from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote, unquote
+from urllib.parse import unquote
 
 import gradio_client.utils as client_utils
 from mcp import types
@@ -583,7 +583,9 @@ class GradioMCPServer:
             if svg_bytes := self.get_svg(output):
                 base64_data = base64.b64encode(svg_bytes).decode("utf-8")
                 mimetype = "image/svg+xml"
-                svg_path = processing_utils.save_bytes_to_cache(svg_bytes, f"{output['orig_name']}", DEFAULT_TEMP_DIR)
+                svg_path = processing_utils.save_bytes_to_cache(
+                    svg_bytes, f"{output['orig_name']}", DEFAULT_TEMP_DIR
+                )
                 svg_url = f"{self.root_url}/gradio_api/file={svg_path}"
                 return_value = [
                     types.ImageContent(

--- a/test/test_mcp.py
+++ b/test/test_mcp.py
@@ -83,6 +83,33 @@ def test_postprocess_output_data(test_mcp_app):
         assert result[1].type == "text"
         assert url in result[1].text
 
+    with tempfile.NamedTemporaryFile(suffix=".svg", mode="w") as temp_file:
+        svg_content = '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><circle cx="50" cy="50" r="40" fill="red"/></svg>'
+        temp_file.write(svg_content)
+        temp_file.flush()
+        url = f"http://localhost:7860/gradio_api/file={temp_file.name}"
+        test_data = [
+            {"path": temp_file.name, "url": url, "meta": {"_type": "gradio.FileData"}}
+        ]
+        result = server.postprocess_output_data(test_data)
+        assert len(result) == 2
+        assert result[0].type == "image"
+        assert result[0].mimeType == "image/svg+xml"
+        assert result[1].type == "text"
+        assert "Image URL:" in result[1].text
+
+    svg_data_uri = "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22100%22%20height%3D%22100%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2240%22%20fill%3D%22blue%22%2F%3E%3C%2Fsvg%3E"
+    test_data = [
+        {"path": None, "url": svg_data_uri, "meta": {"_type": "gradio.FileData"}}
+    ]
+    result = server.postprocess_output_data(test_data)
+    assert len(result) == 2
+    assert result[0].type == "image"
+    assert result[0].mimeType == "image/svg+xml"
+    assert result[1].type == "text"
+    assert "Image URL:" in result[1].text
+    assert "/gradio_api/file=" in result[1].text
+
     test_data = ["test text"]
     result = server.postprocess_output_data(test_data)
     assert len(result) == 1

--- a/test/test_mcp.py
+++ b/test/test_mcp.py
@@ -83,19 +83,22 @@ def test_postprocess_output_data(test_mcp_app):
         assert result[1].type == "text"
         assert url in result[1].text
 
-    with tempfile.NamedTemporaryFile(suffix=".svg", mode="w") as temp_file:
-        svg_content = '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><circle cx="50" cy="50" r="40" fill="red"/></svg>'
-        temp_file.write(svg_content)
-        temp_file.flush()
-        test_data = [
-            {"path": temp_file.name, "url": None, "meta": {"_type": "gradio.FileData"}}
-        ]
-        result = server.postprocess_output_data(test_data)
-        assert len(result) == 2
-        assert result[0].type == "image"
-        assert result[0].mimeType == "image/svg+xml"
-        assert result[1].type == "text"
-        assert "Image URL:" in result[1].text
+    svg_data_uri = "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22100%22%20height%3D%22100%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2240%22%20fill%3D%22blue%22%2F%3E%3C%2Fsvg%3E"
+    test_data = [
+        {
+            "path": None,
+            "url": svg_data_uri,
+            "meta": {"_type": "gradio.FileData"},
+            "orig_name": "test.svg",
+        }
+    ]
+    result = server.postprocess_output_data(test_data)
+    assert len(result) == 2
+    assert result[0].type == "image"
+    assert result[0].mimeType == "image/svg+xml"
+    assert result[1].type == "text"
+    assert "Image URL:" in result[1].text
+    assert "/gradio_api/file=" in result[1].text
 
     test_data = ["test text"]
     result = server.postprocess_output_data(test_data)

--- a/test/test_mcp.py
+++ b/test/test_mcp.py
@@ -87,9 +87,8 @@ def test_postprocess_output_data(test_mcp_app):
         svg_content = '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><circle cx="50" cy="50" r="40" fill="red"/></svg>'
         temp_file.write(svg_content)
         temp_file.flush()
-        url = f"http://localhost:7860/gradio_api/file={temp_file.name}"
         test_data = [
-            {"path": temp_file.name, "url": url, "meta": {"_type": "gradio.FileData"}}
+            {"path": temp_file.name, "url": None, "meta": {"_type": "gradio.FileData"}}
         ]
         result = server.postprocess_output_data(test_data)
         assert len(result) == 2

--- a/test/test_mcp.py
+++ b/test/test_mcp.py
@@ -98,18 +98,6 @@ def test_postprocess_output_data(test_mcp_app):
         assert result[1].type == "text"
         assert "Image URL:" in result[1].text
 
-    svg_data_uri = "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22100%22%20height%3D%22100%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2240%22%20fill%3D%22blue%22%2F%3E%3C%2Fsvg%3E"
-    test_data = [
-        {"path": None, "url": svg_data_uri, "meta": {"_type": "gradio.FileData"}}
-    ]
-    result = server.postprocess_output_data(test_data)
-    assert len(result) == 2
-    assert result[0].type == "image"
-    assert result[0].mimeType == "image/svg+xml"
-    assert result[1].type == "text"
-    assert "Image URL:" in result[1].text
-    assert "/gradio_api/file=" in result[1].text
-
     test_data = ["test text"]
     result = server.postprocess_output_data(test_data)
     assert len(result) == 1


### PR DESCRIPTION
## Description

### Bug  
Tools that returned **SVG** images through a `gr.Image` component produced an MCP payload like:

``` json
{ "type": "text",
  "text": "{'path': None, 'url': 'data:image/svg+xml,%3Csvg…'}" }
```

instead of the expected:

``` json
{ "type": "image",
  "data": "<base-64>",
  "mimeType": "image/svg+xml" }
```

`gr.Image` sanitises SVGs for security and converts them to a **data-URI** that no longer has a filesystem path.  
`GradioMCPServer.postprocess_output_data()` relied on `path` to decide whether an output was an image (it opens the file with PIL). When `path` was missing the function treated the result as plain text, so MCP clients could not render the
diagram.

### Fix  
This PR updates `postprocess_output_data()` to handle SVGs in both forms and to **reconstruct a servable path** when necessary:

1. Detects SVGs arriving as  
   * `url="data:image/svg+xml,<quoted-svg>"` (no `path`), or  
   * `path="…/*.svg"` already on disk.  
2. For data-URIs, decodes the content and writes it to a temp file inside `GRADIO_TEMP_DIR` (`gradio_svg_<hash>.svg`) so that a real path exists.  
   *Why?*  
   * MCP clients expect a downloadable URL (same as PNG/JPEG).  
   * A data-URI cannot be fetched later, so I mirror Gradio’s existing pattern (`/gradio_api/file=<path>`) for consistency and ease of use.  
3. Encodes the SVG bytes in base-64 and returns **two** payloads:

   ``` json
   { "type": "image",
     "data": "<base-64>",
     "mimeType": "image/svg+xml" }
   { "type": "text",
     "text": "Image URL: /gradio_api/file=<path>" }
   ```

This matches the contract already used for PNG/JPEG and unblocks MCP clients.

Other details:

* Adds helper `_save_svg_to_temp()` to handle the file creation.  
* New stdlib imports: `hashlib`, `quote`, `unquote`.  
* Raster handling and public API remain unchanged.

Closes: #11337

---

## 🎯 PRs Should Target Issues

This PR addresses the open issue
[#11337](https://github.com/gradio-app/gradio/issues/11337).

---

## Testing and Formatting Your Code

* Backend tests pass locally: `bash scripts/run_backend_tests.sh`  
* Code formatted: `bash scripts/format_backend.sh`
---

@abidlabs could you please review? 🙏