### PR TITLE
Fix DataFrame Scroll Divergence

### DIFF
--- a/.changeset/flat-rooms-stare.md
+++ b/.changeset/flat-rooms-stare.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": patch
+"gradio": patch
+---
+
+fix:Fix DataFrame Scroll Divergence

--- a/js/dataframe/shared/VirtualTable.svelte
+++ b/js/dataframe/shared/VirtualTable.svelte
@@ -96,7 +96,7 @@
 		let filtered_height_map = height_map.filter((v) => typeof v === "number");
 		average_height =
 			filtered_height_map.reduce((a, b) => a + b, 0) /
-			filtered_height_map.length;
+				filtered_height_map.length || 30;
 
 		bottom = remaining * average_height;
 		if (!isFinite(bottom)) {

--- a/js/dataframe/shared/VirtualTable.svelte
+++ b/js/dataframe/shared/VirtualTable.svelte
@@ -40,12 +40,15 @@
 		? window.requestAnimationFrame
 		: (cb: (...args: any[]) => void) => cb();
 
-	$: mounted && raf(() => refresh_height_map(sortedItems));
+	$: sortedItems, mounted && raf(refresh_height_map);
 
-	let content_height = 0;
-	async function refresh_height_map(_items: typeof items): Promise<void> {
-		if (viewport_height === 0) {
+	async function refresh_height_map(): Promise<void> {
+		if (viewport_height === 0 || !viewport.offsetParent) {
 			return;
+		}
+
+		if (sortedItems.length < start) {
+			await scroll_to_index(sortedItems.length - 1, { behavior: "auto" });
 		}
 
 		// force header height calculation first
@@ -53,30 +56,44 @@
 			viewport.querySelector(".thead")?.getBoundingClientRect().height || 0;
 		await tick();
 
-		const { scrollTop } = viewport;
+		const scrollTop = Math.max(0, viewport.scrollTop);
+		show_scroll_button = scrollTop > 100;
 		table_scrollbar_width = viewport.offsetWidth - viewport.clientWidth;
 
-		content_height = top - (scrollTop - head_height);
-		let i = start;
-
-		while (content_height < max_height && i < _items.length) {
-			let row = rows[i - start];
-			if (!row) {
-				end = i + 1;
-				await tick(); // render the newly visible row
-				row = rows[i - start];
+		const row_top_border = get_computed_px_amount(rows[1], "border-top-width");
+		// acquire height map for currently visible rows
+		for (let v = 0; v < rows.length; v += 1) {
+			height_map[start + v] = rows[v].getBoundingClientRect().height;
+		}
+		let i = 0;
+		// start from top: thead, with its borders, plus the first border to afterwards neglect
+		let y = head_height + row_top_border / 2;
+		// loop items to find new start
+		while (i < sortedItems.length) {
+			const row_height = height_map[i] || average_height;
+			// we only want to jump if the full (incl. border) row is away
+			if (y + row_height > scrollTop) {
+				// this is the last index still inside the viewport
+				start = i;
+				top = y - (head_height + row_top_border / 2);
+				break;
 			}
-			let _h = row?.getBoundingClientRect().height;
-			if (!_h) {
-				_h = average_height;
-			}
-			const row_height = (height_map[i] = _h);
-			content_height += row_height;
+			y += row_height;
 			i += 1;
 		}
 
+		let content_height = head_height;
+		while (i < sortedItems.length) {
+			const row_height = height_map[i] || average_height;
+			content_height += row_height;
+			i += 1;
+			if (content_height - head_height > max_height) {
+				break;
+			}
+		}
+
 		end = i;
-		const remaining = _items.length - end;
+		const remaining = sortedItems.length - end;
 
 		const scrollbar_height = viewport.offsetHeight - viewport.clientHeight;
 		if (scrollbar_height > 0) {
@@ -89,14 +106,19 @@
 			filtered_height_map.length;
 
 		bottom = remaining * average_height;
-		height_map.length = _items.length;
+		if (!isFinite(bottom)) {
+			bottom = 200000;
+		}
+		height_map.length = sortedItems.length;
+		while (i < sortedItems.length) {
+			i += 1;
+			height_map[i] = average_height;
+		}
 		await tick();
-		if (!max_height) {
-			actual_height = content_height + 1;
-		} else if (content_height < max_height) {
-			actual_height = content_height + 2;
-		} else {
+		if (max_height && content_height > max_height) {
 			actual_height = max_height;
+		} else {
+			actual_height = content_height;
 		}
 
 		await tick();
@@ -154,78 +176,6 @@
 		return x;
 	}
 
-	async function handle_scroll(e: Event): Promise<void> {
-		const scroll_top = viewport.scrollTop;
-
-		show_scroll_button = scroll_top > 100;
-
-		if (show_scroll_button) {
-			dispatch("scroll_top", scroll_top);
-		}
-
-		rows = contents.children as HTMLCollectionOf<HTMLTableRowElement>;
-		const is_start_overflow = sortedItems.length < start;
-
-		const row_top_border = get_computed_px_amount(rows[1], "border-top-width");
-
-		const actual_border_collapsed_width = 0;
-
-		if (is_start_overflow) {
-			await scroll_to_index(sortedItems.length - 1, { behavior: "auto" });
-		}
-
-		let new_start = 0;
-		// acquire height map for currently visible rows
-		for (let v = 0; v < rows.length; v += 1) {
-			height_map[start + v] = rows[v].getBoundingClientRect().height;
-		}
-		let i = 0;
-		// start from top: thead, with its borders, plus the first border to afterwards neglect
-		let y = head_height + row_top_border / 2;
-		let row_heights = [];
-		// loop items to find new start
-		while (i < sortedItems.length) {
-			const row_height = height_map[i] || average_height;
-			row_heights[i] = row_height;
-			// we only want to jump if the full (incl. border) row is away
-			if (y + row_height + actual_border_collapsed_width > scroll_top) {
-				// this is the last index still inside the viewport
-				new_start = i;
-				top = y - (head_height + row_top_border / 2);
-				break;
-			}
-			y += row_height;
-			i += 1;
-		}
-
-		new_start = Math.max(0, new_start);
-		while (i < sortedItems.length) {
-			const row_height = height_map[i] || average_height;
-			y += row_height;
-			i += 1;
-			if (y > scroll_top + viewport_height) {
-				break;
-			}
-		}
-		start = new_start;
-		end = i;
-		const remaining = sortedItems.length - end;
-		if (end === 0) {
-			end = 10;
-		}
-		average_height = (y - head_height) / end;
-		let remaining_height = remaining * average_height; // 0
-		// compute height map for remaining items
-		while (i < sortedItems.length) {
-			i += 1;
-			height_map[i] = average_height;
-		}
-		bottom = remaining_height;
-		if (!isFinite(bottom)) {
-			bottom = 200000;
-		}
-	}
-
 	export async function scroll_to_index(
 		index: number,
 		opts: ScrollToOptions,
@@ -269,7 +219,6 @@
 	onMount(() => {
 		rows = contents.children as HTMLCollectionOf<HTMLTableRowElement>;
 		mounted = true;
-		refresh_height_map(items);
 	});
 </script>
 
@@ -280,7 +229,7 @@
 			class:disable-scroll={disable_scroll}
 			bind:this={viewport}
 			bind:contentRect={viewport_box}
-			on:scroll={handle_scroll}
+			on:scroll={refresh_height_map}
 			style="height: {height}; --bw-svt-p-top: {top}px; --bw-svt-p-bottom: {bottom}px; --bw-svt-head-height: {head_height}px; --bw-svt-foot-height: {foot_height}px; --bw-svt-avg-row-height: {average_height}px; --max-height: {max_height}px"
 		>
 			<thead class="thead" bind:offsetHeight={head_height}>

--- a/js/dataframe/shared/VirtualTable.svelte
+++ b/js/dataframe/shared/VirtualTable.svelte
@@ -51,29 +51,23 @@
 			await scroll_to_index(sortedItems.length - 1, { behavior: "auto" });
 		}
 
-		// force header height calculation first
-		head_height =
-			viewport.querySelector(".thead")?.getBoundingClientRect().height || 0;
-
 		const scrollTop = Math.max(0, viewport.scrollTop);
 		show_scroll_button = scrollTop > 100;
 		table_scrollbar_width = viewport.offsetWidth - viewport.clientWidth;
 
-		const row_top_border = get_computed_px_amount(rows[1], "border-top-width");
 		// acquire height map for currently visible rows
 		for (let v = 0; v < rows.length; v += 1) {
 			height_map[start + v] = rows[v].getBoundingClientRect().height;
 		}
 		let i = 0;
-		// start from top: thead, with its borders, plus the first border to afterwards neglect
-		let y = head_height + row_top_border / 2;
+		let y = head_height;
 		// loop items to find new start
 		while (i < sortedItems.length) {
 			const row_height = height_map[i] || average_height;
 			// keep a page of rows buffered above
 			if (y + row_height > scrollTop - max_height) {
 				start = i;
-				top = y - (head_height + row_top_border / 2);
+				top = y - head_height;
 				break;
 			}
 			y += row_height;
@@ -160,16 +154,6 @@
 		}
 
 		return true;
-	}
-
-	function get_computed_px_amount(elem: HTMLElement, property: string): number {
-		if (!elem) {
-			return 0;
-		}
-		const compStyle = getComputedStyle(elem);
-
-		let x = parseInt(compStyle.getPropertyValue(property));
-		return x;
 	}
 
 	export async function scroll_to_index(

--- a/js/dataframe/shared/VirtualTable.svelte
+++ b/js/dataframe/shared/VirtualTable.svelte
@@ -40,13 +40,13 @@
 		? window.requestAnimationFrame
 		: (cb: (...args: any[]) => void) => cb();
 
-	$: sortedItems, mounted && raf(refresh_height_map);
+	$: {
+		if (mounted && viewport_height && viewport.offsetParent) {
+			sortedItems, raf(refresh_height_map);
+		}
+	}
 
 	async function refresh_height_map(): Promise<void> {
-		if (viewport_height === 0 || !viewport.offsetParent) {
-			return;
-		}
-
 		if (sortedItems.length < start) {
 			await scroll_to_index(sortedItems.length - 1, { behavior: "auto" });
 		}

--- a/js/dataframe/shared/VirtualTable.svelte
+++ b/js/dataframe/shared/VirtualTable.svelte
@@ -54,7 +54,6 @@
 		// force header height calculation first
 		head_height =
 			viewport.querySelector(".thead")?.getBoundingClientRect().height || 0;
-		await tick();
 
 		const scrollTop = Math.max(0, viewport.scrollTop);
 		show_scroll_button = scrollTop > 100;
@@ -71,9 +70,8 @@
 		// loop items to find new start
 		while (i < sortedItems.length) {
 			const row_height = height_map[i] || average_height;
-			// we only want to jump if the full (incl. border) row is away
-			if (y + row_height > scrollTop) {
-				// this is the last index still inside the viewport
+			// keep a page of rows buffered above
+			if (y + row_height > scrollTop - max_height) {
 				start = i;
 				top = y - (head_height + row_top_border / 2);
 				break;
@@ -87,7 +85,8 @@
 			const row_height = height_map[i] || average_height;
 			content_height += row_height;
 			i += 1;
-			if (content_height - head_height > max_height) {
+			// keep a page of rows buffered below
+			if (content_height - head_height > 3 * max_height) {
 				break;
 			}
 		}
@@ -114,14 +113,11 @@
 			i += 1;
 			height_map[i] = average_height;
 		}
-		await tick();
 		if (max_height && content_height > max_height) {
 			actual_height = max_height;
 		} else {
 			actual_height = content_height;
 		}
-
-		await tick();
 	}
 
 	$: scroll_and_render(selected);


### PR DESCRIPTION
## Description

Combine the virtual table's mount handler and scroll handler to prevent inconsistencies in the table height changing on scroll. Increase the row buffer from one row to one page (up and down) to prevent render popping. Remove no-op `tick()` calls that delayed row rendering. Remove no-op row border calculation. React to table visibility to fix value changes while hidden.

Closes: #11321


https://github.com/user-attachments/assets/ac3fd531-7ba5-4df3-bc3c-e567cfff2ee9

