### PR TITLE
fix: mount_css missing base path

### DIFF
--- a/.changeset/tall-shirts-yawn.md
+++ b/.changeset/tall-shirts-yawn.md
@@ -1,0 +1,6 @@
+---
+"@gradio/core": minor
+"gradio": minor
+---
+
+feat:fix: mount_css missing base path

--- a/js/core/src/css.ts
+++ b/js/core/src/css.ts
@@ -17,7 +17,7 @@ export function mount_css(url: string, target: HTMLElement): Promise<void> {
 	var _url = url;
 	if (window.location.origin !== base) {
 		// Serving assets over a CDN, generate absolute url
-		_url = new URL(url, base).href;
+		_url = new URL(url, gradio_config.root).href; // .origin not include base path
 	}
 	const existing_link = document.querySelector(`link[href='${_url}']`);
 	if (existing_link) return Promise.resolve();


### PR DESCRIPTION
## Description

Someone just closed my issue without checking carefully: https://github.com/gradio-app/gradio/issues/11075
