### PR TITLE
Fix Gallery thumbnail overflow

### DIFF
--- a/.changeset/stupid-radios-throw.md
+++ b/.changeset/stupid-radios-throw.md
@@ -1,0 +1,6 @@
+---
+"@gradio/gallery": patch
+"gradio": patch
+---
+
+fix:Fix Gallery thumbnail overflow

--- a/js/gallery/shared/Gallery.svelte
+++ b/js/gallery/shared/Gallery.svelte
@@ -232,8 +232,13 @@
 
 	let thumbnails_overflow = false;
 
+	$: console.log("thumbnails_overflow", thumbnails_overflow);
+
 	function check_thumbnails_overflow(): void {
+		console.log("check_thumbnails_overflow", container_element);
 		if (container_element) {
+			console.log("container_element.scrollWidth", container_element.scrollWidth);
+			console.log("container_element.clientWidth", container_element.clientWidth);
 			thumbnails_overflow =
 				container_element.scrollWidth > container_element.clientWidth;
 		}
@@ -250,6 +255,7 @@
 	});
 
 	$: resolved_value, check_thumbnails_overflow();
+	$: container_element, check_thumbnails_overflow();
 </script>
 
 <svelte:window bind:innerHeight={window_height} />

--- a/js/gallery/shared/Gallery.svelte
+++ b/js/gallery/shared/Gallery.svelte
@@ -255,7 +255,9 @@
 	});
 
 	$: resolved_value, check_thumbnails_overflow();
-	$: container_element, check_thumbnails_overflow();
+	$: if (container_element) {
+		check_thumbnails_overflow();
+	}
 </script>
 
 <svelte:window bind:innerHeight={window_height} />

--- a/js/gallery/shared/Gallery.svelte
+++ b/js/gallery/shared/Gallery.svelte
@@ -230,11 +230,26 @@
 			? resolved_value[selected_index]
 			: null;
 
+	let thumbnails_overflow = false;
+
+	function check_thumbnails_overflow(): void {
+		if (container_element) {
+			thumbnails_overflow =
+				container_element.scrollWidth > container_element.clientWidth;
+		}
+	}
+
 	onMount(() => {
+		check_thumbnails_overflow();
 		document.addEventListener("fullscreenchange", () => {
 			is_full_screen = !!document.fullscreenElement;
 		});
+		window.addEventListener("resize", check_thumbnails_overflow);
+		return () =>
+			window.removeEventListener("resize", check_thumbnails_overflow);
 	});
+
+	$: resolved_value, check_thumbnails_overflow();
 </script>
 
 <svelte:window bind:innerHeight={window_height} />
@@ -342,6 +357,9 @@
 					bind:this={container_element}
 					class="thumbnails scroll-hide"
 					data-testid="container_el"
+					style="justify-content: {thumbnails_overflow
+						? 'flex-start'
+						: 'center'};"
 				>
 					{#each resolved_value as media, i}
 						<button
@@ -541,7 +559,7 @@
 		display: flex;
 		position: absolute;
 		bottom: 0;
-		justify-content: center;
+		justify-content: flex-start;
 		align-items: center;
 		gap: var(--spacing-lg);
 		width: var(--size-full);

--- a/js/gallery/shared/Gallery.svelte
+++ b/js/gallery/shared/Gallery.svelte
@@ -232,13 +232,8 @@
 
 	let thumbnails_overflow = false;
 
-	$: console.log("thumbnails_overflow", thumbnails_overflow);
-
 	function check_thumbnails_overflow(): void {
-		console.log("check_thumbnails_overflow", container_element);
 		if (container_element) {
-			console.log("container_element.scrollWidth", container_element.scrollWidth);
-			console.log("container_element.clientWidth", container_element.clientWidth);
 			thumbnails_overflow =
 				container_element.scrollWidth > container_element.clientWidth;
 		}


### PR DESCRIPTION
## Description

Closes: #10211

I was not able to reproduce the original issue exactly. I was able to scroll to the left and right to see the thumbnails that overflowed. The problem I noticed is the thumbnail preview doesn't correctly scroll to the image you clicked on if there are many images. This is because of the `justify-content: center` rule that's applied. My fix is to apply `justify-content: flex-start` when the gallery overflows and `justify-content:center` otherwise.

### Original behavior
Notice that after clicking on the first image, the thumbnails don't show the image I clicked on

![gallery_overflow_large_original](https://github.com/user-attachments/assets/cd64adbc-779c-43af-be1a-efe9b2a67cbe)


### New behavior

![gallery_overflow_large](https://github.com/user-attachments/assets/296a4b3b-2b49-4811-b733-0c7de1ca8991)

### Reacts to screen size
![gallery_overflow](https://github.com/user-attachments/assets/479fbc75-6186-43dd-adcb-dd461ccaa2e7)



## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
