### PR TITLE
Fix zerogu-guide + also pass zero-gpu-token

### DIFF
--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -308,6 +308,9 @@ class Client:
 
     def send_data(self, data, hash_data, protocol):
         headers = self.add_zero_gpu_headers(self.headers)
+        print("#########################")
+        print("HEADERS from client.py file", headers)
+        print("#########################")
         req = httpx.post(
             self.sse_data_url,
             json={**data, **hash_data},
@@ -740,8 +743,11 @@ class Client:
         ):  # this is not running within a Gradio app as Gradio is not installed
             return headers
         request = LocalContext.request.get()
-        if request and hasattr(request, "headers") and "x-ip-token" in request.headers:
-            headers["x-ip-token"] = request.headers["x-ip-token"]
+        if request and hasattr(request, "headers"):
+            if "x-ip-token" in request.headers:
+                headers["x-ip-token"] = request.headers["x-ip-token"]
+            if "x-zerogpu-token" in request.headers:
+                headers["x-zerogpu-token"] = request.headers["x-zerogpu-token"]
         return headers
 
     def _render_endpoints_info(

--- a/js/_website/src/lib/templates/python-client/gradio_client/03_using-zero-gpu-spaces.svx
+++ b/js/_website/src/lib/templates/python-client/gradio_client/03_using-zero-gpu-spaces.svx
@@ -12,7 +12,7 @@ These kinds of spaces are a great foundation to build new applications on top of
 
 ZeroGPU spaces are rate-limited to ensure that a single user does not hog all of the available GPUs.
 The limit is controlled by a special token that the Hugging Face Hub infrastructure adds to all incoming requests to Spaces.
-This token is a request header called `X-IP-Token` and its value changes depending on the user who makes a request to the ZeroGPU space.
+This token is a request header called `X-ZEROGPU-Token` and its value changes depending on the user who makes a request to the ZeroGPU space.
 <br>
 
 Let's say you want to create a space (Space A) that uses a ZeroGPU space (Space B) programmatically.
@@ -24,39 +24,28 @@ How to do this will be explained in the following section.
 
 ### Avoiding Rate Limits 
 
-When a user visits the page, we will extract their token from the `X-IP-Token` header of the incoming request.
-We will use this header value in all subsequent client requests.
+When a user pressed enter in the textbox, we will extract their token from the `X-ZERO-Token` header of the incoming request.
+We will use this header when constructing the gradio client.
 The following hypothetical text-to-image application shows how this is done.
 <br> 
-
-We use the `load` event to extract the user's `x-ip-token` header when they visit the page.
-We create a new client with this header passed to the `headers` parameter.
-This ensures all subsequent predictions pass this header to the ZeroGPU space.
-The client is saved in a State variable so that it's kept independent from other users.
-It will be deleted automatically when the user exits the page.
 
 
 ```python
 import gradio as gr
 from gradio_client import Client
 
-def text_to_image(client, prompt):
+def text_to_image(prompt, request: gr.Request):
+    x_gpu_token = request.headers['x-zerogpu-token']
+    client = Client("hysts/SDXL", headers={"x-zerogpu-token": x_gpu_token})
     img = client.predict(prompt, api_name="/predict")
     return img
 
 
-def set_client_for_session(request: gr.Request):
-    x_ip_token = request.headers['x-ip-token']
-
-    # The "gradio/text-to-image" space is a ZeroGPU space
-    return Client("gradio/text-to-image", headers={"X-IP-Token": x_ip_token})
-
 with gr.Blocks() as demo:
-    client = gr.State()
     image = gr.Image()
     prompt = gr.Textbox(max_lines=1)
 
-    prompt.submit(text_to_image, [client, prompt], [image])
+    prompt.submit(text_to_image, [prompt], [image])
 
     demo.load(set_client_for_session, None, client)
 ```


### PR DESCRIPTION
## Description

Closes: #10914

When I use the `zero-gpu-token` header, my zero-gpu-quota is correctly used (with/without SSR mode).


https://github.com/user-attachments/assets/01684d1d-1b1d-4ad9-816c-142aab1dc581



## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
