### PR TITLE
Fixes hardcoded HTTP protocol in dev reload

### DIFF
--- a/.changeset/ten-coins-sit.md
+++ b/.changeset/ten-coins-sit.md
@@ -1,0 +1,6 @@
+---
+"@self/spa": patch
+"gradio": patch
+---
+
+fix:Fixes hardcoded HTTP protocol in dev reload

--- a/js/spa/src/Index.svelte
+++ b/js/spa/src/Index.svelte
@@ -380,7 +380,7 @@
 		if (config.dev_mode) {
 			setTimeout(() => {
 				const { host } = new URL(api_url);
-				let url = new URL(`http://${host}${app.api_prefix}/dev/reload`);
+				let url = new URL(`${window.location.protocol}//${host}${app.api_prefix}/dev/reload`);
 				stream = new EventSource(url);
 				stream.addEventListener("error", async (e) => {
 					new_message_fn("Error", "Error reloading app", "error");

--- a/js/spa/src/Index.svelte
+++ b/js/spa/src/Index.svelte
@@ -380,7 +380,9 @@
 		if (config.dev_mode) {
 			setTimeout(() => {
 				const { host } = new URL(api_url);
-				let url = new URL(`${window.location.protocol}//${host}${app.api_prefix}/dev/reload`);
+				let url = new URL(
+					`${window.location.protocol}//${host}${app.api_prefix}/dev/reload`
+				);
 				stream = new EventSource(url);
 				stream.addEventListener("error", async (e) => {
 					new_message_fn("Error", "Error reloading app", "error");


### PR DESCRIPTION
## Description

There is the HTTP protocol hardcoded in the dev hot reload mode. Reloading fails when running `gradio app.py`.

Closes: https://github.com/gradio-app/gradio/issues/10048