### PR TITLE
Feat: Implement custom_buttons for Chatbot and ChatInterface

### DIFF
--- a/demo/chatbot_custom_buttons/run.ipynb
+++ b/demo/chatbot_custom_buttons/run.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "302934307671667531413257853548643485645",
+   "metadata": {},
+   "source": [
+    "# Gradio Demo: chatbot_custom_buttons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "272996653310673477252411125948039410165",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q gradio "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "288918539441861185822528903084949547379",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gradio as gr\n",
+    "import copy\n",
+    "\n",
+    "def handle_custom_button(data: gr.CustomButtonsData, history: list[gr.MessageDict]):\n",
+    "    if data.label == \"Example1\":\n",
+    "        return duplicate_chat(history)\n",
+    "    elif data.label == \"Example2\":\n",
+    "        return fill_all_messages(data, history)\n",
+    "    #Doesn't change the history in chatbot (just change a copy)\n",
+    "    else:\n",
+    "        delete_all_messages(copy.deepcopy(history)) \n",
+    "        return history \n",
+    "\n",
+    "def duplicate_chat(history: list[gr.MessageDict]):\n",
+    "    return [item for item in history for _ in range(2)]\n",
+    "\n",
+    "def fill_all_messages(data: gr.CustomButtonsData, history: list[gr.MessageDict]):\n",
+    "    value = data.values[0]\n",
+    "    for message in history:\n",
+    "        message['content'] = value\n",
+    "        \n",
+    "    return history\n",
+    "\n",
+    "def delete_all_messages(history: list[gr.MessageDict]):\n",
+    "    return history[:0]\n",
+    "\n",
+    "examples = [\n",
+    "    {\"role\": \"user\", \"content\": \"User message 1.\"},\n",
+    "    {\"role\": \"user\", \"content\": \"User message 2.\"},\n",
+    "    {\"role\": \"assistant\", \"content\": \"Chatbot message 1.\"},\n",
+    "]\n",
+    "\n",
+    "with gr.Blocks() as demo:\n",
+    "    with gr.Row():\n",
+    "        chatbot = gr.Chatbot(\n",
+    "            type=\"messages\",\n",
+    "            custom_buttons=[\n",
+    "                {\n",
+    "                    \"label\": \"Example1\",\n",
+    "                    \"icon\": \"ArrowUp\",\n",
+    "                    \"visible\": \"chatbot\",\n",
+    "                },\n",
+    "                {\n",
+    "                    \"label\": \"Example2\",\n",
+    "                    \"visible\": \"user\",\n",
+    "                    \"icon\": \"Chat\",\n",
+    "                },\n",
+    "                {\n",
+    "                    \"label\": \"Example3\",\n",
+    "                },\n",
+    "            ],\n",
+    "        )\n",
+    "    with gr.Row():\n",
+    "        concatenated_text = gr.Textbox(label=\"Concatenated Chat\")\n",
+    "    chatbot.custom_button(handle_custom_button, chatbot, chatbot)\n",
+    "\n",
+    "    chatbot.change(lambda m: \"|\".join(m[\"content\"] for m in m), chatbot, concatenated_text)\n",
+    "\n",
+    "    demo.load(lambda: examples, None, chatbot)\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    demo.launch()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/demo/chatbot_custom_buttons/run.py
+++ b/demo/chatbot_custom_buttons/run.py
@@ -1,0 +1,62 @@
+import gradio as gr
+import copy
+
+def handle_custom_button(data: gr.CustomButtonsData, history: list[gr.MessageDict]):
+    if data.label == "Example1":
+        return duplicate_chat(history)
+    elif data.label == "Example2":
+        return fill_all_messages(data, history)
+    #Doesn't change the history in chatbot (just change a copy)
+    else:
+        delete_all_messages(copy.deepcopy(history)) 
+        return history 
+
+def duplicate_chat(history: list[gr.MessageDict]):
+    return [item for item in history for _ in range(2)]
+
+def fill_all_messages(data: gr.CustomButtonsData, history: list[gr.MessageDict]):
+    value = data.values[0]
+    for message in history:
+        message['content'] = value
+        
+    return history
+
+def delete_all_messages(history: list[gr.MessageDict]):
+    return history[:0]
+
+examples = [
+    {"role": "user", "content": "User message 1."},
+    {"role": "user", "content": "User message 2."},
+    {"role": "assistant", "content": "Chatbot message 1."},
+]
+
+with gr.Blocks() as demo:
+    with gr.Row():
+        chatbot = gr.Chatbot(
+            type="messages",
+            custom_buttons=[
+                {
+                    "label": "Example1",
+                    "icon": "ArrowUp",
+                    "visible": "chatbot",
+                },
+                {
+                    "label": "Example2",
+                    "visible": "user",
+                    "icon": "Chat",
+                },
+                {
+                    "label": "Example3",
+                },
+            ],
+        )
+    with gr.Row():
+        concatenated_text = gr.Textbox(label="Concatenated Chat")
+    chatbot.custom_button(handle_custom_button, chatbot, chatbot)
+
+    chatbot.change(lambda m: "|".join(m["content"] for m in m), chatbot, concatenated_text)
+
+    demo.load(lambda: examples, None, chatbot)
+
+if __name__ == "__main__":
+    demo.launch()

--- a/demo/chatinterface_custom_buttons/run.ipynb
+++ b/demo/chatinterface_custom_buttons/run.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "302934307671667531413257853548643485645",
+   "metadata": {},
+   "source": [
+    "# Gradio Demo: chatinterface_custom_buttons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "272996653310673477252411125948039410165",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q gradio "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "288918539441861185822528903084949547379",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gradio as gr\n",
+    "import random\n",
+    "\n",
+    "def create_tuple_messages(data: gr.CustomButtonsData, history: list[gr.MessageDict]):\n",
+    "    return [[\"User message\", \"Chatbot message\"]]\n",
+    "\n",
+    "def random_response(message, history):\n",
+    "    return random.choice([\"Yes\", \"No\"])\n",
+    "\n",
+    "examples = [\n",
+    "    {\"role\": \"user\", \"content\": \"User message 1.\"},\n",
+    "    {\"role\": \"user\", \"content\": \"User message 2.\"},\n",
+    "    {\"role\": \"assistant\", \"content\": \"Chatbot message 1.\"},\n",
+    "]\n",
+    "\n",
+    "with gr.Blocks() as demo:\n",
+    "    with gr.Row():\n",
+    "        chat_interface = gr.ChatInterface(\n",
+    "            fn=random_response,\n",
+    "            type=\"messages\",\n",
+    "            custom_buttons=[\n",
+    "                {\n",
+    "                    \"label\": \"Example1\",\n",
+    "                    \"visible\": \"chatbot\",\n",
+    "                    \"on_click\": create_tuple_messages\n",
+    "                },\n",
+    "                {\n",
+    "                    \"label\": \"Example2\"\n",
+    "                },\n",
+    "            ],\n",
+    "        )\n",
+    "\n",
+    "    with gr.Row():\n",
+    "        concatenated_text = gr.Textbox(label=\"Concatenated Chat\")\n",
+    "\n",
+    "    chat_interface.chatbot.change(lambda m: \"|\".join(m[\"content\"] for m in m), chat_interface.chatbot, concatenated_text)\n",
+    "\n",
+    "    demo.load(lambda: examples, None, chat_interface.chatbot)\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    demo.launch()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/demo/chatinterface_custom_buttons/run.py
+++ b/demo/chatinterface_custom_buttons/run.py
@@ -1,0 +1,41 @@
+import gradio as gr
+import random
+
+def create_tuple_messages(data: gr.CustomButtonsData, history: list[gr.MessageDict]):
+    return [["User message", "Chatbot message"]]
+
+def random_response(message, history):
+    return random.choice(["Yes", "No"])
+
+examples = [
+    {"role": "user", "content": "User message 1."},
+    {"role": "user", "content": "User message 2."},
+    {"role": "assistant", "content": "Chatbot message 1."},
+]
+
+with gr.Blocks() as demo:
+    with gr.Row():
+        chat_interface = gr.ChatInterface(
+            fn=random_response,
+            type="messages",
+            custom_buttons=[
+                {
+                    "label": "Example1",
+                    "visible": "chatbot",
+                    "on_click": create_tuple_messages
+                },
+                {
+                    "label": "Example2"
+                },
+            ],
+        )
+
+    with gr.Row():
+        concatenated_text = gr.Textbox(label="Concatenated Chat")
+
+    chat_interface.chatbot.change(lambda m: "|".join(m["content"] for m in m), chat_interface.chatbot, concatenated_text)
+
+    demo.load(lambda: examples, None, chat_interface.chatbot)
+
+if __name__ == "__main__":
+    demo.launch()

--- a/gradio/__init__.py
+++ b/gradio/__init__.py
@@ -70,6 +70,7 @@ from gradio.components.image_editor import Brush, Eraser, LayerOptions, WebcamOp
 from gradio.data_classes import FileData
 from gradio.events import (
     CopyData,
+    CustomButtonsData,
     DeletedFileData,
     DownloadData,
     EditData,
@@ -142,6 +143,7 @@ __all__ = [
     "ColorPicker",
     "Column",
     "CopyData",
+    "CustomButtonsData",
     "DataFrame",
     "Dataframe",
     "Dataset",

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -459,6 +459,52 @@ class CopyData(EventData):
         """
 
 
+@document()
+class CustomButtonsData(EventData):
+    """
+    The CustomButtonsData class is a subclass of gr.EventData that carries information
+    when a custom button in the Chatbot is clicked. When CustomButtonsData is added as a
+    type hint to an event listener method, a CustomButtonsData object will automatically
+    be passed as the value of that argument.
+    Example:
+        import gradio as gr
+        examples = [
+            {"role": "user", "content": "User message 1."},
+        ]
+
+        def custom_on_click(data: gr.CustomButtonsData, history: list[gr.MessageDict]):
+            history[data.index]["content"]= "Changed"
+            return history
+
+        with gr.Blocks() as demo:
+            chatbot = gr.Chatbot(
+                type="messages",
+                custom_buttons = [{
+                    "label": "CustomButton",
+                    "visible": "all"
+                }]
+            )
+            chatbot.custom_button(custom_on_click, chatbot, chatbot)
+            demo.load(lambda: examples, None, chatbot)
+        demo.launch()
+    """
+
+    def __init__(self, target: Block | None, data: Any):
+        super().__init__(target, data)
+        self.index: int | tuple[int, int] = data["index"]
+        """
+        The index of the message in which the custom button was clicked
+        """
+        self.values: tuple[str] = data["values"]
+        """
+        The value of the message in which the custom button was clicked
+        """
+        self.label: str = data["label"]
+        """
+        The label of the custom button that was clicked
+        """
+
+
 @dataclasses.dataclass
 class EventListenerMethod:
     block: Block | None
@@ -1201,4 +1247,8 @@ class Events:
     copy = EventListener(
         "copy",
         doc="This listener is triggered when the user copies content from the {{ component }}. Uses event data gradio.CopyData to carry information about the copied content. See EventData documentation on how to use this event data",
+    )
+    custom_button = EventListener(
+        "custom_button",
+        doc="This listener is triggered when the user clicks on one of the custom buttons in the chatbot message.",
     )

--- a/js/chatbot/Chatbot.test.ts
+++ b/js/chatbot/Chatbot.test.ts
@@ -234,6 +234,23 @@ describe("Chatbot", () => {
 		);
 	});
 
+	test("renders custom buttons with null icon and non-existing icon", async () => {
+		const customButtons = [
+			{ label: "Example1", icon: "NonExisting", visible: "user" },
+			{ label: "Example2", visible: "chatbot" }
+		];
+
+		const { getByText } = await render(Chatbot, {
+			label: "chatbot",
+			value: [["user message one", "bot message one"]],
+			custom_buttons: customButtons
+		});
+
+		for (const button of customButtons) {
+			expect(getByText(button.label)).toBeInTheDocument();
+		}
+	});
+
 	test("renders messages with allowed HTML tags", async () => {
 		const { container } = await render(Chatbot, {
 			loading_status,

--- a/js/chatbot/Index.svelte
+++ b/js/chatbot/Index.svelte
@@ -6,7 +6,7 @@
 	import type { Gradio, SelectData, LikeData, CopyData } from "@gradio/utils";
 
 	import ChatBot from "./shared/ChatBot.svelte";
-	import type { UndoRetryData } from "./shared/utils";
+	import type { CustomButtonsData, UndoRetryData } from "./shared/utils";
 	import { Block, BlockLabel } from "@gradio/atoms";
 	import type { LoadingStatus } from "@gradio/statustracker";
 	import { Chat } from "@gradio/icons";
@@ -20,6 +20,7 @@
 	} from "./types";
 
 	import { normalise_tuples, normalise_messages } from "./shared/utils";
+	import CustomButtons from "./shared/CustomButtons.svelte";
 
 	export let elem_id = "";
 	export let elem_classes: string[] = [];
@@ -48,6 +49,13 @@
 	export let _undoable = false;
 	export let group_consecutive_messages = true;
 	export let allow_tags: string[] | boolean = false;
+	export let custom_buttons:
+		| {
+				label: string;
+				visible: "all" | "user" | "chatbot";
+				icon: string | null;
+		  }[]
+		| null = null;
 	export let latex_delimiters: {
 		left: string;
 		right: string;
@@ -67,6 +75,7 @@
 		undo: UndoRetryData;
 		clear: null;
 		copy: CopyData;
+		custom_button: CustomButtonsData;
 	}>;
 
 	let _value: NormalisedMessage[] | null = [];
@@ -172,6 +181,7 @@
 				value = value;
 				gradio.dispatch("edit", e.detail);
 			}}
+			on:custom_button={(e) => gradio.dispatch("custom_button", e.detail)}
 			{avatar_images}
 			{sanitize_html}
 			{line_breaks}
@@ -189,6 +199,7 @@
 			{allow_file_downloads}
 			{allow_tags}
 			{watermark}
+			{custom_buttons}
 		/>
 	</div>
 </Block>

--- a/js/chatbot/shared/ButtonPanel.svelte
+++ b/js/chatbot/shared/ButtonPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import LikeDislike from "./LikeDislike.svelte";
+	import CustomButtons from "./CustomButtons.svelte";
 	import Copy from "./Copy.svelte";
 	import type { FileData } from "@gradio/client";
 	import type { NormalisedMessage, TextMessage, ThoughtNode } from "../types";
@@ -23,15 +24,25 @@
 	export let generating: boolean;
 	export let current_feedback: string | null;
 
-	export let handle_action: (selected: string | null) => void;
+	export let handle_action: (
+		selected: string | null,
+		selected_label: string | null
+	) => void;
 	export let layout: "bubble" | "panel";
 	export let dispatch: any;
+	export let custom_buttons:
+		| {
+				label: string;
+				visible: "all" | "user" | "chatbot";
+				icon: string | null;
+		  }[]
+		| null = null;
 
 	$: message_text = is_all_text(message) ? all_text(message) : "";
 	$: show_copy = show_copy_button && message && is_all_text(message);
 </script>
 
-{#if show_copy || show_retry || show_undo || show_edit || likeable}
+{#if show_copy || show_retry || show_undo || show_edit || likeable || custom_buttons}
 	<div
 		class="message-buttons-{position} {layout} message-buttons {avatar !==
 			null && 'with-avatar'}"
@@ -41,13 +52,13 @@
 				<IconButton
 					label={i18n("chatbot.submit")}
 					Icon={Check}
-					on:click={() => handle_action("edit_submit")}
+					on:click={() => handle_action("edit_submit", null)}
 					disabled={generating}
 				/>
 				<IconButton
 					label={i18n("chatbot.cancel")}
 					Icon={Clear}
-					on:click={() => handle_action("edit_cancel")}
+					on:click={() => handle_action("edit_cancel", null)}
 					disabled={generating}
 				/>
 			{:else}
@@ -62,7 +73,7 @@
 					<IconButton
 						Icon={Retry}
 						label={i18n("chatbot.retry")}
-						on:click={() => handle_action("retry")}
+						on:click={() => handle_action("retry", null)}
 						disabled={generating}
 					/>
 				{/if}
@@ -70,7 +81,7 @@
 					<IconButton
 						label={i18n("chatbot.undo")}
 						Icon={Undo}
-						on:click={() => handle_action("undo")}
+						on:click={() => handle_action("undo", null)}
 						disabled={generating}
 					/>
 				{/if}
@@ -78,7 +89,7 @@
 					<IconButton
 						label={i18n("chatbot.edit")}
 						Icon={Edit}
-						on:click={() => handle_action("edit")}
+						on:click={() => handle_action("edit", null)}
 						disabled={generating}
 					/>
 				{/if}
@@ -89,6 +100,9 @@
 						selected={current_feedback}
 						{i18n}
 					/>
+				{/if}
+				{#if custom_buttons}
+					<CustomButtons {handle_action} {custom_buttons} {position} />
 				{/if}
 			{/if}
 		</IconButtonWrapper>

--- a/js/chatbot/shared/CustomButtons.svelte
+++ b/js/chatbot/shared/CustomButtons.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { IconButton } from "@gradio/atoms";
+	import { iconMap, loadIcons } from "./iconMap";
+
+	export let custom_buttons:
+		| {
+				label: string;
+				visible: "all" | "user" | "chatbot";
+				icon: string | null;
+		  }[]
+		| null = null;
+	export let handle_action: (
+		selected: string | null,
+		selected_label: string | null
+	) => void;
+	export let position: "right" | "left";
+	let role = position == "left" ? "chatbot" : "user";
+
+	let loadedIconMap: Record<string, any> | null = null;
+
+	onMount(async () => {
+		loadedIconMap = await loadIcons();
+	});
+
+	function onButtonClick(label: string) {
+		console.log(`Button: ${label}`);
+		handle_action("custom_button", label);
+	}
+</script>
+
+<div class="custom-buttons-container">
+	{#if custom_buttons}
+		{#each custom_buttons as btn}
+			{#if btn.visible === "all" || btn.visible === role}
+				{#if btn.icon && loadedIconMap && btn.icon.toLowerCase() in loadedIconMap}
+					<IconButton
+						Icon={loadedIconMap[btn.icon.toLowerCase()]}
+						label={btn.label}
+						color="var(--block-label-text-color)"
+						on:click={() => onButtonClick(btn["label"])}
+					/>
+				{:else}
+					<button
+						class="text-button"
+						on:click={() => onButtonClick(btn["label"])}
+					>
+						{btn.label}
+					</button>
+				{/if}
+			{/if}
+		{/each}
+	{/if}
+</div>
+
+<style>
+	.custom-buttons-container {
+		display: flex;
+		gap: var(--spacing-sm);
+	}
+
+	.text-button {
+		border: 1px solid var(--border-color-primary);
+		border-radius: var(--radius-sm);
+		color: var(--block-label-text-color);
+		background-color: var(--block-background-fill);
+		font-size: var(--text-xs);
+		padding: var(--spacing-xxs) var(--spacing-sm);
+		cursor: pointer;
+	}
+
+	.text-button:hover {
+		background-color: #9a9a9a;
+		color: white;
+	}
+</style>

--- a/js/chatbot/shared/LikeDislike.svelte
+++ b/js/chatbot/shared/LikeDislike.svelte
@@ -9,7 +9,10 @@
 	import type { I18nFormatter } from "js/core/src/gradio_helper";
 
 	export let i18n: I18nFormatter;
-	export let handle_action: (selected: string | null) => void;
+	export let handle_action: (
+		selected: string | null,
+		selected_label: string | null
+	) => void;
 	export let feedback_options: string[];
 	export let selected: string | null = null;
 	$: extra_feedback = feedback_options.filter(
@@ -18,7 +21,7 @@
 
 	function toggleSelection(newSelection: string): void {
 		selected = selected === newSelection ? null : newSelection;
-		handle_action(selected);
+		handle_action(selected, null);
 	}
 </script>
 
@@ -63,7 +66,7 @@
 					style:font-weight={selected === option ? "bold" : "normal"}
 					on:click={() => {
 						toggleSelection(option);
-						handle_action(selected ? selected : null);
+						handle_action(selected ? selected : null, null);
 					}}>{option}</button
 				>
 			{/each}

--- a/js/chatbot/shared/Message.svelte
+++ b/js/chatbot/shared/Message.svelte
@@ -43,7 +43,10 @@
 	export let show_retry: boolean;
 	export let show_undo: boolean;
 	export let msg_format: "tuples" | "messages";
-	export let handle_action: (selected: string | null) => void;
+	export let handle_action: (
+		selected: string | null,
+		selected_label: string | null
+	) => void;
 	export let scroll: () => void;
 	export let allow_file_downloads: boolean;
 	export let in_edit_mode: boolean;
@@ -52,6 +55,13 @@
 	export let current_feedback: string | null = null;
 	export let allow_tags: string[] | boolean = false;
 	export let watermark: string | null = null;
+	export let custom_buttons:
+		| {
+				label: string;
+				visible: "all" | "user" | "chatbot";
+				icon: string | null;
+		  }[]
+		| null = null;
 	let messageElements: HTMLDivElement[] = [];
 	let previous_edit_mode = false;
 	let message_widths: number[] = Array(messages.length).fill(160);
@@ -93,7 +103,10 @@
 	}
 
 	type ButtonPanelProps = {
-		handle_action: (selected: string | null) => void;
+		handle_action: (
+			selected: string | null,
+			selected_label: string | null
+		) => void;
 		likeable: boolean;
 		feedback_options: string[];
 		show_retry: boolean;
@@ -109,6 +122,13 @@
 		dispatch: any;
 		current_feedback: string | null;
 		watermark: string | null;
+		custom_buttons:
+			| {
+					label: string;
+					visible: "all" | "user" | "chatbot";
+					icon: string | null;
+			  }[]
+			| null;
 	};
 
 	let button_panel_props: ButtonPanelProps;
@@ -128,7 +148,8 @@
 		layout,
 		dispatch,
 		current_feedback,
-		watermark
+		watermark,
+		custom_buttons
 	};
 </script>
 

--- a/js/chatbot/shared/iconMap.ts
+++ b/js/chatbot/shared/iconMap.ts
@@ -1,0 +1,19 @@
+const modules = import.meta.glob("../../icons/src/*.svelte");
+
+type IconMap = Record<string, any>;
+
+const iconMap: IconMap = {};
+
+async function loadIcons(): Promise<IconMap> {
+	for (const path in modules) {
+		const mod = (await modules[path]()) as { default: any };
+		const nameMatch = path.match(/\/([^\/]+)\.svelte$/);
+		if (nameMatch) {
+			const name = nameMatch[1].toLowerCase();
+			iconMap[name] = mod.default;
+		}
+	}
+	return iconMap;
+}
+
+export { iconMap, loadIcons };

--- a/js/chatbot/shared/utils.ts
+++ b/js/chatbot/shared/utils.ts
@@ -108,6 +108,12 @@ export interface EditData {
 	previous_value: string;
 }
 
+export interface CustomButtonsData {
+	index: number | [number, number];
+	label: string | null;
+	values: string[];
+}
+
 const redirect_src_url = (src: string, root: string): string =>
 	src.replace('src="/file', `src="${root}file`);
 

--- a/js/spa/test/chatbot_custom_buttons.spec.ts
+++ b/js/spa/test/chatbot_custom_buttons.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@self/tootils";
+
+test("test custom_buttons of the chatbot", async ({ page }) => {
+	await expect(page.getByLabel("Concatenated Chat")).toHaveValue(
+		"User message 1.|User message 2.|Chatbot message 1."
+	);
+
+	await page.getByRole("button", { name: "Example1" }).click();
+	await expect(page.getByLabel("Concatenated Chat")).toHaveValue(
+		"User message 1.|User message 1.|User message 2.|User message 2.|Chatbot message 1.|Chatbot message 1."
+	);
+
+	await page.getByRole("button", { name: "Example2" }).click();
+	await expect(page.getByLabel("Concatenated Chat")).toHaveValue(
+		"User message 1.|User message 1.|User message 1.|User message 1.|User message 1.|User message 1."
+	);
+
+	await page.getByRole("button", { name: "Example3" }).nth(1).click();
+	await expect(page.getByLabel("Concatenated Chat")).toHaveValue(
+		"User message 1.|User message 1.|User message 1.|User message 1.|User message 1.|User message 1."
+	);
+});

--- a/js/spa/test/chatinterface_custom_buttons.spec.ts
+++ b/js/spa/test/chatinterface_custom_buttons.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "@self/tootils";
+
+test("test custom_buttons of the chatinterface", async ({ page }) => {
+	await expect(page.getByLabel("Concatenated Chat")).toHaveValue(
+		"User message 1.|User message 2.|Chatbot message 1."
+	);
+
+	await page.getByRole("button", { name: "Example1" }).click();
+	await expect(page.getByLabel("Concatenated Chat")).toHaveValue(
+		"User message 1.|User message 2.|Chatbot message 1."
+	);
+
+	await page.getByRole("button", { name: "Example2" }).nth(1).click();
+	await expect(page.getByLabel("Concatenated Chat")).toHaveValue(
+		"User message 1.|User message 2.|Chatbot message 1."
+	);
+});

--- a/test/components/test_chatbot.py
+++ b/test/components/test_chatbot.py
@@ -73,6 +73,7 @@ class TestChatbot:
             "allow_tags": False,
             "show_copy_all_button": False,
             "examples": None,
+            "custom_buttons": None,
             "watermark": None,
         }
 

--- a/test/test_chat_interface.py
+++ b/test/test_chat_interface.py
@@ -227,6 +227,32 @@ class TestInit:
             None,
         )
 
+    def test_custom_chatobot_with_custom_button_events(self):
+        def fake_handler(history, data):
+            return history
+
+        with gr.Blocks() as demo:
+            chatbot = gr.Chatbot()
+            gr.ChatInterface(
+                fn=lambda x, y: x,
+                chatbot=chatbot,
+                custom_buttons=[
+                    {
+                        "label": "x",
+                        "visible": "all",
+                        "icon": "Check",
+                        "on_click": fake_handler,
+                    }
+                ],
+            )
+
+        dependencies = demo.fns.values()
+
+        assert next(
+            (d for d in dependencies if d.targets == [(chatbot._id, "custom_button")]),
+            None,
+        )
+
     def test_chatbot_type_mismatch(self):
         chatbot = gr.Chatbot()
         chat_interface = gr.ChatInterface(


### PR DESCRIPTION


This pull request implements customizable interactive buttons within chat messages for the Chatbot and ChatInterface components, addressing enhancement request [#10803].

## Description

Developers can now attach ***custom interactive buttons*** to individual chat messages. Buttons support:

- ***Labels*** (text display)

- ***Icons*** (leveraging existing icon sets)

- ***Visibility rules*** (chatbot, user, or all)

-  ***Custom callbacks*** (on_click functions in ChatInterface)

This enhancement significantly boosts the interactivity and flexibility of chat-based interfaces.

## Key Features Implemented

***1. CustomButtonsData***

A structured event data type passed to listener functions when a custom button is clicked:

- ***index***: Index of the first message in the group containing the clicked button.

- ***values***: Content of all messages in the group associated with the button.

- ***label***: Label of the button that was clicked.

***2. Custom Buttons Configuration***

a) In *Chatbot*

- ***label***: Text displayed on the button

- ***icon***: Icon representation

- ***visible***: Visibility criteria (chatbot, user, or all)

b) In *ChatInterface* (extends Chatbot config)

- ***on_click***: A Python callback executed on button click, enabling declarative per-button behavior and centralizing logic in the interface component.

This separation allows *ChatInterface* to manage event logic while delegating rendering and dispatch to *Chatbot*.

## 3. Event Handling

 Integrated a `custom_button` event dispatched on button clicks. On the backend, this event is routed and handled based on the button's label or associated function, depending on the context.


## 4. Frontend Integration

- ***Dynamic rendering*** via `CustomButtons.svelte`.

- ***Icon management*** through an internal `iconMap`.

## 5. Backend Integration

- ***Validation*** of button definitions.

- ***Routing*** from `ChatInterface` to `Chatbot`.

- ***Callback matching*** within `ChatInterface` for `on_click`.

## 6. Comprehensive Testing

-  ***Backend unit tests*** for event routing.

-  ***Frontend rendering tests*** for icons UI correctness.

-  ***E2E tests*** (using dedicated demos) to validate full integration and functionality. 


## Example:
```python
import gradio as gr
import copy

# Callback handler
def handle_custom_button(data: gr.CustomButtonsData, history: list[gr.MessageDict]):
    if data.label == "Example1":
        return duplicate_chat(history)
    elif data.label == "Example2":
        return fill_all_messages(data, history)
    else:
        delete_all_messages(copy.deepcopy(history))
        return history

# Helper functions
def duplicate_chat(history):
    return [msg for msg in history for _ in range(2)]

def fill_all_messages(data, history):
    value = data.values[0]
    for msg in history:
        msg['content'] = value
    return history

def delete_all_messages(history):
    return []

# Example messages
demos = [
    {"role": "user", "content": "User message 1."},
    {"role": "assistant", "content": "Assistant message."},
]

# Gradio app setup
with gr.Blocks() as demo:
    chatbot = gr.Chatbot(
        type="messages",
        custom_buttons=[
            {"label": "Example1", "icon": "ArrowUp", "visible": "chatbot"},
            {"label": "Example2", "icon": "Chat",    "visible": "user"},
            {"label": "Example3", "visible": "all"},
        ],
    )

    chatbot.custom_button(handle_custom_button, chatbot, chatbot)
    demo.load(lambda: demos, None, chatbot)
demo.launch()
```
## Demos
Added interactive demos specifically designed for use in E2E testing, verifying full behavior of button interaction, rendering, and callback execution.


Closes gradio-app#10803