### PR TITLE
Add column-specific filtering to `gr.Dataframe`

### DIFF
--- a/js/core/src/lang/en.json
+++ b/js/core/src/lang/en.json
@@ -89,7 +89,8 @@
 		"sort_ascending": "Sort ascending",
 		"sort_descending": "Sort descending",
 		"drop_to_upload": "Drop CSV or TSV files here to import data into dataframe",
-		"clear_sort": "Clear sort"
+		"clear_sort": "Clear sort",
+		"filter": "Filter"
 	},
 	"dropdown": {
 		"dropdown": "Dropdown"

--- a/js/core/src/lang/en.json
+++ b/js/core/src/lang/en.json
@@ -90,7 +90,8 @@
 		"sort_descending": "Sort descending",
 		"drop_to_upload": "Drop CSV or TSV files here to import data into dataframe",
 		"clear_sort": "Clear sort",
-		"filter": "Filter"
+		"filter": "Filter",
+		"clear_filter": "Clear filters"
 	},
 	"dropdown": {
 		"dropdown": "Dropdown"

--- a/js/core/src/lang/pt-BR.json
+++ b/js/core/src/lang/pt-BR.json
@@ -85,7 +85,8 @@
 		"sort_ascending": "Ordenar em ordem crescente",
 		"sort_descending": "Ordenar em ordem decrescente",
 		"drop_to_upload": "Solte arquivos CSV ou TSV aqui para importar dados para o dataframe",
-		"clear_sort": "Limpar classificação"
+		"clear_sort": "Limpar classificação",
+		"filter": "Filtrar"
 	},
 	"dropdown": {
 		"dropdown": "Menu suspenso"

--- a/js/core/src/lang/pt-BR.json
+++ b/js/core/src/lang/pt-BR.json
@@ -86,7 +86,8 @@
 		"sort_descending": "Ordenar em ordem decrescente",
 		"drop_to_upload": "Solte arquivos CSV ou TSV aqui para importar dados para o dataframe",
 		"clear_sort": "Limpar classificação",
-		"filter": "Filtrar"
+		"filter": "Filtrar",
+		"clear_filter": "Limpar filtros"
 	},
 	"dropdown": {
 		"dropdown": "Menu suspenso"

--- a/js/core/src/lang/pt.json
+++ b/js/core/src/lang/pt.json
@@ -74,7 +74,8 @@
 		"sort_ascending": "Ordenar por ordem crescente",
 		"sort_descending": "Ordenar por ordem decrescente",
 		"drop_to_upload": "Solte ficheiros CSV ou TSV aqui para importar dados para o dataframe",
-		"clear_sort": "Limpar ordenação"
+		"clear_sort": "Limpar ordenação",
+		"filter": "Filtrar"
 	},
 	"dropdown": {
 		"dropdown": "Lista suspensa"

--- a/js/core/src/lang/pt.json
+++ b/js/core/src/lang/pt.json
@@ -75,7 +75,8 @@
 		"sort_descending": "Ordenar por ordem decrescente",
 		"drop_to_upload": "Solte ficheiros CSV ou TSV aqui para importar dados para o dataframe",
 		"clear_sort": "Limpar ordenação",
-		"filter": "Filtrar"
+		"filter": "Filtrar",
+		"clear_filter": "Limpar filtros"
 	},
 	"dropdown": {
 		"dropdown": "Lista suspensa"

--- a/js/dataframe/shared/CellMenu.svelte
+++ b/js/dataframe/shared/CellMenu.svelte
@@ -3,7 +3,10 @@
 	import CellMenuIcons from "./CellMenuIcons.svelte";
 	import FilterMenu from "./FilterMenu.svelte";
 	import type { I18nFormatter } from "js/utils/src";
-	import type { SortDirection } from "./context/dataframe_context";
+	import type {
+		SortDirection,
+		FilterDatatype
+	} from "./context/dataframe_context";
 
 	export let x: number;
 	export let y: number;
@@ -22,13 +25,18 @@
 	export let on_clear_sort: () => void = () => {};
 	export let sort_direction: SortDirection | null = null;
 	export let sort_priority: number | null = null;
-	/*export let on_filter: () => void = () => {};*/
+	export let on_filter: (
+		datatype: FilterDatatype,
+		selected_filter: string,
+		value: string
+	) => void = () => {};
+	export let on_clear_filter: () => void = () => {};
 	export let filter_active: boolean | null = null;
 	export let editable = true;
 
 	export let i18n: I18nFormatter;
 	let menu_element: HTMLDivElement;
-	let active_filter_menu: { x: number, y: number } | null = null;
+	let active_filter_menu: { x: number; y: number } | null = null;
 
 	$: is_header = row === -1;
 	$: can_add_rows = editable && row_count[1] === "dynamic";
@@ -61,10 +69,15 @@
 	}
 
 	function toggle_filter_menu(): void {
+		if (filter_active) {
+			on_filter("string", "", "");
+			return;
+		}
+
 		const menu_rect = menu_element.getBoundingClientRect();
 		active_filter_menu = {
 			x: menu_rect.right,
-			y: menu_rect.top + menu_rect.height/2
+			y: menu_rect.top + menu_rect.height / 2
 		};
 	}
 </script>
@@ -100,10 +113,17 @@
 		<button
 			role="menuitem"
 			on:click|stopPropagation={toggle_filter_menu}
-			class:active={filter_active}
+			class:active={filter_active || active_filter_menu}
 		>
 			<CellMenuIcons icon="filter" />
 			{i18n("dataframe.filter")}
+			{#if filter_active}
+				<span class="priority">1</span>
+			{/if}
+		</button>
+		<button role="menuitem" on:click={on_clear_filter}>
+			<CellMenuIcons icon="clear-filter" />
+			{i18n("dataframe.clear_filter")}
 		</button>
 	{/if}
 
@@ -171,6 +191,7 @@
 	<FilterMenu
 		x={active_filter_menu?.x ?? 0}
 		y={active_filter_menu?.y ?? 0}
+		{on_filter}
 	/>
 {/if}
 

--- a/js/dataframe/shared/CellMenu.svelte
+++ b/js/dataframe/shared/CellMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from "svelte";
 	import CellMenuIcons from "./CellMenuIcons.svelte";
+	import FilterMenu from "./FilterMenu.svelte";
 	import type { I18nFormatter } from "js/utils/src";
 	import type { SortDirection } from "./context/dataframe_context";
 
@@ -21,12 +22,13 @@
 	export let on_clear_sort: () => void = () => {};
 	export let sort_direction: SortDirection | null = null;
 	export let sort_priority: number | null = null;
-	export let on_filter: () => void = () => {};
+	/*export let on_filter: () => void = () => {};*/
 	export let filter_active: boolean | null = null;
 	export let editable = true;
 
 	export let i18n: I18nFormatter;
 	let menu_element: HTMLDivElement;
+	let active_filter_menu: { x: number, y: number } | null = null;
 
 	$: is_header = row === -1;
 	$: can_add_rows = editable && row_count[1] === "dynamic";
@@ -56,6 +58,14 @@
 
 		menu_element.style.left = `${new_x}px`;
 		menu_element.style.top = `${new_y}px`;
+	}
+
+	function toggle_filter_menu(): void {
+		const menu_rect = menu_element.getBoundingClientRect();
+		active_filter_menu = {
+			x: menu_rect.right,
+			y: menu_rect.top + menu_rect.height/2
+		};
 	}
 </script>
 
@@ -89,7 +99,7 @@
 		</button>
 		<button
 			role="menuitem"
-			on:click={() => on_filter()}
+			on:click|stopPropagation={toggle_filter_menu}
 			class:active={filter_active}
 		>
 			<CellMenuIcons icon="filter" />
@@ -156,6 +166,13 @@
 		{/if}
 	{/if}
 </div>
+
+{#if active_filter_menu}
+	<FilterMenu
+		x={active_filter_menu?.x ?? 0}
+		y={active_filter_menu?.y ?? 0}
+	/>
+{/if}
 
 <style>
 	.cell-menu {

--- a/js/dataframe/shared/CellMenu.svelte
+++ b/js/dataframe/shared/CellMenu.svelte
@@ -21,6 +21,8 @@
 	export let on_clear_sort: () => void = () => {};
 	export let sort_direction: SortDirection | null = null;
 	export let sort_priority: number | null = null;
+	export let on_filter: () => void = () => {};
+	export let filter_active: boolean | null = null;
 	export let editable = true;
 
 	export let i18n: I18nFormatter;
@@ -84,6 +86,14 @@
 		<button role="menuitem" on:click={on_clear_sort}>
 			<CellMenuIcons icon="clear-sort" />
 			{i18n("dataframe.clear_sort")}
+		</button>
+		<button
+			role="menuitem"
+			on:click={() => on_filter()}
+			class:active={filter_active}
+		>
+			<CellMenuIcons icon="filter" />
+			{i18n("dataframe.filter")}
 		</button>
 	{/if}
 

--- a/js/dataframe/shared/CellMenuIcons.svelte
+++ b/js/dataframe/shared/CellMenuIcons.svelte
@@ -210,4 +210,31 @@
 			stroke-linecap="round"
 		/>
 	</svg>
+{:else if icon == "clear-filter"}
+	<svg viewBox="0 0 24 24" width="16" height="16">
+		<path
+			d="M5 5H19"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+		/>
+		<path
+			d="M8 9H16"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+		/>
+		<path
+			d="M11 13H13"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+		/>
+		<path
+			d="M17 17L21 21M21 17L17 21"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+		/>
+	</svg>
 {/if}

--- a/js/dataframe/shared/CellMenuIcons.svelte
+++ b/js/dataframe/shared/CellMenuIcons.svelte
@@ -189,4 +189,25 @@
 			stroke-linecap="round"
 		/>
 	</svg>
+{:else if icon == "filter"}
+	<svg viewBox="0 0 24 24" width="16" height="16">
+		<path
+			d="M5 5H19"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+		/>
+		<path
+			d="M8 9H16"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+		/>
+		<path
+			d="M11 13H13"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+		/>
+	</svg>
 {/if}

--- a/js/dataframe/shared/FilterMenu.svelte
+++ b/js/dataframe/shared/FilterMenu.svelte
@@ -1,45 +1,42 @@
 <script lang="ts">
-    import { onMount } from "svelte";
+	import { onMount } from "svelte";
 	import { Check } from "@gradio/icons";
 	import DropdownArrow from "../../icons/src/DropdownArrow.svelte";
+	import type { FilterDatatype } from "./context/dataframe_context";
 
-    export let x: number;
+	export let x: number;
 	export let y: number;
+	export let on_filter: (
+		datatype: FilterDatatype,
+		selected_filter: string,
+		value: string
+	) => void = () => {};
 
-    let menu_element: HTMLDivElement;
-    let datatype: "string" | "number" = "string";
-    let current_filter: string = "Contains";
-    let filter_dropdown_open: boolean = false;
+	let menu_element: HTMLDivElement;
+	let datatype: "string" | "number" = "string";
+	let current_filter: string = "Contains";
+	let filter_dropdown_open: boolean = false;
 	let filter_input_value: string = "";
 
 	const filter_options = {
-        string: [
-            "Contains",
-            "Does not contain",
-            "Starts with",
-            "Ends with",
-            "Is",
-            "Is not",
-            "Is empty",
-            "Is not empty"
-        ],
-        number: [
-            "=",
-            "≠",
-            ">",
-            "<",
-            "≥",
-            "≤",
-            "Is empty",
-            "Is not empty"
-        ]
-    };
+		string: [
+			"Contains",
+			"Does not contain",
+			"Starts with",
+			"Ends with",
+			"Is",
+			"Is not",
+			"Is empty",
+			"Is not empty"
+		],
+		number: ["=", "≠", ">", "<", "≥", "≤", "Is empty", "Is not empty"]
+	};
 
-    onMount(() => {
+	onMount(() => {
 		position_menu();
 	});
 
-    function position_menu(): void {
+	function position_menu(): void {
 		if (!menu_element) return;
 
 		const viewport_width = window.innerWidth;
@@ -61,112 +58,116 @@
 		menu_element.style.top = `${new_y}px`;
 	}
 
-    function handle_filter_input(e: Event): void {
+	function handle_filter_input(e: Event): void {
 		const target = e.target as HTMLInputElement;
 		filter_input_value = target.value;
-    }
+	}
 </script>
 
 <div bind:this={menu_element} class="filter-menu">
-    <div class="filter-datatype-container">
-        <span>Filter as</span>
-        <button
-            on:click|stopPropagation={() => {
-                datatype = (datatype === "string" ? "number" : "string");
-                current_filter = filter_options[datatype][0];
-            }}
-        >
-            {datatype}
-        </button>
-    </div>
+	<div class="filter-datatype-container">
+		<span>Filter as</span>
+		<button
+			on:click|stopPropagation={() => {
+				datatype = datatype === "string" ? "number" : "string";
+				current_filter = filter_options[datatype][0];
+			}}
+		>
+			{datatype}
+		</button>
+	</div>
 
-    <div class="input-container">
-        <div class="filter-dropdown">
-            <button on:click|stopPropagation={() => (filter_dropdown_open = !filter_dropdown_open)}>
-                {current_filter}
-                <DropdownArrow />
-            </button>
+	<div class="input-container">
+		<div class="filter-dropdown">
+			<button
+				on:click|stopPropagation={() =>
+					(filter_dropdown_open = !filter_dropdown_open)}
+			>
+				{current_filter}
+				<DropdownArrow />
+			</button>
 
-            {#if filter_dropdown_open}
-                <div class="dropdown-filter-options">
-                    {#each filter_options[datatype] as opt}
-                        <button
-                            on:click|stopPropagation={() => {
-                                current_filter = opt;
-                                filter_dropdown_open = !filter_dropdown_open;
-                            }}
-                            class="filter-option"
-                        >
-                            {opt}
-                        </button>
-                    {/each}
-                </div>
-            {/if}
-        </div>
+			{#if filter_dropdown_open}
+				<div class="dropdown-filter-options">
+					{#each filter_options[datatype] as opt}
+						<button
+							on:click|stopPropagation={() => {
+								current_filter = opt;
+								filter_dropdown_open = !filter_dropdown_open;
+							}}
+							class="filter-option"
+						>
+							{opt}
+						</button>
+					{/each}
+				</div>
+			{/if}
+		</div>
 
-        <input
-            type="text"
-            value={filter_input_value}
-            on:click|stopPropagation
-            on:input={handle_filter_input}
-            placeholder="Type a value"
-            class="filter-input"
-        />
-    </div>
+		<input
+			type="text"
+			value={filter_input_value}
+			on:click|stopPropagation
+			on:input={handle_filter_input}
+			placeholder="Type a value"
+			class="filter-input"
+		/>
+	</div>
 
-    <button
-        class="check-button"
-    >
-        <Check />
-    </button>
+	<button
+		class="check-button"
+		on:click={() => on_filter(datatype, current_filter, filter_input_value)}
+	>
+		<Check />
+	</button>
 </div>
 
 <style>
 	.filter-menu {
-        position: fixed;
+		position: fixed;
 		background: var(--background-fill-primary);
 		border: 1px solid var(--border-color-primary);
 		border-radius: var(--radius-sm);
-		padding: var(--size-1);
+		padding: var(--size-2);
 		display: flex;
 		flex-direction: column;
-		gap: var(--size-1);
+		gap: var(--size-2);
 		box-shadow: var(--shadow-drop-lg);
 		width: 300px;
 		z-index: var(--layer-1);
 	}
 
-    .filter-datatype-container {
-        display: flex;
-        gap: var(--size-1);
-        align-items: center;
-    }
+	.filter-datatype-container {
+		display: flex;
+		gap: var(--size-2);
+		align-items: center;
+	}
 
-    .filter-menu span {
-        font-size: var(--text-sm);
-        color: var(--body-text-color);
-    }
+	.filter-menu span {
+		font-size: var(--text-sm);
+		color: var(--body-text-color);
+	}
 
 	.filter-menu button {
-        background: none;
-        border: 1px solid var(--border-color-primary);
-        border-radius: var(--radius-sm);
-        padding: var(--size-1) var(--size-2);
-        color: var(--body-text-color);
-        font-size: var(--text-sm);
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: var(--size-2);
-    }
+		background: none;
+		border: 1px solid var(--border-color-primary);
+		border-radius: var(--radius-sm);
+		padding: var(--size-1) var(--size-2);
+		color: var(--body-text-color);
+		font-size: var(--text-sm);
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--size-2);
+	}
 
-    .filter-menu button:hover {
-        background-color: var(--background-fill-secondary);
-    }
+	.filter-menu button:hover {
+		background-color: var(--background-fill-secondary);
+	}
 
 	.filter-input {
-        width: var(--size-full);
+		width: var(--size-full);
 		height: var(--size-6);
 		padding: var(--size-2);
 		padding-right: var(--size-8);
@@ -179,51 +180,51 @@
 	}
 
 	.filter-input:hover {
-        border-color: var(--border-color-secondary);
+		border-color: var(--border-color-secondary);
 		background: var(--background-fill-primary);
 	}
 
 	.filter-input:focus {
-        outline: none;
+		outline: none;
 		border-color: var(--color-accent);
 		background: var(--background-fill-primary);
 		box-shadow: 0 0 0 1px var(--color-accent);
 	}
 
-    .dropdown-filter-options {
-        display: flex;
-        flex-direction: column;
-        background: var(--background-fill-primary);
-        border: 1px solid var(--border-color-primary);
-        border-radius: var(--radius-sm);
-        box-shadow: var(--shadow-drop-md);
-        position: absolute;
-        z-index: var(--layer-1);
-    }
+	.dropdown-filter-options {
+		display: flex;
+		flex-direction: column;
+		background: var(--background-fill-primary);
+		border: 1px solid var(--border-color-primary);
+		border-radius: var(--radius-sm);
+		box-shadow: var(--shadow-drop-md);
+		position: absolute;
+		z-index: var(--layer-1);
+	}
 
-    .dropdown-filter-options .filter-option {
-        border: none;
-	    justify-content: flex-start;
-    }
+	.dropdown-filter-options .filter-option {
+		border: none;
+		justify-content: flex-start;
+	}
 
-    .input-container {
-        display: flex;
-        gap: var(--size-1);
-        align-items: center;
-    }
+	.input-container {
+		display: flex;
+		gap: var(--size-2);
+		align-items: center;
+	}
 
-    .input-container button {
-        width: 130px;
-    }
+	.input-container button {
+		width: 130px;
+	}
 
-    :global(svg.dropdown-arrow) {
-        width: var(--size-3);
-        height: var(--size-3);
-        margin-left: auto;
-    }
+	:global(svg.dropdown-arrow) {
+		width: var(--size-4);
+		height: var(--size-4);
+		margin-left: auto;
+	}
 
 	.filter-menu .check-button {
-        background: var(--color-accent);
+		background: var(--color-accent);
 		color: white;
 		border: none;
 		width: var(--size-full);

--- a/js/dataframe/shared/FilterMenu.svelte
+++ b/js/dataframe/shared/FilterMenu.svelte
@@ -1,0 +1,241 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+	import { Check } from "@gradio/icons";
+	import DropdownArrow from "../../icons/src/DropdownArrow.svelte";
+
+    export let x: number;
+	export let y: number;
+
+    let menu_element: HTMLDivElement;
+    let datatype: "string" | "number" = "string";
+    let current_filter: string = "Contains";
+    let filter_dropdown_open: boolean = false;
+	let filter_input_value: string = "";
+
+	const filter_options = {
+        string: [
+            "Contains",
+            "Does not contain",
+            "Starts with",
+            "Ends with",
+            "Is",
+            "Is not",
+            "Is empty",
+            "Is not empty"
+        ],
+        number: [
+            "=",
+            "≠",
+            ">",
+            "<",
+            "≥",
+            "≤",
+            "Is empty",
+            "Is not empty"
+        ]
+    };
+
+    onMount(() => {
+		position_menu();
+	});
+
+    function position_menu(): void {
+		if (!menu_element) return;
+
+		const viewport_width = window.innerWidth;
+		const viewport_height = window.innerHeight;
+		const menu_rect = menu_element.getBoundingClientRect();
+
+		let new_x = x;
+		let new_y = y;
+
+		if (new_x + menu_rect.width > viewport_width) {
+			new_x = x - menu_rect.width - 10;
+		}
+
+		if (new_y + menu_rect.height > viewport_height) {
+			new_y = y - menu_rect.height;
+		}
+
+		menu_element.style.left = `${new_x}px`;
+		menu_element.style.top = `${new_y}px`;
+	}
+
+    function handle_filter_input(e: Event): void {
+		const target = e.target as HTMLInputElement;
+		filter_input_value = target.value;
+    }
+</script>
+
+<div bind:this={menu_element} class="filter-menu">
+    <div class="filter-datatype-container">
+        <span>Filter as</span>
+        <button
+            on:click|stopPropagation={() => {
+                datatype = (datatype === "string" ? "number" : "string");
+                current_filter = filter_options[datatype][0];
+            }}
+        >
+            {datatype}
+        </button>
+    </div>
+
+    <div class="input-container">
+        <div class="filter-dropdown">
+            <button on:click|stopPropagation={() => (filter_dropdown_open = !filter_dropdown_open)}>
+                {current_filter}
+                <DropdownArrow />
+            </button>
+
+            {#if filter_dropdown_open}
+                <div class="dropdown-filter-options">
+                    {#each filter_options[datatype] as opt}
+                        <button
+                            on:click|stopPropagation={() => {
+                                current_filter = opt;
+                                filter_dropdown_open = !filter_dropdown_open;
+                            }}
+                            class="filter-option"
+                        >
+                            {opt}
+                        </button>
+                    {/each}
+                </div>
+            {/if}
+        </div>
+
+        <input
+            type="text"
+            value={filter_input_value}
+            on:click|stopPropagation
+            on:input={handle_filter_input}
+            placeholder="Type a value"
+            class="filter-input"
+        />
+    </div>
+
+    <button
+        class="check-button"
+    >
+        <Check />
+    </button>
+</div>
+
+<style>
+	.filter-menu {
+        position: fixed;
+		background: var(--background-fill-primary);
+		border: 1px solid var(--border-color-primary);
+		border-radius: var(--radius-sm);
+		padding: var(--size-1);
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-1);
+		box-shadow: var(--shadow-drop-lg);
+		width: 300px;
+		z-index: var(--layer-1);
+	}
+
+    .filter-datatype-container {
+        display: flex;
+        gap: var(--size-1);
+        align-items: center;
+    }
+
+    .filter-menu span {
+        font-size: var(--text-sm);
+        color: var(--body-text-color);
+    }
+
+	.filter-menu button {
+        background: none;
+        border: 1px solid var(--border-color-primary);
+        border-radius: var(--radius-sm);
+        padding: var(--size-1) var(--size-2);
+        color: var(--body-text-color);
+        font-size: var(--text-sm);
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--size-2);
+    }
+
+    .filter-menu button:hover {
+        background-color: var(--background-fill-secondary);
+    }
+
+	.filter-input {
+        width: var(--size-full);
+		height: var(--size-6);
+		padding: var(--size-2);
+		padding-right: var(--size-8);
+		border: 1px solid var(--border-color-primary);
+		border-radius: var(--table-radius);
+		font-size: var(--text-sm);
+		color: var(--body-text-color);
+		background: var(--background-fill-secondary);
+		transition: all 0.2s ease;
+	}
+
+	.filter-input:hover {
+        border-color: var(--border-color-secondary);
+		background: var(--background-fill-primary);
+	}
+
+	.filter-input:focus {
+        outline: none;
+		border-color: var(--color-accent);
+		background: var(--background-fill-primary);
+		box-shadow: 0 0 0 1px var(--color-accent);
+	}
+
+    .dropdown-filter-options {
+        display: flex;
+        flex-direction: column;
+        background: var(--background-fill-primary);
+        border: 1px solid var(--border-color-primary);
+        border-radius: var(--radius-sm);
+        box-shadow: var(--shadow-drop-md);
+        position: absolute;
+        z-index: var(--layer-1);
+    }
+
+    .dropdown-filter-options .filter-option {
+        border: none;
+	    justify-content: flex-start;
+    }
+
+    .input-container {
+        display: flex;
+        gap: var(--size-1);
+        align-items: center;
+    }
+
+    .input-container button {
+        width: 130px;
+    }
+
+    :global(svg.dropdown-arrow) {
+        width: var(--size-3);
+        height: var(--size-3);
+        margin-left: auto;
+    }
+
+	.filter-menu .check-button {
+        background: var(--color-accent);
+		color: white;
+		border: none;
+		width: var(--size-full);
+		height: var(--size-6);
+		border-radius: var(--radius-sm);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: var(--size-1);
+	}
+
+	.check-button:hover {
+		background: var(--color-accent-soft);
+	}
+</style>

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -259,6 +259,7 @@
 		} else {
 			df_actions.handle_sort(-1, "asc");
 			df_actions.reset_sort_state();
+			df_actions.reset_filter_state();
 		}
 
 		if ($df_state.current_search_query) {
@@ -345,6 +346,10 @@
 	$: if ($df_state.sort_state.sort_columns.length > 0) {
 		sort_data(data, display_value, styling);
 		df_actions.update_row_order(data);
+	}
+
+	function handle_filter(col: number): void {
+		df_actions.handle_filter(col);
 	}
 
 	async function edit_header(i: number, _select = false): Promise<void> {
@@ -1025,6 +1030,17 @@
 			? $df_state.sort_state.sort_columns.findIndex(
 					(item) => item.col === (active_header_menu?.col ?? -1)
 				) + 1 || null
+			: null}
+		on_filter={active_header_menu
+			? () => {
+					if (active_header_menu) {
+						handle_filter(active_header_menu.col);
+						df_actions.set_active_header_menu(null);
+					}
+				}
+			: undefined}
+		filter_active={active_header_menu
+			? $df_state.filter_state.filter_columns.includes(active_header_menu?.col ?? -1)
 			: null}
 	/>
 {/if}

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -477,6 +477,9 @@
 
 	function set_cell_widths(): void {
 		const column_count = data[0]?.length || 0;
+		if ($df_state.filter_state.filter_columns.length > 0) {
+			return;
+		}
 		if (
 			last_width_data_length === data.length &&
 			last_width_column_count === column_count &&

--- a/js/dataframe/shared/context/dataframe_context.ts
+++ b/js/dataframe/shared/context/dataframe_context.ts
@@ -13,6 +13,7 @@ import {
 export const DATAFRAME_KEY = Symbol("dataframe");
 
 export type SortDirection = "asc" | "desc";
+export type FilterDatatype = "string" | "number";
 export type CellCoordinate = [number, number];
 
 interface DataFrameState {
@@ -41,7 +42,17 @@ interface DataFrameState {
 		} | null;
 	};
 	filter_state: {
-		filter_columns: number[];
+		filter_columns: {
+			col: number;
+			datatype: FilterDatatype;
+			filter: string;
+			value: string;
+		}[];
+		initial_data: {
+			data: { id: string; value: string | number }[][];
+			display_value: string[][] | null;
+			styling: string[][] | null;
+		} | null;
 	};
 	ui_state: {
 		active_cell_menu: { row: number; col: number; x: number; y: number } | null;
@@ -63,7 +74,12 @@ interface DataFrameState {
 interface DataFrameActions {
 	handle_search: (query: string | null) => void;
 	handle_sort: (col: number, direction: SortDirection) => void;
-	handle_filter: (col: number) => void;
+	handle_filter: (
+		col: number,
+		datatype: FilterDatatype,
+		filter: string,
+		value: string
+	) => void;
 	get_sort_status: (name: string, headers: string[]) => "none" | "asc" | "desc";
 	sort_data: (
 		data: any[][],
@@ -214,6 +230,15 @@ function create_actions(
 		return { data: new_data, headers: new_headers };
 	};
 
+	const update_array = (
+		source: { id: string; value: string | number }[][] | string[][] | null,
+		target: any[] | null | undefined
+	): void => {
+		if (source && target) {
+			target.splice(0, target.length, ...JSON.parse(JSON.stringify(source)));
+		}
+	};
+
 	return {
 		handle_search: (query) =>
 			update_state((s) => ({ current_search_query: query })),
@@ -252,18 +277,36 @@ function create_actions(
 					}
 				};
 			}),
-		handle_filter: (col) =>
+		handle_filter: (col, datatype, filter, value) =>
 			update_state((s) => {
-				const filter_cols = s.filter_state.filter_columns.includes(col)
-					? s.filter_state.filter_columns.filter(
-						(c) => c !== col
-					)
-					: [...s.filter_state.filter_columns, col];
+				const filter_cols = s.filter_state.filter_columns.some(
+					(c) => c.col === col
+				)
+					? s.filter_state.filter_columns.filter((c) => c.col !== col)
+					: [
+							...s.filter_state.filter_columns,
+							{ col, datatype, filter, value }
+						];
+
+				const initial_data =
+					s.filter_state.initial_data ||
+					(context.data && filter_cols.length > 0
+						? {
+								data: JSON.parse(JSON.stringify(context.data)),
+								display_value: context.display_value
+									? JSON.parse(JSON.stringify(context.display_value))
+									: null,
+								styling: context.styling
+									? JSON.parse(JSON.stringify(context.styling))
+									: null
+							}
+						: null);
 
 				return {
 					filter_state: {
 						...s.filter_state,
-						filter_columns: filter_cols
+						filter_columns: filter_cols,
+						initial_data: initial_data
 					}
 				};
 			}),
@@ -365,7 +408,8 @@ function create_actions(
 			) {
 				if (!dequal(current_headers, previous_headers)) {
 					update_state((s) => ({
-						sort_state: { sort_columns: [], row_order: [], initial_data: null }
+						sort_state: { sort_columns: [], row_order: [], initial_data: null },
+						filter_state: { filter_columns: [], initial_data: null }
 					}));
 				}
 				dispatch("change", {
@@ -381,22 +425,6 @@ function create_actions(
 				if (s.sort_state.initial_data && context.data) {
 					const original = s.sort_state.initial_data;
 
-					const update_array = (
-						source:
-							| { id: string; value: string | number }[][]
-							| string[][]
-							| null,
-						target: any[] | null | undefined
-					): void => {
-						if (source && target) {
-							target.splice(
-								0,
-								target.length,
-								...JSON.parse(JSON.stringify(source))
-							);
-						}
-					};
-
 					update_array(original.data, context.data);
 					update_array(original.display_value, context.display_value);
 					update_array(original.styling, context.styling);
@@ -408,8 +436,16 @@ function create_actions(
 			}),
 		reset_filter_state: () =>
 			update_state((s) => {
+				if (s.filter_state.initial_data && context.data) {
+					const original = s.filter_state.initial_data;
+
+					update_array(original.data, context.data);
+					update_array(original.display_value, context.display_value);
+					update_array(original.styling, context.styling);
+				}
+
 				return {
-					filter_state: { filter_columns: [] }
+					filter_state: { filter_columns: [], initial_data: null }
 				};
 			}),
 		set_active_cell_menu: (menu) =>
@@ -625,6 +661,7 @@ export function create_dataframe_context(
 		config,
 		current_search_query: null,
 		sort_state: { sort_columns: [], row_order: [], initial_data: null },
+		filter_state: { filter_columns: [], initial_data: null },
 		ui_state: {
 			active_cell_menu: null,
 			active_header_menu: null,

--- a/js/dataframe/shared/context/dataframe_context.ts
+++ b/js/dataframe/shared/context/dataframe_context.ts
@@ -40,6 +40,9 @@ interface DataFrameState {
 			styling: string[][] | null;
 		} | null;
 	};
+	filter_state: {
+		filter_columns: number[];
+	};
 	ui_state: {
 		active_cell_menu: { row: number; col: number; x: number; y: number } | null;
 		active_header_menu: { col: number; x: number; y: number } | null;
@@ -60,6 +63,7 @@ interface DataFrameState {
 interface DataFrameActions {
 	handle_search: (query: string | null) => void;
 	handle_sort: (col: number, direction: SortDirection) => void;
+	handle_filter: (col: number) => void;
 	get_sort_status: (name: string, headers: string[]) => "none" | "asc" | "desc";
 	sort_data: (
 		data: any[][],
@@ -109,6 +113,7 @@ interface DataFrameActions {
 		dispatch: (e: "change" | "input", detail?: any) => void
 	) => Promise<void>;
 	reset_sort_state: () => void;
+	reset_filter_state: () => void;
 	set_active_cell_menu: (
 		menu: { row: number; col: number; x: number; y: number } | null
 	) => void;
@@ -244,6 +249,21 @@ function create_actions(
 						...s.sort_state,
 						sort_columns: sort_cols.slice(-3),
 						initial_data: initial_data
+					}
+				};
+			}),
+		handle_filter: (col) =>
+			update_state((s) => {
+				const filter_cols = s.filter_state.filter_columns.includes(col)
+					? s.filter_state.filter_columns.filter(
+						(c) => c !== col
+					)
+					: [...s.filter_state.filter_columns, col];
+
+				return {
+					filter_state: {
+						...s.filter_state,
+						filter_columns: filter_cols
 					}
 				};
 			}),
@@ -384,6 +404,12 @@ function create_actions(
 
 				return {
 					sort_state: { sort_columns: [], row_order: [], initial_data: null }
+				};
+			}),
+		reset_filter_state: () =>
+			update_state((s) => {
+				return {
+					filter_state: { filter_columns: [] }
 				};
 			}),
 		set_active_cell_menu: (menu) =>

--- a/js/dataframe/shared/utils/filter_utils.ts
+++ b/js/dataframe/shared/utils/filter_utils.ts
@@ -1,0 +1,207 @@
+import { filter_table_data } from "./table_utils";
+
+export type FilterDatatype = "string" | "number";
+
+export function filter_data(
+	data: { id: string; value: string | number }[][],
+	filter_columns: {
+		col: number;
+		datatype: FilterDatatype;
+		filter: string;
+		value: string;
+	}[]
+): number[] {
+	if (!data || !data.length || !data[0]) {
+		return [];
+	}
+	let row_indices = [...Array(data.length)].map((_, i) => i);
+
+	if (filter_columns.length > 0) {
+		filter_columns.forEach((column) => {
+			if (column.datatype === "string") {
+				switch (column.filter) {
+					case "Contains":
+						row_indices = row_indices.filter((i) =>
+							data[i][column.col]?.value.toString().includes(column.value)
+						);
+						break;
+					case "Does not contain":
+						row_indices = row_indices.filter(
+							(i) =>
+								!data[i][column.col]?.value.toString().includes(column.value)
+						);
+						break;
+					case "Starts with":
+						row_indices = row_indices.filter((i) =>
+							data[i][column.col]?.value.toString().startsWith(column.value)
+						);
+						break;
+					case "Ends with":
+						row_indices = row_indices.filter((i) =>
+							data[i][column.col]?.value.toString().endsWith(column.value)
+						);
+						break;
+					case "Is":
+						row_indices = row_indices.filter(
+							(i) => data[i][column.col]?.value.toString() === column.value
+						);
+						break;
+					case "Is not":
+						row_indices = row_indices.filter(
+							(i) => !(data[i][column.col]?.value.toString() === column.value)
+						);
+						break;
+					case "Is empty":
+						row_indices = row_indices.filter(
+							(i) => data[i][column.col]?.value.toString() === ""
+						);
+						break;
+					case "Is not empty":
+						row_indices = row_indices.filter(
+							(i) => !(data[i][column.col]?.value.toString() === "")
+						);
+						break;
+				}
+			} else if (column.datatype === "number") {
+				switch (column.filter) {
+					case "=":
+						row_indices = row_indices.filter((i) => {
+							if (
+								!isNaN(Number(data[i][column.col]?.value)) &&
+								!isNaN(Number(column.value))
+							) {
+								return (
+									Number(data[i][column.col]?.value) === Number(column.value)
+								);
+							}
+							return false;
+						});
+						break;
+					case "≠":
+						row_indices = row_indices.filter((i) => {
+							if (
+								!isNaN(Number(data[i][column.col]?.value)) &&
+								!isNaN(Number(column.value))
+							) {
+								return !(
+									Number(data[i][column.col]?.value) === Number(column.value)
+								);
+							}
+							return false;
+						});
+						break;
+					case ">":
+						row_indices = row_indices.filter((i) => {
+							if (
+								!isNaN(Number(data[i][column.col]?.value)) &&
+								!isNaN(Number(column.value))
+							) {
+								return (
+									Number(data[i][column.col]?.value) > Number(column.value)
+								);
+							}
+							return false;
+						});
+						break;
+					case "<":
+						row_indices = row_indices.filter((i) => {
+							if (
+								!isNaN(Number(data[i][column.col]?.value)) &&
+								!isNaN(Number(column.value))
+							) {
+								return (
+									Number(data[i][column.col]?.value) < Number(column.value)
+								);
+							}
+							return false;
+						});
+						break;
+					case "≥":
+						row_indices = row_indices.filter((i) => {
+							if (
+								!isNaN(Number(data[i][column.col]?.value)) &&
+								!isNaN(Number(column.value))
+							) {
+								return (
+									Number(data[i][column.col]?.value) >= Number(column.value)
+								);
+							}
+							return false;
+						});
+						break;
+					case "≤":
+						row_indices = row_indices.filter((i) => {
+							if (
+								!isNaN(Number(data[i][column.col]?.value)) &&
+								!isNaN(Number(column.value))
+							) {
+								return (
+									Number(data[i][column.col]?.value) <= Number(column.value)
+								);
+							}
+							return false;
+						});
+						break;
+					case "Is empty":
+						row_indices = row_indices.filter(
+							(i) => data[i][column.col]?.value.toString() === ""
+						);
+						break;
+					case "Is not empty":
+						row_indices = row_indices.filter((i) => {
+							if (!isNaN(Number(data[i][column.col]?.value))) {
+								return !(data[i][column.col]?.value.toString() === "");
+							}
+							return false;
+						});
+						break;
+				}
+			}
+		});
+		return row_indices;
+	}
+	return [...Array(data.length)].map((_, i) => i);
+}
+
+export function filter_data_and_preserve_selection(
+	data: { id: string; value: string | number }[][],
+	display_value: string[][] | null,
+	styling: string[][] | null,
+	filter_columns: {
+		col: number;
+		datatype: FilterDatatype;
+		filter: string;
+		value: string;
+	}[],
+	selected: [number, number] | false,
+	get_current_indices: (
+		id: string,
+		data: { id: string; value: string | number }[][]
+	) => [number, number],
+	original_data?: { id: string; value: string | number }[][],
+	original_display_value?: string[][] | null,
+	original_styling?: string[][] | null
+): { data: typeof data; selected: [number, number] | false } {
+	let id = null;
+	if (selected && selected[0] in data && selected[1] in data[selected[0]]) {
+		id = data[selected[0]][selected[1]].id;
+	}
+
+	filter_table_data(
+		data,
+		display_value,
+		styling,
+		filter_columns,
+		original_data,
+		original_display_value,
+		original_styling
+	);
+
+	let new_selected = selected;
+	if (id) {
+		const [i, j] = get_current_indices(id, data);
+		new_selected = [i, j];
+	}
+
+	return { data, selected: new_selected };
+}

--- a/js/dataframe/shared/utils/table_utils.ts
+++ b/js/dataframe/shared/utils/table_utils.ts
@@ -1,6 +1,8 @@
 import type { Headers, HeadersWithIDs, TableCell, TableData } from "../types";
 import { sort_data } from "./sort_utils";
+import { filter_data } from "./filter_utils";
 import type { SortDirection } from "./sort_utils";
+import type { FilterDatatype } from "./filter_utils";
 import { dsvFormat } from "d3-dsv";
 
 export function make_cell_id(row: number, col: number): string {
@@ -45,6 +47,56 @@ export function sort_table_data(
 
 	if (styling) {
 		const new_styling = indices.map((i: number) => styling[i]);
+		styling.splice(0, styling.length, ...new_styling);
+	}
+}
+
+export function filter_table_data(
+	data: TableData,
+	display_value: string[][] | null,
+	styling: string[][] | null,
+	filter_columns: {
+		col: number;
+		datatype: FilterDatatype;
+		filter: string;
+		value: string;
+	}[],
+	original_data?: TableData,
+	original_display_value?: string[][] | null,
+	original_styling?: string[][] | null
+): void {
+	const base_data = original_data ?? data;
+	const base_display_value = original_display_value ?? display_value;
+	const base_styling = original_styling ?? styling;
+
+	if (!filter_columns.length) {
+		data.splice(0, data.length, ...base_data.map((row) => [...row]));
+		if (display_value && base_display_value) {
+			display_value.splice(
+				0,
+				display_value.length,
+				...base_display_value.map((row) => [...row])
+			);
+		}
+		if (styling && base_styling) {
+			styling.splice(0, styling.length, ...base_styling.map((row) => [...row]));
+		}
+		return;
+	}
+	if (!data || !data.length) return;
+
+	const indices = filter_data(base_data, filter_columns);
+
+	const new_data = indices.map((i: number) => base_data[i]);
+	data.splice(0, data.length, ...new_data);
+
+	if (display_value && base_display_value) {
+		const new_display = indices.map((i: number) => base_display_value[i]);
+		display_value.splice(0, display_value.length, ...new_display);
+	}
+
+	if (styling && base_styling) {
+		const new_styling = indices.map((i: number) => base_styling[i]);
 		styling.splice(0, styling.length, ...new_styling);
 	}
 }


### PR DESCRIPTION
This pull request implements column-specific filtering capabilities for the `gr.Dataframe` component, addressing enhancement request [#10885].

## Description

Users can now apply filters to individual columns in `gr.Dataframe`, following a workflow similar to the existing column-sorting feature. This feature introduces filtering options for both text and numerical data types, inspired by the familiar interface used in Notion.

#### Filter options for string columns:
- Contains  
- Does not contain  
- Starts with  
- Ends with  
- Is  
- Is not  
- Is empty  
- Is not empty  

#### Filter options for numeric columns:
- = (Equal)  
- ≠ (Not equal)  
- \> (Greater than)  
- < (Less than)  
- ≥ (Greater than or equal to)  
- ≤ (Less than or equal to)  
- Is empty  
- Is not empty  

This enhancement improves the usability of the gr.Dataframe by providing an intuitive filtering interface directly integrated into each column, consistent with the design of the sorting feature.

#### Users can:
- Add filters on multiple columns independently  
- Reset individual filters
- lear all filters at once 

This addition lays the groundwork for more advanced filtering logic like boolean combinations across multiple columns.

## Example:
### Code:
```python
import gradio as gr
import pandas as pd

data = {
    "Grades": [16, 17, 19, 20, 15, 19, 18, 18],
    "UCs": ["AL", "CDI", "FP", "COM", "SD", "RC", "ML", "AI"],
}

df = pd.DataFrame(data)

with gr.Blocks() as demo:
    gr.Dataframe(value=df)

if __name__ == "__main__":
    demo.launch()
```

### Video Demo

https://github.com/user-attachments/assets/db4c74e5-6e5d-4d25-96a0-853a1ad74c96

Co-authored-by: @Rafalex04 

Closes: #10885