### PR TITLE
Ensure Sync generators get closed if they are cancelled

### DIFF
--- a/.changeset/thick-hands-bet.md
+++ b/.changeset/thick-hands-bet.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Ensure Sync generators get closed if they are cancelled

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -34,6 +34,7 @@ from gradio.utils import (
     LRUCache,
     error_payload,
     run_coro_in_background,
+    safe_aclose_iterator,
     safe_get_lock,
     set_task_name,
 )
@@ -809,7 +810,7 @@ class Queue:
             return
         async with app.lock:
             try:
-                app.iterators[event_id].aclose()  # type: ignore
+                await safe_aclose_iterator(app.iterators[event_id])
             except Exception:
                 pass
             del app.iterators[event_id]

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -808,6 +808,10 @@ class Queue:
             # Failure, but don't raise an error
             return
         async with app.lock:
+            try:
+                app.iterators[event_id].aclose()  # type: ignore
+            except Exception:
+                pass
             del app.iterators[event_id]
             app.iterators_to_reset.add(event_id)
         return

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -734,6 +734,9 @@ class SyncToAsyncIterator:
             run_sync_iterator_async, self.iterator, limiter=self.limiter
         )
 
+    def aclose(self):
+        self.iterator.close()
+
 
 async def async_iteration(iterator):
     return await anext(iterator)

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -1771,3 +1771,27 @@ def get_function_description(fn: Callable) -> tuple[str, dict[str, str], list[st
         pass
 
     return description, parameters, returns
+
+
+async def safe_aclose_iterator(iterator, timeout=60.0, retry_interval=0.05):
+    """
+    Safely close generators by calling the aclose method.
+    Sync generators are tricky because if you call `aclose` while the loop is running
+    then you get a ValueError and the generator will not shut down gracefully.
+    So the solution is to retry calling the aclose method until we succeed (with timeout).
+    """
+    start = time.monotonic()
+    if isinstance(iterator, SyncToAsyncIterator):
+        while True:
+            try:
+                iterator.aclose()
+                break
+            except ValueError as e:
+                if "already executing" in str(e):
+                    if time.monotonic() - start > timeout:
+                        raise
+                    await asyncio.sleep(retry_interval)
+                else:
+                    raise
+    else:
+        iterator.aclose()


### PR DESCRIPTION
## Description

Closes: #8503

You can test with this repro. On main, the `finally` block won't be printed until you refresh the page or close the server. In this PR, it will be printed. This means the iterator resources, in this case the directory, are properly deleted.

```python
from tempfile import TemporaryDirectory
import gradio as gr
import time
import asyncio

def create_tmpdir():
    try:
        with TemporaryDirectory() as tmpdir:
            print(tmpdir)
            while True:
                yield
    except Exception as e:
        print(f"Error: {e}")
    finally:
        print("FINALLY")

with gr.Blocks() as demo:
    run_btn = gr.Button()
    stop_btn = gr.Button("Stop")

    event = run_btn.click(create_tmpdir)
    stop_btn.click(None, cancels=event) # tmpdir persists until we exit gradio
    demo.queue().launch()
```



## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
