### PR TITLE
Make the method for getting the `asyncio` event loop more robust

### DIFF
--- a/.changeset/brave-boxes-melt.md
+++ b/.changeset/brave-boxes-melt.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Make the method for getting the `asyncio` event loop more robust

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -109,10 +109,15 @@ def safe_get_lock() -> asyncio.Lock:
 
 def safe_get_stop_event() -> asyncio.Event:
     try:
-        asyncio.get_event_loop()
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
         return asyncio.Event()
     except RuntimeError:
-        return None  # type: ignore
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return asyncio.Event()
 
 
 class BaseReloader(ABC):

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -101,10 +101,15 @@ def safe_get_lock() -> asyncio.Lock:
     the main thread.
     """
     try:
-        asyncio.get_event_loop()
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
         return asyncio.Lock()
     except RuntimeError:
-        return None  # type: ignore
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return asyncio.Lock()
 
 
 def safe_get_stop_event() -> asyncio.Event:


### PR DESCRIPTION
Fixes this error, which can be quite frustrating, closes: https://github.com/gradio-app/gradio/issues/11280

Repro (which fails on `main` but works on this PR for me):

```py
import asyncio

import gradio as gr


def my_ui():
    with gr.Blocks(fill_width=True, title="Test") as demo:
        toggle_all_traces = gr.Button("On", scale=0, min_width=200)

        def do_toggle_all_traces(state):
            new_state = not state
            new_label = "On" if new_state else "Off"
            return gr.update(value=new_label), new_state

        show_all_traces_toggle_state = gr.State(value=False)

        toggle_all_traces.click(
            fn=do_toggle_all_traces,
            inputs=[show_all_traces_toggle_state],
            outputs=[toggle_all_traces, show_all_traces_toggle_state],
        )
    return demo


async def test():
    await asyncio.sleep(1)


asyncio.run(test())

demo = my_ui()
demo.launch()
```