### PR TITLE
Remove gap parametger from gr.Column

### DIFF
--- a/.changeset/busy-cooks-obey.md
+++ b/.changeset/busy-cooks-obey.md
@@ -3,4 +3,4 @@
 "gradio": patch
 ---
 
-fix:Fix Hot Reload Gap
+fix:Remove gap parametger from gr.Column

--- a/.changeset/busy-cooks-obey.md
+++ b/.changeset/busy-cooks-obey.md
@@ -1,0 +1,6 @@
+---
+"@gradio/column": patch
+"gradio": patch
+---
+
+fix:Fix Hot Reload Gap

--- a/js/column/Index.svelte
+++ b/js/column/Index.svelte
@@ -4,7 +4,6 @@
 	import type { Gradio } from "@gradio/utils";
 
 	export let scale: number | null = null;
-	export let gap = true;
 	export let min_width = 0;
 	export let elem_id = "";
 	export let elem_classes: string[] = [];
@@ -18,7 +17,6 @@
 <div
 	id={elem_id}
 	class="column {elem_classes.join(' ')}"
-	class:gap
 	class:compact={variant === "compact"}
 	class:panel={variant === "panel"}
 	class:hide={!visible}
@@ -45,15 +43,12 @@
 		display: flex;
 		position: relative;
 		flex-direction: column;
+		gap: var(--layout-gap);
 	}
 
 	div > :global(*),
 	div > :global(.form > *) {
 		width: var(--size-full);
-	}
-
-	.gap {
-		gap: var(--layout-gap);
 	}
 
 	.hide {


### PR DESCRIPTION
## Description

~~Set the `gap` default in the binding to allow explicit `undefined` updates to gracefully fallback to `true`.~~

Prevent the column gap from disappearing on hot reload.

Closes: #8887
  

https://github.com/user-attachments/assets/2e4df007-3cd5-4ce3-9747-1eeca8aca36f

