### PR TITLE
fix exports + add browser build

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+	"permissions": {
+		"allow": [
+			"Bash(pnpm ts:check:*)",
+			"Bash(grep:*)",
+			"Bash(pnpm build)",
+			"Bash(ls:*)"
+		],
+		"deny": []
+	}
+}

--- a/client/js/package.json
+++ b/client/js/package.json
@@ -9,7 +9,9 @@
 	"exports": {
 		".": {
 			"gradio": "./src/index.ts",
-			"import": "./dist/index.js"
+			"browser": "./dist/browser.js",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
 		},
 		"./package.json": "./package.json"
 	},
@@ -30,8 +32,10 @@
 	},
 	"scripts": {
 		"bundle": "vite build --ssr",
+		"bundle:browser": "BROWSER_BUILD=true vite build",
 		"generate_types": "tsc",
-		"build": "pnpm bundle && pnpm generate_types",
+		"clean": "rm -rf dist",
+		"build": "pnpm clean && pnpm bundle && pnpm bundle:browser && pnpm generate_types",
 		"test": "pnpm test:client && pnpm test:client:node",
 		"test:client": "vitest run -c vite.config.js",
 		"test:client:node": "TEST_MODE=node vitest run -c vite.config.js",

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -214,8 +214,10 @@ export class Client {
 			(typeof window === "undefined" || !("WebSocket" in window)) &&
 			!global.WebSocket
 		) {
-			const ws = await import("ws");
-			global.WebSocket = ws.WebSocket as unknown as typeof WebSocket;
+			if (!BROWSER_BUILD) {
+				const ws = await import("ws");
+				global.WebSocket = ws.WebSocket as unknown as typeof WebSocket;
+			}
 		}
 
 		if (this.options.auth) {

--- a/client/js/src/vite-env.d.ts
+++ b/client/js/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const BROWSER_BUILD: boolean;

--- a/client/js/vite.config.js
+++ b/client/js/vite.config.js
@@ -4,17 +4,22 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 const TEST_MODE = process.env.TEST_MODE || "happy-dom";
 
 export default defineConfig(({ mode }) => {
+	const production = mode === "production";
+	const isBrowserBuild = process.env.BROWSER_BUILD === "true";
+	
 	if (mode === "preview") {
 		return {
 			entry: "index.html"
 		};
 	}
+	
 	return {
 		build: {
+			emptyOutDir: false,
 			lib: {
 				entry: "src/index.ts",
 				formats: ["es"],
-				fileName: (format) => `index.${format}.js`
+				fileName: (format) => isBrowserBuild ? `browser.${format}.js` : `index.${format}.js`
 			},
 			rollupOptions: {
 				input: "src/index.ts",
@@ -24,7 +29,9 @@ export default defineConfig(({ mode }) => {
 			}
 		},
 		plugins: [svelte()],
-
+		define: {
+			BROWSER_BUILD: JSON.stringify(isBrowserBuild)
+		},
 		mode: process.env.MODE || "development",
 		test: {
 			include: ["./src/test/*.test.*"],


### PR DESCRIPTION
## Description

Adds a `default` export condition as a fallback and adds a `browser` build to keep funky imports out of browser only packages.

Closes #10795.  Closes #4260. Closes #4348. Closes #7693. Closes #8864.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
