### PR TITLE
Fix Static Dataframe Story

### DIFF
--- a/js/dataframe/Dataframe.stories.svelte
+++ b/js/dataframe/Dataframe.stories.svelte
@@ -116,7 +116,7 @@
 		await userEvent.keyboard("new value");
 
 		const final_value = cells[0].textContent;
-		if (initial_value !== final_value) {
+		if (initial_value.strip() !== final_value.strip()) {
 			throw new Error("Cell content changed when it should be non-editable");
 		}
 


### PR DESCRIPTION
## Description

The "Static dataframe" playwright story has been failing on virtual whitespace computed by `textContent` for the selection buttons. Stripping the whitespace from the compared values ensures that only real content changes are detected.
  
<img width="1339" alt="Screenshot 2025-06-26 at 4 10 41 PM" src="https://github.com/user-attachments/assets/82830c23-c3a6-45de-95fa-a0db8bd32163" />
