### PR TITLE
Prevent thead problem with sse-starlette

### DIFF
--- a/client/python/gradio_client/cli/deploy_discord.py
+++ b/client/python/gradio_client/cli/deploy_discord.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Optional
+from typing import Annotated
 
 from typer import Option
 
@@ -7,7 +7,7 @@ from gradio_client import Client
 
 def main(
     src: Annotated[
-        Optional[str],
+        str | None,
         Option(
             help="The space id or url or gradio app you want to deploy as a gradio bot."
         ),
@@ -19,10 +19,10 @@ def main(
         list[str], Option(help="Api names to turn into discord bots")
     ] = None,
     to_id: Annotated[
-        Optional[str], Option(help="Name of the space used to host the discord bot")
+        str | None, Option(help="Name of the space used to host the discord bot")
     ] = None,
     hf_token: Annotated[
-        Optional[str],
+        str | None,
         Option(
             help=(
                 "Hugging Face token. Can be ommitted if you are logged in via huggingface_hub cli. "

--- a/client/python/gradio_client/templates/discord_chat.py
+++ b/client/python/gradio_client/templates/discord_chat.py
@@ -2,7 +2,6 @@ import asyncio
 import os
 import threading
 from threading import Event
-from typing import Optional
 
 import discord
 import gradio as gr
@@ -23,7 +22,7 @@ async def wait(job):
         await asyncio.sleep(0.2)
 
 
-def get_client(session: Optional[str] = None) -> grc.Client:
+def get_client(session: str | None = None) -> grc.Client:
     client = grc.Client("<<app-src>>", hf_token=os.getenv("HF_TOKEN"))
     if session:
         client.session_hash = session

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -24,7 +24,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    Optional,
     TypedDict,
     Union,
     get_args,
@@ -191,11 +190,11 @@ class Status(Enum):
 
 @dataclass
 class ProgressUnit:
-    index: Optional[int]
-    length: Optional[int]
-    unit: Optional[str]
-    progress: Optional[float]
-    desc: Optional[str]
+    index: int | None
+    length: int | None
+    unit: str | None
+    progress: float | None
+    desc: str | None
 
     @classmethod
     def from_msg(cls, data: list[dict]) -> list[ProgressUnit]:

--- a/gradio/cli/commands/components/build.py
+++ b/gradio/cli/commands/components/build.py
@@ -4,7 +4,7 @@ import importlib
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 import semantic_version
 import typer
@@ -36,7 +36,7 @@ def _build(
         bool, typer.Option(help="Whether to generate the documentation as well.")
     ] = True,
     python_path: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             help="Path to python executable. If None, will use the default path found by `which python3`. If python3 is not found, `which python` will be tried. If both fail an error will be raised."
         ),

--- a/gradio/cli/commands/components/create.py
+++ b/gradio/cli/commands/components/create.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 from rich import print
@@ -25,13 +25,13 @@ def _create(
         ),
     ],
     directory: Annotated[
-        Optional[Path],
+        Path | None,
         typer.Option(
             help="Directory to create the component in. Default is None. If None, will be created in <component-name> directory in the current directory."
         ),
     ] = None,
     package_name: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(help="Name of the package. Default is gradio_{name.lower()}"),
     ] = None,
     template: Annotated[
@@ -51,7 +51,7 @@ def _create(
         typer.Option(help="NPM install command to use. Default is 'npm install'."),
     ] = "npm install",
     pip_path: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             help="Path to pip executable. If None, will use the default path found by `which pip3`. If pip3 is not found, `which pip` will be tried. If both fail an error will be raised."
         ),

--- a/gradio/cli/commands/components/dev.py
+++ b/gradio/cli/commands/components/dev.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 from rich import print
@@ -35,13 +35,13 @@ def _dev(
         ),
     ] = "localhost",
     python_path: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             help="Path to python executable. If None, will use the default path found by `which python3`. If python3 is not found, `which python` will be tried. If both fail an error will be raised."
         ),
     ] = None,
     gradio_path: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             help="Path to gradio executable. If None, will use the default path found by `shutil.which`."
         ),

--- a/gradio/cli/commands/components/docs.py
+++ b/gradio/cli/commands/components/docs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 import re
 from pathlib import Path
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any
 
 import requests
 import tomlkit as toml
@@ -20,15 +20,13 @@ def _docs(
     path: Annotated[
         Path, Argument(help="The directory of the custom component.")
     ] = Path("."),
-    demo_dir: Annotated[
-        Optional[Path], Option(help="Path to the demo directory.")
-    ] = None,
-    demo_name: Annotated[Optional[str], Option(help="Name of the demo file.")] = None,
+    demo_dir: Annotated[Path | None, Option(help="Path to the demo directory.")] = None,
+    demo_name: Annotated[str | None, Option(help="Name of the demo file.")] = None,
     readme_path: Annotated[
-        Optional[Path], Option(help="Path to the README.md file.")
+        Path | None, Option(help="Path to the README.md file.")
     ] = None,
     space_url: Annotated[
-        Optional[str], Option(help="URL of the Space to use for the demo.")
+        str | None, Option(help="URL of the Space to use for the demo.")
     ] = None,
     generate_space: Annotated[
         bool,

--- a/gradio/cli/commands/components/install_component.py
+++ b/gradio/cli/commands/components/install_component.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 from rich.markup import escape
 from typer import Argument, Option
@@ -99,7 +99,7 @@ def _install(
         str, Option(help="NPM install command to use. Default is 'npm install'.")
     ] = "npm install",
     pip_path: Annotated[
-        Optional[str],
+        str | None,
         Option(
             help="Path to pip executable. If None, will use the default path found by `which pip3`. If pip3 is not found, `which pip` will be tried. If both fail an error will be raised."
         ),

--- a/gradio/cli/commands/components/publish.py
+++ b/gradio/cli/commands/components/publish.py
@@ -4,7 +4,7 @@ import re
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 import semantic_version
 from huggingface_hub import HfApi
@@ -30,13 +30,13 @@ def _ignore(_src, names):
     return ignored
 
 
-def _get_version_from_file(dist_file: Path) -> Optional[str]:
+def _get_version_from_file(dist_file: Path) -> str | None:
     match = re.search(r"-(\d+\.\d+\.\d+[a-zA-Z]*\d*)-", dist_file.name)
     if match:
         return match.group(1)
 
 
-def _get_max_version(distribution_files: list[Path]) -> Optional[str]:
+def _get_max_version(distribution_files: list[Path]) -> str | None:
     versions = []
     for p in distribution_files:
         version = _get_version_from_file(p)
@@ -61,15 +61,13 @@ def _publish(
     upload_demo: Annotated[
         bool, Option(help="Whether to upload demo to HuggingFace.")
     ] = True,
-    demo_dir: Annotated[
-        Optional[Path], Option(help="Path to the demo directory.")
-    ] = None,
+    demo_dir: Annotated[Path | None, Option(help="Path to the demo directory.")] = None,
     source_dir: Annotated[
         Path,
         Option(help="Path to the source directory of the custom component."),
     ] = Path("."),
     hf_token: Annotated[
-        Optional[str],
+        str | None,
         Option(
             help="HuggingFace token for uploading demo. Can be omitted if already logged in via huggingface cli."
         ),
@@ -87,7 +85,7 @@ def _publish(
         ),
     ] = False,
     repo_id: Annotated[
-        Optional[str],
+        str | None,
         Option(
             help="The repository id to upload the demo to. If not provided, a space will be created with the same name as the package in the HuggingFace account corresponding to the hf_token."
         ),

--- a/gradio/cli/commands/deploy_space.py
+++ b/gradio/cli/commands/deploy_space.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import re
-from typing import Annotated, Optional
+from typing import Annotated
 
 import huggingface_hub
 from rich import print
@@ -118,9 +118,9 @@ def format_title(title: str):
 
 
 def deploy(
-    title: Annotated[Optional[str], Option(help="Spaces app title")] = None,
+    title: Annotated[str | None, Option(help="Spaces app title")] = None,
     app_file: Annotated[
-        Optional[str], Option(help="File containing the Gradio app")
+        str | None, Option(help="File containing the Gradio app")
     ] = None,
 ):
     if (

--- a/gradio/cli/commands/display.py
+++ b/gradio/cli/commands/display.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import time
 from types import TracebackType
-from typing import Optional
 
 from rich.live import Live
 from rich.panel import Panel
@@ -25,8 +24,8 @@ class LivePanelDisplay:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         self._panel.stop()

--- a/gradio/cli/commands/reload.py
+++ b/gradio/cli/commands/reload.py
@@ -16,7 +16,6 @@ import subprocess
 import sys
 import threading
 from pathlib import Path
-from typing import Optional
 
 import typer
 from rich import print
@@ -106,7 +105,7 @@ def _setup_config(
 def main(
     demo_path: Path,
     demo_name: str = "demo",
-    watch_dirs: Optional[list[str]] = None,
+    watch_dirs: list[str] | None = None,
     encoding: str = "utf-8",
 ):
     # default execution pattern to start the server and watch changes

--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -12,7 +12,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    Optional,
     Union,
     cast,
 )
@@ -72,10 +71,10 @@ class OptionDict(TypedDict):
 
 class FileDataDict(TypedDict):
     path: str  # server filepath
-    url: NotRequired[Optional[str]]  # normalised server url
-    size: NotRequired[Optional[int]]  # size in bytes
-    orig_name: NotRequired[Optional[str]]  # original filename
-    mime_type: NotRequired[Optional[str]]
+    url: NotRequired[str | None]  # normalised server url
+    size: NotRequired[int | None]  # size in bytes
+    orig_name: NotRequired[str | None]  # original filename
+    mime_type: NotRequired[str | None]
     is_stream: NotRequired[bool]
     meta: dict[Literal["_type"], Literal["gradio.FileData"]]
 
@@ -89,7 +88,7 @@ class MessageDict(TypedDict):
 
 class FileMessage(GradioModel):
     file: FileData
-    alt_text: Optional[str] = None
+    alt_text: str | None = None
 
 
 class ComponentMessage(GradioModel):
@@ -110,9 +109,9 @@ class ChatbotDataTuples(GradioRootModel):
 
 class Message(GradioModel):
     role: str
-    metadata: Optional[MetadataDict] = None
+    metadata: MetadataDict | None = None
     content: Union[str, FileMessage, ComponentMessage]
-    options: Optional[list[OptionDict]] = None
+    options: list[OptionDict] | None = None
 
 
 class ExampleMessage(TypedDict):

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -8,7 +8,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    Optional,
     Union,
 )
 
@@ -45,7 +44,7 @@ def _import_polars():
 class DataframeData(GradioModel):
     headers: list[Any]
     data: Union[list[list[Any]], list[tuple[Any, ...]]]
-    metadata: Optional[dict[str, Optional[list[Any]]]] = None
+    metadata: dict[str, list[Any] | None] | None = None
 
 
 @document()

--- a/gradio/components/gallery.py
+++ b/gradio/components/gallery.py
@@ -9,7 +9,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    Optional,
     Union,
 )
 from urllib.parse import quote, urlparse
@@ -37,12 +36,12 @@ CaptionedGalleryMediaType = tuple[GalleryMediaType, str]
 
 class GalleryImage(GradioModel):
     image: ImageData
-    caption: Optional[str] = None
+    caption: str | None = None
 
 
 class GalleryVideo(GradioModel):
     video: FileData
-    caption: Optional[str] = None
+    caption: str | None = None
 
 
 class GalleryData(GradioRootModel):

--- a/gradio/components/image_editor.py
+++ b/gradio/components/image_editor.py
@@ -11,7 +11,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    Optional,
     Union,
     cast,
 )
@@ -35,33 +34,33 @@ ImageType = Union[np.ndarray, PIL.Image.Image, str]
 
 
 class EditorValue(TypedDict):
-    background: Optional[ImageType]
+    background: ImageType | None
     layers: list[ImageType]
-    composite: Optional[ImageType]
+    composite: ImageType | None
 
 
 class EditorExampleValue(TypedDict):
-    background: Optional[str]
-    layers: Optional[list[Union[str, None]]]
-    composite: Optional[str]
+    background: str | None
+    layers: list[Union[str, None]] | None
+    composite: str | None
 
 
 class EditorData(GradioModel):
-    background: Optional[FileData] = None
+    background: FileData | None = None
     layers: list[FileData] = []
-    composite: Optional[FileData] = None
-    id: Optional[str] = None
+    composite: FileData | None = None
+    id: str | None = None
 
 
 class EditorDataBlobs(GradioModel):
-    background: Optional[bytes]
+    background: bytes | None
     layers: list[Union[bytes, None]]
-    composite: Optional[bytes]
+    composite: bytes | None
 
 
 class BlobData(TypedDict):
     type: str
-    index: Optional[int]
+    index: int | None
     file: bytes
     id: str
 

--- a/gradio/components/label.py
+++ b/gradio/components/label.py
@@ -6,7 +6,7 @@ import json
 import operator
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from gradio_client.documentation import document
 
@@ -20,13 +20,13 @@ if TYPE_CHECKING:
 
 
 class LabelConfidence(GradioModel):
-    label: Optional[Union[str, int, float]] = None
-    confidence: Optional[float] = None
+    label: Union[str, int, float] | None = None
+    confidence: float | None = None
 
 
 class LabelData(GradioModel):
-    label: Optional[Union[str, int, float]] = None
-    confidences: Optional[list[LabelConfidence]] = None
+    label: Union[str, int, float] | None = None
+    confidences: list[LabelConfidence] | None = None
 
 
 @document()

--- a/gradio/components/textbox.py
+++ b/gradio/components/textbox.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import dataclasses
 import warnings
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from gradio_client.documentation import document
 
@@ -35,20 +35,20 @@ class InputHTMLAttributes:
         aria_placeholder: The aria-placeholder attribute for the input/textarea element. A string providing placeholder text for screen readers.
     """
 
-    autocapitalize: Optional[
-        Literal["off", "none", "on", "sentences", "words", "characters"]
-    ] = None
-    autocorrect: Optional[Literal["on", "off"]] = None
-    spellcheck: Optional[bool] = None
-    autocomplete: Optional[str] = None
-    tabindex: Optional[int] = None
-    enterkeyhint: Optional[
-        Literal["enter", "done", "go", "next", "previous", "search", "send"]
-    ] = None
-    lang: Optional[str] = None
-    aria_label: Optional[str] = None
-    aria_describedby: Optional[str] = None
-    aria_placeholder: Optional[str] = None
+    autocapitalize: (
+        Literal["off", "none", "on", "sentences", "words", "characters"] | None
+    ) = None
+    autocorrect: Literal["on", "off"] | None = None
+    spellcheck: bool | None = None
+    autocomplete: str | None = None
+    tabindex: int | None = None
+    enterkeyhint: (
+        Literal["enter", "done", "go", "next", "previous", "search", "send"] | None
+    ) = None
+    lang: str | None = None
+    aria_label: str | None = None
+    aria_describedby: str | None = None
+    aria_placeholder: str | None = None
 
 
 @document()

--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -9,7 +9,7 @@ import tempfile
 import warnings
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from gradio_client import handle_file
 from gradio_client import utils as client_utils
@@ -34,7 +34,7 @@ if not wasm_utils.IS_WASM:
 
 class VideoData(GradioModel):
     video: FileData
-    subtitles: Optional[FileData] = None
+    subtitles: FileData | None = None
 
 
 @document()

--- a/gradio/data_classes.py
+++ b/gradio/data_classes.py
@@ -14,7 +14,6 @@ from typing import (
     Any,
     Literal,
     NewType,
-    Optional,
     Union,
 )
 
@@ -56,7 +55,7 @@ class CancelBody(BaseModel):
 
 class SimplePredictBody(BaseModel):
     data: list[Any]
-    session_hash: Optional[str] = None
+    session_hash: str | None = None
 
 
 class _StarletteRequestPydanticAnnotation:
@@ -84,14 +83,14 @@ PydanticStarletteRequest = Annotated[Request, _StarletteRequestPydanticAnnotatio
 
 
 class PredictBody(BaseModel):
-    session_hash: Optional[str] = None
-    event_id: Optional[str] = None
+    session_hash: str | None = None
+    event_id: str | None = None
     data: list[Any]
-    event_data: Optional[Any] = None
-    fn_index: Optional[int] = None
-    trigger_id: Optional[int] = None
+    event_data: Any | None = None
+    fn_index: int | None = None
+    trigger_id: int | None = None
     simple_format: bool = False
-    batched: Optional[bool] = (
+    batched: bool | None = (
         False  # Whether the data is a batch of samples (i.e. called from the queue if batch=True) or a single sample (i.e. called from the UI)
     )
 
@@ -117,7 +116,7 @@ class PredictBody(BaseModel):
 class PredictBodyInternal(PredictBody):
     "Separate class to avoid exposing PydanticStarletteRequest in the API validation"
 
-    request: Optional[PydanticStarletteRequest] = (
+    request: PydanticStarletteRequest | None = (
         None  # dictionary of request headers, query parameters, url, etc. (used to to pass in request for queuing)
     )
 
@@ -202,10 +201,10 @@ GradioDataModel = Union[GradioModel, GradioRootModel]
 
 class FileDataDict(TypedDict):
     path: str  # server filepath
-    url: NotRequired[Optional[str]]  # normalised server url
-    size: NotRequired[Optional[int]]  # size in bytes
-    orig_name: NotRequired[Optional[str]]  # original filename
-    mime_type: NotRequired[Optional[str]]
+    url: NotRequired[str | None]  # normalised server url
+    size: NotRequired[int | None]  # size in bytes
+    orig_name: NotRequired[str | None]  # original filename
+    mime_type: NotRequired[str | None]
     is_stream: bool
     meta: NotRequired[dict]
 
@@ -230,10 +229,10 @@ class FileData(GradioModel):
     """
 
     path: str  # server filepath
-    url: Optional[str] = None  # normalised server url
-    size: Optional[int] = None  # size in bytes
-    orig_name: Optional[str] = None  # original filename
-    mime_type: Optional[str] = None
+    url: str | None = None  # normalised server url
+    size: int | None = None  # size in bytes
+    orig_name: str | None = None  # original filename
+    mime_type: str | None = None
     is_stream: bool = False
     meta: FileDataMeta = Field(default_factory=lambda: {"_type": "gradio.FileData"})
 
@@ -414,13 +413,13 @@ class MediaStreamChunk(TypedDict):
 
 
 class ImageData(GradioModel):
-    path: Optional[str] = Field(default=None, description="Path to a local file")
-    url: Optional[str] = Field(
+    path: str | None = Field(default=None, description="Path to a local file")
+    url: str | None = Field(
         default=None, description="Publicly available url or base64 encoded image"
     )
-    size: Optional[int] = Field(default=None, description="Size of image in bytes")
-    orig_name: Optional[str] = Field(default=None, description="Original filename")
-    mime_type: Optional[str] = Field(default=None, description="mime type of image")
+    size: int | None = Field(default=None, description="Size of image in bytes")
+    orig_name: str | None = Field(default=None, description="Original filename")
+    mime_type: str | None = Field(default=None, description="mime type of image")
     is_stream: bool = Field(default=False, description="Can always be set to False")
     meta: dict = {"_type": "gradio.FileData"}
 

--- a/gradio/pipelines_utils.py
+++ b/gradio/pipelines_utils.py
@@ -3,7 +3,7 @@ Defines internal helper methods for handling transformers and diffusers pipeline
 These are used by load_from_pipeline method in pipelines.py.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 from PIL import Image
@@ -11,7 +11,7 @@ from PIL import Image
 from gradio import components
 
 
-def handle_transformers_pipeline(pipeline: Any) -> Optional[dict[str, Any]]:
+def handle_transformers_pipeline(pipeline: Any) -> dict[str, Any] | None:
     try:
         import transformers
     except ImportError as ie:
@@ -196,7 +196,7 @@ def handle_transformers_pipeline(pipeline: Any) -> Optional[dict[str, Any]]:
     raise ValueError(f"Unsupported transformers pipeline type: {type(pipeline)}")
 
 
-def handle_diffusers_pipeline(pipeline: Any) -> Optional[dict[str, Any]]:
+def handle_diffusers_pipeline(pipeline: Any) -> dict[str, Any] | None:
     try:
         import diffusers
     except ImportError as ie:

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -22,7 +22,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     BinaryIO,
-    Optional,
     Union,
 )
 from urllib.parse import urlparse
@@ -236,8 +235,8 @@ def get_fn(blocks: Blocks, api_name: str | None, body: PredictBody) -> BlockFunc
 def compile_gr_request(
     body: PredictBodyInternal,
     fn: BlockFunction,
-    username: Optional[str],
-    request: Optional[fastapi.Request],
+    username: str | None,
+    request: fastapi.Request | None,
 ):
     # If this fn_index cancels jobs, then the only input we need is the
     # current session hash

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -25,7 +25,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    Optional,
     Union,
     cast,
 )
@@ -445,7 +444,7 @@ class App(FastAPI):
 
         @router.get("/user")
         @router.get("/user/")
-        def get_current_user(request: fastapi.Request) -> Optional[str]:
+        def get_current_user(request: fastapi.Request) -> str | None:
             if app.auth_dependency is not None:
                 return app.auth_dependency(request)
             token = request.cookies.get(
@@ -1625,7 +1624,7 @@ class App(FastAPI):
         async def upload_file(
             request: fastapi.Request,
             bg_tasks: BackgroundTasks,
-            upload_id: Optional[str] = None,
+            upload_id: str | None = None,
         ):
             content_type_header = request.headers.get("Content-Type")
             content_type: bytes

--- a/gradio/server_messages.py
+++ b/gradio/server_messages.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Union
+from typing import Literal, Union
 
 from gradio_client.utils import ServerMessage
 from pydantic import BaseModel
@@ -6,15 +6,15 @@ from pydantic import BaseModel
 
 class BaseMessage(BaseModel):
     msg: ServerMessage
-    event_id: Optional[str] = None
+    event_id: str | None = None
 
 
 class ProgressUnit(BaseModel):
-    index: Optional[int | float] = None
-    length: Optional[int | float] = None
-    unit: Optional[str] = None
-    progress: Optional[float] = None
-    desc: Optional[str] = None
+    index: int | float | None = None
+    length: int | float | None = None
+    unit: str | None = None
+    progress: float | None = None
+    desc: str | None = None
 
 
 class ProgressMessage(BaseMessage):
@@ -26,28 +26,28 @@ class LogMessage(BaseMessage):
     msg: Literal[ServerMessage.log] = ServerMessage.log  # type: ignore
     log: str
     level: Literal["info", "warning", "success"]
-    duration: Optional[float] = 10
+    duration: float | None = 10
     visible: bool = True
     title: str
 
 
 class EstimationMessage(BaseMessage):
     msg: Literal[ServerMessage.estimation] = ServerMessage.estimation  # type: ignore
-    rank: Optional[int] = None
+    rank: int | None = None
     queue_size: int
-    rank_eta: Optional[float] = None
+    rank_eta: float | None = None
 
 
 class ProcessStartsMessage(BaseMessage):
     msg: Literal[ServerMessage.process_starts] = ServerMessage.process_starts  # type: ignore
-    eta: Optional[float] = None
+    eta: float | None = None
 
 
 class ProcessCompletedMessage(BaseMessage):
     msg: Literal[ServerMessage.process_completed] = ServerMessage.process_completed  # type: ignore
     output: dict
     success: bool
-    title: Optional[str] = None
+    title: str | None = None
 
 
 class ProcessGeneratingMessage(BaseMessage):
@@ -56,7 +56,7 @@ class ProcessGeneratingMessage(BaseMessage):
     )
     output: dict
     success: bool
-    time_limit: Optional[float] = None
+    time_limit: float | None = None
 
 
 class HeartbeatMessage(BaseMessage):

--- a/test/test_api_info.py
+++ b/test/test_api_info.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
-from typing import ClassVar, Literal, Optional, Union
+from typing import ClassVar, Literal, Union
 from uuid import UUID
 
 import pytest
@@ -49,7 +49,7 @@ class DictModel2(GradioModel):
 
 
 class OptionalModel(GradioModel):
-    optional_data: Optional[int]
+    optional_data: int | None
 
     answer: ClassVar = "dict(optional_data: int | None)"
 

--- a/test/test_mcp.py
+++ b/test/test_mcp.py
@@ -216,12 +216,17 @@ def test_mcp_sse_transport(test_mcp_app):
 
 @pytest.mark.serial
 def test_mcp_mount_gradio_app():
+    import asyncio
     import threading
 
     import uvicorn
     from fastapi import FastAPI
+    from sse_starlette.sse import AppStatus
 
     from gradio.routes import mount_gradio_app
+
+    # Fix: Reset shared event object for the current thread/event loop
+    AppStatus.should_exit_event = asyncio.Event()
 
     with gr.Blocks() as app:
         t1 = gr.Textbox(label="Test Textbox")


### PR DESCRIPTION
This PR will fix this problem:
```
__________________________ test_mcp_mount_gradio_app ___________________________

    @contextlib.contextmanager
    def map_httpcore_exceptions() -> typing.Iterator[None]:
        global HTTPCORE_EXC_MAP
        if len(HTTPCORE_EXC_MAP) == 0:
            HTTPCORE_EXC_MAP = _load_httpcore_exceptions()
        try:
>           yield

/usr/lib/python3.13/site-packages/httpx/_transports/default.py:101: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3.13/site-packages/httpx/_transports/default.py:127: in __iter__
    for part in self._httpcore_stream:
                ^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.13/site-packages/httpcore/_sync/connection_pool.py:407: in __iter__
    raise exc from None
/usr/lib/python3.13/site-packages/httpcore/_sync/connection_pool.py:403: in __iter__
    for part in self._stream:
                ^^^^^^^^^^^^
/usr/lib/python3.13/site-packages/httpcore/_sync/http11.py:342: in __iter__
    raise exc
/usr/lib/python3.13/site-packages/httpcore/_sync/http11.py:334: in __iter__
    for chunk in self._connection._receive_response_body(**kwargs):
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.13/site-packages/httpcore/_sync/http11.py:203: in _receive_response_body
    event = self._receive_event(timeout=timeout)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.13/site-packages/httpcore/_sync/http11.py:213: in _receive_event
    with map_exceptions({h11.RemoteProtocolError: RemoteProtocolError}):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.13/contextlib.py:162: in __exit__
    self.gen.throw(value)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

map = {<class 'h11._util.RemoteProtocolError'>: <class 'httpcore.RemoteProtocolError'>}

    @contextlib.contextmanager
    def map_exceptions(map: ExceptionMapping) -> typing.Iterator[None]:
        try:
            yield
        except Exception as exc:  # noqa: PIE786
            for from_exc, to_exc in map.items():
                if isinstance(exc, from_exc):
>                   raise to_exc(exc) from exc
E                   httpcore.RemoteProtocolError: peer closed connection without sending complete message body (incomplete chunked read)

/usr/lib/python3.13/site-packages/httpcore/_exceptions.py:14: RemoteProtocolError

The above exception was the direct cause of the following exception:

    @pytest.mark.serial
    def test_mcp_mount_gradio_app():
        import threading
    
        import uvicorn
        from fastapi import FastAPI
    
        from gradio.routes import mount_gradio_app
    
        with gr.Blocks() as app:
            t1 = gr.Textbox(label="Test Textbox")
            t2 = gr.Textbox(label="Test Textbox 2")
            t1.submit(lambda x: x, t1, t2, api_name="test_tool")
    
        fastapi_app = FastAPI()
        mount_gradio_app(fastapi_app, app, path="/test", mcp_server=True)
    
        thread = threading.Thread(
            target=uvicorn.run, args=(fastapi_app,), kwargs={"port": 6868}, daemon=True
        )
        thread.start()
    
        max_retries = 4
        retry_delay = 0.1
    
        for attempt in range(max_retries):
            try:
                with httpx.Client(timeout=1) as test_client:
                    test_response = test_client.get("http://localhost:6868/test/")
                    if test_response.status_code == 200:
                        break
            except (httpx.ConnectError, httpx.TimeoutException):
                if attempt == max_retries - 1:
                    raise Exception("Gradio app did not start") from None
                time.sleep(retry_delay * (2**attempt))
    
        with httpx.Client(timeout=5) as client:
            config_url = "http://localhost:6868/test/config"
            config_response = client.get(config_url)
            assert config_response.is_success
            assert config_response.json()["mcp_server"] is True
    
            sse_url = "http://localhost:6868/test/gradio_api/mcp/sse"
    
            with client.stream("GET", sse_url) as response:
                assert response.is_success
    
                terminate_next = False
                line = ""
>               for line in response.iter_lines():
                            ^^^^^^^^^^^^^^^^^^^^^

test/test_mcp.py:266: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3.13/site-packages/httpx/_models.py:929: in iter_lines
    for text in self.iter_text():
                ^^^^^^^^^^^^^^^^
/usr/lib/python3.13/site-packages/httpx/_models.py:916: in iter_text
    for byte_content in self.iter_bytes():
                        ^^^^^^^^^^^^^^^^^
/usr/lib/python3.13/site-packages/httpx/_models.py:897: in iter_bytes
    for raw_bytes in self.iter_raw():
                     ^^^^^^^^^^^^^^^
/usr/lib/python3.13/site-packages/httpx/_models.py:951: in iter_raw
    for raw_stream_bytes in self.stream:
                            ^^^^^^^^^^^
/usr/lib/python3.13/site-packages/httpx/_client.py:153: in __iter__
    for chunk in self._stream:
                 ^^^^^^^^^^^^
/usr/lib/python3.13/site-packages/httpx/_transports/default.py:126: in __iter__
    with map_httpcore_exceptions():
         ^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.13/contextlib.py:162: in __exit__
    self.gen.throw(value)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    @contextlib.contextmanager
    def map_httpcore_exceptions() -> typing.Iterator[None]:
        global HTTPCORE_EXC_MAP
        if len(HTTPCORE_EXC_MAP) == 0:
            HTTPCORE_EXC_MAP = _load_httpcore_exceptions()
        try:
            yield
        except Exception as exc:
            mapped_exc = None
    
            for from_exc, to_exc in HTTPCORE_EXC_MAP.items():
                if not isinstance(exc, from_exc):
                    continue
                # We want to map to the most specific exception we can find.
                # Eg if exc is an httpcore.ReadTimeout, we want to map to
                # httpx.ReadTimeout, not just httpx.TimeoutException.
                if mapped_exc is None or issubclass(to_exc, mapped_exc):
                    mapped_exc = to_exc
    
            if mapped_exc is None:  # pragma: no cover
                raise
    
            message = str(exc)
>           raise mapped_exc(message) from exc
E           httpx.RemoteProtocolError: peer closed connection without sending complete message body (incomplete chunked read)

/usr/lib/python3.13/site-packages/httpx/_transports/default.py:118: RemoteProtocolError
---------------------------- Captured stderr setup -----------------------------
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        self.scope, self.receive, self.send
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib/python3.13/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/lib/python3.13/site-packages/starlette/applications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/lib/python3.13/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/usr/lib/python3.13/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/home/medaminezghal/Documents/AUR_Packages/python-gradio/test/src/gradio-gradio-5.35.0/gradio/route_utils.py", line 850, in __call__
    await self.app(scope, receive, send)
  File "/usr/lib/python3.13/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/usr/lib/python3.13/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/usr/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 716, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 736, in app
    await route.handle(scope, receive, send)
  File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 462, in handle
    await self.app(scope, receive, send)
  File "/usr/lib/python3.13/site-packages/starlette/applications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/lib/python3.13/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/usr/lib/python3.13/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/usr/lib/python3.13/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/usr/lib/python3.13/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/usr/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 716, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 736, in app
    await route.handle(scope, receive, send)
  File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 462, in handle
    await self.app(scope, receive, send)
  File "/usr/lib/python3.13/site-packages/mcp/server/sse.py", line 224, in handle_post_message
    await writer.send(session_message)
  File "/usr/lib/python3.13/site-packages/anyio/streams/memory.py", line 242, in send
    self.send_nowait(item)
    ~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/lib/python3.13/site-packages/anyio/streams/memory.py", line 211, in send_nowait
    raise ClosedResourceError
anyio.ClosedResourceError
----------------------------- Captured stdout call -----------------------------
INFO:     127.0.0.1:50104 - "GET /test/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:50114 - "GET /test/config HTTP/1.1" 200 OK
INFO:     127.0.0.1:50114 - "GET /test/gradio_api/mcp/sse HTTP/1.1" 200 OK
MCP SSE connection error: unhandled errors in a TaskGroup (1 sub-exception)
----------------------------- Captured stderr call -----------------------------
INFO:     Started server process [922141]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:6868 (Press CTRL+C to quit)
ERROR:    Exception in ASGI application
  + Exception Group Traceback (most recent call last):
  |   File "/usr/lib/python3.13/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
  |     result = await app(  # type: ignore[func-returns-value]
  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |         self.scope, self.receive, self.send
  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |     )
  |     ^
  |   File "/usr/lib/python3.13/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
  |     return await self.app(scope, receive, send)
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/usr/lib/python3.13/site-packages/fastapi/applications.py", line 1054, in __call__
  |     await super().__call__(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/applications.py", line 113, in __call__
  |     await self.middleware_stack(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/middleware/errors.py", line 186, in __call__
  |     raise exc
  |   File "/usr/lib/python3.13/site-packages/starlette/middleware/errors.py", line 164, in __call__
  |     await self.app(scope, receive, _send)
  |   File "/usr/lib/python3.13/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
  |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
  |     raise exc
  |   File "/usr/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
  |     await app(scope, receive, sender)
  |   File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 716, in __call__
  |     await self.middleware_stack(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 736, in app
  |     await route.handle(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 462, in handle
  |     await self.app(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/fastapi/applications.py", line 1054, in __call__
  |     await super().__call__(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/applications.py", line 113, in __call__
  |     await self.middleware_stack(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/middleware/errors.py", line 186, in __call__
  |     raise exc
  |   File "/usr/lib/python3.13/site-packages/starlette/middleware/errors.py", line 164, in __call__
  |     await self.app(scope, receive, _send)
  |   File "/home/medaminezghal/Documents/AUR_Packages/python-gradio/test/src/gradio-gradio-5.35.0/gradio/route_utils.py", line 850, in __call__
  |     await self.app(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
  |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
  |     raise exc
  |   File "/usr/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
  |     await app(scope, receive, sender)
  |   File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 716, in __call__
  |     await self.middleware_stack(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 736, in app
  |     await route.handle(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 462, in handle
  |     await self.app(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/applications.py", line 113, in __call__
  |     await self.middleware_stack(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/middleware/errors.py", line 186, in __call__
  |     raise exc
  |   File "/usr/lib/python3.13/site-packages/starlette/middleware/errors.py", line 164, in __call__
  |     await self.app(scope, receive, _send)
  |   File "/usr/lib/python3.13/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
  |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
  |     raise exc
  |   File "/usr/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
  |     await app(scope, receive, sender)
  |   File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 716, in __call__
  |     await self.middleware_stack(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 736, in app
  |     await route.handle(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 290, in handle
  |     await self.app(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 78, in app
  |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  |   File "/usr/lib/python3.13/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
  |     raise exc
  |   File "/usr/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
  |     await app(scope, receive, sender)
  |   File "/usr/lib/python3.13/site-packages/starlette/routing.py", line 75, in app
  |     response = await f(request)
  |                ^^^^^^^^^^^^^^^^
  |   File "/home/medaminezghal/Documents/AUR_Packages/python-gradio/test/src/gradio-gradio-5.35.0/gradio/mcp.py", line 246, in handle_sse
  |     async with sse.connect_sse(
  |                ~~~~~~~~~~~~~~~^
  |         request.scope, request.receive, request._send
  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |     ) as streams:
  |     ^
  |   File "/usr/lib/python3.13/contextlib.py", line 235, in __aexit__
  |     await self.gen.athrow(value)
  |   File "/usr/lib/python3.13/site-packages/mcp/server/sse.py", line 155, in connect_sse
  |     async with anyio.create_task_group() as tg:
  |                ~~~~~~~~~~~~~~~~~~~~~~~^^
  |   File "/usr/lib/python3.13/site-packages/anyio/_backends/_asyncio.py", line 772, in __aexit__
  |     raise BaseExceptionGroup(
  |         "unhandled errors in a TaskGroup", self._exceptions
  |     ) from None
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Exception Group Traceback (most recent call last):
    |   File "/usr/lib/python3.13/site-packages/mcp/server/sse.py", line 163, in response_wrapper
    |     await EventSourceResponse(content=sse_stream_reader, data_sender_callable=sse_writer)(
    |         scope, receive, send
    |     )
    |   File "/usr/lib/python3.13/site-packages/sse_starlette/sse.py", line 237, in __call__
    |     async with anyio.create_task_group() as task_group:
    |                ~~~~~~~~~~~~~~~~~~~~~~~^^
    |   File "/usr/lib/python3.13/site-packages/anyio/_backends/_asyncio.py", line 772, in __aexit__
    |     raise BaseExceptionGroup(
    |         "unhandled errors in a TaskGroup", self._exceptions
    |     ) from None
    | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
    +-+---------------- 1 ----------------
      | Traceback (most recent call last):
      |   File "/usr/lib/python3.13/site-packages/sse_starlette/sse.py", line 240, in cancel_on_finish
      |     await coro()
      |   File "/usr/lib/python3.13/site-packages/sse_starlette/sse.py", line 201, in _listen_for_exit_signal
      |     await AppStatus.should_exit_event.wait()
      |   File "/usr/lib/python3.13/site-packages/anyio/_backends/_asyncio.py", line 1774, in wait
      |     await self._event.wait()
      |   File "/usr/lib/python3.13/asyncio/locks.py", line 210, in wait
      |     fut = self._get_loop().create_future()
      |           ~~~~~~~~~~~~~~^^
      |   File "/usr/lib/python3.13/asyncio/mixins.py", line 20, in _get_loop
      |     raise RuntimeError(f'{self!r} is bound to a different event loop')
      | RuntimeError: <asyncio.locks.Event object at 0x7f9d94246c30 [unset]> is bound to a different event loop
      +------------------------------------
```