### PR TITLE
Improve logic for sanitizing MCP tool names

### DIFF
--- a/.changeset/social-pumas-ask.md
+++ b/.changeset/social-pumas-ask.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Improve logic for sanitizing MCP tool names

--- a/gradio/mcp.py
+++ b/gradio/mcp.py
@@ -1,7 +1,6 @@
 import base64
 import contextlib
 import os
-import re
 import tempfile
 import warnings
 from collections.abc import AsyncIterator, Sequence
@@ -51,12 +50,8 @@ class GradioMCPServer:
         self.api_info = self.blocks.get_api_info()
         self.mcp_server = self.create_mcp_server()
         self.root_path = ""
-        tool_prefix = utils.get_space()
-        if tool_prefix:
-            tool_prefix = tool_prefix.split("/")[-1] + "_"
-            self.tool_prefix = re.sub(r"[^a-zA-Z0-9]", "_", tool_prefix)
-        else:
-            self.tool_prefix = ""
+        space_id = utils.get_space()
+        self.tool_prefix = space_id.split("/")[-1] + "_" if space_id else ""
         self.tool_to_endpoint = self.get_tool_to_endpoint()
         self.warn_about_state_inputs()
 
@@ -95,6 +90,26 @@ class GradioMCPServer:
         else:
             return "/gradio_api/mcp/http"
 
+    @staticmethod
+    def valid_and_unique_tool_name(
+        tool_name: str, existing_tool_names: set[str]
+    ) -> str:
+        """
+        Sanitizes a tool name to make it a valid MCP tool name (only
+        alphanumeric characters, underscores, and hyphens, <= 128 characters).
+        and is unique among the existing tool names.
+        """
+        tool_name = "".join(
+            [char for char in tool_name if char.isalnum() or char in "_-"]
+        )
+        tool_name = tool_name[:120]  # Leave room for suffix if needed
+        tool_name_base = tool_name
+        suffix = 1
+        while tool_name in existing_tool_names:
+            tool_name = tool_name_base + f"_{suffix}"
+            suffix += 1
+        return tool_name
+
     def get_tool_to_endpoint(self) -> dict[str, str]:
         """
         Gets all of the tools that are exposed by the Gradio app and also
@@ -115,8 +130,9 @@ class GradioMCPServer:
                     or endpoint_name.lstrip("/")
                 )
                 tool_name = self.tool_prefix + fn_name
-                while tool_name in tool_to_endpoint:
-                    tool_name = tool_name + "_"
+                tool_name = self.valid_and_unique_tool_name(
+                    tool_name, set(tool_to_endpoint.keys())
+                )
                 tool_to_endpoint[tool_name] = endpoint_name
         return tool_to_endpoint
 

--- a/gradio/mcp.py
+++ b/gradio/mcp.py
@@ -1,6 +1,7 @@
 import base64
 import contextlib
 import os
+import re
 import tempfile
 import warnings
 from collections.abc import AsyncIterator, Sequence
@@ -96,12 +97,10 @@ class GradioMCPServer:
     ) -> str:
         """
         Sanitizes a tool name to make it a valid MCP tool name (only
-        alphanumeric characters, underscores, and hyphens, <= 128 characters).
+        alphanumeric characters, underscores, <= 128 characters)
         and is unique among the existing tool names.
         """
-        tool_name = "".join(
-            [char for char in tool_name if char.isalnum() or char in "_-"]
-        )
+        tool_name = re.sub(r"[^a-zA-Z0-9]", "_", tool_name)
         tool_name = tool_name[:120]  # Leave room for suffix if needed
         tool_name_base = tool_name
         suffix = 1

--- a/test/test_mcp.py
+++ b/test/test_mcp.py
@@ -44,8 +44,8 @@ def test_generate_tool_names_correctly_for_interfaces():
     server = GradioMCPServer(app)
     assert list(server.tool_to_endpoint.keys()) == [
         "echo",
-        "echo_",
-        "<lambda>",
+        "echo_1",
+        "_lambda_",
         "MyCallable",
     ]
 
@@ -130,10 +130,10 @@ def test_simplify_filedata_schema(test_mcp_app):
 
 def test_tool_prefix_character_replacement(test_mcp_app):
     test_cases = [
-        ("test-space", "test_space_"),
-        ("flux.1_schnell", "flux_1_schnell_"),
-        ("test\\backslash", "test_backslash_"),
-        ("test:colon spaces ", "test_colon_spaces__"),
+        ("test-space", "test_space_test_tool"),
+        ("flux.1_schnell", "flux_1_schnell_test_tool"),
+        ("test\\backslash", "test_backslash_test_tool"),
+        ("test:colon spaces ", "test_colon_spaces__test_tool"),
     ]
 
     original_system = os.environ.get("SYSTEM")
@@ -141,10 +141,10 @@ def test_tool_prefix_character_replacement(test_mcp_app):
 
     try:
         os.environ["SYSTEM"] = "spaces"
-        for input_prefix, expected_prefix in test_cases:
-            os.environ["SPACE_ID"] = input_prefix
+        for space_id, tool_name in test_cases:
+            os.environ["SPACE_ID"] = space_id
             server = GradioMCPServer(test_mcp_app)
-            assert server.tool_prefix == expected_prefix
+            assert tool_name in server.tool_to_endpoint
     finally:
         if original_system is not None:
             os.environ["SYSTEM"] = original_system


### PR DESCRIPTION
Fixes: https://github.com/gradio-app/gradio/issues/11455

e.g. test with:

```py
import gradio as gr

with gr.Blocks() as demo:
    reuse_button = gr.Button()
    reuse_button.click(
        fn = lambda x:x*2,
        inputs = [reuse_button],
        outputs = [reuse_button]
    )    
    reuse_button2 = gr.Button()
    reuse_button2.click(
        fn = lambda x:x*2,
        inputs = [reuse_button2],
        outputs = [reuse_button2]
    )    

demo.launch(mcp_server=True)
```

cc @evalstate for visibility