### PR TITLE
Update @huggingface/space-header to 1.0.4

### DIFF
--- a/js/app/package.json
+++ b/js/app/package.json
@@ -28,7 +28,7 @@
 		"@gradio/core": "workspace:^",
 		"@gradio/theme": "workspace:^",
 		"@gradio/wasm": "workspace:^",
-		"@huggingface/space-header": "^1.0.3",
+		"@huggingface/space-header": "^1.0.4",
 		"@self/build": "workspace:^",
 		"@sveltejs/adapter-node": "^5.2.2",
 		"svelte-preprocess": "^6.0.3"

--- a/js/spa/package.json
+++ b/js/spa/package.json
@@ -14,12 +14,12 @@
 		"build:css": "pollen -c pollen.config.cjs -o src/pollen-dev.css"
 	},
 	"devDependencies": {
-		"@self/build": "workspace:^",
 		"@gradio/client": "workspace:^",
 		"@gradio/core": "workspace:^",
 		"@gradio/theme": "workspace:^",
 		"@gradio/wasm": "workspace:^",
-		"@huggingface/space-header": "^1.0.3",
+		"@huggingface/space-header": "^1.0.4",
+		"@self/build": "workspace:^",
 		"@types/eventsource": "^1.1.15",
 		"cross-env": "^7.0.3"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,8 +595,8 @@ importers:
         specifier: workspace:^
         version: link:../wasm
       '@huggingface/space-header':
-        specifier: ^1.0.3
-        version: 1.0.3
+        specifier: ^1.0.4
+        version: 1.0.4
       '@self/build':
         specifier: workspace:^
         version: link:../build
@@ -2333,8 +2333,8 @@ importers:
         specifier: workspace:^
         version: link:../wasm
       '@huggingface/space-header':
-        specifier: ^1.0.3
-        version: 1.0.3
+        specifier: ^1.0.4
+        version: 1.0.4
       '@self/build':
         specifier: workspace:^
         version: link:../build
@@ -3694,8 +3694,8 @@ packages:
   '@formatjs/intl-localematcher@0.5.4':
     resolution: {integrity: sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==}
 
-  '@huggingface/space-header@1.0.3':
-    resolution: {integrity: sha512-7W9QzGsBNl+IGFRjb3Py2cJpWCNgULL8RR+u69URP8FG4cPVH+5g6kKS2OrapPfZ/IoakFZSoI84ORSToL6qTw==}
+  '@huggingface/space-header@1.0.4':
+    resolution: {integrity: sha512-GZu/LJZ6W1kuhiCevOt4iZrNb/vJvm8egSp7jTvjWlACkYddvKNEFGZ3HK8FE7fM2tUztotauMrbHVe8eQ9/ww==}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -10808,7 +10808,7 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  '@huggingface/space-header@1.0.3': {}
+  '@huggingface/space-header@1.0.4': {}
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:


### PR DESCRIPTION
## Description

Updates the `@huggingface/space-header` dependency from version `1.0.3` to `1.0.4` (latest) in both `js/app` and `js/spa` packages. 

## Changes Made
- Updated `js/app/package.json`: `@huggingface/space-header` from `^1.0.3` to `^1.0.4`
- Updated `js/spa/package.json`: `@huggingface/space-header` from `^1.0.3` to `^1.0.4`  
- Updated `pnpm-lock.yaml` with new dependency locks and integrity hashes

Closes: #9992

## 🎯 PRs Should Target Issues

This PR addresses the specific issue requesting the update of `@huggingface/space-header` to version 1.0.4 as outlined in the issue.
