### PR TITLE
Draft: Add I18n for Dropdown Choices

### DIFF
--- a/.changeset/curvy-bears-fry.md
+++ b/.changeset/curvy-bears-fry.md
@@ -1,0 +1,6 @@
+---
+"@gradio/core": minor
+"gradio": minor
+---
+
+feat:Draft: Add I18n for Dropdown Choices

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -46,13 +46,13 @@ class Dropdown(FormComponent):
 
     def __init__(
         self,
-        choices: Sequence[str | int | float | tuple[str, str | int | float]]
-        | None = None,
+        choices: Sequence[str | int | float | I18nData | tuple[str | I18nData, str | int | float]] | None = None,
         *,
         value: str
         | int
         | float
-        | Sequence[str | int | float]
+        | I18nData
+        | Sequence[str | I18nData | int | float]
         | Callable
         | DefaultValue
         | None = DEFAULT_VALUE,
@@ -194,7 +194,7 @@ class Dropdown(FormComponent):
         if payload is None:
             return None
 
-        choice_values = [value for _, value in self.choices]
+        choice_values = [value if not isinstance(value, I18nData) else value.key for _, value in self.choices]
         if not self.allow_custom_value:
             if isinstance(payload, list):
                 for value in payload:
@@ -232,8 +232,8 @@ class Dropdown(FormComponent):
         )
 
     def postprocess(
-        self, value: str | int | float | list[str | int | float] | None
-    ) -> str | int | float | list[str | int | float] | None:
+        self, value: str | I18nData | int | float | list[str | I18nData | int | float] | None
+    ) -> str | I18nData | int | float | list[str | I18nData | int | float] | None:
         """
         Parameters:
             value: Expects a `str | int | float` corresponding to the value of the dropdown entry to be selected. Or, if `multiselect` is True, expects a `list` of values corresponding to the selected dropdown entries.

--- a/gradio/i18n.py
+++ b/gradio/i18n.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import warnings
 from typing import Any
@@ -37,7 +38,6 @@ class I18nData:
         This returns a special format that can be recognized by the frontend
         as needing translation.
         """
-        import json
 
         return f"__i18n__{json.dumps(self.to_dict())}"
 
@@ -72,6 +72,14 @@ class I18nData:
             return self
 
         return method
+
+    def __eq__(self, other):
+        if type(self) is type(other):
+            return str(self) == str(other)
+        return False
+
+    def __hash__(self) -> int:
+        return hash(str(self))
 
     def tojson(self) -> dict[str, Any]:
         """

--- a/js/core/src/RenderComponent.svelte
+++ b/js/core/src/RenderComponent.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
 	import type { ComponentMeta, ThemeMode } from "./types";
 	import type { SvelteComponent, ComponentType } from "svelte";
-	import { translate_if_needed } from "./i18n";
+	import { translate_if_needed, extractI18nKey } from "./i18n";
 	// @ts-ignore
 	import { bind, binding_callbacks } from "svelte/internal";
 
@@ -60,27 +60,6 @@
 		"label",
 		"choices"
 	];
-
-	function extractI18nKey(input: string): string {
-		const prefix = "__i18n__";
-		if (!input.startsWith(prefix)) return input;
-
-		const jsonPart = input.slice(prefix.length);
-		try {
-			const parsed = JSON.parse(jsonPart);
-			if (
-			typeof parsed === "object" &&
-			parsed !== null &&
-			parsed.__type__ === "translation_metadata" &&
-			typeof parsed.key === "string"
-			) {
-				const decodedKey = JSON.parse(`"${parsed.key}"`);
-				return decodedKey;
-			}
-		} catch {
-		}
-		return input;
-	}
 
 	function translate_prop(obj: SvelteRestProps): void {
 		for (const key in obj) {


### PR DESCRIPTION
## Description

Add Support for Dropdown Choices I18n

Demo:
```python
gr.Dropdown(choices=[i18n("greeting"), i18n("submit"),"111"], value="111", interactive=True,allow_custom_value=True)
```
<img width="1710" height="1069" alt="image" src="https://github.com/user-attachments/assets/f734516d-b15e-470a-acee-1e38f5ab1e94" />


Closes: #11557 

## 🎯 PRs Should Target Issues

Translate dropdown choices while preserving the original values for backend use.

## Testing and Formatting Your Code

This implementation has been tested on gradio@5.35.0, but I was unable to test it on gradio@5.36.2 due to issue #11554.

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
