### PR TITLE
`gr.Datraframe` returns a `number` \ `bool` when the corresponding column is edited

### DIFF
--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -235,6 +235,25 @@ class Dataframe(Component):
         """
         import pandas as pd
 
+        # Quick Fix better change it in js
+        if isinstance(self.datatype, list):
+            for row in payload.data:
+                if isinstance(row, list):
+                    for i, col in enumerate(row):
+                        if i < len(self.datatype):
+                            if self.datatype[i] == "number":
+                                try:
+                                    row[i] = float(col) if col not in [None, ""] else None
+                                except ValueError:
+                                    row[i] = None
+                            elif self.datatype[i] == "bool":
+                                row[i] = str(col).lower() == 'true'
+                            elif self.datatype[i] == "date":
+                                try:
+                                    row[i] = pd.to_datetime(col)
+                                except Exception:
+                                    row[i] = col
+
         if self.type == "pandas":
             if payload.headers is not None:
                 return pd.DataFrame(


### PR DESCRIPTION
## Description

Quick Fix for the Bug #11492. If a cell in a `number` or `bool` column is edited, a string is always returned. This PR avoids the problem by converting the corresponding columns to `bool` or `number` in the `preprocess()`-function in Python.

Closes: #11492

## Additional Infos
I think the better solution is to fix this Bug in js. But I don't know JS, and from the look into it, it seems to me that there are more than one line where this change needs to be addressed.
  
