### PR TITLE
Fix reload mode

### DIFF
--- a/gradio/state_holder.py
+++ b/gradio/state_holder.py
@@ -139,15 +139,23 @@ class SessionState:
     def state_components(self) -> Iterator[tuple[State, Any, bool]]:
         from gradio.components import State
 
-        for id in self.state_data:
-            block = self.blocks_config.blocks[id]
-            if isinstance(block, State) and id in self._state_ttl:
-                time_to_live, created_at = self._state_ttl[id]
+        state_ids_to_delete = []
+        for _id in self.state_data:
+            if _id not in self.blocks_config.blocks:
+                # state may have been deleted in reload or re-render
+                state_ids_to_delete.append(_id)
+                continue
+            block = self.blocks_config.blocks[_id]
+            if isinstance(block, State) and _id in self._state_ttl:
+                time_to_live, created_at = self._state_ttl[_id]
                 if self.is_closed:
                     time_to_live = self.STATE_TTL_WHEN_CLOSED
-                value = self.state_data[id]
+                value = self.state_data[_id]
                 yield (
                     block,
                     value,
                     (datetime.datetime.now() - created_at).seconds > time_to_live,
                 )
+        for _id in state_ids_to_delete:
+            del self.state_data[_id]
+            del self._state_ttl[_id]

--- a/js/app/src/routes/[...catchall]/+page.svelte
+++ b/js/app/src/routes/[...catchall]/+page.svelte
@@ -301,9 +301,9 @@
 						{
 							status_callback: handle_status,
 							with_null_state: true,
-							events: ["data", "log", "status", "render"]
+							events: ["data", "log", "status", "render"],
+							session_hash: app.session_hash
 						},
-						app.session_hash
 					);
 
 					if (!app.config) {

--- a/js/core/src/init.ts
+++ b/js/core/src/init.ts
@@ -114,8 +114,14 @@ export function create_components(initial_layout: ComponentMeta | undefined): {
 		if (instance_map) {
 			// re-render in reload mode
 			components.forEach((c) => {
-				if (c.props.value == null && c.id in instance_map) {
-					c.props.value = instance_map[c.id].props.value;
+				if (c.props.value == null && c.key) {
+					// If the component has a key, we preserve its value by finding a matching instance with the same key
+					const matching_instance = Object.values(instance_map).find(
+						(instance) => instance.key === c.key
+					);
+					if (matching_instance) {
+						c.props.value = matching_instance.props.value;
+					}
 				}
 			});
 		}

--- a/js/spa/test/hello_blocks.reload.spec.ts
+++ b/js/spa/test/hello_blocks.reload.spec.ts
@@ -55,12 +55,11 @@ test("gradio dev mode correctly reloads the page", async ({ page }) => {
 		console.log("Connected to port", port);
 
 		await page.goto(`http://localhost:${port}`);
-		await page.waitForTimeout(2000);
 
 		await page.getByLabel("x").fill("abcde");
 		await expect(page.getByLabel("y")).toHaveValue("edcba");
 
-		const demo = `
+		const demo1 = `
 import gradio as gr
     
 with gr.Blocks() as demo:
@@ -74,7 +73,7 @@ if __name__ == "__main__":
     demo.launch()
     `;
 		// write contents of demo to a local 'run.py' file
-		spawnSync(`echo '${demo}' > ${join(process.cwd(), "run.py")}`, {
+		spawnSync(`echo '${demo1}' > ${join(process.cwd(), "run.py")}`, {
 			shell: true,
 			stdio: "pipe",
 			env: {
@@ -123,6 +122,358 @@ if __name__ == "__main__":
 		await expect(page.getByLabel("x")).toHaveValue("");
 		await expect(page.getByLabel("y")).toHaveValue("");
 		await expect(page.getByLabel("z")).toHaveValue("");
+
+
+		const demo3 = `
+import gradio as gr
+    
+with gr.Blocks() as demo:
+	with gr.Row():
+		t1 = gr.Textbox("new", label="x")
+		btn = gr.Button("Swap")
+		t2 = gr.Textbox(label="y")
+	btn.click(lambda x, y: [y, x], inputs=[t1, t2], outputs=[t1, t2])
+
+if __name__ == "__main__":
+    demo.launch()
+    `;
+		// write contents of demo to a local 'run.py' file
+		spawnSync(`echo '${demo3}' > ${join(process.cwd(), "run.py")}`, {
+			shell: true,
+			stdio: "pipe",
+			env: {
+				...process.env,
+				PYTHONUNBUFFERED: "true"
+			}
+		});
+
+		await expect(page.getByLabel("x")).toHaveValue("new");
+		await expect(page.getByLabel("y")).toHaveValue("");
+
+		await page.getByLabel("x").fill("test");
+		await page.getByRole("button", { name: "Swap" }).click();
+		await expect(page.getByLabel("x")).toHaveValue("");
+		await expect(page.getByLabel("y")).toHaveValue("test");
+	} finally {
+		if (_process) kill_process(_process);
+	}
+});
+
+test("gradio dev mode works with removing / changing existing elements", async ({ page }) => {
+	test.setTimeout(20 * 1000);
+
+	try {
+		const { _process: server_process, port: port } =
+			await launch_app_background(
+				`gradio ${join(process.cwd(), "run.py")}`,
+				process.cwd()
+			);
+
+		_process = server_process;
+		console.log("Connected to port", port);
+
+		await page.goto(`http://localhost:${port}`);
+
+		const demo = `
+import gradio as gr
+    
+with gr.Blocks() as demo:
+	t1 = gr.Textbox("a", label="x")
+	t2 = gr.Textbox("b", label="y")
+	btn = gr.Button("Button")
+
+if __name__ == "__main__":
+    demo.launch()
+    `;
+		// write contents of demo to a local 'run.py' file
+		spawnSync(`echo '${demo}' > ${join(process.cwd(), "run.py")}`, {
+			shell: true,
+			stdio: "pipe",
+			env: {
+				...process.env,
+				PYTHONUNBUFFERED: "true"
+			}
+		});
+
+		await expect(page.getByLabel("x")).toHaveValue("a");
+		await expect(page.getByLabel("y")).toHaveValue("b");
+		await page.getByRole("button", { name: "Button" }).click();
+
+		const demo2 = `
+import gradio as gr
+
+with gr.Blocks() as demo:
+	t1 = gr.Textbox("a", label="x")
+	btn = gr.Button("Button")
+
+if __name__ == "__main__":
+	demo.launch()
+    `;
+		// write contents of demo to a local 'run.py' file
+		spawnSync(`echo '${demo2}' > ${join(process.cwd(), "run.py")}`, {
+			shell: true,
+			stdio: "pipe",
+			env: {
+				...process.env,
+				PYTHONUNBUFFERED: "true"
+			}
+		});
+
+		await expect(page.getByLabel("x")).toHaveValue("a");
+		await page.getByRole("button", { name: "Button" }).click();
+
+		const demo3 = `
+import gradio as gr
+
+with gr.Blocks() as demo:
+	t1 = gr.Textbox(label="a")
+	t2 = gr.Textbox(label="b")
+	
+	with gr.Row():
+		t3 = gr.Textbox(label="c")
+		t4 = gr.Textbox(label="d")
+		t5 = gr.Textbox(label="e")
+
+	btn = gr.Button("Button")
+	btn.click(lambda *args: args, inputs=[t1, t2, t3, t4, t5], outputs=[t2, t3, t4, t5, t1])
+
+if __name__ == "__main__":
+	demo.launch()
+    `;
+		// write contents of demo to a local 'run.py' file
+		spawnSync(`echo '${demo3}' > ${join(process.cwd(), "run.py")}`, {
+			shell: true,
+			stdio: "pipe",
+			env: {
+				...process.env,
+				PYTHONUNBUFFERED: "true"
+			}
+		});
+
+		await page.getByLabel("a").fill("a");
+		await page.getByLabel("b").fill("b");
+		await page.getByLabel("c").fill("c");
+		await page.getByLabel("d").fill("d");
+		await page.getByLabel("e").fill("e");
+
+		await page.getByRole("button", { name: "Button" }).click();
+
+		await expect(page.getByLabel("a")).toHaveValue("e");
+		await expect(page.getByLabel("b")).toHaveValue("a");
+		await expect(page.getByLabel("c")).toHaveValue("b");
+		await expect(page.getByLabel("d")).toHaveValue("c");
+		await expect(page.getByLabel("e")).toHaveValue("d");
+
+		const demo4 = `
+import gradio as gr
+
+with gr.Blocks() as demo:
+	t1 = gr.Textbox(label="a")
+	t2 = gr.Textbox(label="b")
+	tx = gr.Textbox(label="x")
+	
+	with gr.Row():
+		t3 = gr.Textbox(label="c")
+		with gr.Column():
+			t4 = gr.Textbox(label="d")
+			t5 = gr.Textbox(label="e")
+
+	btn = gr.Button("Button")
+	btn.click(lambda *args: args, inputs=[t1, t2, t3, t4, t5], outputs=[t2, t3, t4, t5, t1])
+
+if __name__ == "__main__":
+	demo.launch()
+    `;
+		// write contents of demo to a local 'run.py' file
+		spawnSync(`echo '${demo4}' > ${join(process.cwd(), "run.py")}`, {
+			shell: true,
+			stdio: "pipe",
+			env: {
+				...process.env,
+				PYTHONUNBUFFERED: "true"
+			}
+		});
+
+		await expect(page.getByLabel("a")).toHaveValue("e");
+		await expect(page.getByLabel("b")).toHaveValue("a");
+		await expect(page.getByLabel("x")).toHaveValue("");
+		await expect(page.getByLabel("c")).toHaveValue("");
+		await expect(page.getByLabel("d")).toHaveValue("");
+		await expect(page.getByLabel("e")).toHaveValue("");
+
+		await page.getByRole("button", { name: "Button" }).click();
+
+		await expect(page.getByLabel("a")).toHaveValue("");
+		await expect(page.getByLabel("b")).toHaveValue("e");
+		await expect(page.getByLabel("c")).toHaveValue("a");
+	} finally {
+		if (_process) kill_process(_process);
+	}
+});
+
+
+test("gradio dev mode works when switching between interface / blocks / chatinterface", async ({ page }) => {
+	test.setTimeout(20 * 1000);
+
+	try {
+		const { _process: server_process, port: port } =
+			await launch_app_background(
+				`gradio ${join(process.cwd(), "run.py")}`,
+				process.cwd()
+			);
+
+		_process = server_process;
+		console.log("Connected to port", port);
+
+		await page.goto(`http://localhost:${port}`);
+
+		const demo1 = `
+import gradio as gr
+
+def echo(message, history):
+	return f"{len(history)}: {message}"
+
+demo = gr.ChatInterface(
+    echo,
+    type="messages",
+)
+
+if __name__ == "__main__":
+	demo.launch()
+    `;
+		// write contents of demo to a local 'run.py' file
+		spawnSync(`echo '${demo1}' > ${join(process.cwd(), "run.py")}`, {
+			shell: true,
+			stdio: "pipe",
+			env: {
+				...process.env,
+				PYTHONUNBUFFERED: "true"
+			}
+		});
+
+
+		await expect(page.getByText("Chatbot")).toBeVisible();
+		const textbox = page.getByTestId("textbox");
+		await textbox.fill("Hello");
+		await page.keyboard.press("Enter");
+		const bot_message = await page
+			.getByTestId("bot")
+			.first()
+			.getByRole("paragraph")
+			.textContent();
+		expect(bot_message).toEqual("0: Hello");
+
+		await textbox.fill("World");
+		await page.keyboard.press("Enter");
+
+		const bot_message2 = await page
+			.getByTestId("bot")
+			.nth(1)
+			.getByRole("paragraph")
+			.textContent();
+
+		expect(bot_message2).toEqual("2: World");
+
+		const demo2 = `
+import gradio as gr
+import numpy as np
+
+with gr.Blocks() as demo:
+	def create_image_noise(width, height):
+		return np.random.randint(0, 255, (height, width, 3), dtype=np.uint8)
+
+	with gr.Row():
+		w = gr.Number(label="Width")
+		h = gr.Number(label="Height")
+
+	create_btn = gr.Button("Create")
+	img = gr.Image(label="Image")
+
+	create_btn.click(create_image_noise, inputs=[w, h], outputs=img)
+
+	def count_pixels(image):
+		return np.shape(image)[0] * np.shape(image)[1]
+
+	count_btn = gr.Button("Count Pixels")
+	count = gr.Number(label="Total Pixels")
+	count_btn.click(count_pixels, inputs=img, outputs=count)
+
+if __name__ == "__main__":
+	demo.launch()
+    `;
+		// write contents of demo to a local 'run.py' file
+		spawnSync(`echo '${demo2}' > ${join(process.cwd(), "run.py")}`, {
+			shell: true,
+			stdio: "pipe",
+			env: {
+				...process.env,
+				PYTHONUNBUFFERED: "true"
+			}
+		});
+
+		await page.getByLabel("Width").fill("100");
+		await page.getByLabel("Height").fill("100");
+		await page.getByRole("button", { name: "Create" }).click();
+		const image = page.getByTestId("image").locator("img").first();
+		expect(await image.getAttribute("src")).toContain("/file=");
+		await page.getByRole("button", { name: "Count Pixels" }).click();
+		await expect(page.getByLabel("Total Pixels")).toHaveValue("10000");
+
+		const demo3 = `
+import gradio as gr
+
+with gr.Blocks() as demo:
+	t1 = gr.Textbox()
+	ERROR_WTF
+
+if __name__ == "__main__":
+	demo.launch()
+    `;
+		// write contents of demo to a local 'run.py' file
+		spawnSync(`echo '${demo3}' > ${join(process.cwd(), "run.py")}`, {
+			shell: true,
+			stdio: "pipe",
+			env: {
+				...process.env,
+				PYTHONUNBUFFERED: "true"
+			}
+		});
+
+		await expect(page.getByText("Error reloading")).toBeVisible();
+
+		const demo4 = `
+import gradio as gr
+
+def count_letter(sentence, letter):
+	return sentence.count(letter)
+
+demo = gr.Interface(
+	count_letter, 
+	[gr.Textbox(label="sentence"), gr.Textbox(label="letter")], 
+	gr.Number(label="count")
+)
+
+if __name__ == "__main__":
+	demo.launch()
+`;
+		// write contents of demo to a local 'run.py' file
+		spawnSync(`echo '${demo4}' > ${join(process.cwd(), "run.py")}`, {
+			shell: true,
+			stdio: "pipe",
+			env: {
+				...process.env,
+				PYTHONUNBUFFERED: "true"
+			}
+		});
+
+		
+		await page.getByLabel("sentence").fill("We looove Gradio!");
+		await page.getByLabel("letter").fill("o");
+		await page.getByRole("button", { name: "Submit" }).click();
+		await expect(page.getByLabel("count")).toHaveValue("4");
+
+
+
 	} finally {
 		if (_process) kill_process(_process);
 	}


### PR DESCRIPTION
This PR fixes reload mode which was quite broken. Also added a lot more testing to reload mode so hopefully should not break in the future. Reload mode will be integral to the Gradio AI editor so it will become essential this workflow does not break.

Previously, very simple interactions using reload mode would break, e.g.

launch this with reload mode:
```python
import gradio as gr

with gr.Blocks() as demo:
    a = gr.Textbox()

if __name__ == "__main__":
    demo.launch()
```

and then change to this
```python
import gradio as gr

with gr.Blocks() as demo:
    a = gr.Textbox()
    btn = gr.Button()

if __name__ == "__main__":
    demo.launch()
```

Fixed a lot of issues with reload mode, and also added a lot more comprehensive testing.

Removed two recently added features that were causing issues:
1. Preserving state across reloads - state will now be reset on reload
2. Components will have their values preserved, but not their ids, meaning that the components will be recreated in the frontend on reload. There was some bug that seems to be part of svelte that was causing unset props to become set to undefined when other props were set.


