### PR TITLE
fix: add missing space at end of warning sentences for proper grammar

### DIFF
--- a/.changeset/small-ads-hang.md
+++ b/.changeset/small-ads-hang.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:fix: add missing space at end of warning sentences for proper grammar
+fix:fix: add missing space at end of warning sentences for proper grammar

--- a/.changeset/small-ads-hang.md
+++ b/.changeset/small-ads-hang.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:fix: add missing space at end of warning sentences for proper grammar

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -303,7 +303,7 @@ class Interface(Blocks):
 
             if cache_examples:
                 warnings.warn(
-                    "Cache examples cannot be used with state inputs and outputs."
+                    "Cache examples cannot be used with state inputs and outputs. "
                     "Setting cache_examples to False."
                 )
             self.cache_examples = False
@@ -423,7 +423,7 @@ class Interface(Blocks):
         # (2) check for env variable, (3) default to "manual"
         if allow_flagging is not None:
             warnings.warn(
-                "The `allow_flagging` parameter in `Interface` is deprecated."
+                "The `allow_flagging` parameter in `Interface` is deprecated. "
                 "Use `flagging_mode` instead."
             )
             flagging_mode = allow_flagging


### PR DESCRIPTION
## Description

The first segment of two warnings in `interface.py` was missing a trailing space before the next literal, causing the sentences to run together. This commit appends a space to:

- “Cache examples cannot be used with state inputs and outputs. ”
- “The `allow_flagging` parameter in `Interface` is deprecated. ”
  
## Current Behavior

<img width="1706" height="92" alt="image" src="https://github.com/user-attachments/assets/e12b3388-8327-4404-8540-fe4032f6d5bb" />

