### PR TITLE
Fix for the JSON component's ability to display a formatted JSON string

### DIFF
--- a/gradio/components/json_component.py
+++ b/gradio/components/json_component.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from collections.abc import Callable, Sequence
 from typing import (
     TYPE_CHECKING,
@@ -113,6 +114,7 @@ class JSON(Component):
         Returns:
             Returns the JSON as a `list` or `dict`.
         """
+
         def default_json(o):
             """
             Check if the string representation of the object is already a valid JSON string. If it is,
@@ -122,10 +124,10 @@ class JSON(Component):
                 return orjson.loads(str(o))
             except orjson.JSONDecodeError:
                 return str(o)
-            
+
         if value is None:
             return None
-        
+
         if not isinstance(value, (str, dict, list, Callable)):
             warnings.warn(
                 f"JSON component received unexpected type {type(value)}. "

--- a/gradio/components/json_component.py
+++ b/gradio/components/json_component.py
@@ -113,8 +113,26 @@ class JSON(Component):
         Returns:
             Returns the JSON as a `list` or `dict`.
         """
+        def default_json(o):
+            """
+            Check if the string representation of the object is already a valid JSON string. If it is,
+            parse it as JSON without the need to double quote it as string.
+            """
+            try:
+                return orjson.loads(str(o))
+            except orjson.JSONDecodeError:
+                return str(o)
+            
         if value is None:
             return None
+        
+        if not isinstance(value, (str, dict, list, Callable)):
+            warnings.warn(
+                f"JSON component received unexpected type {type(value)}. "
+                "Expected a string (including a valid JSON string), dict, list, or Callable.",
+                UserWarning,
+            )
+
         if isinstance(value, str):
             return JsonData(orjson.loads(value))
         else:
@@ -127,7 +145,7 @@ class JSON(Component):
                         value,
                         option=orjson.OPT_SERIALIZE_NUMPY
                         | orjson.OPT_PASSTHROUGH_DATETIME,
-                        default=str,
+                        default=default_json,
                     )
                 )
             )


### PR DESCRIPTION
## Description

The JSON component is unable to display a formatted JSON string returned by a `__str__` method implementation of a class. Instead, it considers that as a string (not valid JSON) and captures as a literal string.

In the `postprocess` function of the JSON component, make `orjson` check if the value supplied to it is already a valid JSON string, in which case, there is no further need to make it a string. This way, if a class as a `__str__` implementation, which returns a valid JSON representation of some underlying data, it will be parsed correctly as a `dict` or a `list` without double quoting the valid JSON as a string.

Closes: #11592 

## 🎯 PRs Should Target Issues

> Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 
> 
> Not adhering to this guideline will result in the PR being closed. 

Followed this guideline.

## Testing and Formatting Your Code

> 1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

Run these tests with **errors** reported for _Docker_ (`test/test_docker/`) only. See attached file [backend_tests.log](https://github.com/user-attachments/files/21332043/backend_tests.log).

> 2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

 - Run formatter with the following output
 ```bash
 bash scripts/format_backend.sh
Formatting the backend... Our style follows the ruff code style.
All checks passed!
236 files left unchanged
 ```
 - Frontend testing is not applicable.  
