### PR TITLE
Add `auth_token` and `exclude_paths` to `gr.load_openapi`

### DIFF
--- a/.changeset/warm-goats-stop.md
+++ b/.changeset/warm-goats-stop.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Add `auth_token` and `exclude_paths` to `gr.load_openapi`

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -917,8 +917,6 @@ def load_openapi(
     api_paths = spec.get("paths", {})
 
     if paths is not None or exclude_paths is not None:
-        import re
-
         filtered_paths = {}
         for path in api_paths:
             if exclude_paths:

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -878,6 +878,7 @@ def load_openapi(
     *,
     paths: list[str] | None = None,
     methods: list[Literal["get", "post", "put", "patch", "delete"]] | None = None,
+    auth_token: str | None = None,
 ) -> Blocks:
     """
     Load a Gradio app from an OpenAPI v3 specification.
@@ -887,6 +888,7 @@ def load_openapi(
         base_url: Base URL for the API endpoints, e.g. "https://api.example.com/v1". This is used to construct the full URL for each endpoint.
         paths: Optional list of specific API paths to create Gradio endpoints from. Supports regex patterns, e.g. ["/api/v1/books", ".*users.*"]. If None, all paths in the OpenAPI spec will be included.
         methods: Optional list of HTTP methods to include in the Gradio endpoints. If None, all methods will be included.
+        auth_token: Optional authentication token to be sent as a Bearer token in the Authorization header for all API requests.
     Returns:
         A Gradio Blocks app with endpoints generated from the OpenAPI spec
     """
@@ -966,7 +968,7 @@ def load_openapi(
                     components_list.append(body_component)
 
             endpoint_fn = external_utils.create_endpoint_fn(
-                path, method, operation, base_url
+                path, method, operation, base_url, auth_token
             )
             endpoint_fn.__name__ = (
                 f"{method}_{path.replace('/', '_').replace('{', '').replace('}', '')}"

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -888,7 +888,7 @@ def load_openapi(
     Parameters:
         openapi_spec: URL, file path, or dictionary containing the OpenAPI specification (v3, JSON format only)
         base_url: Base URL for the API endpoints, e.g. "https://api.example.com/v1". This is used to construct the full URL for each endpoint.
-        paths: Optional list of specific API paths to create Gradio endpoints from. Supports regex patterns, e.g. ["/api/v1/books", ".*users.*"]. If None, all paths in the OpenAPI spec will be included.
+        paths: Optional list of specific API paths to create Gradio endpoints from. Supports regex patterns, e.g. ["/api/v1/books", ".*user.*"]. If None, all paths in the OpenAPI spec will be included.
         exclude_paths: Optional list of API paths to exclude from the Gradio endpoints. Supports regex patterns and takes precedence over `paths`. For example, [".*internal.*"] will exclude all paths containing "internal".
         methods: Optional list of HTTP methods to include in the Gradio endpoints. If None, all methods will be included.
         auth_token: Optional authentication token to be sent as a Bearer token in the Authorization header for all API requests.

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -877,8 +877,10 @@ def load_openapi(
     base_url: str,
     *,
     paths: list[str] | None = None,
+    exclude_paths: list[str] | None = None,
     methods: list[Literal["get", "post", "put", "patch", "delete"]] | None = None,
     auth_token: str | None = None,
+    **interface_kwargs,
 ) -> Blocks:
     """
     Load a Gradio app from an OpenAPI v3 specification.
@@ -887,8 +889,10 @@ def load_openapi(
         openapi_spec: URL, file path, or dictionary containing the OpenAPI specification (v3, JSON format only)
         base_url: Base URL for the API endpoints, e.g. "https://api.example.com/v1". This is used to construct the full URL for each endpoint.
         paths: Optional list of specific API paths to create Gradio endpoints from. Supports regex patterns, e.g. ["/api/v1/books", ".*users.*"]. If None, all paths in the OpenAPI spec will be included.
+        exclude_paths: Optional list of API paths to exclude from the Gradio endpoints. Supports regex patterns and takes precedence over `paths`. For example, [".*internal.*"] will exclude all paths containing "internal".
         methods: Optional list of HTTP methods to include in the Gradio endpoints. If None, all methods will be included.
         auth_token: Optional authentication token to be sent as a Bearer token in the Authorization header for all API requests.
+        interface_kwargs: Additional keyword arguments to pass to each generated gr.Interface instance (e.g., title, description, article, examples_per_page, etc.)
     Returns:
         A Gradio Blocks app with endpoints generated from the OpenAPI spec
     """
@@ -911,15 +915,29 @@ def load_openapi(
         raise ValueError("openapi_spec must be a string (URL/file path) or dictionary")
 
     api_paths = spec.get("paths", {})
-    if paths is not None:
+
+    if paths is not None or exclude_paths is not None:
         import re
 
         filtered_paths = {}
         for path in api_paths:
-            for pattern in paths:
-                if re.match(pattern, path):
-                    filtered_paths[path] = api_paths[path]
-                    break
+            if exclude_paths:
+                excluded = False
+                for exclude_pattern in exclude_paths:
+                    if re.match(exclude_pattern, path):
+                        excluded = True
+                        break
+                if excluded:
+                    continue
+
+            if paths is not None:
+                for pattern in paths:
+                    if re.match(pattern, path):
+                        filtered_paths[path] = api_paths[path]
+                        break
+            else:
+                filtered_paths[path] = api_paths[path]
+
         api_paths = filtered_paths
 
     if not api_paths:
@@ -988,6 +1006,7 @@ def load_openapi(
                 fn=endpoint_fn,
                 inputs=inputs,
                 outputs=output,
+                **interface_kwargs,
             )
 
     return demo

--- a/gradio/external_utils.py
+++ b/gradio/external_utils.py
@@ -297,6 +297,7 @@ def create_endpoint_fn(
     endpoint_method: str,
     endpoint_operation: dict,
     base_url: str,
+    auth_token: str | None = None,
 ):
     # Get request body info for docstring generation
     request_body = endpoint_operation.get("requestBody", {})
@@ -305,6 +306,8 @@ def create_endpoint_fn(
         url = f"{base_url.rstrip('/')}{endpoint_path}"
 
         headers = {"Content-Type": "application/json"}
+        if auth_token:
+            headers["Authorization"] = f"Bearer {auth_token}"
 
         params = {}
         body_data = {}
@@ -333,7 +336,7 @@ def create_endpoint_fn(
             if is_file_upload:
                 file_data = args[param_index]
                 if file_data:
-                    headers = {"Content-Type": "application/octet-stream"}
+                    headers["Content-Type"] = "application/octet-stream"
                     body_data = file_data
                 else:
                     body_data = b""


### PR DESCRIPTION
As suggested by @evalstate and @Wauplin [internally](https://huggingface.slack.com/archives/C02136Y252P/p1753341289591279?thread_ts=1753317024.694709&cid=C02136Y252P), this adds support for excluding certain paths and an auth token to `gr.load_openapi`. Also adds arbitrary kwargs which are passed into the resulting `Interface` that is created. 