### PR TITLE
Improve schema for `gr.Number` and `gr.Slider` and other related changes around precision and minimum/maximum range

### DIFF
--- a/.changeset/loud-mirrors-sin.md
+++ b/.changeset/loud-mirrors-sin.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Improve schema for `gr.Number` and `gr.Slider` and other related changes around precision and minimum/maximum range

--- a/gradio/components/number.py
+++ b/gradio/components/number.py
@@ -101,7 +101,7 @@ class Number(FormComponent):
         )
 
     @staticmethod
-    def _round_to_precision(num: float | int, precision: int | None) -> float | int:
+    def round_to_precision(num: float | int, precision: int | None) -> float | int:
         """
         Round to a given precision.
 
@@ -120,8 +120,8 @@ class Number(FormComponent):
         else:
             return round(num, precision)
 
-    @staticmethod   
-    def _raise_if_out_of_bounds(num: float | int, minimum: float | int | None, maximum: float | int | None) -> None:
+    @staticmethod
+    def raise_if_out_of_bounds(num: float | int, minimum: float | int | None, maximum: float | int | None) -> None:
         if minimum is not None and num < minimum:
             raise Error(f"Value {num} is less than minimum value {minimum}.")
         if maximum is not None and num > maximum:
@@ -136,8 +136,8 @@ class Number(FormComponent):
         """
         if payload is None:
             return None
-        self._raise_if_out_of_bounds(payload, self.minimum, self.maximum)
-        return self._round_to_precision(payload, self.precision)
+        self.raise_if_out_of_bounds(payload, self.minimum, self.maximum)
+        return self.round_to_precision(payload, self.precision)
 
     def postprocess(self, value: float | int | None) -> float | int | None:
         """
@@ -148,7 +148,7 @@ class Number(FormComponent):
         """
         if value is None:
             return None
-        return self._round_to_precision(value, self.precision)
+        return self.round_to_precision(value, self.precision)
 
     def api_info(self) -> dict[str, str]:
         if self.precision == 0:
@@ -156,7 +156,7 @@ class Number(FormComponent):
         return {"type": "number"}
 
     def example_payload(self) -> Any:
-        return self._round_to_precision(3 if self.minimum is None else self.minimum, self.precision)
+        return self.round_to_precision(3 if self.minimum is None else self.minimum, self.precision)
 
     def example_value(self) -> Any:
-        return self._round_to_precision(3 if self.minimum is None else self.minimum, self.precision)
+        return self.round_to_precision(3 if self.minimum is None else self.minimum, self.precision)

--- a/gradio/components/number.py
+++ b/gradio/components/number.py
@@ -121,7 +121,9 @@ class Number(FormComponent):
             return round(num, precision)
 
     @staticmethod
-    def raise_if_out_of_bounds(num: float | int, minimum: float | int | None, maximum: float | int | None) -> None:
+    def raise_if_out_of_bounds(
+        num: float | int, minimum: float | int | None, maximum: float | int | None
+    ) -> None:
         if minimum is not None and num < minimum:
             raise Error(f"Value {num} is less than minimum value {minimum}.")
         if maximum is not None and num > maximum:
@@ -156,7 +158,11 @@ class Number(FormComponent):
         return {"type": "number"}
 
     def example_payload(self) -> Any:
-        return self.round_to_precision(3 if self.minimum is None else self.minimum, self.precision)
+        return self.round_to_precision(
+            3 if self.minimum is None else self.minimum, self.precision
+        )
 
     def example_value(self) -> Any:
-        return self.round_to_precision(3 if self.minimum is None else self.minimum, self.precision)
+        return self.round_to_precision(
+            3 if self.minimum is None else self.minimum, self.precision
+        )

--- a/gradio/components/number.py
+++ b/gradio/components/number.py
@@ -120,6 +120,13 @@ class Number(FormComponent):
         else:
             return round(num, precision)
 
+    @staticmethod   
+    def _raise_if_out_of_bounds(num: float | int, minimum: float | int | None, maximum: float | int | None) -> None:
+        if minimum is not None and num < minimum:
+            raise Error(f"Value {num} is less than minimum value {minimum}.")
+        if maximum is not None and num > maximum:
+            raise Error(f"Value {num} is greater than maximum value {maximum}.")
+
     def preprocess(self, payload: float | None) -> float | int | None:
         """
         Parameters:
@@ -129,12 +136,7 @@ class Number(FormComponent):
         """
         if payload is None:
             return None
-        elif self.minimum is not None and payload < self.minimum:
-            raise Error(f"Value {payload} is less than minimum value {self.minimum}.")
-        elif self.maximum is not None and payload > self.maximum:
-            raise Error(
-                f"Value {payload} is greater than maximum value {self.maximum}."
-            )
+        self._raise_if_out_of_bounds(payload, self.minimum, self.maximum)
         return self._round_to_precision(payload, self.precision)
 
     def postprocess(self, value: float | int | None) -> float | int | None:
@@ -149,10 +151,12 @@ class Number(FormComponent):
         return self._round_to_precision(value, self.precision)
 
     def api_info(self) -> dict[str, str]:
+        if self.precision == 0:
+            return {"type": "integer"}
         return {"type": "number"}
 
     def example_payload(self) -> Any:
-        return 3
+        return self._round_to_precision(3 if self.minimum is None else self.minimum, self.precision)
 
     def example_value(self) -> Any:
-        return 3
+        return self._round_to_precision(3 if self.minimum is None else self.minimum, self.precision)

--- a/gradio/components/slider.py
+++ b/gradio/components/slider.py
@@ -140,7 +140,9 @@ class Slider(FormComponent):
         Returns:
             The value of the slider within the range.
         """
-        return Number.round_to_precision(self.minimum if value is None else value, self.precision)
+        return Number.round_to_precision(
+            self.minimum if value is None else value, self.precision
+        )
 
     def preprocess(self, payload: float) -> float:
         """

--- a/gradio/components/slider.py
+++ b/gradio/components/slider.py
@@ -140,7 +140,7 @@ class Slider(FormComponent):
         Returns:
             The value of the slider within the range.
         """
-        return Number._round_to_precision(self.minimum if value is None else value, self.precision)
+        return Number.round_to_precision(self.minimum if value is None else value, self.precision)
 
     def preprocess(self, payload: float) -> float:
         """
@@ -149,5 +149,5 @@ class Slider(FormComponent):
         Returns:
             Passes slider value as a {float} into the function.
         """
-        Number._raise_if_out_of_bounds(payload, self.minimum, self.maximum)
-        return Number._round_to_precision(payload, self.precision)
+        Number.raise_if_out_of_bounds(payload, self.minimum, self.maximum)
+        return Number.round_to_precision(payload, self.precision)

--- a/gradio/components/slider.py
+++ b/gradio/components/slider.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from gradio_client.documentation import document
 
 from gradio.components.base import Component, FormComponent
+from gradio.components.number import Number
 from gradio.events import Events
 from gradio.i18n import I18nData
 
@@ -35,6 +36,7 @@ class Slider(FormComponent):
         value: float | Callable | None = None,
         *,
         step: float | None = None,
+        precision: int | None = None,
         label: str | I18nData | None = None,
         info: str | I18nData | None = None,
         every: Timer | float | None = None,
@@ -55,10 +57,11 @@ class Slider(FormComponent):
     ):
         """
         Parameters:
-            minimum: minimum value for slider.
-            maximum: maximum value for slider.
+            minimum: minimum value for slider. When used as an input, if a user provides a smaller value, a gr.Error exception is raised by the backend.
+            maximum: maximum value for slider. When used as an input, if a user provides a larger value, a gr.Error exception is raised by the backend.
             value: default value for slider. If a function is provided, the function will be called each time the app loads to set the initial value of this component. Ignored if randomized=True.
             step: increment between slider values.
+            precision: Precision to round input/output to. If set to 0, will round to nearest integer and convert type to int. If None, no rounding happens.
             label: the label for this component, displayed above the component if `show_label` is `True` and is also used as the header if there are a table of examples for this component. If None and used in a `gr.Interface`, the label will be the name of the parameter this component corresponds to.
             info: additional component description, appears below the label in smaller font. Supports markdown / HTML syntax.
             every: Continously calls `value` to recalculate it if `value` is a function (has no effect otherwise). Can provide a Timer whose tick resets `value`, or a float that provides the regular interval for the reset Timer.
@@ -79,6 +82,7 @@ class Slider(FormComponent):
         """
         self.minimum = minimum
         self.maximum = maximum
+        self.precision = precision
         if step is None:
             difference = maximum - minimum
             power = math.floor(math.log10(difference) - 2)
@@ -109,7 +113,7 @@ class Slider(FormComponent):
 
     def api_info(self) -> dict[str, Any]:
         return {
-            "type": "number",
+            "type": "integer" if self.precision == 0 else "number",
             "description": f"numeric value between {self.minimum} and {self.maximum}",
         }
 
@@ -136,7 +140,7 @@ class Slider(FormComponent):
         Returns:
             The value of the slider within the range.
         """
-        return self.minimum if value is None else value
+        return Number._round_to_precision(self.minimum if value is None else value, self.precision)
 
     def preprocess(self, payload: float) -> float:
         """
@@ -145,4 +149,5 @@ class Slider(FormComponent):
         Returns:
             Passes slider value as a {float} into the function.
         """
-        return payload
+        Number._raise_if_out_of_bounds(payload, self.minimum, self.maximum)
+        return Number._round_to_precision(payload, self.precision)

--- a/test/components/test_number.py
+++ b/test/components/test_number.py
@@ -1,3 +1,5 @@
+import pytest
+
 import gradio as gr
 
 
@@ -86,6 +88,17 @@ class TestNumber:
         assert numeric_input.postprocess(5.6784) == 5.68
         assert numeric_input.postprocess(2.1421) == 2.14
         assert numeric_input.postprocess(None) is None
+
+    def test_raise_if_out_of_bounds(self):
+        """
+        raise_if_out_of_bounds
+        """
+        numeric_input = gr.Number(precision=2, minimum=0, maximum=10)
+        numeric_input.preprocess(5)
+        with pytest.raises(gr.Error):
+            numeric_input.preprocess(11)
+        with pytest.raises(gr.Error):
+            numeric_input.preprocess(-1)
 
     def test_precision_none_with_integer(self):
         """

--- a/test/components/test_slider.py
+++ b/test/components/test_slider.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 import gradio as gr
 
 
@@ -19,6 +21,7 @@ class TestSlider:
             "minimum": 10,
             "maximum": 20,
             "step": 1,
+            "precision": None,
             "value": 15,
             "name": "slider",
             "show_label": True,
@@ -69,3 +72,26 @@ class TestSlider:
         # because 0.30000000000000004 != 0.3
         assert slider.get_random_value() == 0.3
         mock_randint.assert_called()
+
+    def test_raise_if_out_of_bounds(self):
+        """
+        raise_if_out_of_bounds
+        """
+        slider = gr.Slider(precision=2, minimum=0, maximum=10)
+        slider.preprocess(5)
+        with pytest.raises(gr.Error):
+            slider.preprocess(11)
+        with pytest.raises(gr.Error):
+            slider.preprocess(-1)
+
+    def test_precision(self):
+        """
+        Preprocess, postprocess
+        """
+        slider = gr.Slider(precision=None)
+        assert slider.preprocess(5.1) == 5.1
+        assert slider.api_info()["type"] == "number"
+
+        slider = gr.Slider(precision=0)
+        assert slider.preprocess(5.1) == 5
+        assert slider.api_info()["type"] == "integer"


### PR DESCRIPTION
This PR:

* Adds precision support to `gr.Slider`, enabling rounding and integer type conversion when `precision=0`
* Refactors min/max validation logic in `gr.Number` to a shared `raise_if_out_of_bounds` method, which is now also used by `gr.Slider` (closes: https://github.com/gradio-app/gradio/issues/3878) 
* Updates json schema based on the precision (closes: https://github.com/gradio-app/gradio/issues/11579)
* Adds unit tests