### PR TITLE
Support passing in gr.Request in server functions

### DIFF
--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -82,6 +82,7 @@ from gradio.data_classes import (
     VibeEditBody,
 )
 from gradio.exceptions import Error, InvalidPathError
+from gradio.helpers import special_args
 from gradio.i18n import I18n
 from gradio.node_server import (
     start_node_server,
@@ -1580,10 +1581,16 @@ class App(FastAPI):
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail="Function not found.",
                 )
+            processed_input, _, _ = special_args(
+                fn,
+                [body.data],
+                request,  # type: ignore
+                None,
+            )
             if inspect.iscoroutinefunction(fn):
-                return await fn(body.data)
+                return await fn(*processed_input)
             else:
-                return fn(body.data)
+                return fn(*processed_input)
 
         @router.get(
             "/queue/status",


### PR DESCRIPTION
## Description

If a component server function has a parameter with a gr.Request typehint, then the gradio server will now pass it to the function.

The main motivation for doing this is supporting "Sign in With HuggingFace" in FastRTC. This will make it a lot nicer to host immersive demos that use the inference api on Spaces.

For context, the FastRTC event processing does not go through the regular gradio queue to support minimal latency, so we need a different approach to get the request info to the event handlers.

Demo of HF Oauth with FastRTC:

https://github.com/user-attachments/assets/0dac6b77-db87-4380-8b29-f7512557f8d9


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
