### PR TITLE
Remove gray line present in ChatInterface demos

### DIFF
--- a/gradio/components/browser_state.py
+++ b/gradio/components/browser_state.py
@@ -8,12 +8,12 @@ from typing import Any
 
 from gradio_client.documentation import document
 
-from gradio.components.base import FormComponent
+from gradio.components.base import Component
 from gradio.events import Events
 
 
 @document()
-class BrowserState(FormComponent):
+class BrowserState(Component):
     EVENTS = [Events.change]
     """
     Special component that stores state in the browser's localStorage in an encrypted format.
@@ -73,3 +73,7 @@ class BrowserState(FormComponent):
 
     def example_value(self) -> Any:
         return "test"
+
+    def breaks_grouping(self) -> bool:
+        """State components should not break wrapper grouping chains."""
+        return False


### PR DESCRIPTION
## Description

[Context](https://huggingface.slack.com/archives/C03BHNJCBC4/p1755270709535769)

Issue was that BrowserState was introducing an empty FormComponent

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
