### PR TITLE
Fix file upload error due to file extension case differences.

### DIFF
--- a/.changeset/bright-webs-rescue.md
+++ b/.changeset/bright-webs-rescue.md
@@ -1,0 +1,6 @@
+---
+"@gradio/upload": patch
+"gradio": patch
+---
+
+fix:Fix file upload error due to file extension case differences.

--- a/js/upload/src/Upload.svelte
+++ b/js/upload/src/Upload.svelte
@@ -211,7 +211,7 @@
 
 	async function load_files_from_upload(files: File[]): Promise<void> {
 		const files_to_load = files.filter((file) => {
-			const file_extension = "." + file.name.split(".").pop()?.toLowerCase();
+			const file_extension = "." + file.name.toLowerCase().split(".").pop();
 			if (
 				file_extension &&
 				is_valid_mimetype(accept_file_types, file_extension, file.type)

--- a/js/upload/src/Upload.svelte
+++ b/js/upload/src/Upload.svelte
@@ -211,7 +211,7 @@
 
 	async function load_files_from_upload(files: File[]): Promise<void> {
 		const files_to_load = files.filter((file) => {
-			const file_extension = "." + file.name.split(".").pop();
+			const file_extension = "." + file.name.split(".").pop()?.toLowerCase();
 			if (
 				file_extension &&
 				is_valid_mimetype(accept_file_types, file_extension, file.type)


### PR DESCRIPTION
## Description

Closes: https://github.com/gradio-app/gradio/issues/10746

When using the `File()` component, if you specify file extensions for the `file_types` argument, this ends up being case sensitive. For example, if `file_types=[".pdf"]` and you upload "file.PDF", the file will not upload, and an error will appear in the Gradio frontend: "Invalid file type only .pdf allowed."

The error comes from the `load_files_from_upload` function. The file type validation compares the acceptabile types to the uploaded file's file extension _exactly_, without controlling for case.

This does not match the logic of the other occurrences of file type validation within the [same file](js/upload/src/Upload.svelte), such as in `is_valid_file`, which makes the filename lowercase before validation, nor does it match the behavior of the Python code for the `File` class, which also uses a lowercase version of the string for comparison. Therefore, I believe this to be a mistake and have provided a simple fix which just makes `file_extension` lowercase while keeping everything else the same.




