### PR TITLE
Set Progress Animation to cover component height 

### DIFF
--- a/.changeset/tired-otters-open.md
+++ b/.changeset/tired-otters-open.md
@@ -1,0 +1,6 @@
+---
+"@gradio/statustracker": patch
+"gradio": patch
+---
+
+fix:Set Progress Animation to cover component height 

--- a/js/statustracker/static/index.svelte
+++ b/js/statustracker/static/index.svelte
@@ -318,7 +318,6 @@
 		border-radius: var(--block-radius);
 		background: var(--block-background-fill);
 		padding: 0 var(--size-6);
-		max-height: var(--size-screen-h);
 		overflow: hidden;
 	}
 


### PR DESCRIPTION
## Description

Closes: #11695

Progress animation max-height was set to not max screen height. Removing that.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
