### PR TITLE
Consolidate copy button implementations to use IconButton

### DIFF
--- a/.changeset/old-parrots-fold.md
+++ b/.changeset/old-parrots-fold.md
@@ -1,7 +1,7 @@
 ---
-"@gradio/dialogue": minor
-"@gradio/textbox": minor
-"gradio": minor
+"@gradio/dialogue": patch
+"@gradio/textbox": patch
+"gradio": patch
 ---
 
 feat:Consolidate copy button implementations to use IconButton

--- a/.changeset/old-parrots-fold.md
+++ b/.changeset/old-parrots-fold.md
@@ -1,0 +1,7 @@
+---
+"@gradio/dialogue": minor
+"@gradio/textbox": minor
+"gradio": minor
+---
+
+feat:Consolidate copy button implementations to use IconButton

--- a/js/dialogue/Dialogue.svelte
+++ b/js/dialogue/Dialogue.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { createEventDispatcher, tick, onMount } from "svelte";
-	import { BlockTitle } from "@gradio/atoms";
+	import { BlockTitle, IconButton, IconButtonWrapper } from "@gradio/atoms";
 	import { Copy, Check, Send, Plus, Trash } from "@gradio/icons";
 	import { fade } from "svelte/transition";
 	import { BaseDropdown, BaseDropdownOptions } from "@gradio/dropdown";
@@ -454,21 +454,13 @@
 
 <label class:container>
 	{#if show_label && show_copy_button}
-		{#if copied}
-			<button
-				in:fade={{ duration: 300 }}
-				class="copy-button"
-				aria-label="Copied"
-				aria-roledescription="Text copied"><Check /></button
-			>
-		{:else}
-			<button
+		<IconButtonWrapper>
+			<IconButton
+				Icon={copied ? Check : Copy}
 				on:click={handle_copy}
-				class="copy-button"
-				aria-label="Copy"
-				aria-roledescription="Copy text"><Copy /></button
-			>
-		{/if}
+				label={copied ? "Copied" : "Copy"}
+			/>
+		</IconButtonWrapper>
 	{/if}
 
 	<BlockTitle {show_label} {info}>{label}</BlockTitle>
@@ -931,27 +923,6 @@
 	.submit-button :global(svg) {
 		height: 22px;
 		width: 22px;
-	}
-
-	.copy-button {
-		display: flex;
-		position: absolute;
-		top: var(--block-label-margin);
-		right: var(--block-label-margin);
-		align-items: center;
-		box-shadow: var(--shadow-drop);
-		border: 1px solid var(--border-color-primary);
-		border-top: none;
-		border-right: none;
-		border-radius: var(--block-label-right-radius);
-		background: var(--block-label-background-fill);
-		padding: 5px;
-		width: 22px;
-		height: 22px;
-		overflow: hidden;
-		color: var(--block-label-color);
-		font: var(--font-sans);
-		font-size: var(--button-small-text-size);
 	}
 
 	.tag-menu {

--- a/js/textbox/shared/Textbox.svelte
+++ b/js/textbox/shared/Textbox.svelte
@@ -5,7 +5,7 @@
 		createEventDispatcher,
 		tick
 	} from "svelte";
-	import { BlockTitle } from "@gradio/atoms";
+	import { BlockTitle, IconButton, IconButtonWrapper } from "@gradio/atoms";
 	import { Copy, Check, Send, Square } from "@gradio/icons";
 	import { fade } from "svelte/transition";
 	import type { SelectData, CopyData } from "@gradio/utils";
@@ -238,21 +238,13 @@
 <!-- svelte-ignore a11y-autofocus -->
 <label class:container class:show_textbox_border>
 	{#if show_label && show_copy_button}
-		{#if copied}
-			<button
-				in:fade={{ duration: 300 }}
-				class="copy-button"
-				aria-label="Copied"
-				aria-roledescription="Text copied"><Check /></button
-			>
-		{:else}
-			<button
+		<IconButtonWrapper>
+			<IconButton
+				Icon={copied ? Check : Copy}
 				on:click={handle_copy}
-				class="copy-button"
-				aria-label="Copy"
-				aria-roledescription="Copy text"><Copy /></button
-			>
-		{/if}
+				label={copied ? "Copied" : "Copy"}
+			/>
+		</IconButtonWrapper>
 	{/if}
 	<BlockTitle {show_label} {info}>{label}</BlockTitle>
 
@@ -447,27 +439,6 @@
 	input::placeholder,
 	textarea::placeholder {
 		color: var(--input-placeholder-color);
-	}
-
-	.copy-button {
-		display: flex;
-		position: absolute;
-		top: var(--block-label-margin);
-		right: var(--block-label-margin);
-		align-items: center;
-		box-shadow: var(--shadow-drop);
-		border: 1px solid var(--border-color-primary);
-		border-top: none;
-		border-right: none;
-		border-radius: var(--block-label-right-radius);
-		background: var(--block-label-background-fill);
-		padding: 5px;
-		width: 22px;
-		height: 22px;
-		overflow: hidden;
-		color: var(--block-label-color);
-		font: var(--font-sans);
-		font-size: var(--button-small-text-size);
 	}
 
 	/* Same submit button style as MultimodalTextbox for the consistent UI */


### PR DESCRIPTION
Replace custom copy button styling in Textbox and Dialogue components with standardized IconButton from atoms. Besides reduces code duplication, this fixes dark mode visibility issues in citrus theme, see below:

```py
import gradio as gr

with gr.Blocks(theme="citrus") as demo:
    gr.JSON({"a":"b"})
    gr.Textbox("abc", show_copy_button=True)

demo.launch()
```

Before:

https://github.com/user-attachments/assets/bde982ae-1f03-4f22-8ec2-1721d971f29e


After:

https://github.com/user-attachments/assets/57496245-39e7-4661-b7c1-d8ae0c39c4e2


