### PR TITLE
Fix minimum Pandas version to support `future.no_silent_downcasting`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ markupsafe>=2.0,<4.0
 numpy>=1.0,<3.0
 orjson~=3.0
 packaging
-pandas>=1.0,<3.0
+pandas>=2.2.0,<3.0
 pillow>=8.0,<12.0
 pydantic>=2.0,<2.12
 python-multipart>=0.0.18 # required for fastapi forms.


### PR DESCRIPTION
## Description

Gradio uses a Pandas feature that was added in v2.2.0, and throws exceptions on older versions.

https://github.com/pandas-dev/pandas/blob/main/doc/source/whatsnew/v2.2.0.rst

Fixes this Gradio exception:

```sh
Traceback (most recent call last):
  File "/app/conda_env/lib/python3.10/site-packages/gradio/queueing.py", line 698, in process_events
    await run_sync(self.compute_analytics_summary, self.event_analytics)
  File "/app/conda_env/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 2476, in run_sync_in_worker_thread
    return await future
  File "/app/conda_env/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 967, in run
    result = context.run(func, *args)
  File "/app/conda_env/lib/python3.10/site-packages/gradio/queueing.py", line 154, in compute_analytics_summary
    with pd.option_context("future.no_silent_downcasting", True):
  File "/app/conda_env/lib/python3.10/site-packages/pandas/_config/config.py", line 478, in __enter__
    self.undo = [(pat, _get_option(pat)) for pat, val in self.ops]
  File "/app/conda_env/lib/python3.10/site-packages/pandas/_config/config.py", line 478, in <listcomp>
    self.undo = [(pat, _get_option(pat)) for pat, val in self.ops]
  File "/app/conda_env/lib/python3.10/site-packages/pandas/_config/config.py", line 146, in _get_option
    key = _get_single_key(pat, silent)
  File "/app/conda_env/lib/python3.10/site-packages/pandas/_config/config.py", line 132, in _get_single_key
    raise OptionError(f"No such keys(s): {repr(pat)}")
pandas._config.config.OptionError: No such keys(s): 'future.no_silent_downcasting'
```