### PR TITLE
Don't use deprecated HfFolder

### DIFF
--- a/client/python/test/test_utils.py
+++ b/client/python/test/test_utils.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
-from huggingface_hub import HfFolder
+from huggingface_hub import get_token
 
 from gradio_client import media_data, utils
 
@@ -21,7 +21,7 @@ types["MultipleFile"] = {
 }
 types["SingleFile"] = {"type": "string", "description": "filepath or URL to file"}
 types["FileWithAdditionalProperties"] = {"type": "object", "additionalProperties": True}
-HF_TOKEN = os.getenv("HF_TOKEN") or HfFolder.get_token()
+HF_TOKEN = get_token()
 
 
 class TestEnum(Enum):


### PR DESCRIPTION
Same as https://github.com/gradio-app/gradio/pull/10064

`HfFolder` is deprecated and will be removed in the coming weeks.