### PR TITLE
Add show_select_all parameter to CheckboxGroup

### DIFF
--- a/demo/checkbox_select_all_demo.py
+++ b/demo/checkbox_select_all_demo.py
@@ -1,0 +1,47 @@
+import gradio as gr
+
+def process_selections(selected):
+    return f"You selected: {', '.join(selected) if selected else 'None'}"
+
+choices = ["Option 1", "Option 2", "Option 3", "Option 4", "Option 5"]
+
+with gr.Blocks() as demo:
+    gr.Markdown("# CheckboxGroup with Select All")
+    gr.Markdown("Test the new `show_select_all` parameter for CheckboxGroup")
+    
+    with gr.Row():
+        with gr.Column():
+            gr.Markdown("## With Select All")
+            checkbox_with_select_all = gr.CheckboxGroup(
+                choices=choices, 
+                label="Choose Options",
+                show_select_all=True,
+                value=["Option 1"]
+            )
+            
+        with gr.Column():
+            gr.Markdown("## Without Select All")
+            checkbox_without_select_all = gr.CheckboxGroup(
+                choices=choices,
+                label="Choose Options", 
+                show_select_all=False,
+                value=["Option 1"]
+            )
+    
+    output1 = gr.Textbox(label="Selected (with select all)")
+    output2 = gr.Textbox(label="Selected (without select all)")
+    
+    checkbox_with_select_all.change(
+        process_selections,
+        inputs=checkbox_with_select_all,
+        outputs=output1
+    )
+    
+    checkbox_without_select_all.change(
+        process_selections,
+        inputs=checkbox_without_select_all,
+        outputs=output2
+    )
+
+if __name__ == "__main__":
+    demo.launch()

--- a/gradio/components/checkboxgroup.py
+++ b/gradio/components/checkboxgroup.py
@@ -37,6 +37,7 @@ class CheckboxGroup(FormComponent):
         every: Timer | float | None = None,
         inputs: Component | Sequence[Component] | set[Component] | None = None,
         show_label: bool | None = None,
+        show_select_all: bool = False,
         container: bool = True,
         scale: int | None = None,
         min_width: int = 160,
@@ -58,6 +59,7 @@ class CheckboxGroup(FormComponent):
             every: Continously calls `value` to recalculate it if `value` is a function (has no effect otherwise). Can provide a Timer whose tick resets `value`, or a float that provides the regular interval for the reset Timer.
             inputs: Components that are used as inputs to calculate `value` if `value` is a function (has no effect otherwise). `value` is recalculated any time the inputs change.
             show_label: If True, will display label.
+            show_select_all: If True, will display a select/deselect all checkbox next to the label. Only available when show_label is True.
             container: If True, will place the component in a container - providing some extra padding around the border.
             scale: Relative width compared to adjacent Components in a Row. For example, if Component A has scale=2, and Component B has scale=1, A will be twice as wide as B. Should be an integer.
             min_width: Minimum pixel width, will wrap if not sufficient screen space to satisfy this value. If a certain scale value results in this Component being narrower than min_width, the min_width parameter will be respected first.
@@ -82,6 +84,9 @@ class CheckboxGroup(FormComponent):
                 f"Invalid value for parameter `type`: {type}. Please choose from one of: {valid_types}"
             )
         self.type = type
+        if show_select_all and show_label is False:
+            raise ValueError("show_select_all requires show_label to be True")
+        self.show_select_all = show_select_all
         super().__init__(
             label=label,
             info=info,


### PR DESCRIPTION
Adds a new show_select_all parameter that displays a select/deselect all checkbox next to the label. The checkbox shows three states: unchecked, checked, and indeterminate based on the selection state. Only available when show_label is True. Closes: #11851