### PR TITLE
Add max_height parameter to ParamViewer

### DIFF
--- a/.changeset/honest-horses-begin.md
+++ b/.changeset/honest-horses-begin.md
@@ -1,0 +1,6 @@
+---
+"@gradio/paramviewer": minor
+"gradio": minor
+---
+
+feat:Add max_height parameter to ParamViewer

--- a/gradio/components/paramviewer.py
+++ b/gradio/components/paramviewer.py
@@ -44,6 +44,7 @@ class ParamViewer(Component):
         preserved_by_key: list[str] | str | None = "value",
         header: str | None = "Parameters",
         anchor_links: bool | str = False,
+        max_height: int | str | None = None,
     ):
         """
         Parameters:
@@ -57,12 +58,14 @@ class ParamViewer(Component):
             preserved_by_key: A list of parameters from this component's constructor. Inside a gr.render() function, if a component is re-rendered with the same key, these (and only these) parameters will be preserved in the UI (if they have been changed by the user or an event listener) instead of re-rendered based on the values provided during constructor.
             header: The header to display above the table of parameters, also includes a toggle button that closes/opens all details at once. If None, no header will be displayed.
             anchor_links: If True, creates anchor links for each parameter that can be used to link directly to that parameter. If a string, creates anchor links with the given string as the prefix to prevent conflicts with other ParamViewer components.
+            max_height: The maximum height of the component, specified in pixels if a number is passed, or in CSS units if a string is passed. If content exceeds the height, the parameter table will scroll vertically while the header remains fixed in place. If content is shorter than the height, the component will shrink to fit the content.
         """
         self.value = value or {}
         self.language = language
         self.linkify = linkify
         self.header = header
         self.anchor_links = anchor_links
+        self.max_height = max_height
         super().__init__(
             every=every,
             inputs=inputs,

--- a/js/paramviewer/Index.svelte
+++ b/js/paramviewer/Index.svelte
@@ -13,6 +13,7 @@
 	export let linkify: string[] = [];
 	export let header: string | null = null;
 	export let anchor_links = false;
+	export let max_height: number | string | undefined = undefined;
 </script>
 
-<ParamViewer docs={value} {linkify} {header} {anchor_links} />
+<ParamViewer docs={value} {linkify} {header} {anchor_links} {max_height} />

--- a/js/paramviewer/ParamViewer.svelte
+++ b/js/paramviewer/ParamViewer.svelte
@@ -19,6 +19,7 @@
 	export let linkify: string[] = [];
 	export let header: string | null;
 	export let anchor_links: string | boolean = false;
+	export let max_height: number | string | undefined = undefined;
 
 	let component_root: HTMLElement;
 	let _docs: Param[];
@@ -114,9 +115,26 @@
 			detail.scrollIntoView({ behavior: "smooth" });
 		}
 	}
+
+	const get_dimension = (
+		dimension_value: string | number | undefined
+	): string | undefined => {
+		if (dimension_value === undefined) {
+			return undefined;
+		}
+		if (typeof dimension_value === "number") {
+			return dimension_value + "px";
+		} else if (typeof dimension_value === "string") {
+			return dimension_value;
+		}
+	};
 </script>
 
-<div class="wrap" bind:this={component_root}>
+<div
+	class="wrap"
+	bind:this={component_root}
+	style:max-height={get_dimension(max_height)}
+>
 	{#if header !== null}
 		<div class="header">
 			<span class="title">{header}</span>
@@ -130,37 +148,39 @@
 		</div>
 	{/if}
 	{#if _docs}
-		{#each _docs as { type, description, default: _default, name } (name)}
-			<details
-				class="param md"
-				id={anchor_links ? create_slug(name || "", anchor_links) : undefined}
-			>
-				<summary class="type">
-					{#if anchor_links}
-						<a
-							href="#{create_slug(name || '', anchor_links)}"
-							class="param-link"
-						>
-							<span class="link-icon">🔗</span>
-						</a>
+		<div class="param-content">
+			{#each _docs as { type, description, default: _default, name } (name)}
+				<details
+					class="param md"
+					id={anchor_links ? create_slug(name || "", anchor_links) : undefined}
+				>
+					<summary class="type">
+						{#if anchor_links}
+							<a
+								href="#{create_slug(name || '', anchor_links)}"
+								class="param-link"
+							>
+								<span class="link-icon">🔗</span>
+							</a>
+						{/if}
+						<pre class="language-{lang}"><code
+								>{name}{#if type}: {@html type}{/if}</code
+							></pre>
+					</summary>
+					{#if _default}
+						<div class="default" class:last={!description}>
+							<span style:padding-right={"4px"}>default</span>
+							<code>= {@html _default}</code>
+						</div>
 					{/if}
-					<pre class="language-{lang}"><code
-							>{name}{#if type}: {@html type}{/if}</code
-						></pre>
-				</summary>
-				{#if _default}
-					<div class="default" class:last={!description}>
-						<span style:padding-right={"4px"}>default</span>
-						<code>= {@html _default}</code>
-					</div>
-				{/if}
-				{#if description}
-					<div class="description">
-						<p>{@html render_links(description)}</p>
-					</div>
-				{/if}
-			</details>
-		{/each}
+					{#if description}
+						<div class="description">
+							<p>{@html render_links(description)}</p>
+						</div>
+					{/if}
+				</details>
+			{/each}
+		</div>
 	{/if}
 </div>
 
@@ -252,6 +272,8 @@
 		width: 100%;
 		line-height: var(--line-sm);
 		color: var(--body-text-color);
+		display: grid;
+		grid-template-rows: auto 1fr;
 	}
 
 	.type {
@@ -340,5 +362,9 @@
 
 	.param-link:hover {
 		opacity: 1 !important;
+	}
+
+	.param-content {
+		overflow-y: auto;
 	}
 </style>


### PR DESCRIPTION
## Description
Added a max_height parameter to ParamViewer. If this value is set and the content exceeds it, the parameter table will scroll vertically while the header remains fixed in place.


Closes: [#11900]([https://github.com/gradio-app/gradio/issues/11900])


https://github.com/user-attachments/assets/e6e6de0d-c707-4cab-94f9-0174a0694a94

