### PR TITLE
Add navbar visibility controls and customization options

### DIFF
--- a/demo/navbar_query_params/run.py
+++ b/demo/navbar_query_params/run.py
@@ -1,0 +1,60 @@
+import gradio as gr
+
+def update_navbar_with_query(choice):
+    """Updates navbar links to preserve query parameters"""
+    if choice:
+        return [("Main Page", f"?option={choice.lower().replace(' ', '_')}"), ("Page 2", f"page-2/?option={choice.lower().replace(' ', '_')}")]
+    return [("Main Page", ""), ("Page 2", "page-2")]
+
+update_url_js = """
+(choice) => {
+    console.log("choice", choice);
+    if (choice) {
+        const url = new URL(window.location);
+        url.searchParams.set('option', choice.toLowerCase().replace(' ', '_'));
+        window.history.replaceState({}, '', url);
+    }
+    return choice;
+}
+"""
+
+with gr.Blocks() as demo:
+    navbar1 = gr.Navbar(
+        value=[("Main Page", ""),("Page 2", "page-2")],
+        visible=True,
+        main_page_name=False,
+    )
+
+    dropdown1 = gr.Dropdown(
+        choices=["Option A", "Option B", "Option C"],
+        label="Select an option",
+        value=None
+    )
+
+    dropdown1.change(
+        fn=update_navbar_with_query,
+        inputs=[dropdown1],
+        outputs=[navbar1],
+        js=update_url_js
+    )
+
+with demo.route("Page 2", show_in_navbar=False):
+    navbar2 = gr.Navbar(
+        visible=True,
+        main_page_name=False,
+    )
+    
+    dropdown2 = gr.Dropdown(
+        choices=["Value 1", "Value 2", "Value 3"],
+        label="Select a value",
+        value=None
+    )
+    dropdown2.change(
+        fn=update_navbar_with_query,
+        inputs=[dropdown2],
+        outputs=[navbar2],
+        js=update_url_js
+    )
+
+if __name__ == "__main__":
+    demo.launch()

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -894,7 +894,8 @@ class BlocksConfig:
             "dependencies": [],
         }
 
-        for page, _ in self.root_block.pages:
+        for page_tuple in self.root_block.pages:
+            page = page_tuple[0]
             if page not in config["page"]:
                 config["page"][page] = {
                     "layout": {"id": self.root_block._id, "children": []},
@@ -1156,7 +1157,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
         self.root_path = os.environ.get("GRADIO_ROOT_PATH", "")
         self.proxy_urls = set()
 
-        self.pages: list[tuple[str, str]] = [("", "Home")]
+        self.pages: list[tuple[str, str, bool]] = [("", "Home", True)]
         self.current_page = ""
 
         if self.analytics_enabled:
@@ -2245,7 +2246,7 @@ Received inputs:
             "fill_width": self.fill_width,
             "theme_hash": self.theme_hash,
             "pwa": self.pwa,
-            "pages": self.pages,
+            "pages": [(p[0], p[1], p[2] if len(p) > 2 else True) for p in self.pages],
             "page": {},
             "mcp_server": self.mcp_server,
             "i18n_translations": (
@@ -3137,12 +3138,13 @@ Received inputs:
         return target_events
 
     @document()
-    def route(self, name: str, path: str | None = None) -> Blocks:
+    def route(self, name: str, path: str | None = None, show_in_navbar: bool = True) -> Blocks:
         """
         Adds a new page to the Blocks app.
         Parameters:
             name: The name of the page as it appears in the nav bar.
             path: The URL suffix appended after your Gradio app's root URL to access this page (e.g. if path="/test", the page may be accessible e.g. at http://localhost:7860/test). If not provided, the path is generated from the name by converting to lowercase and replacing spaces with hyphens. Any leading or trailing forward slashes are stripped.
+            show_in_navbar: If True, the page will appear in the navbar. If False, the page will be accessible via URL but not shown in the navbar. Defaults to True.
         Example:
             with gr.Blocks() as demo:
                 name = gr.Textbox(label="Name")
@@ -3172,6 +3174,6 @@ Received inputs:
             )
         while path in INTERNAL_ROUTES or path in [page[0] for page in self.pages]:
             path = "_" + path
-        self.pages.append((path, name))
+        self.pages.append((path, name, show_in_navbar))
         self.current_page = path
         return self

--- a/js/core/src/Embed.svelte
+++ b/js/core/src/Embed.svelte
@@ -14,7 +14,7 @@
 	export let display: boolean;
 	export let info: boolean;
 	export let loaded: boolean;
-	export let pages: [string, string][] = [];
+	export let pages: [string, string, boolean][] = [];
 	export let current_page = "";
 	export let root: string;
 	export let components: any[] = [];
@@ -48,16 +48,26 @@
 		pages.length > 1 && (navbar === null || navbar.visible !== false);
 
 	$: effective_pages = (() => {
+		// Filter pages based on visibility
+		let visible_pages = pages.filter(([route, label, show], index) => {
+			// Handle main page visibility
+			if (index === 0 && route === "") {
+				return navbar?.main_page_name !== false;
+			}
+			// Handle other pages visibility (default to true if not specified)
+			return show !== false;
+		});
+
 		let base_pages =
 			navbar &&
 			navbar.main_page_name !== false &&
 			navbar.main_page_name !== "Home"
-				? pages.map(([route, label], index) =>
+				? visible_pages.map(([route, label, show], index) =>
 						index === 0 && route === "" && label === "Home"
 							? ([route, navbar!.main_page_name] as [string, string])
 							: ([route, label] as [string, string])
 					)
-				: pages;
+				: visible_pages.map(([route, label]) => [route, label] as [string, string]);
 
 		if (navbar?.value && navbar.value.length > 0) {
 			const existing_routes = new Set(base_pages.map(([route]) => route));

--- a/js/spa/src/Index.svelte
+++ b/js/spa/src/Index.svelte
@@ -34,7 +34,7 @@
 		username: string | null;
 		api_prefix?: string;
 		max_file_size?: number;
-		pages: [string, string][];
+		pages: [string, string, boolean][];
 		current_page: string;
 		deep_link_state?: "valid" | "invalid" | "none";
 		page: Record<


### PR DESCRIPTION
Adds show_in_navbar parameter to route() method to control page visibility in navbar. Supports hiding the main page from navbar using main_page_name=False. Includes demo showing navbar customization with dynamic query parameter preservation.