### PR TITLE
Fix bug where setting interactive prop of gr.Datetime from the backend was not working

### DIFF
--- a/.changeset/red-deer-melt.md
+++ b/.changeset/red-deer-melt.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix bug where setting interactive prop of gr.Datetime from the backend was not working

--- a/gradio/components/datetime.py
+++ b/gradio/components/datetime.py
@@ -66,7 +66,6 @@ class DateTime(FormComponent):
         """
         self.type = type
         self.include_time = include_time
-        self.interactive = interactive
         self.time_format = "%Y-%m-%d %H:%M:%S" if include_time else "%Y-%m-%d"
         self.timezone = timezone
         self._value_description = (
@@ -92,6 +91,7 @@ class DateTime(FormComponent):
             key=key,
             preserved_by_key=preserved_by_key,
             value=value,
+            interactive=interactive,
         )
 
     def preprocess(self, payload: str | None) -> str | float | datetime | None:


### PR DESCRIPTION
## Description

Closes: #11840

You can test with repro from issue

![datetime_interactivity_toggle](https://github.com/user-attachments/assets/9ee15605-26c3-4181-901f-1188bed508a4)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
