### PR TITLE
Fix Bug where select events of ZeroGPU were causing errors

### DIFF
--- a/gradio/components/state.py
+++ b/gradio/components/state.py
@@ -13,6 +13,10 @@ from gradio.components.base import Component
 from gradio.events import Events
 
 
+def default_delete_callback(x: Any) -> None:
+    pass
+
+
 @document()
 class State(Component):
     EVENTS = [Events.change]
@@ -43,7 +47,7 @@ class State(Component):
         self.time_to_live = self.time_to_live = (
             math.inf if time_to_live is None else time_to_live
         )
-        self.delete_callback = delete_callback or (lambda a: None)  # noqa: ARG005
+        self.delete_callback = delete_callback or default_delete_callback  # noqa: ARG005
         try:
             value = deepcopy(value)
         except TypeError as err:

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -322,6 +322,10 @@ def prepare_event_data(
         blocks_config.blocks.get(target) if target else None,
         body.event_data,
     )
+    # Set parent to None to avoid pickle issues in ZeroGPU
+    # See https://github.com/gradio-app/gradio/issues/11551
+    if hasattr(event_data.target, "parent"):
+        event_data.target.parent = None  # type: ignore
     return event_data
 
 


### PR DESCRIPTION
## Description

Closes: #11551

When you have a `SelectData` in your function, gradio will add a reference to the `target` which is the block that was selected. Now, each block has a `parent` ref, which you can theoretically follow all the way up to the parent `gr.Blocks` application. ZeroGPU pickles the function arguments so that they can be sent to the worker. The error was arising from zerogpu trying to pickle the parent `gr.Blocks` which contains some non-pickleable things (like `StateHolder`). So what I did was set the `parent` attribute of the `target` to None. This is technically a breaking change but I think it will impact a small subset of apps, if any at all as this is quite niche. 

The real mystery though is that the `parent` ref is set to None after uploading an image via the examples. That's why using the click event after clicking an example was wokring.

You can test with this demo: https://huggingface.co/spaces/freddyaboulton/zerogpu-gr-state

![zero-gpu-fix](https://github.com/user-attachments/assets/fdbaeaae-aef1-41e6-b4a1-05dbf43d62f3)


## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
