### PR TITLE
Fix KeyError that can be caused by cancelling the same event twice

### DIFF
--- a/.changeset/social-bees-rescue.md
+++ b/.changeset/social-bees-rescue.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix KeyError that can be caused by cancelling the same event twice

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1477,9 +1477,20 @@ class App(FastAPI):
                                 isinstance(message, ProcessCompletedMessage)
                                 and message.event_id
                             ):
-                                blocks._queue.pending_event_ids_session[
-                                    session_hash
-                                ].remove(message.event_id)
+                                # It's possible that the event_id has already been removed
+                                # for example, the user sent two duplicate `/cancel` requests.
+                                # The firtst one would have removed the event_id from pending_event_ids_session
+                                if (
+                                    message.event_id
+                                    in (
+                                        blocks._queue.pending_event_ids_session[
+                                            session_hash
+                                        ]
+                                    )
+                                ):
+                                    blocks._queue.pending_event_ids_session[
+                                        session_hash
+                                    ].remove(message.event_id)
                                 if message.msg == ServerMessage.server_stopped or (
                                     message.msg == ServerMessage.process_completed
                                     and (

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1479,7 +1479,7 @@ class App(FastAPI):
                             ):
                                 # It's possible that the event_id has already been removed
                                 # for example, the user sent two duplicate `/cancel` requests.
-                                # The firtst one would have removed the event_id from pending_event_ids_session
+                                # The first one would have removed the event_id from pending_event_ids_session
                                 if (
                                     message.event_id
                                     in (


### PR DESCRIPTION
## Description

Closes: #11497 

Write up from the issue:

> Hi @goudakrishna - the issue is caused by two things:

> - Firstly, in order for gradio to finish cancelling the request it needs to wait for the `asyncio.sleep` call to finish. The reason is that in python you can only cancel iterators once they are not actively iterating. So the next time gradio is able to cancel the request is the second `yield` event (at which time the event is basically over) 
> - Basically this means that in practice you end up hitting the stop button twice.  This tells the gradio backend to remove the event from the processing queue. The second time it tries to remove the event you get the `KeyError` because the event was already removed.

> So I will open a PR to fix the issue in the second point. For the first point, it would be better if the response function can be rewritten so that it yields more frequently (event the entire message is not ready). I will also look at if we can report progress on the cancel request so that users are not tempted to hit it more than once.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
