### PR TITLE
Serialize i18n data for events that dont go through queue

### DIFF
--- a/.changeset/solid-brooms-lose.md
+++ b/.changeset/solid-brooms-lose.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Serialize i18n data for events that dont go through queue

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1302,7 +1302,7 @@ class App(FastAPI):
                     content=content,
                     status_code=500,
                 )
-            return output
+            return ORJSONResponse(output)
 
         @router.post("/call/{api_name}", dependencies=[Depends(login_check)])
         @router.post("/call/{api_name}/", dependencies=[Depends(login_check)])


### PR DESCRIPTION
## Description

Closes: #11351

Issue was that we don't use orjson to serialize the data if the request doesn't go through the queue. This means that the i18n dict was kept as `{"__type__": "translation_metadata", "key": "Image"}` instead of the `__i18n__` string the frontend expects.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
