### PR TITLE
Remove references to deleted lite guide - Fix website build

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ That's the gist of the core `gradio` Python library, but Gradio is actually so m
 
 * [Gradio Python Client](https://www.gradio.app/guides/getting-started-with-the-python-client) (`gradio_client`): query any Gradio app programmatically in Python.
 * [Gradio JavaScript Client](https://www.gradio.app/guides/getting-started-with-the-js-client) (`@gradio/client`): query any Gradio app programmatically in JavaScript.
-* [Gradio-Lite](https://www.gradio.app/guides/gradio-lite) (`@gradio/lite`): write Gradio apps in Python that run entirely in the browser (no server needed!), thanks to Pyodide. 
 * [Hugging Face Spaces](https://huggingface.co/spaces): the most popular place to host Gradio applications — for free!
 
 ### What's Next?

--- a/guides/01_getting-started/01_quickstart.md
+++ b/guides/01_getting-started/01_quickstart.md
@@ -106,7 +106,6 @@ That's the gist of the core `gradio` Python library, but Gradio is actually so m
 
 * [Gradio Python Client](https://www.gradio.app/guides/getting-started-with-the-python-client) (`gradio_client`): query any Gradio app programmatically in Python.
 * [Gradio JavaScript Client](https://www.gradio.app/guides/getting-started-with-the-js-client) (`@gradio/client`): query any Gradio app programmatically in JavaScript.
-* [Gradio-Lite](https://www.gradio.app/guides/gradio-lite) (`@gradio/lite`): write Gradio apps in Python that run entirely in the browser (no server needed!), thanks to Pyodide. 
 * [Hugging Face Spaces](https://huggingface.co/spaces): the most popular place to host Gradio applications — for free!
 
 ## What's Next?

--- a/js/_website/src/routes/[[version]]/docs/+page.svelte
+++ b/js/_website/src/routes/[[version]]/docs/+page.svelte
@@ -190,22 +190,6 @@
 				application.
 			</div>
 		</a>
-		<a
-			href="../guides/gradio-lite"
-			target="_self"
-			class="w-full shadow-alternate hover:scale-[1.02] group group relative flex flex-col overflow-hidden md:first:row-span-2 rounded-xl bg-gradient-to-r px-3 py-4 dark:border-gray-900 from-{data
-				.COLOR_SETS[5]}-50 hover:shadow-alternate to-white shadow-none transition-shadow dark:from-gray-850 dark:to-gray-950 dark:hover:from-gray-800"
-		>
-			<div class="relative mb-2 flex items-center text-lg font-semibold">
-				<span>Gradio Lite</span>
-			</div>
-			<code class="font-light text-md mb-2">@gradio/lite</code>
-
-			<div class="relative pr-4 text-lg font-light">
-				Run Gradio's Python code serverless (entirely in your browser) using
-				WebAssembly.
-			</div>
-		</a>
 	</div>
 
 	<h1 class="mb-4 flex items-center text-2xl font-light mt-8">

--- a/js/_website/src/routes/playground/+page.svelte
+++ b/js/_website/src/routes/playground/+page.svelte
@@ -127,17 +127,6 @@
 			</a>
 			<p class="self-center text-xl font-light -m-1">Playground</p>
 		</div>
-
-		<nav class="flex w-auto flex-row gap-6">
-			<a class="thin-link flex items-center gap-3" href="/docs" target="_blank"
-				><span>✍️</span> <span>Docs</span></a
-			>
-			<a
-				class="thin-link flex items-center gap-3"
-				href="/guides/gradio-lite"
-				target="_blank"><span>💡</span> <span>Gradio Lite</span></a
-			>
-		</nav>
 	</div>
 </div>
 


### PR DESCRIPTION
website build failing due to some references to a deleted lite guide. I had to do some surgery to the released aws json buckets so lets let the build complete first before merging