### PR TITLE
Fix multiple: route with accents doesnt work (#11935)

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -73,7 +73,7 @@ from gradio.exceptions import (
 from gradio.helpers import create_tracker, skip, special_args
 from gradio.i18n import I18n, I18nData
 from gradio.node_server import start_node_server
-from gradio.route_utils import API_PREFIX, MediaStream
+from gradio.route_utils import API_PREFIX, MediaStream, slugify
 from gradio.routes import INTERNAL_ROUTES, VERSION, App, Request
 from gradio.state_holder import SessionState, StateHolder
 from gradio.themes import Default as DefaultTheme
@@ -3170,10 +3170,9 @@ Received inputs:
         if path in INTERNAL_ROUTES:
             raise ValueError(f"Route with path '{path}' already exists")
         if path is None:
-            path = name.lower().replace(" ", "-")
-            path = "".join(
-                [letter for letter in path if letter.isalnum() or letter == "-"]
-            )
+            path = slugify(name)
+            if not path:
+                raise ValueError(f"Route with path '{name}' is not valid")
         while path in INTERNAL_ROUTES or path in [page[0] for page in self.pages]:
             path = "_" + path
         self.pages.append((path, name, show_in_navbar))

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -1041,3 +1041,20 @@ def create_url_safe_hash(data: bytes, digest_size=8):
     url_safe_hash = base64.urlsafe_b64encode(hash_obj.digest()).decode().rstrip("=")
 
     return url_safe_hash
+
+
+def slugify(value):
+    """
+    Convert to ASCII. Convert spaces or repeated dashes to single dashes.
+    Remove characters that aren't alphanumerics, underscores, or hyphens.
+    Convert to lowercase. Also strip leading and trailing whitespace,
+    dashes, and underscores.
+    """
+    import unicodedata
+
+    value = str(value)
+    value = (
+        unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
+    )
+    value = re.sub(r"[^\w\s-]", "", value.lower())
+    return re.sub(r"[-\s]+", "-", value).strip("-_")


### PR DESCRIPTION
## Description

This add `slugify` function to transform name in a route when using multipage.  This avoid all problems cleaning strings 
with chars like accents or any other.  

```
Convert to ASCII. Convert spaces or repeated dashes to single dashes.
Remove characters that aren't alphanumerics, underscores, or hyphens.
Convert to lowercase. Also strip leading and trailing whitespace,
dashes, and underscores.
```

This kind of feature is present in almosts all CMS or frameworks. In particular this code is inspired in django slugigy function.

Closes: #11935 