### PR TITLE
Fix bug where keyboard navigation on a textbox would skip forward the audio waveform playbacl

### DIFF
--- a/js/audio/player/AudioPlayer.svelte
+++ b/js/audio/player/AudioPlayer.svelte
@@ -32,6 +32,7 @@
 
 	let container: HTMLDivElement;
 	let waveform: WaveSurfer | undefined;
+	let waveform_component_wrapper: HTMLDivElement;
 	let playing = false;
 
 	let subtitle_container: HTMLDivElement;
@@ -218,6 +219,11 @@
 	onMount(() => {
 		window.addEventListener("keydown", (e) => {
 			if (!waveform || show_volume_slider) return;
+
+			const is_focused_in_waveform =
+				waveform_component_wrapper &&
+				waveform_component_wrapper.contains(document.activeElement);
+			if (!is_focused_in_waveform) return;
 			if (e.key === "ArrowRight" && mode !== "edit") {
 				skip_audio(waveform, 0.1);
 			} else if (e.key === "ArrowLeft" && mode !== "edit") {
@@ -337,6 +343,7 @@
 	<div
 		class="component-wrapper"
 		data-testid={label ? "waveform-" + label : "unlabelled-audio"}
+		bind:this={waveform_component_wrapper}
 	>
 		<div class="waveform-container">
 			<div


### PR DESCRIPTION
## Description

Closes: #7499

Now you need to interactive with the waveform (play, pause, change playback speed) for the keyboard navigation to take effect.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
