### PR TITLE
bump node

### DIFF
--- a/.github/actions/install-frontend-deps/action.yml
+++ b/.github/actions/install-frontend-deps/action.yml
@@ -22,7 +22,7 @@ runs:
         version: 9.1.x
     - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 22
         cache: pnpm
         cache-dependency-path: pnpm-lock.yaml
     - name: Install deps

--- a/.github/workflows/npm-previews.yml
+++ b/.github/workflows/npm-previews.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - name: package
         run: pnpm package
       - name: build client

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
 		"wikidata-lang": "4.1.2"
 	},
 	"engines": {
-		"node": ">=18.0.0",
+		"node": ">=22.0.0",
 		"pnpm": "^9"
 	},
 	"pnpm": {


### PR DESCRIPTION
The version of npm that supports trusted publishing requires a higher node version