### PR TITLE
Allow gradio to run with huggingface_hub 1.x

### DIFF
--- a/.changeset/rotten-donkeys-know.md
+++ b/.changeset/rotten-donkeys-know.md
@@ -1,0 +1,6 @@
+---
+"gradio": minor
+"gradio_client": minor
+---
+
+feat:Allow gradio to run with huggingface_hub 1.x

--- a/.changeset/rotten-donkeys-know.md
+++ b/.changeset/rotten-donkeys-know.md
@@ -1,6 +1,6 @@
 ---
-"gradio": minor
-"gradio_client": minor
+"gradio": patch
+"gradio_client": patch
 ---
 
-feat:Allow gradio to run with huggingface_hub 1.x
+fix:Allow gradio to run with huggingface_hub 1.x

--- a/client/python/requirements.txt
+++ b/client/python/requirements.txt
@@ -1,6 +1,6 @@
 fsspec
 httpx>=0.24.1
-huggingface_hub>=0.19.3
+huggingface_hub>=0.19.3,<2.0
 packaging
 typing_extensions~=4.0
 websockets>=13.0,<16.0

--- a/gradio/cli/commands/deploy_space.py
+++ b/gradio/cli/commands/deploy_space.py
@@ -303,7 +303,7 @@ def deploy(
             app_file,
         )
 
-    space_id = huggingface_hub.create_repo(
+    space_id = hf_api.create_repo(
         configuration["title"],
         space_sdk="gradio",
         repo_type="space",
@@ -317,5 +317,5 @@ def deploy(
     )
     if configuration.get("secrets"):
         for secret_name, secret_value in configuration["secrets"].items():
-            huggingface_hub.add_space_secret(space_id, secret_name, secret_value)
+            hf_api.add_space_secret(space_id, secret_name, secret_value)
     print(f"Space available at https://huggingface.co/spaces/{space_id}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ffmpy
 groovy~=0.1
 gradio_client==1.13.2
 httpx>=0.24.1,<1.0
-huggingface_hub>=0.33.5,<1.0
+huggingface_hub>=0.33.5,<2.0
 Jinja2<4.0
 markupsafe>=2.0,<4.0
 numpy>=1.0,<3.0


### PR DESCRIPTION
This PR update the dependency requirements to allow `huggingface_hub` 1.x version.

No need for any change in the code as some minor changes have already been made in https://github.com/gradio-app/gradio/pull/11830 and https://github.com/gradio-app/gradio/pull/11852.