### PR TITLE
Clean fix for support of async auth functions in login (#9244)

### DIFF
--- a/.changeset/floppy-plums-suffer.md
+++ b/.changeset/floppy-plums-suffer.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Clean fix for support of async auth functions in login (#9244)

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -522,7 +522,7 @@ class App(FastAPI):
 
         @app.post("/login")
         @app.post("/login/")
-        def login(
+        async def login(
             request: fastapi.Request, form_data: OAuth2PasswordRequestForm = Depends()
         ):
             username, password = form_data.username.strip(), form_data.password
@@ -537,7 +537,14 @@ class App(FastAPI):
                 not callable(app.auth)
                 and username in app.auth  # type: ignore
                 and compare_passwords_securely(password, app.auth[username])  # type: ignore
-            ) or (callable(app.auth) and app.auth.__call__(username, password)):  # type: ignore
+            ) or (
+                callable(app.auth)
+                   and (
+                       await app.auth(username, password)
+                       if inspect.iscoroutinefunction(app.auth)
+                       else app.auth(username, password)
+                )
+            ):  # type: ignore
                 token = secrets.token_urlsafe(16)
                 app.tokens[token] = username
                 response = JSONResponse(content={"success": True})

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -539,10 +539,10 @@ class App(FastAPI):
                 and compare_passwords_securely(password, app.auth[username])  # type: ignore
             ) or (
                 callable(app.auth)
-                   and (
-                       await app.auth(username, password)
-                       if inspect.iscoroutinefunction(app.auth)
-                       else app.auth(username, password)
+                and (
+                    await app.auth(username, password)
+                    if inspect.iscoroutinefunction(app.auth)
+                    else app.auth(username, password)
                 )
             ):  # type: ignore
                 token = secrets.token_urlsafe(16)


### PR DESCRIPTION
## Description

The changes made is in the `gradio/routes.py` in the login function making it an async function using `inspect.iscoroutine()` to check if it needs to `await`. Otherwise it processes `app.auth`. 

Closes: #9244 