### PR TITLE
Trigger Change Event if component is in inactive tab

### DIFF
--- a/.changeset/legal-zoos-swim.md
+++ b/.changeset/legal-zoos-swim.md
@@ -1,0 +1,6 @@
+---
+"@gradio/core": minor
+"gradio": minor
+---
+
+feat:Trigger Change Event if component is in inactive tab

--- a/.changeset/legal-zoos-swim.md
+++ b/.changeset/legal-zoos-swim.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/core": minor
-"gradio": minor
+"@gradio/core": patch
+"gradio": patch
 ---
 
-feat:Trigger Change Event if component is in inactive tab
+fix:Trigger Change Event if component is in inactive tab

--- a/js/core/src/init.ts
+++ b/js/core/src/init.ts
@@ -999,8 +999,7 @@ function determine_visible_components(
 		child_visible.forEach((id) => visible_components.add(id));
 	} else if (component.type === "tabitem") {
 		if (
-			is_tab_item_visible(component, component_visible, parent_tabs_context) ||
-			should_load
+			is_tab_item_visible(component, component_visible, parent_tabs_context)
 		) {
 			visible_components.add(layout.id);
 
@@ -1108,6 +1107,12 @@ function is_visible(component: ComponentMeta): boolean {
 	) {
 		return false;
 	} else if (component.parent) {
+		if (component.parent.type === "tabitem") {
+			return is_tab_item_visible(
+				component.parent,
+				is_visible(component.parent)
+			);
+		}
 		return is_visible(component.parent);
 	}
 	return true;

--- a/js/core/src/init.ts
+++ b/js/core/src/init.ts
@@ -999,7 +999,8 @@ function determine_visible_components(
 		child_visible.forEach((id) => visible_components.add(id));
 	} else if (component.type === "tabitem") {
 		if (
-			is_tab_item_visible(component, component_visible, parent_tabs_context)
+			is_tab_item_visible(component, component_visible, parent_tabs_context) ||
+			should_load
 		) {
 			visible_components.add(layout.id);
 


### PR DESCRIPTION
## Description

Closes: #11984

In https://github.com/gradio-app/gradio/pull/11615, we trigger change events if the component is explicitly hidden. But not if it is implicitly hidden in an unselected tab. 

You can test with the following demo:

```python
import gradio as gr
import random

with gr.Blocks() as demo:
    gr.Markdown("## Tabs with visibility control")
    num = gr.Number(label="Number")
    with gr.Tabs():
        with gr.Tab("Tab 1") as tab1:
            gr.Markdown("This tab is visible by default")
        with gr.Tab("Tab 2") as tab2:
            tb = gr.Textbox(label="This tab is hidden by default")
            tb.change(lambda: random.randint(0, 100000), None, num)
            btn = gr.Button("Show the textbox", variant="primary")
            btn.click(lambda: gr.update(visible=True, interactive=True), None, tb)

    demo.load(lambda: "Loaded!", None, tb)

if __name__ == "__main__":
    demo.launch()
```

You should see the number component update to a random value whenever the page loads.

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
