### PR TITLE
fix: render checkbox info text below label for consistency

### DIFF
--- a/.changeset/stale-cycles-sit.md
+++ b/.changeset/stale-cycles-sit.md
@@ -1,0 +1,6 @@
+---
+"@gradio/checkbox": patch
+"gradio": patch
+---
+
+fix:fix: render checkbox info text below label for consistency

--- a/js/checkbox/Index.svelte
+++ b/js/checkbox/Index.svelte
@@ -52,10 +52,6 @@
 		on:clear_status={() => gradio.dispatch("clear_status", loading_status)}
 	/>
 
-	{#if info}
-		<Info {info} />
-	{/if}
-
 	<BaseCheckbox
 		bind:value
 		{label}
@@ -63,4 +59,7 @@
 		on:change={handle_change}
 		on:select={(e) => gradio.dispatch("select", e.detail)}
 	/>
+	{#if info}
+		<Info {info} />
+	{/if}
 </Block>


### PR DESCRIPTION
## Description
Earlier  the app renders the info text above the label, now will show info below checkbox.

Closes: #11897

Ran:
Formatting/Linting
```bash
bash scripts/format_frontend.sh
```  
