### PR TITLE
Fix MultimodalTextbox autofocus issue when file_types is specified

### DIFF
--- a/js/multimodaltextbox/Index.svelte
+++ b/js/multimodaltextbox/Index.svelte
@@ -123,6 +123,8 @@
 		| "upload,microphone"
 		| "microphone"
 		| "microphone,upload";
+
+	$: file_types_string = (file_types || []).join(",") || null;
 </script>
 
 <Block
@@ -149,7 +151,7 @@
 		bind:value_is_output
 		bind:dragging
 		bind:active_source
-		{file_types}
+		{file_types_string}
 		{root}
 		{label}
 		{info}

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -48,7 +48,7 @@
 	export let text_align: "left" | "right" | undefined = undefined;
 	export let autoscroll = true;
 	export let root: string;
-	export let file_types: string[] | null = null;
+	export let file_types_string: string | null = null;
 	export let max_file_size: number | null = null;
 	export let upload: Client["upload"];
 	export let stream_handler: Client["stream"];
@@ -84,6 +84,9 @@
 		| "upload"
 		| "microphone"
 	)[];
+	$: file_types = file_types_string
+		? file_types_string.split(",").map((s) => s.trim())
+		: null;
 	$: dispatch("drag", dragging);
 	let mic_audio: FileData | null = null;
 


### PR DESCRIPTION
## Description

Closes: #12015

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
