### PR TITLE
gradio.Audio does not preload the file in browser style since 5.46.0

### DIFF
--- a/js/audio/player/AudioPlayer.svelte
+++ b/js/audio/player/AudioPlayer.svelte
@@ -158,7 +158,6 @@
 		}
 	}
 
-	
 	$: if (subtitles && waveform) {
 		if (subtitles_toggle) {
 			add_subtitles_to_waveform(waveform, subtitles);
@@ -166,10 +165,10 @@
 			hide_subtitles();
 		}
 	}
-	
+
 	function load_stream(value: FileData | null): void {
 		if (!value || !value.is_stream || !value.url) return;
-		
+
 		if (Hls.isSupported() && !stream_active) {
 			// Set config to start playback after 1 second of data received
 			const hls = new Hls({
@@ -192,14 +191,14 @@
 							);
 							hls.startLoad();
 							break;
-							case Hls.ErrorTypes.MEDIA_ERROR:
-								console.error("Fatal media error encountered, trying to recover");
-								hls.recoverMediaError();
-								break;
-								default:
-									console.error("Fatal error, cannot recover");
-									hls.destroy();
-									break;
+						case Hls.ErrorTypes.MEDIA_ERROR:
+							console.error("Fatal media error encountered, trying to recover");
+							hls.recoverMediaError();
+							break;
+						default:
+							console.error("Fatal error, cannot recover");
+							hls.destroy();
+							break;
 					}
 				}
 			});
@@ -218,7 +217,7 @@
 	$: if (audio_player && value?.is_stream) {
 		load_stream(value);
 	}
-	
+
 	onMount(() => {
 		window.addEventListener("keydown", (e) => {
 			if (!waveform || show_volume_slider) return;

--- a/js/audio/player/AudioPlayer.svelte
+++ b/js/audio/player/AudioPlayer.svelte
@@ -158,8 +158,7 @@
 		}
 	}
 
-	$: url && load_audio(url);
-
+	
 	$: if (subtitles && waveform) {
 		if (subtitles_toggle) {
 			add_subtitles_to_waveform(waveform, subtitles);
@@ -167,10 +166,10 @@
 			hide_subtitles();
 		}
 	}
-
+	
 	function load_stream(value: FileData | null): void {
 		if (!value || !value.is_stream || !value.url) return;
-
+		
 		if (Hls.isSupported() && !stream_active) {
 			// Set config to start playback after 1 second of data received
 			const hls = new Hls({
@@ -193,14 +192,14 @@
 							);
 							hls.startLoad();
 							break;
-						case Hls.ErrorTypes.MEDIA_ERROR:
-							console.error("Fatal media error encountered, trying to recover");
-							hls.recoverMediaError();
-							break;
-						default:
-							console.error("Fatal error, cannot recover");
-							hls.destroy();
-							break;
+							case Hls.ErrorTypes.MEDIA_ERROR:
+								console.error("Fatal media error encountered, trying to recover");
+								hls.recoverMediaError();
+								break;
+								default:
+									console.error("Fatal error, cannot recover");
+									hls.destroy();
+									break;
 					}
 				}
 			});
@@ -212,10 +211,14 @@
 		}
 	}
 
+	$: if (audio_player && url) {
+		load_audio(url);
+	}
+
 	$: if (audio_player && value?.is_stream) {
 		load_stream(value);
 	}
-
+	
 	onMount(() => {
 		window.addEventListener("keydown", (e) => {
 			if (!waveform || show_volume_slider) return;


### PR DESCRIPTION
## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #12025 
```
async function load_audio(data: string): Promise<void> {
		stream_active = false;

		if (waveform_options.show_recording_waveform) {
			waveform?.load(data);
		} else if (audio_player) {
			audio_player.src = data;
		}
	}
```

When the show_recording_waveform was set to false the code block that was executed was 'audio_player.src = data;' but the audio_player was not yet intialized thus no data was set.

Solution: 
Added the code block that re executes when the audio_player is set and sets the data.


## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [x] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
