### PR TITLE
Add support for alpha versions in `gradio cc publish`

### DIFF
--- a/gradio/cli/commands/components/publish.py
+++ b/gradio/cli/commands/components/publish.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Annotated
 
 import semantic_version
+from packaging.version import Version as PEP440Version
 from huggingface_hub import HfApi
 from rich import print
 from rich.console import Console
@@ -34,6 +35,20 @@ def _get_version_from_file(dist_file: Path) -> str | None:
     match = re.search(r"-(\d+\.\d+\.\d+[a-zA-Z]*\d*)-", dist_file.name)
     if match:
         return match.group(1)
+    return None
+
+
+def _parse_version(
+    version_string: str,
+) -> semantic_version.Version | PEP440Version | None:
+    """Parse a version string, trying semantic_version first, then PEP440."""
+    try:
+        return semantic_version.Version(version_string)
+    except ValueError:
+        try:
+            return PEP440Version(version_string)
+        except Exception:
+            return None
 
 
 def _get_max_version(distribution_files: list[Path]) -> str | None:
@@ -43,9 +58,10 @@ def _get_max_version(distribution_files: list[Path]) -> str | None:
         # If anything goes wrong, just return None so we upload all files
         # better safe than sorry
         if version:
-            try:
-                versions.append(semantic_version.Version(version))
-            except ValueError:
+            parsed = _parse_version(version)
+            if parsed:
+                versions.append(parsed)
+            else:
                 return None
     return str(max(versions)) if versions else None
 
@@ -110,9 +126,17 @@ def _publish(
     distribution_files = [
         p.resolve() for p in Path(dist_dir).glob("*") if p.suffix in {".whl", ".gz"}
     ]
+
+    def _get_wheel_version(path: Path):
+        version_str = str(path.name).split("-")[1]
+        parsed = _parse_version(version_str)
+        if parsed is None:
+            raise ValueError(f"Could not parse version {version_str} from {path.name}")
+        return parsed
+
     wheel_file = max(
         (p for p in distribution_files if p.suffix == ".whl"),
-        key=lambda s: semantic_version.Version(str(s.name).split("-")[1]),
+        key=_get_wheel_version,
     )
     if not wheel_file:
         raise ValueError(
@@ -210,6 +234,7 @@ def _publish(
                 or source_dir
             )
             source_dir = Path(source_dir_).resolve()
+
     if upload_demo:
         pyproject_toml_path = source_dir / "pyproject.toml"
 


### PR DESCRIPTION
## Description

The custom component CLI failed to publish packages with alpha versions (e.g. `0.26.0-alpha.1`) because `gradio cc build` outputs PEP 440 versions (e.g. 0.26.0a1).

This change makes the CLI fall back to PEP 440 parsing when semantic version parsing fails.

Closes: #11999 

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I did not use AI
  
