### PR TITLE
Migrate Audio to Svelte 5

### DIFF
--- a/js/audio/Index.svelte
+++ b/js/audio/Index.svelte
@@ -1,52 +1,21 @@
 <svelte:options accessors={true} />
 
 <script lang="ts">
-	import type { Gradio, ShareData } from "@gradio/utils";
-
-	import type { FileData } from "@gradio/client";
+	import { Gradio } from "@gradio/utils";
+	import { StatusTracker } from "@gradio/statustracker";
 	import type { LoadingStatus } from "@gradio/statustracker";
-	import { afterUpdate, onMount } from "svelte";
+	import { onMount } from "svelte";
 
 	import StaticAudio from "./static/StaticAudio.svelte";
 	import InteractiveAudio from "./interactive/InteractiveAudio.svelte";
-	import { StatusTracker } from "@gradio/statustracker";
 	import { Block, UploadText } from "@gradio/atoms";
-	import type { WaveformOptions, SubtitleData } from "./shared/types";
+	import type { AudioEvents, AudioProps } from "./shared/types";
 
-	export let value_is_output = false;
-	export let elem_id = "";
-	export let elem_classes: string[] = [];
-	export let visible: boolean | "hidden" = true;
-	export let interactive: boolean;
-	export let value: null | FileData = null;
-	export let sources:
-		| ["microphone"]
-		| ["upload"]
-		| ["microphone", "upload"]
-		| ["upload", "microphone"];
-	export let label: string;
-	export let root: string;
-	export let show_label: boolean;
-	export let container = true;
-	export let scale: number | null = null;
-	export let min_width: number | undefined = undefined;
-	export let loading_status: LoadingStatus;
-	export let autoplay = false;
-	export let loop = false;
-	export let show_download_button: boolean;
-	export let show_share_button = false;
-	export let editable = true;
-	export let waveform_options: WaveformOptions = {
-		show_recording_waveform: true
-	};
-	export let pending: boolean;
-	export let streaming: boolean;
-	export let stream_every: number;
-	export let input_ready: boolean;
-	export let recording = false;
-	export let subtitles: null | FileData | SubtitleData[] = null;
+	let props = $props();
+	const gradio = new Gradio<AudioEvents, AudioProps>(props);
 	let uploading = false;
-	$: input_ready = !uploading;
+	let active_source = $derived.by(() => gradio.props.sources ? gradio.props.sources[0] : null);
+	let initial_value = gradio.props.value;
 
 	let stream_state = "closed";
 	let _modify_stream: (state: "open" | "closed" | "waiting") => void;
@@ -57,94 +26,34 @@
 		_modify_stream(state);
 	}
 	export const get_stream_state: () => void = () => stream_state;
-	export let set_time_limit: (time: number) => void;
-	export let gradio: Gradio<{
-		input: never;
-		change: typeof value;
-		stream: typeof value;
-		error: string;
-		warning: string;
-		edit: never;
-		play: never;
-		pause: never;
-		stop: never;
-		end: never;
-		start_recording: never;
-		pause_recording: never;
-		stop_recording: never;
-		upload: never;
-		clear: never;
-		share: ShareData;
-		clear_status: LoadingStatus;
-		close_stream: string;
-	}>;
-
-	let old_value: null | FileData = null;
-
-	let active_source: "microphone" | "upload";
-
-	let initial_value: null | FileData = value;
-
-	$: if (value && initial_value === null) {
-		initial_value = value;
-	}
+	let set_time_limit: (time: number) => void = props.set_time_limit;
 
 	const handle_reset_value = (): void => {
-		if (initial_value === null || value === initial_value) {
+		if (initial_value === null || gradio.props.value === initial_value) {
 			return;
 		}
-
-		value = initial_value;
+		gradio.props.value = initial_value;
 	};
-
-	$: {
-		if (JSON.stringify(value) !== JSON.stringify(old_value)) {
-			old_value = value;
-			gradio.dispatch("change");
-			if (!value_is_output) {
-				gradio.dispatch("input");
-			}
-		}
-	}
 
 	let dragging: boolean;
 
-	$: if (!active_source && sources) {
-		active_source = sources[0];
-	}
-
-	let waveform_settings: Record<string, any>;
-
 	let color_accent = "darkorange";
 
-	onMount(() => {
-		color_accent = getComputedStyle(document?.documentElement).getPropertyValue(
-			"--color-accent"
-		);
-		set_trim_region_colour();
-		waveform_settings.waveColor = waveform_options.waveform_color || "#9ca3af";
-		waveform_settings.progressColor =
-			waveform_options.waveform_progress_color || color_accent;
-		waveform_settings.mediaControls = waveform_options.show_controls;
-		waveform_settings.sampleRate = waveform_options.sample_rate || 44100;
-	});
-
-	$: waveform_settings = {
+	let waveform_settings = $derived({
 		height: 50,
-
 		barWidth: 2,
 		barGap: 3,
 		cursorWidth: 2,
 		cursorColor: "#ddd5e9",
-		autoplay: autoplay,
+		autoplay: gradio.props.autoplay,
 		barRadius: 10,
 		dragToSeek: true,
 		normalize: true,
 		minPxPerSec: 20
-	};
+	});
 
 	const trim_region_settings = {
-		color: waveform_options.trim_region_color,
+		color: gradio.props.waveform_options.trim_region_color,
 		drag: true,
 		resize: true
 	};
@@ -160,49 +69,61 @@
 		const [level, status] = detail.includes("Invalid file type")
 			? ["warning", "complete"]
 			: ["error", "error"];
-		loading_status = loading_status || {};
-		loading_status.status = status as LoadingStatus["status"];
-		loading_status.message = detail;
+		if (gradio.shared.loading_status) {
+			gradio.shared.loading_status.status = status as LoadingStatus["status"];
+			gradio.shared.loading_status.message = detail;
+		}
 		gradio.dispatch(level as "error" | "warning", detail);
 	}
 
-	afterUpdate(() => {
-		value_is_output = false;
+	onMount(() => {
+		color_accent = getComputedStyle(document?.documentElement).getPropertyValue(
+			"--color-accent"
+		);
+		set_trim_region_colour();
+		waveform_settings.waveColor = gradio.props.waveform_options.waveform_color || "#9ca3af";
+		waveform_settings.progressColor =
+			gradio.props.waveform_options.waveform_progress_color || color_accent;
+		waveform_settings.mediaControls = gradio.props.waveform_options.show_controls;
+		waveform_settings.sampleRate = gradio.props.waveform_options.sample_rate || 44100;
 	});
+
+	$effect(() => {
+		gradio.dispatch("change", gradio.props.value);
+	})
 </script>
 
-{#if !interactive}
+{#if !gradio.shared.interactive}
 	<Block
 		variant={"solid"}
 		border_mode={dragging ? "focus" : "base"}
 		padding={false}
 		allow_overflow={false}
-		{elem_id}
-		{elem_classes}
-		{visible}
-		{container}
-		{scale}
-		{min_width}
+		elem_id={gradio.shared.elem_id}
+		elem_classes={gradio.shared.elem_classes}
+		visible={gradio.shared.visible}
+		container={gradio.shared.container}
+		scale={gradio.shared.scale}
+		min_width={gradio.shared.min_width}
 	>
 		<StatusTracker
-			autoscroll={gradio.autoscroll}
+			autoscroll={gradio.shared.autoscroll}
 			i18n={gradio.i18n}
-			{...loading_status}
-			on:clear_status={() => gradio.dispatch("clear_status", loading_status)}
+			{...gradio.shared.loading_status}
+			on:clear_status={() => gradio.dispatch("clear_status", gradio.shared.loading_status)}
 		/>
 
 		<StaticAudio
 			i18n={gradio.i18n}
-			{show_label}
-			{show_download_button}
-			{show_share_button}
-			{value}
-			{subtitles}
-			{label}
-			{loop}
+			show_label={gradio.shared.show_label}
+			buttons={gradio.props.buttons}
+			value={gradio.props.value}
+			subtitles={gradio.props.subtitles}
+			label={gradio.shared.label}
+			loop={gradio.props.loop}
 			{waveform_settings}
-			{waveform_options}
-			{editable}
+			waveform_options={gradio.props.waveform_options}
+			editable={gradio.props.editable}
 			on:share={(e) => gradio.dispatch("share", e.detail)}
 			on:error={(e) => gradio.dispatch("error", e.detail)}
 			on:play={() => gradio.dispatch("play")}
@@ -212,45 +133,45 @@
 	</Block>
 {:else}
 	<Block
-		variant={value === null && active_source === "upload" ? "dashed" : "solid"}
+		variant={gradio.props.value === null && active_source === "upload" ? "dashed" : "solid"}
 		border_mode={dragging ? "focus" : "base"}
 		padding={false}
 		allow_overflow={false}
-		{elem_id}
-		{elem_classes}
-		{visible}
-		{container}
-		{scale}
-		{min_width}
+		elem_id={gradio.shared.elem_id}
+		elem_classes={gradio.shared.elem_classes}
+		visible={gradio.shared.visible}
+		container={gradio.shared.container}
+		scale={gradio.shared.scale}
+		min_width={gradio.shared.min_width}
 	>
 		<StatusTracker
-			autoscroll={gradio.autoscroll}
+			autoscroll={gradio.shared.autoscroll}
 			i18n={gradio.i18n}
-			{...loading_status}
-			on:clear_status={() => gradio.dispatch("clear_status", loading_status)}
+			{...gradio.shared.loading_status}
+			on:clear_status={() => gradio.dispatch("clear_status", gradio.shared.loading_status)}
 		/>
 		<InteractiveAudio
-			{label}
-			{show_label}
-			{show_download_button}
-			{value}
-			{subtitles}
-			on:change={({ detail }) => (value = detail)}
+			label={gradio.shared.label}
+			show_label={gradio.shared.show_label}
+			buttons={gradio.props.buttons}
+			value={gradio.props.value}
+			subtitles={gradio.props.subtitles}
+			on:change={({ detail }) => (gradio.props.value = detail)}
 			on:stream={({ detail }) => {
-				value = detail;
-				gradio.dispatch("stream", value);
+				gradio.props.value = detail;
+				gradio.dispatch("stream", gradio.props.value);
 			}}
 			on:drag={({ detail }) => (dragging = detail)}
-			{root}
-			{sources}
-			{active_source}
-			{pending}
-			{streaming}
-			bind:recording
-			{loop}
-			max_file_size={gradio.max_file_size}
+			root={gradio.shared.root}
+			sources={gradio.props.sources}
+			active_source={active_source}
+			pending={gradio.props.pending}
+			streaming={gradio.props.streaming}
+			bind:recording={gradio.props.recording}
+			loop={gradio.props.loop}
+			max_file_size={gradio.shared.max_file_size}
 			{handle_reset_value}
-			{editable}
+			editable={gradio.props.editable}
 			bind:dragging
 			bind:uploading
 			on:edit={() => gradio.dispatch("edit")}
@@ -259,20 +180,29 @@
 			on:stop={() => gradio.dispatch("stop")}
 			on:start_recording={() => gradio.dispatch("start_recording")}
 			on:pause_recording={() => gradio.dispatch("pause_recording")}
-			on:stop_recording={(e) => gradio.dispatch("stop_recording")}
-			on:upload={() => gradio.dispatch("upload")}
-			on:clear={() => gradio.dispatch("clear")}
+			on:stop_recording={(e) => {
+				gradio.dispatch("stop_recording");
+				gradio.dispatch("input");
+			}}
+			on:upload={() => {
+				gradio.dispatch("upload");
+				gradio.dispatch("input");
+			}}
+			on:clear={() => {
+				gradio.dispatch("clear");
+				gradio.dispatch("input");
+			}}
 			on:error={handle_error}
 			on:close_stream={() => gradio.dispatch("close_stream", "stream")}
 			i18n={gradio.i18n}
 			{waveform_settings}
-			{waveform_options}
+			waveform_options={gradio.props.waveform_options}
 			{trim_region_settings}
-			{stream_every}
+			stream_every={gradio.props.stream_every}
 			bind:modify_stream={_modify_stream}
 			bind:set_time_limit
-			upload={(...args) => gradio.client.upload(...args)}
-			stream_handler={(...args) => gradio.client.stream(...args)}
+			upload={(...args) => gradio.shared.client.upload(...args)}
+			stream_handler={(...args) => gradio.shared.client.stream(...args)}
 		>
 			<UploadText i18n={gradio.i18n} type="audio" />
 		</InteractiveAudio>

--- a/js/audio/interactive/InteractiveAudio.svelte
+++ b/js/audio/interactive/InteractiveAudio.svelte
@@ -22,7 +22,6 @@
 	export let root: string;
 	export let loop: boolean;
 	export let show_label = true;
-	export let show_download_button = false;
 	export let sources:
 		| ["microphone"]
 		| ["upload"]
@@ -45,6 +44,7 @@
 	export let uploading = false;
 	export let recording = false;
 	export let class_name = "";
+	export let buttons: string[];
 
 	let time_limit: number | null = null;
 	let stream_state: "open" | "waiting" | "closed" = "closed";
@@ -292,7 +292,7 @@
 			{i18n}
 			on:clear={clear}
 			on:edit={() => (mode = "edit")}
-			download={show_download_button ? value.url : null}
+			download={buttons.includes("download") ? value.url : null}
 		/>
 
 		<AudioPlayer

--- a/js/audio/recorder/AudioRecorder.svelte
+++ b/js/audio/recorder/AudioRecorder.svelte
@@ -124,6 +124,8 @@
 		playing = false;
 	});
 
+	let record_mounted = false;
+
 	const create_mic_waveform = (): void => {
 		if (microphoneContainer) microphoneContainer.innerHTML = "";
 		if (micWaveform !== undefined) micWaveform.destroy();
@@ -154,6 +156,7 @@
 				create_recording_waveform();
 			}
 		});
+		record_mounted = true;
 	};
 
 	const create_recording_waveform = (): void => {
@@ -225,7 +228,7 @@
 		</div>
 	{/if}
 
-	{#if microphoneContainer && !recordedAudio}
+	{#if microphoneContainer && !recordedAudio && record_mounted}
 		<WaveformRecordControls
 			bind:record
 			{i18n}

--- a/js/audio/shared/types.ts
+++ b/js/audio/shared/types.ts
@@ -1,3 +1,5 @@
+import {FileData} from "@gradio/client";
+
 export type WaveformOptions = {
 	waveform_color?: string;
 	waveform_progress_color?: string;
@@ -12,4 +14,43 @@ export interface SubtitleData {
 	start: number;
 	end: number;
 	text: string;
+}
+
+export interface AudioProps {
+    sources: | ["microphone"]
+		| ["upload"]
+		| ["microphone", "upload"]
+		| ["upload", "microphone"]
+    value: FileData | null;
+    type: "numpy" | "filepath";
+    autoplay: boolean;
+    buttons: ("play" | "download")[];
+    recording: boolean;
+    loop: boolean;
+    subtitles: FileData | SubtitleData[] | null;
+	waveform_options: WaveformOptions;
+	editable: boolean;
+	pending: boolean;
+	streaming: boolean;
+	stream_every: number;
+	input_ready: boolean;
+}
+
+export interface AudioEvents {
+	change: any;
+	upload: any;
+	stream: any;
+	clear: any;
+	play: any;
+	pause: any;
+	stop: any;
+	start_recording: any;
+	pause_recording: any;
+	stop_recording: any;
+	input: any;
+	error: any;
+	warning: any;
+	clear_status: any;
+	close_stream: any;
+	edit: any
 }

--- a/js/audio/static/StaticAudio.svelte
+++ b/js/audio/static/StaticAudio.svelte
@@ -19,8 +19,6 @@
 	export let subtitles: null | FileData | SubtitleData[] = null;
 	export let label: string;
 	export let show_label = true;
-	export let show_download_button = true;
-	export let show_share_button = false;
 	export let i18n: I18nFormatter;
 	export let waveform_settings: Record<string, any> = {};
 	export let waveform_options: WaveformOptions = {
@@ -29,6 +27,7 @@
 	export let editable = true;
 	export let loop: boolean;
 	export let display_icon_button_wrapper_top_corner = false;
+	export let buttons: string[];
 
 	const dispatch = createEventDispatcher<{
 		change: FileData;
@@ -52,7 +51,7 @@
 	<IconButtonWrapper
 		display_top_corner={display_icon_button_wrapper_top_corner}
 	>
-		{#if show_download_button}
+		{#if buttons.includes("download")}
 			<DownloadLink
 				href={value.is_stream
 					? value.url?.replace("playlist.m3u8", "playlist-file")
@@ -62,7 +61,7 @@
 				<IconButton Icon={Download} label={i18n("common.download")} />
 			</DownloadLink>
 		{/if}
-		{#if show_share_button}
+		{#if buttons.includes("share")}
 			<ShareButton
 				{i18n}
 				on:error

--- a/js/core/src/types.ts
+++ b/js/core/src/types.ts
@@ -4,6 +4,8 @@ import type { LoadingStatus } from "js/statustracker";
 import type { load_component } from "@gradio/utils";
 import type { get_component } from "./init_utils.js";
 
+export type ServerFunctions = Record<string, (...args: any[]) => Promise<any>>;
+
 // import type { I18nFormatter } from "./i18n.js";
 // import type { component_loader } from "./init.js";
 /** The props that are always present on a component */
@@ -35,6 +37,7 @@ export interface SharedProps {
 	theme?: "light" | "dark";
 	show_progress: boolean;
 	api_prefix: string;
+	server: ServerFunctions;
 }
 
 /** The metadata for a component

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -399,7 +399,7 @@
 			{root}
 			loop={false}
 			show_label={false}
-			show_download_button={false}
+			buttons={["share"]}
 			dragging={false}
 		/>
 	{/if}

--- a/js/upload/src/Upload.svelte
+++ b/js/upload/src/Upload.svelte
@@ -232,7 +232,6 @@
 			dispatch("error", `Invalid file type only ${filetype} allowed.`);
 			return false;
 		});
-
 		if (format != "blob") {
 			await load_files(files_to_load);
 		} else {


### PR DESCRIPTION
## Description

The i18n is not working and I can't figure out why the waveform is not working

Test with

```python
import gradio as gr
import numpy as np


def audio_identity(audio):
    return audio, audio


with gr.Blocks() as demo:
    with gr.Row():
        with gr.Column():
            # Create a simple audio value for testing
            audio_input = gr.Audio(
                label="Input Audio",
                sources=["upload", "microphone"],
                type="numpy",
            )
            submit = gr.Button("Submit", variant="primary")
        with gr.Column():
            audio_output_text = gr.Textbox(label="Audio Output Info")
            audio_output = gr.Audio(label="Output Audio")

    submit.click(
        fn=audio_identity,
        inputs=audio_input,
        outputs=[audio_output_text, audio_output],
    )

    # Event handlers for input audio
    with gr.Row():
        with gr.Column():
            input_audio_change_event = gr.Textbox(label="Input Audio Change Event")
            input_audio_input_event = gr.Textbox(label="Input Audio Input Event")
            input_audio_upload_event = gr.Textbox(label="Input Audio Upload Event")
        with gr.Column():
            output_audio_change_event = gr.Textbox(label="Output Audio Change Event")
            output_audio_input_event = gr.Textbox(label="Output Audio Input Event")
            output_audio_play_event = gr.Textbox(label="Output Audio Play Event")

    audio_input.change(
        lambda audio: f"Input audio change event triggered with value: {audio}",
        inputs=[audio_input],
        outputs=[input_audio_change_event],
    )
    audio_input.input(
        lambda audio: f"Input audio input event triggered with value: {audio}",
        inputs=[audio_input],
        outputs=[input_audio_input_event],
    )
    audio_input.upload(
        lambda audio: f"Input audio upload event triggered with value: {audio}",
        inputs=[audio_input],
        outputs=[input_audio_upload_event],
    )

    audio_output.change(
        lambda audio: f"Output audio change event triggered with value: {audio}",
        inputs=[audio_output],
        outputs=[output_audio_change_event],
    )
    audio_output.input(
        lambda audio: f"Output audio input event triggered with value: {audio}",
        inputs=[audio_output],
        outputs=[output_audio_input_event],
    )
    audio_output.play(
        lambda audio: f"Output audio play event triggered with value: {audio}",
        inputs=[audio_output],
        outputs=[output_audio_play_event],
    )

    # Property update handlers
    with gr.Row():
        with gr.Column():
            audio_type = gr.Dropdown(
                label="Audio Type",
                choices=["numpy", "filepath"],
                value="numpy",
            )
            audio_format = gr.Dropdown(
                label="Audio Format",
                choices=["wav", "mp3", "None"],
                value="None",
            )
            audio_autoplay = gr.Checkbox(
                label="Autoplay",
                value=False,
            )
        with gr.Column():
            audio_loop = gr.Checkbox(
                label="Loop",
                value=False,
            )
            audio_editable = gr.Checkbox(
                label="Editable",
                value=True,
            )
            make_interactive = gr.Button("Make Audio Non-Interactive")
            make_interactive2 = gr.Button("Make Audio Interactive")

    def update_audio_type(audio_type_val):
        return gr.Audio(type=audio_type_val)

    audio_type.change(
        fn=update_audio_type,
        inputs=[audio_type],
        outputs=[audio_input],
    )

    def update_audio_format(format_val):
        if format_val == "None":
            format_val = None
        return gr.Audio(format=format_val)

    audio_format.change(
        fn=update_audio_format,
        inputs=[audio_format],
        outputs=[audio_input],
    )

    def update_audio_autoplay(autoplay):
        return gr.Audio(autoplay=autoplay)

    audio_autoplay.change(
        fn=update_audio_autoplay,
        inputs=[audio_autoplay],
        outputs=[audio_output],
    )

    def update_audio_loop(loop):
        return gr.Audio(loop=loop)

    audio_loop.change(
        fn=update_audio_loop,
        inputs=[audio_loop],
        outputs=[audio_output],
    )

    def update_audio_editable(editable):
        return gr.Audio(editable=editable)

    audio_editable.change(
        fn=update_audio_editable,
        inputs=[audio_editable],
        outputs=[audio_input],
    )

    make_interactive.click(lambda: gr.Audio(interactive=False), None, audio_input)
    make_interactive2.click(lambda: gr.Audio(interactive=True), None, audio_input)


if __name__ == "__main__":
    demo.launch()
```


![audio_update](https://github.com/user-attachments/assets/3bf4c93b-2fa1-48b4-8b2b-8f4e261c6ee6)


## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
