### PR TITLE
Migrate Image to Svelte 5

### DIFF
--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -74,7 +74,6 @@ class Image(StreamingInput, Component):
         every: Timer | float | None = None,
         inputs: Component | Sequence[Component] | set[Component] | None = None,
         show_label: bool | None = None,
-        show_download_button: bool = True,
         container: bool = True,
         scale: int | None = None,
         min_width: int = 160,
@@ -90,9 +89,9 @@ class Image(StreamingInput, Component):
         webcam_options: WebcamOptions | None = None,
         show_share_button: bool | None = None,
         placeholder: str | None = None,
-        show_fullscreen_button: bool = True,
         webcam_constraints: dict[str, Any] | None = None,
         watermark: str | Path | PIL.Image.Image | np.ndarray | None = None,
+        buttons: list[Literal["download", "share", "fullscreen"]] | None = None,
     ):
         """
         Parameters:
@@ -107,7 +106,6 @@ class Image(StreamingInput, Component):
             every: Continously calls `value` to recalculate it if `value` is a function (has no effect otherwise). Can provide a Timer whose tick resets `value`, or a float that provides the regular interval for the reset Timer.
             inputs: Components that are used as inputs to calculate `value` if `value` is a function (has no effect otherwise). `value` is recalculated any time the inputs change.
             show_label: if True, will display label.
-            show_download_button: If True, will display button to download image. Only applies if interactive is False (e.g. if the component is used as an output).
             container: If True, will place the component in a container - providing some extra padding around the border.
             scale: relative size compared to adjacent Components. For example if Components A and B are in a Row, and A has scale=2, and B has scale=1, A will be twice as wide as B. Should be an integer. scale applies in Rows, and to top-level Components in Blocks where fill_height=True.
             min_width: minimum pixel width, will wrap if not sufficient screen space to satisfy this value. If a certain scale value results in this Component being narrower than min_width, the min_width parameter will be respected first.
@@ -120,11 +118,10 @@ class Image(StreamingInput, Component):
             key: in a gr.render, Components with the same key across re-renders are treated as the same component, not a new component. Properties set in 'preserved_by_key' are not reset across a re-render.
             preserved_by_key: A list of parameters from this component's constructor. Inside a gr.render() function, if a component is re-rendered with the same key, these (and only these) parameters will be preserved in the UI (if they have been changed by the user or an event listener) instead of re-rendered based on the values provided during constructor.
             mirror_webcam: If True webcam will be mirrored. Default is True.
-            show_share_button: If True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
             placeholder: Custom text for the upload area. Overrides default upload messages when provided. Accepts new lines and `#` to designate a heading.
-            show_fullscreen_button: If True, will show a fullscreen icon in the corner of the component that allows user to view the image in fullscreen mode. If False, icon does not appear.
             webcam_constraints: A dictionary that allows developers to specify custom media constraints for the webcam stream. This parameter provides flexibility to control the video stream's properties, such as resolution and front or rear camera on mobile devices. See $demo/webcam_constraints
             watermark: If provided and this component is used to display a `value` image, the `watermark` image will be displayed on the bottom right of the `value` image, 10 pixels from the bottom and 10 pixels from the right. The watermark image will not be resized. Supports `PIL.Image`, `numpy.array`, `pathlib.Path`, and `str` filepaths. SVGs and GIFs are not supported as `watermark` images nor can they be watermarked.
+            buttons: A list of buttons to show in the corner of the component. Valid options are "download" to download the image, "share" to share to Hugging Face Spaces Discussions, and "fullscreen" to view in fullscreen mode. By default, all buttons are shown.
         """
         self.format = format
 
@@ -153,6 +150,7 @@ class Image(StreamingInput, Component):
         self.height = height
         self.width = width
         self.image_mode = image_mode
+        self.buttons = buttons or ["download", "fullscreen",]
         valid_sources = ["upload", "webcam", "clipboard"]
         if sources is None:
             self.sources = (
@@ -168,7 +166,6 @@ class Image(StreamingInput, Component):
                     f"`sources` must a list consisting of elements in {valid_sources}"
                 )
         self.streaming = streaming
-        self.show_download_button = show_download_button
         if streaming and self.sources != ["webcam"]:
             raise ValueError(
                 "Image streaming only available if sources is ['webcam']. Streaming not supported with multiple sources."
@@ -178,7 +175,6 @@ class Image(StreamingInput, Component):
             if show_share_button is None
             else show_share_button
         )
-        self.show_fullscreen_button = show_fullscreen_button
         self.placeholder = placeholder
         self.watermark = watermark
 

--- a/js/image/Index.svelte
+++ b/js/image/Index.svelte
@@ -9,19 +9,16 @@
 </script>
 
 <script lang="ts">
-	import type { Gradio, SelectData, ValueData } from "@gradio/utils";
+	import { Gradio} from "@gradio/utils";
 	import StaticImage from "./shared/ImagePreview.svelte";
 	import ImageUploader from "./shared/ImageUploader.svelte";
-	import { afterUpdate } from "svelte";
-	import type { WebcamOptions } from "./shared/types";
-
 	import { Block, Empty, UploadText } from "@gradio/atoms";
 	import { Image } from "@gradio/icons";
 	import { StatusTracker } from "@gradio/statustracker";
-	import { upload, type FileData } from "@gradio/client";
-	import type { LoadingStatus } from "@gradio/statustracker";
+	import type { ImageProps, ImageEvents,  } from "./shared/types";
 
-	type sources = "upload" | "webcam" | "clipboard" | null;
+	const props = $props();
+	const gradio = new Gradio<ImageEvents, ImageProps>(props);
 
 	let stream_state = "closed";
 	let _modify_stream: (state: "open" | "closed" | "waiting") => void = () => {};
@@ -31,76 +28,15 @@
 		stream_state = state;
 		_modify_stream(state);
 	}
+
 	export const get_stream_state: () => void = () => stream_state;
-	export let set_time_limit: (arg0: number) => void;
-	export let value_is_output = false;
-	export let elem_id = "";
-	export let elem_classes: string[] = [];
-	export let visible: boolean | "hidden" = true;
-	export let value: null | FileData = null;
-	let old_value: null | FileData = null;
-	export let label: string;
-	export let show_label: boolean;
-	export let show_download_button: boolean;
-	export let root: string;
+	let set_time_limit: (arg0: number) => void = props.set_time_limit;
+	
+	let fullscreen = $state(false);
+	let uploading = $state(false);
+	let dragging = $state(false);
+	let active_source = $derived.by(() => gradio.props.sources ? gradio.props.sources[0] : null);
 
-	export let height: number | undefined;
-	export let width: number | undefined;
-	export let stream_every: number;
-
-	export let _selectable = false;
-	export let container = true;
-	export let scale: number | null = null;
-	export let min_width: number | undefined = undefined;
-	export let loading_status: LoadingStatus;
-	export let show_share_button = false;
-	export let sources: ("clipboard" | "webcam" | "upload")[] = [
-		"upload",
-		"clipboard",
-		"webcam"
-	];
-	export let interactive: boolean;
-	export let streaming: boolean;
-	export let pending: boolean;
-	export let placeholder: string | undefined = undefined;
-	export let show_fullscreen_button: boolean;
-	export let input_ready: boolean;
-	export let webcam_options: WebcamOptions;
-	let fullscreen = false;
-
-	let uploading = false;
-	$: input_ready = !uploading;
-	export let gradio: Gradio<{
-		input: never;
-		change: never;
-		error: string;
-		edit: never;
-		stream: ValueData;
-		drag: never;
-		upload: never;
-		clear: never;
-		select: SelectData;
-		share: ShareData;
-		clear_status: LoadingStatus;
-		close_stream: string;
-	}>;
-
-	$: {
-		if (JSON.stringify(value) !== JSON.stringify(old_value)) {
-			old_value = value;
-			gradio.dispatch("change");
-			if (!value_is_output) {
-				gradio.dispatch("input");
-			}
-		}
-	}
-
-	afterUpdate(() => {
-		value_is_output = false;
-	});
-
-	let dragging: boolean;
-	let active_source: sources = null;
 	let upload_component: ImageUploader;
 	const handle_drag_event = (event: Event): void => {
 		const drag_event = event as DragEvent;
@@ -114,7 +50,7 @@
 	};
 
 	const handle_drop = (event: Event): void => {
-		if (interactive) {
+		if (gradio.shared.interactive) {
 			const drop_event = event as DragEvent;
 			drop_event.preventDefault();
 			drop_event.stopPropagation();
@@ -125,28 +61,37 @@
 			}
 		}
 	};
+
+	let old_value = $state(gradio.props.value);
+
+	$effect(() => {
+		if (old_value != gradio.props.value) {
+			old_value = gradio.props.value;
+			gradio.dispatch("change");
+		}
+	});
 </script>
 
-{#if !interactive}
+{#if !gradio.shared.interactive}
 	<Block
-		{visible}
+		visible={gradio.shared.visible}
 		variant={"solid"}
 		border_mode={dragging ? "focus" : "base"}
 		padding={false}
-		{elem_id}
-		{elem_classes}
-		height={height || undefined}
-		{width}
+		elem_id={gradio.shared.elem_id}
+		elem_classes={gradio.shared.elem_classes}
+		height={gradio.props.height || undefined}
+		width={gradio.props.width}
 		allow_overflow={false}
-		{container}
-		{scale}
-		{min_width}
+		container={gradio.shared.container}
+		scale{gradio.shared.scale}
+		min_width={gradio.shared.min_width}
 		bind:fullscreen
 	>
 		<StatusTracker
-			autoscroll={gradio.autoscroll}
+			autoscroll={gradio.shared.autoscroll}
 			i18n={gradio.i18n}
-			{...loading_status}
+			{...gradio.shared.loading_status}
 		/>
 		<StaticImage
 			on:select={({ detail }) => gradio.dispatch("select", detail)}
@@ -156,30 +101,30 @@
 				fullscreen = detail;
 			}}
 			{fullscreen}
-			{value}
-			{label}
-			{show_label}
-			{show_download_button}
-			selectable={_selectable}
-			{show_share_button}
+			value={gradio.props.value}
+			label={gradio.shared.label}
+			show_label={gradio.shared.show_label}
+			show_download_button={gradio.props.buttons.includes("download")}
+			selectable={gradio.props._selectable}
+			show_share_button={gradio.props.buttons.includes("share")}
 			i18n={gradio.i18n}
-			{show_fullscreen_button}
+			show_fullscreen_button={gradio.props.buttons.includes("fullscreen")}
 		/>
 	</Block>
 {:else}
 	<Block
-		{visible}
-		variant={value === null ? "dashed" : "solid"}
+		visible={gradio.shared.visible}
+		variant={gradio.props.value === null ? "dashed" : "solid"}
 		border_mode={dragging ? "focus" : "base"}
 		padding={false}
-		{elem_id}
-		{elem_classes}
-		height={height || undefined}
-		{width}
+		elem_id={gradio.shared.elem_id}
+		elem_classes={gradio.shared.elem_classes}
+		height={gradio.props.height || undefined}
+		width={gradio.props.width}
 		allow_overflow={false}
-		{container}
-		{scale}
-		{min_width}
+		container={gradio.shared.container}
+		scale={gradio.shared.scale}
+		min_width={gradio.shared.min_width}
 		bind:fullscreen
 		on:dragenter={handle_drag_event}
 		on:dragleave={handle_drag_event}
@@ -187,21 +132,21 @@
 		on:drop={handle_drop}
 	>
 		<StatusTracker
-			autoscroll={gradio.autoscroll}
+			autoscroll={gradio.shared.autoscroll}
 			i18n={gradio.i18n}
-			{...loading_status}
-			on:clear_status={() => gradio.dispatch("clear_status", loading_status)}
+			{...gradio.shared.loading_status}
+			on:clear_status={() => gradio.dispatch("clear_status", gradio.shared.loading_status)}
 		/>
 
 		<ImageUploader
 			bind:this={upload_component}
 			bind:uploading
 			bind:active_source
-			bind:value
+			bind:value={gradio.props.value}
 			bind:dragging
-			selectable={_selectable}
-			{root}
-			{sources}
+			selectable={gradio.props._selectable}
+			root={gradio.shared.root}
+			sources={gradio.props.sources}
 			{fullscreen}
 			on:edit={() => gradio.dispatch("edit")}
 			on:clear={() => {
@@ -214,8 +159,7 @@
 			on:select={({ detail }) => gradio.dispatch("select", detail)}
 			on:share={({ detail }) => gradio.dispatch("share", detail)}
 			on:error={({ detail }) => {
-				loading_status = loading_status || {};
-				loading_status.status = "error";
+				gradio.shared.loading_status.status = "error";
 				gradio.dispatch("error", detail);
 			}}
 			on:close_stream={() => {
@@ -224,21 +168,22 @@
 			on:fullscreen={({ detail }) => {
 				fullscreen = detail;
 			}}
-			{label}
-			{show_label}
-			{pending}
-			{streaming}
-			{webcam_options}
-			{stream_every}
+			label={gradio.shared.label}
+			show_label={gradio.shared.show_label}
+			pending={gradio.props.pending}
+			streaming={gradio.props.streaming}
+			webcam_options={gradio.props.webcam_options}
+			stream_every={gradio.props.stream_every}
+			show_fullscreen_button={gradio.props.buttons.includes("fullscreen")}
 			bind:modify_stream={_modify_stream}
 			bind:set_time_limit
-			max_file_size={gradio.max_file_size}
+			max_file_size={gradio.shared.max_file_size}
 			i18n={gradio.i18n}
-			upload={(...args) => gradio.client.upload(...args)}
-			stream_handler={gradio.client?.stream}
+			upload={(...args) => gradio.shared.client.upload(...args)}
+			stream_handler={gradio.shared.client?.stream}
 		>
 			{#if active_source === "upload" || !active_source}
-				<UploadText i18n={gradio.i18n} type="image" {placeholder} />
+				<UploadText i18n={gradio.i18n} type="image" placeholder={gradio.props.placeholder} />
 			{:else if active_source === "clipboard"}
 				<UploadText i18n={gradio.i18n} type="clipboard" mode="short" />
 			{:else}

--- a/js/image/shared/types.ts
+++ b/js/image/shared/types.ts
@@ -1,3 +1,6 @@
+import type { LoadingStatus } from "@gradio/statustracker";
+import type { FileData } from "@gradio/client";
+
 export interface Base64File {
 	url: string;
 	alt_text: string;
@@ -6,4 +9,32 @@ export interface Base64File {
 export interface WebcamOptions {
 	mirror: boolean;
 	constraints: MediaStreamConstraints;
+}
+
+export interface ImageProps {
+	_selectable: boolean;
+	sources: ("clipboard" | "webcam" | "upload")[];
+	height: number;
+	width: number;
+	webcam_options: WebcamOptions;
+	value: FileData | null;
+	buttons: string[];
+	pending: boolean;
+	streaming: boolean;
+	stream_every: number;
+	input_ready: boolean;
+	placeholder: string;
+	watermark: FileData | null;
+}
+
+export interface ImageEvents {
+	clear: void;
+    change: any;
+    stream: any;
+    select: any;
+    upload: any;
+    input: any;
+	clear_status: LoadingStatus;
+	share: any;
+	error: any;
 }


### PR DESCRIPTION
## Description

Test with
```python
import gradio as gr
import random


def image_identity(image):
    return f"Image received: {image}", image


with gr.Blocks() as demo:
    with gr.Row():
        with gr.Column():
            image_input = gr.Image(
                label="Input Image",
                type="numpy",
                sources=["upload", "webcam", "clipboard"],
            )
            submit = gr.Button("Submit", variant="primary")
        with gr.Column():
            image_output_text = gr.Textbox(label="Image Output Info")
            image_output = gr.Image(label="Output Image")

    submit.click(
        fn=image_identity,
        inputs=image_input,
        outputs=[image_output_text, image_output],
    )

    # Event handlers for input image
    with gr.Row():
        with gr.Column():
            input_image_change_event = gr.Textbox(label="Input Image Change Event")
            input_image_select_event = gr.Textbox(label="Input Image Select Event")
            input_image_upload_event = gr.Textbox(label="Input Image Upload Event")
        with gr.Column():
            output_image_change_event = gr.Textbox(label="Output Image Change Event")
            output_image_input_event = gr.Textbox(label="Output Image Input Event")
            output_image_clear_event = gr.Textbox(label="Output Image Clear Event")

    image_input.change(
        lambda image: f"Input image change event triggered {random.randint(0, 1000)}",
        inputs=[image_input],
        outputs=[input_image_change_event],
    )
    image_input.select(
        lambda image: f"Input image select event triggered {random.randint(0, 1000)}",
        inputs=[image_input],
        outputs=[input_image_select_event],
    )
    image_input.upload(
        lambda image: f"Input image upload event triggered with value: {random.randint(0, 1000)}",
        inputs=[image_input],
        outputs=[input_image_upload_event],
    )

    image_output.change(
        lambda image: f"Output image change event triggered with value: {random.randint(0, 1000)}",
        inputs=[image_output],
        outputs=[output_image_change_event],
    )
    image_output.input(
        lambda image: f"Output image input event triggered with value: {random.randint(0, 1000)}",
        inputs=[image_output],
        outputs=[output_image_input_event],
    )
    image_output.clear(
        lambda: "Output image clear event triggered",
        outputs=[output_image_clear_event],
    )

    # Property update handlers
    with gr.Row():
        with gr.Column():
            image_type = gr.Dropdown(
                label="Image Type",
                choices=["numpy", "pil", "filepath"],
                value="numpy",
            )
            image_format = gr.Textbox(
                label="Image Format",
                value="webp",
            )
            image_mode = gr.Dropdown(
                label="Image Mode",
                choices=["RGB", "RGBA", "L", "1", "P", "CMYK", "YCbCr", "LAB", "HSV", "I", "F"],
                value="RGB",
            )
        with gr.Column():
            buttons = gr.CheckboxGroup(
                label="Show Buttons",
                choices=["download", "fullscreen"],
                value=["download", "fullscreen"],
            )
            make_interactive = gr.Button("Make Image Non-Interactive")
            make_interactive2 = gr.Button("Make Image Interactive")

    def update_image_type(image_type_val):
        return gr.Image(type=image_type_val)

    image_type.change(
        fn=update_image_type,
        inputs=[image_type],
        outputs=[image_input],
    )

    def update_image_format(format_val):
        return gr.Image(format=format_val)

    image_format.change(
        fn=update_image_format,
        inputs=[image_format],
        outputs=[image_input],
    )

    def update_image_mode(mode_val):
        if mode_val == "None":
            mode_val = None
        return gr.Image(image_mode=mode_val)

    image_mode.change(
        fn=update_image_mode,
        inputs=[image_mode],
        outputs=[image_input],
    )

    buttons.input(
        fn=lambda selected_buttons: gr.Image(buttons=selected_buttons),
        inputs=[buttons],
        outputs=[image_output],
    )

    make_interactive.click(lambda: gr.Image(interactive=False), None, image_input)
    make_interactive2.click(lambda: gr.Image(interactive=True), None, image_input)


if __name__ == "__main__":
    demo.launch()

```
![image_migration](https://github.com/user-attachments/assets/d2563b50-3042-4f42-8af3-ad5d341ab319)


## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
