### PR TITLE
Migrate Video To Svelte 5

### DIFF
--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -91,10 +91,7 @@ class Video(StreamingOutput, Component):
         webcam_options: WebcamOptions | None = None,
         include_audio: bool | None = None,
         autoplay: bool = False,
-        show_share_button: bool | None = None,
-        show_download_button: bool | None = None,
-        min_length: int | None = None,
-        max_length: int | None = None,
+        buttons: list[Literal["download", "share"]] | None = None,
         loop: bool = False,
         streaming: bool = False,
         watermark: str | Path | None = None,
@@ -123,10 +120,7 @@ class Video(StreamingOutput, Component):
             preserved_by_key: A list of parameters from this component's constructor. Inside a gr.render() function, if a component is re-rendered with the same key, these (and only these) parameters will be preserved in the UI (if they have been changed by the user or an event listener) instead of re-rendered based on the values provided during constructor.
             include_audio: whether the component should record/retain the audio track for a video. By default, audio is excluded for webcam videos and included for uploaded videos.
             autoplay: whether to automatically play the video when the component is used as an output. Note: browsers will not autoplay video files if the user has not interacted with the page yet.
-            show_share_button: if True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
-            show_download_button: if True, will show a download icon in the corner of the component that allows user to download the output. If False, icon does not appear. By default, it will be True for output components and False for input components.
-            min_length: the minimum length of video (in seconds) that the user can pass into the prediction function. If None, there is no minimum length.
-            max_length: the maximum length of video (in seconds) that the user can pass into the prediction function. If None, there is no maximum length.
+            buttons: A list of buttons to show in the top right corner of the component. Valid options are "download" and "share". The "download" button allows the user to save the video to their device. The "share" button allows the user to share the video via Hugging Face Spaces Discussions. By default, no buttons are shown if the component is interactive and both buttons are shown if the component is not interactive.
             loop: if True, the video will loop when it reaches the end and continue playing from the beginning.
             streaming: when used set as an output, takes video chunks yielded from the backend and combines them into one streaming video output. Each chunk should be a video file with a .ts extension using an h.264 encoding. Mp4 files are also accepted but they will be converted to h.264 encoding.
             watermark: an image file to be included as a watermark on the video. The image is not scaled and is displayed on the bottom right of the video. Valid formats for the image are: jpeg, png.
@@ -169,14 +163,7 @@ class Video(StreamingOutput, Component):
         self.include_audio = (
             include_audio if include_audio is not None else "upload" in self.sources
         )
-        self.show_share_button = (
-            (utils.get_space() is not None)
-            if show_share_button is None
-            else show_share_button
-        )
-        self.show_download_button = show_download_button
-        self.min_length = min_length
-        self.max_length = max_length
+        self.buttons = buttons or ["share", "download"]
         self.streaming = streaming
         self.watermark = watermark
         super().__init__(
@@ -213,19 +200,6 @@ class Video(StreamingOutput, Component):
         uploaded_format = file_name.suffix.replace(".", "")
         needs_formatting = self.format is not None and uploaded_format != self.format
         flip = self.sources == ["webcam"] and self.webcam_options.mirror
-
-        if self.min_length is not None or self.max_length is not None:
-            # With this if-clause, avoid unnecessary execution of `processing_utils.get_video_length`.
-            # This is necessary for the Wasm-mode, because it uses ffprobe, which is not available in the browser.
-            duration = processing_utils.get_video_length(file_name)
-            if self.min_length is not None and duration < self.min_length:
-                raise gr.Error(
-                    f"Video is too short, and must be at least {self.min_length} seconds"
-                )
-            if self.max_length is not None and duration > self.max_length:
-                raise gr.Error(
-                    f"Video is too long, and must be at most {self.max_length} seconds"
-                )
         # TODO: Check other image extensions to see if they work.
         valid_watermark_extensions = [".png", ".jpg", ".jpeg"]
         if self.watermark is not None:

--- a/js/video/Index.svelte
+++ b/js/video/Index.svelte
@@ -1,114 +1,45 @@
 <svelte:options accessors={true} />
 
 <script lang="ts">
-	import type { Gradio, ShareData } from "@gradio/utils";
-
 	import type { FileData } from "@gradio/client";
 	import { Block, UploadText } from "@gradio/atoms";
 	import StaticVideo from "./shared/VideoPreview.svelte";
 	import Video from "./shared/InteractiveVideo.svelte";
 	import { StatusTracker } from "@gradio/statustracker";
-	import type { LoadingStatus } from "@gradio/statustracker";
-	import type { WebcamOptions } from "./shared/utils";
-	export let elem_id = "";
-	export let elem_classes: string[] = [];
-	export let visible: boolean | "hidden" = true;
-	export let value: { video: FileData; subtitles: FileData | null } | null =
-		null;
-	let old_value: { video: FileData; subtitles: FileData | null } | null = null;
+	import { Gradio } from "@gradio/utils";
+	import type { VideoProps, VideoEvents } from "./types";
 
-	export let label: string;
-	export let sources:
-		| ["webcam"]
-		| ["upload"]
-		| ["webcam", "upload"]
-		| ["upload", "webcam"];
-	export let root: string;
-	export let show_label: boolean;
-	export let loading_status: LoadingStatus;
-	export let height: number | undefined;
-	export let width: number | undefined;
+	const props = $props();
+	const gradio = new Gradio<VideoEvents, VideoProps>(props);
 
-	export let container = false;
-	export let scale: number | null = null;
-	export let min_width: number | undefined = undefined;
-	export let autoplay = false;
-	export let show_share_button = true;
-	export let show_download_button: boolean;
-	export let gradio: Gradio<{
-		change: never;
-		clear: never;
-		play: never;
-		pause: never;
-		upload: never;
-		stop: never;
-		end: never;
-		start_recording: never;
-		stop_recording: never;
-		share: ShareData;
-		error: string;
-		warning: string;
-		clear_status: LoadingStatus;
-	}>;
-	export let interactive: boolean;
-	export let webcam_options: WebcamOptions;
-	export let include_audio: boolean;
-	export let loop = false;
-	export let input_ready: boolean;
-	let uploading = false;
-	$: input_ready = !uploading;
+	let old_value = $state(gradio.props.value);
+	let uploading = $state(false);
+	let dragging = $state(false);
+	let active_source = $derived.by(() => gradio.props.sources ? gradio.props.sources[0] : undefined);
+	let initial_value: { video: FileData | null; subtitles: FileData | null } | null = gradio.props.value;
 
-	let _video: FileData | null = null;
-	let _subtitle: FileData | null = null;
-
-	let active_source: "webcam" | "upload";
-
-	let initial_value: { video: FileData; subtitles: FileData | null } | null =
-		value;
-
-	$: if (value && initial_value === null) {
-		initial_value = value;
-	}
-
-	const handle_reset_value = (): void => {
-		if (initial_value === null || value === initial_value) {
-			return;
-		}
-
-		value = initial_value;
-	};
-
-	$: if (sources && !active_source) {
-		active_source = sources[0];
-	}
-
-	$: {
-		if (value != null) {
-			_video = value.video;
-			_subtitle = value.subtitles;
-		} else {
-			_video = null;
-			_subtitle = null;
-		}
-	}
-
-	let dragging = false;
-
-	$: {
-		if (JSON.stringify(value) !== JSON.stringify(old_value)) {
-			old_value = value;
+	$effect(() => {
+		if (old_value != gradio.props.value) {
+			old_value = gradio.props.value;
 			gradio.dispatch("change");
 		}
-	}
+	});
+
+	const handle_reset_value = (): void => {
+		if (initial_value === null || gradio.props.value === initial_value) {
+			return;
+		}
+		gradio.props.value = initial_value;
+	};
 
 	function handle_change({ detail }: CustomEvent<FileData | null>): void {
 		if (detail != null) {
-			value = { video: detail, subtitles: null } as {
+			gradio.props.value = { video: detail, subtitles: null } as {
 				video: FileData;
 				subtitles: FileData | null;
 			} | null;
 		} else {
-			value = null;
+			gradio.props.value = null;
 		}
 	}
 
@@ -116,44 +47,43 @@
 		const [level, status] = detail.includes("Invalid file type")
 			? ["warning", "complete"]
 			: ["error", "error"];
-		loading_status = loading_status || {};
-		loading_status.status = status as LoadingStatus["status"];
-		loading_status.message = detail;
+		gradio.shared.loading_status.status = status as any;
+		gradio.shared.loading_status.message = detail;
 		gradio.dispatch(level as "error" | "warning", detail);
 	}
 </script>
 
-{#if !interactive}
+{#if !gradio.shared.interactive}
 	<Block
-		{visible}
-		variant={value === null && active_source === "upload" ? "dashed" : "solid"}
+		visible={gradio.shared.visible}
+		variant={gradio.props.value === null && active_source === "upload" ? "dashed" : "solid"}
 		border_mode={dragging ? "focus" : "base"}
 		padding={false}
-		{elem_id}
-		{elem_classes}
-		{height}
-		{width}
-		{container}
-		{scale}
-		{min_width}
+		elem_id={gradio.shared.elem_id}
+		elem_classes={gradio.shared.elem_classes}
+		height={gradio.props.height || undefined}
+		width={gradio.props.width}
+		container={gradio.shared.container}
+		scale={gradio.shared.scale}
+		min_width={gradio.shared.min_width}
 		allow_overflow={false}
 	>
 		<StatusTracker
-			autoscroll={gradio.autoscroll}
+			autoscroll={gradio.shared.autoscroll}
 			i18n={gradio.i18n}
-			{...loading_status}
-			on:clear_status={() => gradio.dispatch("clear_status", loading_status)}
+			{...gradio.shared.loading_status}
+			on:clear_status={() => gradio.dispatch("clear_status", gradio.shared.loading_status)}
 		/>
 
 		<StaticVideo
-			value={_video}
-			subtitle={_subtitle}
-			{label}
-			{show_label}
-			{autoplay}
-			{loop}
-			{show_share_button}
-			{show_download_button}
+			value={gradio.props.value?.video}
+			subtitle={gradio.props.value?.subtitles}
+			label={gradio.shared.label}
+			show_label={gradio.shared.show_label}
+			autoplay={gradio.props.autoplay}
+			loop={gradio.props.loop}
+			show_share_button={gradio.props.buttons.includes("share")}
+			show_download_button={gradio.props.buttons.includes("download")}
 			on:play={() => gradio.dispatch("play")}
 			on:pause={() => gradio.dispatch("pause")}
 			on:stop={() => gradio.dispatch("stop")}
@@ -161,50 +91,53 @@
 			on:share={({ detail }) => gradio.dispatch("share", detail)}
 			on:error={({ detail }) => gradio.dispatch("error", detail)}
 			i18n={gradio.i18n}
-			upload={(...args) => gradio.client.upload(...args)}
+			upload={(...args) => gradio.shared.client.upload(...args)}
 		/>
 	</Block>
 {:else}
 	<Block
-		{visible}
-		variant={value === null && active_source === "upload" ? "dashed" : "solid"}
+		visible={gradio.shared.visible}
+		variant={gradio.props.value === null && active_source === "upload" ? "dashed" : "solid"}
 		border_mode={dragging ? "focus" : "base"}
 		padding={false}
-		{elem_id}
-		{elem_classes}
-		{height}
-		{width}
-		{container}
-		{scale}
-		{min_width}
+		elem_id={gradio.shared.elem_id}
+		elem_classes={gradio.shared.elem_classes}
+		height={gradio.props.height || undefined}
+		width={gradio.props.width}
+		container={gradio.shared.container}
+		scale={gradio.shared.scale}
+		min_width={gradio.shared.min_width}
 		allow_overflow={false}
 	>
 		<StatusTracker
-			autoscroll={gradio.autoscroll}
+			autoscroll={gradio.shared.autoscroll}
 			i18n={gradio.i18n}
-			{...loading_status}
-			on:clear_status={() => gradio.dispatch("clear_status", loading_status)}
+			{...gradio.shared.loading_status}
+			on:clear_status={() => gradio.dispatch("clear_status", gradio.shared.loading_status)}
 		/>
 
 		<Video
-			value={_video}
-			subtitle={_subtitle}
+			value={gradio.props.value?.video}
+			subtitle={gradio.props.value?.subtitles}
 			on:change={handle_change}
 			on:drag={({ detail }) => (dragging = detail)}
 			on:error={handle_error}
 			bind:uploading
-			{label}
-			{show_label}
-			{show_download_button}
-			{sources}
+			label={gradio.shared.label}
+			show_label={gradio.shared.show_label}
+			show_download_button={gradio.props.buttons.includes("download")}
+			sources={gradio.props.sources}
 			{active_source}
-			{webcam_options}
-			{include_audio}
-			{autoplay}
-			{root}
-			{loop}
+			webcam_options={gradio.props.webcam_options}
+			include_audio={gradio.props.include_audio}
+			autoplay={gradio.props.autoplay}
+			root={gradio.shared.root}
+			loop={gradio.props.loop}
 			{handle_reset_value}
-			on:clear={() => gradio.dispatch("clear")}
+			on:clear={() => {
+				gradio.props.value = null;
+				gradio.dispatch("clear")
+			}}
 			on:play={() => gradio.dispatch("play")}
 			on:pause={() => gradio.dispatch("pause")}
 			on:upload={() => gradio.dispatch("upload")}
@@ -213,9 +146,9 @@
 			on:start_recording={() => gradio.dispatch("start_recording")}
 			on:stop_recording={() => gradio.dispatch("stop_recording")}
 			i18n={gradio.i18n}
-			max_file_size={gradio.max_file_size}
-			upload={(...args) => gradio.client.upload(...args)}
-			stream_handler={(...args) => gradio.client.stream(...args)}
+			max_file_size={gradio.shared.max_file_size}
+			upload={(...args) => gradio.shared.client.upload(...args)}
+			stream_handler={(...args) => gradio.shared.client.stream(...args)}
 		>
 			<UploadText i18n={gradio.i18n} type="video" />
 		</Video>

--- a/js/video/shared/InteractiveVideo.svelte
+++ b/js/video/shared/InteractiveVideo.svelte
@@ -78,7 +78,7 @@
 
 <BlockLabel {show_label} Icon={Video} label={label || "Video"} />
 <div data-testid="video" class="video-container">
-	{#if value === null || value.url === undefined}
+	{#if value === null || value?.url === undefined}
 		<div class="upload-container">
 			{#if active_source === "upload"}
 				<Upload

--- a/js/video/types.ts
+++ b/js/video/types.ts
@@ -1,0 +1,31 @@
+import type { FileData } from "@gradio/client";
+import type { LoadingStatus } from "@gradio/statustracker";
+import type { WebcamOptions } from "./shared/utils";
+
+export interface VideoProps {
+	value: { video: FileData | null; subtitles: FileData | null } | null;
+	height: number | undefined;
+	width: number | undefined;
+	autoplay: boolean;
+	buttons: ("share" | "download" | "fullscreen")[];
+	sources: ["webcam"] | ["upload"] | ["webcam", "upload"] | ["upload", "webcam"];
+	webcam_options: WebcamOptions;
+	include_audio: boolean;
+	loop: boolean;
+	webcam_constraints: object;
+}
+
+export interface VideoEvents {
+	change: never;
+	clear: never;
+	play: never;
+	pause: never;
+	upload: never;
+	stop: never;
+	end: never;
+	start_recording: never;
+	stop_recording: never;
+	clear_status: LoadingStatus;
+	share: any;
+	error: any;
+}


### PR DESCRIPTION
## Description

Test with

```python
import gradio as gr


def video_identity(video):
    return f"Video received", video


with gr.Blocks() as demo:
    with gr.Row():
        with gr.Column():
            video_input = gr.Video(
                label="Input Video",
                sources=["upload", "webcam"],
            )
            submit = gr.Button("Submit", variant="primary")
        with gr.Column():
            video_output_text = gr.Textbox(label="Video Output Info")
            video_output = gr.Video(label="Output Video")

    submit.click(
        fn=video_identity,
        inputs=video_input,
        outputs=[video_output_text, video_output],
    )

    # Event handlers for input video
    with gr.Row():
        with gr.Column():
            input_video_change_event = gr.Textbox(label="Input Video Change Event")
            input_video_upload_event = gr.Textbox(label="Input Video Upload Event")
            input_video_clear_event = gr.Textbox(label="Input Video Clear Event")
        with gr.Column():
            output_video_change_event = gr.Textbox(label="Output Video Change Event")
            output_video_play_event = gr.Textbox(label="Output Video Play Event")
            output_video_pause_event = gr.Textbox(label="Output Video Pause Event")

    video_input.change(
        lambda video: f"Input video change event triggered with value: {video}",
        inputs=[video_input],
        outputs=[input_video_change_event],
    )
    video_input.upload(
        lambda video: f"Input video upload event triggered with value: {video}",
        inputs=[video_input],
        outputs=[input_video_upload_event],
    )
    video_input.clear(
        lambda: "Input video clear event triggered",
        outputs=[input_video_clear_event],
    )

    video_output.change(
        lambda video: f"Output video change event triggered with value: {video}",
        inputs=[video_output],
        outputs=[output_video_change_event],
    )
    video_output.play(
        lambda video: f"Output video play event triggered with value: {video}",
        inputs=[video_output],
        outputs=[output_video_play_event],
    )
    video_output.pause(
        lambda video: f"Output video pause event triggered with value: {video}",
        inputs=[video_output],
        outputs=[output_video_pause_event],
    )

    # Property update handlers
    with gr.Row():
        with gr.Column():
            video_format = gr.Dropdown(
                label="Video Format",
                choices=["mp4", "webm", "ogg", "None"],
                value="None",
            )
            video_sources = gr.Dropdown(
                label="Video Sources",
                choices=["upload", "webcam", "both"],
                value="both",
            )
            video_autoplay = gr.Checkbox(
                label="Autoplay",
                value=False,
            )
        with gr.Column():
            video_loop = gr.Checkbox(
                label="Loop",
                value=False,
            )
            video_include_audio = gr.Checkbox(
                label="Include Audio",
                value=True,
            )
            make_interactive = gr.Button("Make Video Non-Interactive")
            make_interactive2 = gr.Button("Make Video Interactive")

    def update_video_format(format_val):
        if format_val == "None":
            format_val = None
        return gr.Video(format=format_val)

    video_format.change(
        fn=update_video_format,
        inputs=[video_format],
        outputs=[video_input],
    )

    def update_video_sources(sources_val):
        if sources_val == "both":
            sources_val = ["upload", "webcam"]
        elif sources_val == "upload":
            sources_val = ["upload"]
        else:
            sources_val = ["webcam"]
        return gr.Video(sources=sources_val)

    video_sources.change(
        fn=update_video_sources,
        inputs=[video_sources],
        outputs=[video_input],
    )

    def update_video_autoplay(autoplay):
        return gr.Video(autoplay=autoplay)

    video_autoplay.change(
        fn=update_video_autoplay,
        inputs=[video_autoplay],
        outputs=[video_output],
    )

    def update_video_loop(loop):
        return gr.Video(loop=loop)

    video_loop.change(
        fn=update_video_loop,
        inputs=[video_loop],
        outputs=[video_output],
    )

    def update_video_include_audio(include_audio):
        return gr.Video(include_audio=include_audio)

    video_include_audio.change(
        fn=update_video_include_audio,
        inputs=[video_include_audio],
        outputs=[video_input],
    )

    make_interactive.click(lambda: gr.Video(interactive=False), None, video_input)
    make_interactive2.click(lambda: gr.Video(interactive=True), None, video_input)


if __name__ == "__main__":
    demo.launch()
```

![video_migration](https://github.com/user-attachments/assets/1ce73070-6cee-4f70-80d8-83346078563c)


## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
