### PR TITLE
Migrate Gallery

### DIFF
--- a/gradio/components/gallery.py
+++ b/gradio/components/gallery.py
@@ -106,11 +106,9 @@ class Gallery(Component):
         object_fit: (
             Literal["contain", "cover", "fill", "none", "scale-down"] | None
         ) = None,
-        show_share_button: bool | None = None,
-        show_download_button: bool | None = True,
+        buttons: list[Literal["share", "download", "fullscreen"]] | None = None,
         interactive: bool | None = None,
         type: Literal["numpy", "pil", "filepath"] = "filepath",
-        show_fullscreen_button: bool = True,
     ):
         """
         Parameters:
@@ -137,11 +135,9 @@ class Gallery(Component):
             preview: If True, Gallery will start in preview mode, which shows all of the images as thumbnails and allows the user to click on them to view them in full size. Only works if allow_preview is True.
             selected_index: The index of the image that should be initially selected. If None, no image will be selected at start. If provided, will set Gallery to preview mode unless allow_preview is set to False.
             object_fit: CSS object-fit property for the thumbnail images in the gallery. Can be "contain", "cover", "fill", "none", or "scale-down".
-            show_share_button: If True, will show a share icon in the corner of the component that allows user to share outputs to Hugging Face Spaces Discussions. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
-            show_download_button: If True, will show a download button in the corner of the selected image. If False, the icon does not appear. Default is True.
+            buttons: A list of buttons to show in the top right corner of the component. Valid options are "share", "download", and "fullscreen". The "share" button allows the user to share outputs to Hugging Face Spaces Discussions. The "download" button allows the user to download the selected image. The "fullscreen" button allows the user to view the gallery in fullscreen mode. By default, all buttons are shown.
             interactive: If True, the gallery will be interactive, allowing the user to upload images. If False, the gallery will be static. Default is True.
             type: The format the image is converted to before being passed into the prediction function. "numpy" converts the image to a numpy array with shape (height, width, 3) and values from 0 to 255, "pil" converts the image to a PIL image object, "filepath" passes a str path to a temporary file containing the image. If the image is SVG, the `type` is ignored and the filepath of the SVG is returned.
-            show_fullscreen_button: If True, will show a fullscreen icon in the corner of the component that allows user to view the gallery in fullscreen mode. If False, icon does not appear. If set to None (default behavior), then the icon appears if this Gradio app is launched on Spaces, but not otherwise.
         """
         self.format = format
         self.columns = columns
@@ -150,25 +146,15 @@ class Gallery(Component):
         self.preview = preview
         self.object_fit = object_fit
         self.allow_preview = allow_preview
-        self.show_download_button = (
-            (utils.get_space() is not None)
-            if show_download_button is None
-            else show_download_button
-        )
         self.selected_index = selected_index
         if type not in ["numpy", "pil", "filepath"]:
             raise ValueError(
                 f"Invalid type: {type}. Must be one of ['numpy', 'pil', 'filepath']"
             )
         self.type = type
-        self.show_fullscreen_button = show_fullscreen_button
         self.file_types = file_types
+        self.buttons = buttons or ["download", "fullscreen"]
 
-        self.show_share_button = (
-            (utils.get_space() is not None)
-            if show_share_button is None
-            else show_share_button
-        )
         super().__init__(
             label=label,
             every=every,

--- a/js/gallery/Index.svelte
+++ b/js/gallery/Index.svelte
@@ -4,70 +4,32 @@
 </script>
 
 <script lang="ts">
-	import type { GalleryImage, GalleryVideo } from "./types";
 	import type { FileData } from "@gradio/client";
-	import type { Gradio, ShareData, SelectData } from "@gradio/utils";
 	import { Block, UploadText } from "@gradio/atoms";
 	import Gallery from "./shared/Gallery.svelte";
-	import type { LoadingStatus } from "@gradio/statustracker";
 	import { StatusTracker } from "@gradio/statustracker";
-	import { createEventDispatcher } from "svelte";
+	import { Gradio } from "@gradio/utils";
 	import { BaseFileUpload } from "@gradio/file";
+	import type { GalleryProps, GalleryEvents, GalleryData } from "./types";
 
-	type GalleryData = GalleryImage | GalleryVideo;
+	const props = $props();
+	const gradio = new Gradio<GalleryEvents, GalleryProps>(props);
 
-	export let loading_status: LoadingStatus;
-	export let show_label: boolean;
-	export let label: string;
-	export let root: string;
-	export let elem_id = "";
-	export let elem_classes: string[] = [];
-	export let visible: boolean | "hidden" = true;
-	export let value: GalleryData[] | null = null;
-	export let file_types: string[] | null = ["image", "video"];
-	export let container = true;
-	export let scale: number | null = null;
-	export let min_width: number | undefined = undefined;
-	export let columns: number | number[] | undefined = [2];
-	export let rows: number | number[] | undefined = undefined;
-	export let height: number | "auto" = "auto";
-	export let preview: boolean;
-	export let allow_preview = true;
-	export let selected_index: number | null = null;
-	export let object_fit: "contain" | "cover" | "fill" | "none" | "scale-down" =
-		"cover";
-	export let show_share_button = false;
-	export let interactive: boolean;
-	export let show_download_button = false;
-	export let gradio: Gradio<{
-		change: typeof value;
-		upload: typeof value;
-		select: SelectData;
-		share: ShareData;
-		error: string;
-		delete: { file: FileData; index: number };
-		prop_change: Record<string, any>;
-		clear_status: LoadingStatus;
-		preview_open: never;
-		preview_close: never;
-	}>;
-	export let show_fullscreen_button = true;
-	export let fullscreen = false;
+	let fullscreen = $state(false);
 
-	const dispatch = createEventDispatcher();
-
-	$: no_value = value === null ? true : value.length === 0;
+	let no_value = $derived(
+		gradio.props.value === null ? true : gradio.props.value.length === 0
+	);
 
 	function handle_delete(
 		event: CustomEvent<{ file: FileData; index: number }>
 	): void {
-		if (!value) return;
+		if (!gradio.props.value) return;
 		const { index } = event.detail;
 		gradio.dispatch("delete", event.detail);
-		value = value.filter((_, i) => i !== index);
-		gradio.dispatch("change", value);
+		gradio.props.value = gradio.props.value.filter((_, i) => i !== index);
+		gradio.dispatch("change", gradio.props.value);
 	}
-	$: selected_index, dispatch("prop_change", { selected_index });
 
 	async function process_upload_files(
 		files: FileData[]
@@ -92,47 +54,49 @@
 				: { image: x, caption: null }
 		);
 	}
+
+	$inspect("value", gradio.props.value);
 </script>
 
 <Block
-	{visible}
+	visible={gradio.shared.visible}
 	variant="solid"
 	padding={false}
-	{elem_id}
-	{elem_classes}
-	{container}
-	{scale}
-	{min_width}
+	elem_id={gradio.shared.elem_id}
+	elem_classes={gradio.shared.elem_classes}
+	container={gradio.shared.container}
+	scale={gradio.shared.scale}
+	min_width={gradio.shared.min_width}
 	allow_overflow={false}
-	height={typeof height === "number" ? height : undefined}
+	height={typeof gradio.props.height === "number" ? gradio.props.height : undefined}
 	bind:fullscreen
 >
 	<StatusTracker
-		autoscroll={gradio.autoscroll}
+		autoscroll={gradio.shared.autoscroll}
 		i18n={gradio.i18n}
-		{...loading_status}
-		on:clear_status={() => gradio.dispatch("clear_status", loading_status)}
+		{...gradio.shared.loading_status}
+		on:clear_status={() => gradio.dispatch("clear_status", gradio.shared.loading_status)}
 	/>
-	{#if interactive && no_value}
+	{#if gradio.shared.interactive && no_value}
 		<BaseFileUpload
 			value={null}
-			{root}
-			{label}
-			max_file_size={gradio.max_file_size}
+			root={gradio.shared.root}
+			label={gradio.shared.label}
+			max_file_size={gradio.shared.max_file_size}
 			file_count={"multiple"}
-			{file_types}
+			file_types={gradio.props.file_types}
 			i18n={gradio.i18n}
-			upload={(...args) => gradio.client.upload(...args)}
-			stream_handler={(...args) => gradio.client.stream(...args)}
+			upload={(...args) => gradio.shared.client.upload(...args)}
+			stream_handler={(...args) => gradio.shared.client.stream(...args)}
 			on:upload={async (e) => {
 				const files = Array.isArray(e.detail) ? e.detail : [e.detail];
-				value = await process_upload_files(files);
-				gradio.dispatch("upload", value);
-				gradio.dispatch("change", value);
+				gradio.props.value = await process_upload_files(files);
+				gradio.dispatch("upload", gradio.props.value);
+				gradio.dispatch("change", gradio.props.value);
 			}}
 			on:error={({ detail }) => {
-				loading_status = loading_status || {};
-				loading_status.status = "error";
+				gradio.shared.loading_status = gradio.shared.loading_status || {};
+				gradio.shared.loading_status.status = "error";
 				gradio.dispatch("error", detail);
 			}}
 		>
@@ -140,7 +104,7 @@
 		</BaseFileUpload>
 	{:else}
 		<Gallery
-			on:change={() => gradio.dispatch("change", value)}
+			on:change={() => gradio.dispatch("change")}
 			on:select={(e) => gradio.dispatch("select", e.detail)}
 			on:share={(e) => gradio.dispatch("share", e.detail)}
 			on:error={(e) => gradio.dispatch("error", e.detail)}
@@ -153,32 +117,32 @@
 			on:upload={async (e) => {
 				const files = Array.isArray(e.detail) ? e.detail : [e.detail];
 				const new_value = await process_upload_files(files);
-				value = value ? [...value, ...new_value] : new_value;
+				gradio.props.value = gradio.props.value ? [...gradio.props.value, ...new_value] : new_value;
 				gradio.dispatch("upload", new_value);
-				gradio.dispatch("change", value);
+				gradio.dispatch("change", gradio.props.value);
 			}}
-			{label}
-			{show_label}
-			{columns}
-			{rows}
-			{height}
-			{preview}
-			{object_fit}
-			{interactive}
-			{allow_preview}
-			bind:selected_index
-			bind:value
-			{show_share_button}
-			{show_download_button}
+			label={gradio.shared.label}
+			show_label={gradio.shared.show_label}
+			columns={gradio.props.columns}
+			rows={gradio.props.rows}
+			height={gradio.props.height}
+			preview={gradio.props.preview}
+			object_fit={gradio.props.object_fit}
+			interactive={gradio.shared.interactive}
+			allow_preview={gradio.props.allow_preview}
+			bind:selected_index={gradio.props.selected_index}
+			bind:value={gradio.props.value}
+			show_share_button={gradio.props.buttons.includes("share")}
+			show_download_button={gradio.props.buttons.includes("download")}
 			i18n={gradio.i18n}
-			_fetch={(...args) => gradio.client.fetch(...args)}
-			{show_fullscreen_button}
+			_fetch={(...args) => gradio.shared.client.fetch(...args)}
+			show_fullscreen_button={gradio.props.buttons.includes("fullscreen")}
 			{fullscreen}
-			{root}
-			{file_types}
-			max_file_size={gradio.max_file_size}
-			upload={(...args) => gradio.client.upload(...args)}
-			stream_handler={(...args) => gradio.client.stream(...args)}
+			root={gradio.shared.root}
+			file_types={gradio.props.file_types}
+			max_file_size={gradio.shared.max_file_size}
+			upload={(...args) => gradio.shared.client.upload(...args)}
+			stream_handler={(...args) => gradio.shared.client.stream(...args)}
 		/>
 	{/if}
 </Block>

--- a/js/gallery/types.ts
+++ b/js/gallery/types.ts
@@ -1,4 +1,4 @@
-import type { FileData } from "@gradio/client";
+import type { FileData, SelectData } from "@gradio/client";
 
 export interface GalleryImage {
 	image: FileData;
@@ -8,4 +8,32 @@ export interface GalleryImage {
 export interface GalleryVideo {
 	video: FileData;
 	caption: string | null;
+}
+
+export type GalleryData = GalleryImage | GalleryVideo;
+
+export interface GalleryProps {
+	value: GalleryData[] | null;
+	file_types: string[] | null;
+	columns: number | number[] | undefined;
+	rows: number | number[] | undefined;
+	height: number | "auto";
+	preview: boolean;
+	allow_preview: boolean;
+	selected_index: number | null;
+	object_fit: "contain" | "cover" | "fill" | "none" | "scale-down";
+	buttons: string[];
+	type: "numpy" | "pil" | "filepath";
+}
+
+export interface GalleryEvents {
+	change: GalleryData[] | null;
+	upload: GalleryData[] | null;
+	select: SelectData;
+	delete: { file: FileData; index: number };
+	preview_open: never;
+	preview_close: never;
+	clear_status: any;
+	share: any;
+	error: any;
 }


### PR DESCRIPTION
## Description

Test with

```python
import gradio as gr
import random


def gallery_identity(gallery):
    return f"Gallery received with {len(gallery) if gallery else 0} items", gallery


with gr.Blocks() as demo:
    with gr.Row():
        with gr.Column():
            gallery_input = gr.Gallery(
                label="Input Gallery",
                columns=2,
                rows=2,
                object_fit="cover",
                allow_preview=True,
                type="filepath",
            )
            submit = gr.Button("Submit", variant="primary")
        with gr.Column():
            gallery_output_text = gr.Textbox(label="Gallery Output Info")
            gallery_output = gr.Gallery(label="Output Gallery")

    submit.click(
        fn=gallery_identity,
        inputs=gallery_input,
        outputs=[gallery_output_text, gallery_output],
    )

    # Event handlers for input gallery
    with gr.Row():
        with gr.Column():
            input_gallery_change_event = gr.Textbox(label="Input Gallery Change Event")
            input_gallery_select_event = gr.Textbox(label="Input Gallery Select Event")
            input_gallery_upload_event = gr.Textbox(label="Input Gallery Upload Event")
        with gr.Column():
            output_gallery_change_event = gr.Textbox(label="Output Gallery Change Event")
            output_gallery_select_event = gr.Textbox(label="Output Gallery Select Event")
            output_gallery_preview_open = gr.Textbox(label="Output Gallery Preview Open")

    input_gallery_change_event_var = gr.Textbox(visible=False)
    input_gallery_select_event_var = gr.Textbox(visible=False)
    input_gallery_upload_event_var = gr.Textbox(visible=False)
    output_gallery_change_event_var = gr.Textbox(visible=False)
    output_gallery_select_event_var = gr.Textbox(visible=False)
    output_gallery_preview_open_var = gr.Textbox(visible=False)

    gallery_input.change(
        lambda gallery: f"Input gallery change event triggered with {len(gallery) if gallery else 0} items",
        inputs=[gallery_input],
        outputs=[input_gallery_change_event],
    )
    gallery_input.select(
        lambda: f"Input gallery select event triggered with value: {random.randint(0,1000)}",
        outputs=[input_gallery_select_event],
    )
    gallery_input.upload(
        lambda gallery: f"Input gallery upload event triggered {random.randint(0,1000)} ({len(gallery)}) items",
        inputs=[gallery_input],
        outputs=[input_gallery_upload_event],
    )

    gallery_output.change(
        lambda gallery: f"Output gallery change event triggered with {len(gallery) if gallery else 0} items",
        inputs=[gallery_output],
        outputs=[output_gallery_change_event],
    )
    gallery_output.select(
        lambda: f"Output gallery select event triggered with value: {random.randint(0,1000)}",
        outputs=[output_gallery_select_event],
    )
    gallery_output.preview_open(
        lambda: "Output gallery preview open event triggered",
        outputs=[output_gallery_preview_open],
    )

    # Property update handlers
    with gr.Row():
        with gr.Column():
            gallery_columns = gr.Slider(
                minimum=1,
                maximum=5,
                value=2,
                step=1,
                label="Columns",
            )
            gallery_rows = gr.Slider(
                minimum=1,
                maximum=5,
                value=2,
                step=1,
                label="Rows",
            )
            gallery_object_fit = gr.Dropdown(
                label="Object Fit",
                choices=["contain", "cover", "fill", "none", "scale-down"],
                value="cover",
            )
        with gr.Column():
            gallery_allow_preview = gr.Checkbox(
                label="Allow Preview",
                value=True,
            )
            gallery_preview = gr.Checkbox(
                label="Preview Mode",
                value=False,
            )
            make_interactive = gr.Button("Make Gallery Non-Interactive")
            make_interactive2 = gr.Button("Make Gallery Interactive")

    def update_gallery_columns(columns):
        return gr.Gallery(columns=int(columns))

    gallery_columns.change(
        fn=update_gallery_columns,
        inputs=[gallery_columns],
        outputs=[gallery_input],
    )

    def update_gallery_rows(rows):
        if rows == 0:
            rows = None
        return gr.Gallery(rows=rows)

    gallery_rows.change(
        fn=update_gallery_rows,
        inputs=[gallery_rows],
        outputs=[gallery_input],
    )

    def update_gallery_object_fit(object_fit):
        return gr.Gallery(object_fit=object_fit)

    gallery_object_fit.change(
        fn=update_gallery_object_fit,
        inputs=[gallery_object_fit],
        outputs=[gallery_input],
    )

    def update_gallery_allow_preview(allow_preview):
        return gr.Gallery(allow_preview=allow_preview)

    gallery_allow_preview.change(
        fn=update_gallery_allow_preview,
        inputs=[gallery_allow_preview],
        outputs=[gallery_input],
    )

    def update_gallery_preview(preview):
        return gr.Gallery(preview=preview)

    gallery_preview.change(
        fn=update_gallery_preview,
        inputs=[gallery_preview],
        outputs=[gallery_input],
    )

    make_interactive.click(lambda: gr.Gallery(interactive=False), None, gallery_input)
    make_interactive2.click(lambda: gr.Gallery(interactive=True), None, gallery_input)


if __name__ == "__main__":
    demo.launch()
```

![gallery_migration](https://github.com/user-attachments/assets/8298ddb0-3afe-40ad-a0f9-f26cdf3a0719)



## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
