### PR TITLE
Migrate UploadButton

### DIFF
--- a/js/uploadbutton/Index.svelte
+++ b/js/uploadbutton/Index.svelte
@@ -3,32 +3,21 @@
 </script>
 
 <script lang="ts">
-	import type { Gradio } from "@gradio/utils";
+	import type { UploadButtonProps, UploadButtonEvents } from "./types";
 	import type { FileData } from "@gradio/client";
+	import { Gradio } from "@gradio/utils";
 	import UploadButton from "./shared/UploadButton.svelte";
 
-	export let elem_id = "";
-	export let elem_classes: string[] = [];
-	export let visible: boolean | "hidden" = true;
-	export let label: string | null;
-	export let value: null | FileData | FileData[];
-	export let file_count: string;
-	export let file_types: string[] = [];
-	export let root: string;
-	export let size: "sm" | "lg" = "lg";
-	export let scale: number | null = null;
-	export let icon: FileData | null = null;
-	export let min_width: number | undefined = undefined;
-	export let variant: "primary" | "secondary" | "stop" = "secondary";
-	export let gradio: Gradio<{
-		change: never;
-		upload: never;
-		click: never;
-		error: string;
-	}>;
-	export let interactive: boolean;
+	const props = $props();
+	const gradio = new Gradio<UploadButtonEvents, UploadButtonProps>(props);
 
-	$: disabled = !interactive;
+	let value = $state(gradio.props.value);
+
+	$effect(() => {
+		if (value !== gradio.props.value) {
+			gradio.props.value = value;
+		}
+	});
 
 	async function handle_event(
 		detail: null | FileData | FileData[],
@@ -37,31 +26,33 @@
 		value = detail;
 		gradio.dispatch(event);
 	}
+
+	const disabled = $derived(!gradio.shared.interactive);
 </script>
 
 <UploadButton
-	{elem_id}
-	{elem_classes}
-	{visible}
-	{file_count}
-	{file_types}
-	{size}
-	{scale}
-	{icon}
-	{min_width}
-	{root}
-	{value}
-	{disabled}
-	{variant}
-	{label}
-	max_file_size={gradio.max_file_size}
+	elem_id={gradio.shared.elem_id}
+	elem_classes={gradio.shared.elem_classes}
+	visible={gradio.shared.visible}
+	file_count={gradio.props.file_count}
+	file_types={gradio.props.file_types}
+	size={gradio.props.size}
+	scale={gradio.shared.scale}
+	icon={gradio.props.icon}
+	min_width={gradio.shared.min_width}
+	root={gradio.shared.root}
+	value={value}
+	disabled={disabled}
+	variant={gradio.props.variant}
+	label={gradio.shared.label}
+	max_file_size={gradio.shared.max_file_size}
 	on:click={() => gradio.dispatch("click")}
 	on:change={({ detail }) => handle_event(detail, "change")}
 	on:upload={({ detail }) => handle_event(detail, "upload")}
 	on:error={({ detail }) => {
 		gradio.dispatch("error", detail);
 	}}
-	upload={(...args) => gradio.client.upload(...args)}
+	upload={(...args) => gradio.shared.client.upload(...args)}
 >
-	{label ?? ""}
+	{gradio.shared.label ?? ""}
 </UploadButton>

--- a/js/uploadbutton/types.ts
+++ b/js/uploadbutton/types.ts
@@ -1,0 +1,17 @@
+import type { FileData } from "@gradio/client";
+
+export interface UploadButtonProps {
+	value: null | FileData | FileData[];
+	file_count: string;
+	file_types: string[];
+	size: "sm" | "lg";
+	icon: FileData | null;
+	variant: "primary" | "secondary" | "stop";
+}
+
+export interface UploadButtonEvents {
+	change: never;
+	upload: never;
+	click: never;
+	error: string;
+}


### PR DESCRIPTION
## Description

Test with the following demo

```python
import gradio as gr


def upload_button_id(files):
    """Identity function that returns the uploaded files"""
    if files is None:
        return "No files uploaded", None
    
    # Handle single or multiple files
    if isinstance(files, list):
        file_names = ", ".join([f.name if hasattr(f, 'name') else str(f) for f in files])
        return f"You uploaded: {file_names}", files
    else:
        file_name = files.name if hasattr(files, 'name') else str(files)
        return f"You uploaded: {file_name}", files


with gr.Blocks() as demo:
    with gr.Row():
        with gr.Column():
            upload = gr.UploadButton(label="Upload Files", file_types=["file"], value="")
            submit = gr.Button("Submit", variant="primary")
        with gr.Column():
            result = gr.Textbox(label="Result")
            output_upload = gr.UploadButton(label="Output Upload")

    submit.click(
        fn=upload_button_id,
        inputs=upload,
        outputs=[result, output_upload],
    )

    with gr.Row():
        with gr.Column():
            # Test props that can be updated
            upload_variant = gr.Dropdown(
                label="Upload Button Variant",
                choices=["primary", "secondary", "stop"],
                value="secondary"
            )
            upload_size = gr.Dropdown(
                label="Upload Button Size",
                choices=["sm", "md", "lg"],
                value="lg"
            )
            upload_file_count = gr.Dropdown(
                label="File Count Mode",
                choices=["single", "multiple", "directory"],
                value="single"
            )
            upload_file_types = gr.Textbox(
                label="File Types (comma-separated)",
                value="file",
                info="e.g., 'image', 'audio', 'video', 'text', or 'file'"
            )

            make_interactive = gr.Button("Make Upload Non-Interactive")
            make_interactive2 = gr.Button("Make Upload Interactive")
        with gr.Column():
            # Event outputs
            out_upload_click_event = gr.Textbox(label="Output Upload Button Click Event")
            out_upload_upload_event = gr.Textbox(label="Output Upload Button Upload Event")
            in_upload_click_event = gr.Textbox(label="Input Upload Button Click Event")
            in_upload_upload_event = gr.Textbox(label="Input Upload Button Upload Event")

    # Event handlers for input upload button
    upload.click(
        lambda: "Input upload button click event triggered",
        outputs=[in_upload_click_event],
    )
    upload.upload(
        lambda files: f"Input upload button upload event triggered with files: {files}",
        inputs=[upload],
        outputs=[in_upload_upload_event],
    )

    # Event handlers for output upload button
    output_upload.click(
        lambda: "Output upload button click event triggered",
        outputs=[out_upload_click_event],
    )
    output_upload.upload(
        lambda files: f"Output upload button upload event triggered with files: {files}",
        inputs=[output_upload],
        outputs=[out_upload_upload_event],
    )

    # Update upload button props
    upload_variant.change(
        fn=lambda variant: gr.UploadButton(variant=variant, file_types=["file"]),
        inputs=[upload_variant],
        outputs=[upload],
    )

    upload_size.change(
        fn=lambda size: gr.UploadButton(size=size, file_types=["file"]),
        inputs=[upload_size],
        outputs=[upload],
    )

    upload_file_count.change(
        fn=lambda file_count: gr.UploadButton(file_count=file_count, file_types=["file"]),
        inputs=[upload_file_count],
        outputs=[upload],
    )

    def parse_file_types(file_types_str):
        """Parse comma-separated file types"""
        if not file_types_str or file_types_str.strip() == "":
            return None
        return [ft.strip() for ft in file_types_str.split(",")]

    upload_file_types.change(
        fn=lambda file_types: gr.UploadButton(file_types=parse_file_types(file_types)),
        inputs=[upload_file_types],
        outputs=[upload],
    )

    make_interactive.click(
        lambda: gr.UploadButton(interactive=False, file_types=["file"]),
        None,
        upload
    )
    make_interactive2.click(
        lambda: gr.UploadButton(interactive=True, file_types=["file"]),
        None,
        upload
    )


if __name__ == "__main__":
    demo.launch()
```

![Uploading upload_component.gif…]()



## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
