### PR TITLE
Fix success failure event triggers 

### DIFF
--- a/js/core/src/dependency.ts
+++ b/js/core/src/dependency.ts
@@ -208,7 +208,6 @@ export class DependencyManager {
 				const unset_args = await this.set_event_args(dep.id, dep.event_args);
 
 				const { success, failure, all } = dep.get_triggers();
-				console.log("success", success, "failure", failure, "all", all);
 
 				try {
 					const dep_submission = await dep.run(


### PR DESCRIPTION
## Description

Fixes the tests in blocks_chained_events demo. Tests that need the toasts to show up still fail.

```

  4 failed
    [chrome] › test/blocks_chained_events.spec.ts:41:1 › gr.Error makes the toast show up ───
    [chrome] › test/blocks_chained_events.spec.ts:51:1 › ValueError makes the toast show up when show_error=True
    [chrome] › test/blocks_chained_events.spec.ts:63:1 › gr.Info makes the toast show up ────
    [chrome] › test/blocks_chained_events.spec.ts:73:1 › gr.Warning makes the toast show up ─
  4 passed (1.6m)
```

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
