### PR TITLE
Fix radio change/input events

### DIFF
--- a/js/radio/Index.svelte
+++ b/js/radio/Index.svelte
@@ -17,26 +17,12 @@
 
 	let disabled = $derived(!gradio.shared.interactive);
 
-	let pending_select: { value: string | number; index: number } | null =
-		$state(null);
-
-	function trigger_change(
-		value: typeof gradio.props.value,
-		pending_select: { value: string | number; index: number } | null
-	): void {
-		gradio.dispatch("change", value);
-		if (pending_select && value === pending_select.value) {
-			gradio.dispatch("select", {
-				value: pending_select.value,
-				index: pending_select.index
-			});
-			gradio.dispatch("input");
-			pending_select = null;
-		}
-	}
-
+	let old_value = $state(gradio.props.value);
 	$effect(() => {
-		trigger_change(gradio.props.value, pending_select);
+		if (old_value != gradio.props.value) {
+			old_value = gradio.props.value;
+			gradio.dispatch("change");
+		}
 	});
 </script>
 
@@ -71,7 +57,11 @@
 				{disabled}
 				rtl={gradio.props.rtl}
 				on_input={() => {
-					pending_select = { value: internal_value, index: i };
+					gradio.dispatch("select", {
+						value: internal_value,
+						index: i
+					});
+					gradio.dispatch("input");
 				}}
 			/>
 		{/each}


### PR DESCRIPTION
## Description

Fixes blocks_essay e2e tests

```
Server started. Running tests on port 7860.

Running 4 tests using 1 worker

  ✓  1 [chrome] › test/blocks_essay.spec.ts:3:1 › updates frontend correctly (948ms)
  ✓  2 [chrome] › test/blocks_essay.spec.ts:23:1 › updates interactivity correctly (508ms)
  ✓  3 [chrome] › test/blocks_essay.spec.ts:35:1 › updates backend correctly (512ms)
  ✓  4 …rome] › test/blocks_essay.spec.ts:54:1 › updates dropdown choices correctly (512ms)

Tests complete, cleaning up!

  4 passed (13.8s)
```
## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
