### PR TITLE
Fix Chatbot Editing

### DIFF
--- a/js/chatbot/Index.svelte
+++ b/js/chatbot/Index.svelte
@@ -9,82 +9,11 @@
 	import { Chat } from "@gradio/icons";
 	import type { FileData } from "@gradio/client";
 	import { StatusTracker } from "@gradio/statustracker";
-	import type {
-		Message,
-		ExampleMessage,
-		TupleFormat,
-		NormalisedMessage
-	} from "./types";
+	import type { Message, ExampleMessage, NormalisedMessage } from "./types";
 	import type { SharedProps } from "@gradio/core";
 	import type { ChatbotProps, ChatbotEvents } from "./types";
-	import { normalise_tuples, normalise_messages } from "./shared/utils";
+	import { normalise_messages } from "./shared/utils";
 	import { Gradio } from "@gradio/utils";
-	// export let elem_id = "";
-	// export let elem_classes: string[] = [];
-	// export let visible: boolean | "hidden" = true;
-	// export let value: TupleFormat | Message[] = [];
-	// export let scale: number | null = null;
-	// export let min_width: number | undefined = undefined;
-	// export let label: string;
-	// export let show_label = true;
-	// export let root: string;
-	// export let _selectable = false;
-	// export let likeable = false;
-	// export let feedback_options: string[] = ["Like", "Dislike"];
-	// export let feedback_value: (string | null)[] | null = null;
-	// export let show_share_button = false;
-	// export let rtl = false;
-	// export let show_copy_button = true;
-	// export let show_copy_all_button = false;
-	// export let sanitize_html = true;
-	// export let layout: "bubble" | "panel" = "bubble";
-	// export let type: "tuples" | "messages" = "tuples";
-	// export let render_markdown = true;
-	// export let line_breaks = true;
-	// export let autoscroll = true;
-	// export let _retryable = false;
-	// export let _undoable = false;
-	// export let group_consecutive_messages = true;
-	// export let allow_tags: string[] | boolean = false;
-	// export let latex_delimiters: {
-	// 	left: string;
-	// 	right: string;
-	// 	display: boolean;
-	// }[];
-	// export let gradio: Gradio<{
-	// 	change: typeof value;
-	// 	select: SelectData;
-	// 	share: ShareData;
-	// 	error: string;
-	// 	like: LikeData;
-	// 	clear_status: LoadingStatus;
-	// 	example_select: SelectData;
-	// 	option_select: SelectData;
-	// 	edit: SelectData;
-	// 	retry: UndoRetryData;
-	// 	undo: UndoRetryData;
-	// 	clear: null;
-	// 	copy: CopyData;
-	// }>;
-
-	// $: _value =
-	// 	type === "tuples"
-	// 		? normalise_tuples(value as TupleFormat, root)
-	// 		: normalise_messages(value as Message[], root);
-
-	// export let avatar_images: [FileData | null, FileData | null] = [null, null];
-	// export let like_user_message = false;
-	// export let loading_status: LoadingStatus | undefined = undefined;
-	// export let height: number | string | undefined;
-	// export let resizable: boolean;
-	// export let min_height: number | string | undefined;
-	// export let max_height: number | string | undefined;
-	// export let editable: "user" | "all" | null = null;
-	// export let placeholder: string | null = null;
-	// export let examples: ExampleMessage[] | null = null;
-	// export let theme_mode: "system" | "light" | "dark";
-	// export let allow_file_downloads = true;
-	// export let watermark: string | null = null;
 
 	let props = $props();
 	const gradio = new Gradio<ChatbotEvents, ChatbotProps>(props);
@@ -174,7 +103,9 @@
 				if (gradio.props.value === null || gradio.props.value.length === 0)
 					return;
 				//@ts-ignore
-				gradio.props.value[e.detail.index].content = e.detail.value;
+				gradio.props.value[e.detail.index].content = [
+					{ text: e.detail.value, type: "text" }
+				];
 				gradio.dispatch("edit", e.detail);
 			}}
 			avatar_images={gradio.props.avatar_images}


### PR DESCRIPTION
## Description

Fixes chatbot_editable e2e tests

```
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:7860 (Press CTRL+C to quit)

 =========== END ===========

Server started. Running tests on port 7860.

Running 2 tests using 1 worker

  ✓  1 [chrome] › test/chatbot_editable.spec.ts:3:1 › test editing chatbot messages (1.9s)
  ✓  2 …test/chatbot_editable.spec.ts:32:1 › test editing consecutive user messages (989ms)

Tests complete, cleaning up!

  2 passed (13.9s)
```

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
