### PR TITLE
fix: Add WebP MIME type support for image file validation

### DIFF
--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -712,8 +712,8 @@ def download_tmp_copy_of_file(
 def get_mimetype(filename: str) -> str | None:
     if filename.endswith(".vtt"):
         return "text/vtt"
-    if filename.endswith(".webp"):  # ADD THIS LINE
-        return "image/webp"           # ADD THIS LINE
+    if filename.endswith(".webp"):
+        return "image/webp"
     mimetype = mimetypes.guess_type(filename)[0]
     if mimetype is not None:
         mimetype = mimetype.replace("x-wav", "wav").replace("x-flac", "flac")


### PR DESCRIPTION
## Description
Fixes #12036 

This PR adds explicit WebP MIME type support to the `get_mimetype()` function in `gradio_client/utils.py`.

## Problem
WebP images were not being recognized when using `file_types=['image']` in file upload components. This caused an "Invalid file type" error even though WebP is a valid image format.

The issue occurred because Python's built-in `mimetypes.guess_type()` doesn't consistently recognize `.webp` files across all systems.

## Solution
Added explicit WebP MIME type detection in the `get_mimetype()` function:
```python
if filename.endswith(".webp"):
    return "image/webp"
```

This follows the same pattern already used for `.vtt` files in the codebase.

## Testing
- ✅ Verified WebP files now return correct MIME type (`image/webp`)
- ✅ Tested with `file_types=['image']` - WebP files now validate correctly
- ✅ Tested with `file_types=['.webp']` - extension-based validation still works
- ✅ Other image formats (PNG, JPEG, GIF) remain unaffected

## Changes
- Modified `get_mimetype()` in `client/python/gradio_client/utils.py` (2 lines added)
- Minimal change with no breaking effects
  
