### PR TITLE
Fix Failing ChatInterface tests

### DIFF
--- a/js/chatbot/Index.svelte
+++ b/js/chatbot/Index.svelte
@@ -5,12 +5,9 @@
 <script lang="ts">
 	import ChatBot from "./shared/ChatBot.svelte";
 	import { Block, BlockLabel } from "@gradio/atoms";
-	import type { LoadingStatus } from "@gradio/statustracker";
 	import { Chat } from "@gradio/icons";
-	import type { FileData } from "@gradio/client";
 	import { StatusTracker } from "@gradio/statustracker";
 	import type { Message, ExampleMessage, NormalisedMessage } from "./types";
-	import type { SharedProps } from "@gradio/core";
 	import type { ChatbotProps, ChatbotEvents } from "./types";
 	import { normalise_messages } from "./shared/utils";
 	import { Gradio } from "@gradio/utils";

--- a/js/core/src/init.svelte.ts
+++ b/js/core/src/init.svelte.ts
@@ -271,13 +271,14 @@ export class AppTree {
 	 * */
 	async update_state(
 		id: number,
-		new_state: Partial<SharedProps> & Record<string, unknown>
+		new_state: Partial<SharedProps> & Record<string, unknown>,
+		check_visibility: boolean = true
 	) {
 		const _set_data = this.#set_callbacks.get(id);
 		if (!_set_data) return;
 
 		await _set_data(new_state);
-
+		if (!check_visibility) return;
 		this.root = this.traverse(this.root!, (n) =>
 			handle_visibility(n, this.#config.root)
 		);

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -169,9 +169,9 @@
 	}
 
 	async function handle_keypress(e: KeyboardEvent): Promise<void> {
-		await tick();
 		if (e.key === "Enter" && e.shiftKey && lines > 1) {
 			e.preventDefault();
+			await tick();
 			dispatch("submit");
 		} else if (
 			e.key === "Enter" &&
@@ -180,6 +180,7 @@
 			max_lines >= 1
 		) {
 			e.preventDefault();
+			await tick();
 			dispatch("submit");
 			active_source = null;
 			add_mic_audio_to_files();


### PR DESCRIPTION
## Description

Tests were flaking for the chatinterface. There were several different types of failures. For example, the textbox state would not be cleared after generation. This was confusing because the backend correctly sends all the data, it's just not being reflected in the UI. After adding lots of `$inspects` everywhere, I saw that even though `depedency.ts` sets a prop in a component, it wouldn't actually be reflected in the component's state. My hunch was that the `update_visibility` was updating a node in the tree while another prop was being updated. I changed our update_state_callback to only walk the tree to check for visibility if a `visible` prop is passed in. This made the tests pass. 

I think this makes sense. Thechat interface fires off a lot of events concurrently on each submission (updating text box state, saving chatbot state, clearing textbox, etc) and creating a new tree on every prop update (sometimes we return multiple updated props for the textbox in an event) was causing the textbox state to go out of synch.


test_chatinterface_streaming_echo (only api recorder tests fail)
```
  ✓   1 …terface works with streaming functions and all buttons behave as expected (1.6s)
  ✘   2 …:2 › test case messages the api recorder correctly records the api calls (10.1s)
  ✓   3 …terface works with streaming functions and all buttons behave as expected (1.6s)
  ✘   4 …ase multimodal_messages the api recorder correctly records the api calls (10.1s)
  ✓   5 …terface works with streaming functions and all buttons behave as expected (1.2s)
  ✘   6 …e multimodal_non_stream the api recorder correctly records the api calls (10.1s)
  ✓   7 …terface works with streaming functions and all buttons behave as expected (1.7s)
  ✘   8 …ltimodal_group_messages the api recorder correctly records the api calls (10.1s)
  ✓   9 …test_chatinterface_streaming_echo.spec.ts:97:1 › test stopping generation (2.7s)
  ✓  10 …› test/test_chatinterface_streaming_echo.spec.ts:124:1 › editing messages (1.5s)`
```

chatinterface_multimodal_examples
```
  ✓  1 …ot_cached: clicked example is added to history and passed to chat function (1.7s)
  ✓  2 …se cached: clicked example is added to history and passed to chat function (1.3s)
```

Checked that visibility can still be toggled

![visibility-checl](https://github.com/user-attachments/assets/7e931229-e618-4654-82a6-2f851869b4bf)


## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
