### PR TITLE
Fix ready promise on AppTree

### DIFF
--- a/js/app/src/routes/[...catchall]/+page.svelte
+++ b/js/app/src/routes/[...catchall]/+page.svelte
@@ -425,7 +425,6 @@
 			{version}
 			search_params={$page.url.searchParams}
 			initial_layout={data.layout}
-			on_ready={() => null}
 		/>
 	{/if}
 </Embed>

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -66,7 +66,7 @@
 		vibe_mode,
 		search_params,
 		render_complete = false,
-		on_ready
+		ready = $bindable(false)
 	}: {
 		root: string;
 		components: ComponentMeta[];
@@ -92,7 +92,7 @@
 		vibe_mode: boolean;
 		search_params: URLSearchParams;
 		render_complete: boolean;
-		on_ready: () => void;
+		ready: boolean;
 	} = $props();
 
 	components.forEach((comp) => {
@@ -364,8 +364,8 @@
 		res.observe(root_container);
 
 		app_tree.ready.then(() => {
+			ready = true;
 			dep_manager.dispatch_load_events();
-			on_ready();
 		});
 
 		return () => {

--- a/js/core/src/init.svelte.ts
+++ b/js/core/src/init.svelte.ts
@@ -76,7 +76,7 @@ export class AppTree {
 			true
 		);
 		for (const comp of components) {
-			this.components_to_register.add(comp.id);
+			if (comp.props.visible != false) this.components_to_register.add(comp.id);
 		}
 
 		this.client = app;
@@ -133,7 +133,12 @@ export class AppTree {
 	postprocess(tree: ProcessedComponentMeta) {
 		this.root = this.traverse(tree, [
 			(node) => handle_visibility(node, this.#config.root),
-			(node) => handle_empty_forms(node, this.#config.root),
+			(node) =>
+				handle_empty_forms(
+					node,
+					this.#config.root,
+					this.components_to_register
+				),
 			(node) => translate_props(node, this.#config.root)
 		]);
 	}
@@ -416,7 +421,8 @@ function handle_visibility(
 
 function handle_empty_forms(
 	node: ProcessedComponentMeta,
-	root: string
+	root: string,
+	components_to_register: Set<number>
 ): ProcessedComponentMeta {
 	// Check if the node is visible
 	if (node.type === "form") {
@@ -428,6 +434,7 @@ function handle_empty_forms(
 
 		if (all_children_invisible) {
 			node.props.shared_props.visible = false;
+			components_to_register.delete(node.id);
 			return node;
 		}
 	}

--- a/js/form/Index.svelte
+++ b/js/form/Index.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
 	import { Gradio } from "@gradio/utils";
-	// export let visible: boolean | "hidden" = true;
-	// export let scale: number | null = null;
-	// export let min_width = 0;
 
 	let props = $props();
-
 	const gradio = new Gradio(props);
 </script>
 

--- a/js/group/Index.svelte
+++ b/js/group/Index.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
-	export let elem_id = "";
-	export let elem_classes: string[] = [];
-	export let visible: boolean | "hidden" = true;
+	import { Gradio } from "@gradio/utils";
+
+	const props = $props();
+
+	// Register the component with Gradio
+	const _ = new Gradio<{}, {}>(props);
+
+	const elem_id = $derived(props.elem_id || "");
+	const elem_classes = $derived(props.elem_classes || []);
+	const visible = $derived(props.visible === undefined ? true : props.visible);
 </script>
 
 <div

--- a/js/group/package.json
+++ b/js/group/package.json
@@ -21,6 +21,9 @@
 	"peerDependencies": {
 		"svelte": "^5.43.4"
 	},
+	"dependencies": {
+		"@gradio/utils": "workspace:^"
+	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/gradio-app/gradio.git",

--- a/js/spa/src/Index.svelte
+++ b/js/spa/src/Index.svelte
@@ -506,7 +506,6 @@
 			if (header) spaceheader = header.element;
 		}
 	}
-
 	onDestroy(() => {
 		spaceheader?.remove();
 	});
@@ -584,14 +583,12 @@
 			<Blocks
 				{app}
 				{...config}
+				bind:ready
 				fill_height={!is_embed && config.fill_height}
 				theme_mode={active_theme_mode}
 				{control_page_title}
 				target={wrapper}
 				{autoscroll}
-				on_ready={() => {
-					ready = true;
-				}}
 				bind:render_complete
 				bind:add_new_message={new_message_fn}
 				footer_links={is_embed ? [] : config.footer_links}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1514,6 +1514,9 @@ importers:
 
   js/group:
     dependencies:
+      '@gradio/utils':
+        specifier: workspace:^
+        version: link:../utils
       svelte:
         specifier: ^5.43.4
         version: 5.43.4


### PR DESCRIPTION
## Description

The `ready` promise on the App tree was not resolving if:
1. Any components were invisible
2. There were Group components
3. There were empty form components

If your demo had any one of these, you would see a loading spinner on the page in SPA mode and load events would not trigger.

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

5. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
