### PR TITLE
Fix website build in svelte5 

### DIFF
--- a/.github/actions/install-frontend-deps/action.yml
+++ b/.github/actions/install-frontend-deps/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # @v4
       with:
-        version: 10
+        version: 10.17.0
     - uses: actions/setup-node@v4
       with:
         node-version: 22


### PR DESCRIPTION
since we pinned pnpm in the package.json we need to specify that same version in the pnpm install in install-frontend-deps. will test build after merge