### PR TITLE
fix Issue #11168: Sanitizing HTML in Chatbot to prevent style leakage

### DIFF
--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import inspect
+import html
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -491,7 +492,8 @@ class Chatbot(Component):
         | TextMessageDict,
     ) -> Union[TextMessage, FileMessage, ComponentMessage, None]:
         if isinstance(chat_message, str):
-            return TextMessage(text=inspect.cleandoc(chat_message))
+            sanitized_html = html.escape(inspect.cleandoc(chat_message))
+            return TextMessage(text=sanitized_html)
         elif isinstance(chat_message, (FileMessage, ComponentMessage)):
             return chat_message
         elif isinstance(chat_message, FileData):
@@ -519,7 +521,11 @@ class Chatbot(Component):
                 alt_text=chat_message.get("alt_text"),
             )
         elif isinstance(chat_message, dict) and chat_message.get("type") == "text":
-            return TextMessage(**chat_message)  # type: ignore
+            escaped_dict = {
+            "text": html.escape(inspect.cleandoc(chat_message["text"])),
+            "type": "text"
+            }
+            return TextMessage(**escaped_dict)  # type: ignore
         elif isinstance(chat_message, dict) and chat_message.get("type") == "component":
             return ComponentMessage(**chat_message)  # type: ignore
         elif isinstance(chat_message, dict) and chat_message.get("type") == "file":


### PR DESCRIPTION
## Description

Previously when displaying an HTML string inside a gr.Chatbot, the styles inside the <style> tag of the HTML are applied to the entire Gradio app, leading to style leakage. This could lead to unintended outcomes when attempting to display textual code, or malicious injections utilizing other Gradio UI options. This PR introduces two instances of sanitization the post_processing function to correctly display HTML code as textual and avoid any future injections.
Closes: #11168

## AI Disclosure

- I used AI to understand the project as a whole, and help me set up the testing environment.


  
