### PR TITLE
docs: Clarify function input list vs set syntax

### DIFF
--- a/guides/03_building-with-blocks/01_blocks-and-event-listeners.md
+++ b/guides/03_building-with-blocks/01_blocks-and-event-listeners.md
@@ -51,7 +51,7 @@ Here's an example of a "multi-step" demo, where the output of one model (a speec
 $code_blocks_speech_text_sentiment
 $demo_blocks_speech_text_sentiment
 
-## Function Input List vs Dict
+## Function Input List vs Set
 
 The event listeners you've seen so far have a single input component. If you'd like to have multiple input components pass data to the function, you have two options on how the function can accept input component values:
 
@@ -64,7 +64,7 @@ $code_calculator_list_and_dict
 Both `add()` and `sub()` take `a` and `b` as inputs. However, the syntax is different between these listeners.
 
 1. To the `add_btn` listener, we pass the inputs as a list. The function `add()` takes each of these inputs as arguments. The value of `a` maps to the argument `num1`, and the value of `b` maps to the argument `num2`.
-2. To the `sub_btn` listener, we pass the inputs as a set (note the curly brackets!). The function `sub()` takes a single dictionary argument `data`, where the keys are the input components, and the values are the values of those components.
+2. To the `sub_btn` listener, we pass the inputs as a set (note the curly brackets!). When you pass a set, the function `sub()` receives a single dictionary argument `data`, where the keys are the input components and the values are the values of those components.
 
 It is a matter of preference which syntax you prefer! For functions with many input components, option 2 may be easier to manage.
 

--- a/guides/cn/03_building-with-blocks/01_blocks-and-event-listeners.md
+++ b/guides/cn/03_building-with-blocks/01_blocks-and-event-listeners.md
@@ -44,7 +44,7 @@ $demo_reversible_flow
 $code_blocks_speech_text_sentiment
 $demo_blocks_speech_text_sentiment
 
-## 函数输入列表与字典 (Function Input List vs Dict)
+## 函数输入列表与集合 (Function Input List vs Set)
 
 到目前为止，您看到的事件监听器都只有一个输入组件。如果您希望有多个输入组件将数据传递给函数，有两种选项可供函数接受输入组件值：
 
@@ -57,7 +57,7 @@ $code_calculator_list_and_dict
 `add()` 和 `sub()` 都将 `a` 和 `b` 作为输入。然而，这些监听器之间的语法不同。
 
 1. 对于 `add_btn` 监听器，我们将输入作为列表传递。函数 `add()` 将每个输入作为参数。`a` 的值映射到参数 `num1`，`b` 的值映射到参数 `num2`。
-2. 对于 `sub_btn` 监听器，我们将输入作为集合传递（注意花括号！）。函数 `sub()` 接受一个名为 `data` 的单个字典参数，其中键是输入组件，值是这些组件的值。
+2. 对于 `sub_btn` 监听器，我们将输入作为集合传递（注意花括号！）。当您传递集合时，函数 `sub()` 接受一个名为 `data` 的单个字典参数，其中键是输入组件，值是这些组件的值。
 
 使用哪种语法是个人偏好！对于具有许多输入组件的函数，选项 2 可能更容易管理。
 


### PR DESCRIPTION
## Summary
- Renamed section from "Function Input List vs Dict" to "Function Input List vs Set" to accurately reflect the Python syntax used
- Clarified that when you pass a **set** of inputs `{a, b}`, the function receives a **dictionary** with components as keys
- Updated both English and Chinese documentation

The previous wording was confusing because it described passing a "set" but titled the section "List vs Dict". This clarifies that:
- `inputs=[a, b]` (list) → function receives separate arguments  
- `inputs={a, b}` (set) → function receives a dictionary

Fixes #11176

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=101010297