### PR TITLE
Fix reload mode test

### DIFF
--- a/js/spa/test/test_chatinterface.reload.spec.ts
+++ b/js/spa/test/test_chatinterface.reload.spec.ts
@@ -60,7 +60,7 @@ import gradio as gr
 def greet(msg, history):
 	return f"You typed: {msg}"
 
-demo = gr.ChatInterface(fn=greet, textbox=gr.Textbox(label="foo", placeholder="Type a message..."))
+demo = gr.ChatInterface(fn=greet, textbox=gr.Textbox(label="foo", placeholder="Hello..."))
 
 if __name__ == "__main__":
 	demo.launch()
@@ -77,10 +77,11 @@ if __name__ == "__main__":
 			}
 		});
 
-		await expect(page.getByLabel("foo")).toBeVisible();
+		await expect(page.getByPlaceholder("Hello...")).toBeVisible();
 		const textbox = page.getByTestId("textbox").first();
 
 		await textbox.fill("hello");
+		await page.waitForTimeout(500);
 		await textbox.press("Enter");
 
 		await expect(textbox).toHaveValue("");


### PR DESCRIPTION
## Description

The `getByLabel` in the chatinterface reload test is failing to locate an element. This is because we manually set `show_label=False` for the textbox in the chat interface. Not sure how this was working before though.


## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
  
