### PR TITLE
Fix HighlightedText remove icon not appearing on multi-line labels

### DIFF
--- a/js/highlightedtext/shared/HighlightedText.svelte
+++ b/js/highlightedtext/shared/HighlightedText.svelte
@@ -393,6 +393,7 @@
 
 	.token-container {
 		position: relative;
+		display: inline-block;
 	}
 
 	.token {
@@ -465,6 +466,7 @@
 		cursor: pointer;
 		justify-content: center;
 		align-items: center;
+		z-index: 1;
 	}
 
 	:global(.dark) .remove-btn {


### PR DESCRIPTION
## Summary
- Fixed remove icon not appearing when highlighted labels span multiple lines (issue #12798)
- Changed token-container display property to properly contain multi-line content

## Changes
- Updated `js/highlightedtext/shared/HighlightedText.svelte`:
  - Changed `.token-container` from default inline display to `display: inline-block`
  - Added `z-index: 1` to `.remove-btn` to ensure it appears above content

## Root Cause
The `.token-container` element was using the default inline display, which doesn't properly contain multi-line content. When highlighted text wrapped to multiple lines, the container's dimensions weren't calculated correctly, causing the absolutely positioned remove button (positioned at `top: 0, right: 0`) to not appear in the expected location or not be visible at all.

## Test Plan
### Manual Testing
- [x] Created test file `test_highlightedtext_bug.py` from the issue example
- [x] Verified remove icon appears on multi-line labels
- [x] Verified remove icon positioned correctly at top-right
- [x] Verified remove icon is clickable and removes highlight
- [x] Verified single-line labels still work correctly

### Test Steps
1. Run the test file: `python test_highlightedtext_bug.py`
2. Click "Submit" to generate the diff
3. Manually add labels that span multiple lines
4. Hover over multi-line highlighted labels
5. Remove icon (red X) appears at top-right
6. Click remove icon to remove highlight

## Before/After
**Before:** Remove icon hidden or incorrectly positioned on multi-line labels
**After:** Remove icon visible and functional on both single and multi-line labels

Fixes #12798

