### PR TITLE
Fix shared props read from wrong source (gradio.props vs gradio.shared)

### DIFF
--- a/js/button/Index.svelte
+++ b/js/button/Index.svelte
@@ -34,7 +34,7 @@
 	elem_id={gradio.shared.elem_id}
 	elem_classes={gradio.shared.elem_classes}
 	size={gradio.props.size}
-	scale={gradio.props.scale}
+	scale={gradio.shared.scale}
 	link={gradio.props.link}
 	icon={gradio.props.icon}
 	min_width={gradio.shared.min_width}

--- a/js/html/Index.svelte
+++ b/js/html/Index.svelte
@@ -36,7 +36,7 @@
 	elem_id={gradio.shared.elem_id}
 	elem_classes={gradio.shared.elem_classes}
 	container={gradio.shared.container}
-	padding={gradio.props.padding !== false}
+	padding={gradio.shared.padding !== false}
 	overflow_behavior="visible"
 >
 	{#if gradio.shared.show_label && gradio.props.buttons && gradio.props.buttons.length > 0}

--- a/js/json/Index.svelte
+++ b/js/json/Index.svelte
@@ -64,7 +64,7 @@
 	<JSON
 		value={gradio.props.value}
 		open={gradio.props.open}
-		theme_mode={gradio.props.theme_mode}
+		theme_mode={gradio.shared.theme_mode}
 		show_indices={gradio.props.show_indices}
 		show_copy_button={gradio.props.buttons == null
 			? true

--- a/js/markdown/Index.svelte
+++ b/js/markdown/Index.svelte
@@ -61,7 +61,7 @@
 	/>
 	<div
 		bind:this={wrapper}
-		class:padding={gradio.props.padding}
+		class:padding={gradio.shared.padding}
 		class:pending={gradio.shared.loading_status?.status === "pending"}
 	>
 		<Markdown

--- a/js/plot/Index.svelte
+++ b/js/plot/Index.svelte
@@ -65,7 +65,7 @@
 	/>
 	<Plot
 		value={gradio.props.value}
-		theme_mode={gradio.props.theme_mode}
+		theme_mode={gradio.shared.theme_mode}
 		show_label={gradio.shared.show_label}
 		caption={gradio.props.caption}
 		bokeh_version={gradio.props.bokeh_version}

--- a/js/tabitem/Index.svelte
+++ b/js/tabitem/Index.svelte
@@ -20,7 +20,7 @@
 	interactive={gradio.shared.interactive}
 	id={gradio.props.id}
 	order={gradio.props.order}
-	scale={gradio.props.scale}
+	scale={gradio.shared.scale}
 	component_id={gradio.props.component_id}
 	on:select={({ detail }) => gradio.dispatch("select", detail)}
 >

--- a/js/textbox/Index.svelte
+++ b/js/textbox/Index.svelte
@@ -32,7 +32,7 @@
 
 	async function handle_input(value: string): Promise<void> {
 		if (!gradio.shared || !gradio.props) return;
-		gradio.props.validation_error = null;
+		gradio.shared.validation_error = null;
 		gradio.props.value = value;
 		await tick();
 		gradio.dispatch("input");
@@ -44,7 +44,7 @@
 
 	function handle_change(value: string): void {
 		if (!gradio.shared || !gradio.props) return;
-		gradio.props.validation_error = null;
+		gradio.shared.validation_error = null;
 		gradio.props.value = value;
 	}
 </script>


### PR DESCRIPTION
## Summary

Fixes #12881

When shared props were introduced, several components ended up reading props like `scale`, `padding`, `theme_mode`, and `validation_error` from `gradio.props` (where they're `undefined`) instead of `gradio.shared` (where they're actually stored by `create_props_shared_props`). This caused these props to silently fail — most visibly, `Button.scale` was completely ignored.

Credit to @deckar01 for the thorough analysis in the issue, which traced the regression back to the shared props refactor and identified all the affected components.

## Changes

Fixed 7 components reading shared props from the wrong source:

| Component | Prop | Before | After |
|-----------|------|--------|-------|
| `button/Index.svelte` | `scale` | `gradio.props.scale` | `gradio.shared.scale` |
| `html/Index.svelte` | `padding` | `gradio.props.padding` | `gradio.shared.padding` |
| `json/Index.svelte` | `theme_mode` | `gradio.props.theme_mode` | `gradio.shared.theme_mode` |
| `markdown/Index.svelte` | `padding` | `gradio.props.padding` | `gradio.shared.padding` |
| `plot/Index.svelte` | `theme_mode` | `gradio.props.theme_mode` | `gradio.shared.theme_mode` |
| `tabitem/Index.svelte` | `scale` | `gradio.props.scale` | `gradio.shared.scale` |
| `textbox/Index.svelte` | `validation_error` | `gradio.props.validation_error = null` | `gradio.shared.validation_error = null` |

I left `chatbot/autoscroll`, `tabitem/id`, and `draggable/show_progress` unchanged — those are special-cased in `create_props_shared_props` (for `id` and `autoscroll`) or defined as component-specific props (for `show_progress` in `DraggableProps`), so reading from `gradio.props` is correct for those.

## How to test

```python
import gradio as gr

with gr.Blocks() as demo:
    with gr.Row():
        gr.Button("Scale 1", scale=1)
        gr.Button("Scale 3", scale=3)
        gr.Button("Scale 1", scale=1)

demo.launch()
```

The buttons should now respect their `scale` values. Previously all three would render at equal width.