### PR TITLE
fix: improve Dropdown/Listbox accessibility for screen readers

### DIFF
--- a/js/dropdown/shared/Dropdown.svelte
+++ b/js/dropdown/shared/Dropdown.svelte
@@ -12,6 +12,8 @@
 
 	const is_browser = typeof window !== "undefined";
 
+	let listbox_id = "dropdown-listbox-" + Math.random().toString(36).slice(2, 9);
+
 	let {
 		label = "Dropdown",
 		info = undefined,
@@ -193,9 +195,12 @@
 		<div class="wrap-inner" class:show_options>
 			<div class="secondary-wrap">
 				<input
-					role="listbox"
-					aria-controls="dropdown-options"
+					role="combobox"
+					aria-controls={listbox_id}
 					aria-expanded={show_options}
+					aria-haspopup="listbox"
+					aria-autocomplete={filterable ? "list" : "none"}
+					aria-activedescendant={active_index !== null && show_options ? `${listbox_id}-option-${active_index}` : undefined}
 					aria-label={label}
 					class="border-none"
 					class:subdued={!choices_names.includes(input_text) &&
@@ -229,6 +234,8 @@
 			{disabled}
 			selected_indices={selected_index === null ? [] : [selected_index]}
 			{active_index}
+			{listbox_id}
+			label_text={label}
 			onchange={handle_option_selected}
 			onload={() => (initialized = true)}
 		/>

--- a/js/dropdown/shared/DropdownOptions.svelte
+++ b/js/dropdown/shared/DropdownOptions.svelte
@@ -10,6 +10,8 @@
 		remember_scroll = false,
 		offset_from_top = 0,
 		from_top = false,
+		listbox_id = "dropdown-options",
+		label_text = "",
 		onchange,
 		onload
 	}: {
@@ -22,6 +24,8 @@
 		remember_scroll?: boolean;
 		offset_from_top?: number;
 		from_top?: boolean;
+		listbox_id?: string;
+		label_text?: string;
 		onchange?: (index: any) => void;
 		onload?: () => void;
 	} = $props();
@@ -108,6 +112,7 @@
 {#if show_options && !disabled}
 	<ul
 		class="options"
+		id={listbox_id}
 		transition:fly={{ duration: 200, y: 5 }}
 		onmousedown={(e) => {
 			e.preventDefault();
@@ -120,10 +125,12 @@
 		style:width={input_width + "px"}
 		bind:this={listElement}
 		role="listbox"
+		aria-label={label_text || undefined}
 	>
 		{#each filtered_indices as index}
 			<li
 				class="item"
+				id="{listbox_id}-option-{index}"
 				class:selected={selected_indices.includes(index)}
 				class:active={index === active_index}
 				class:bg-gray-100={index === active_index}

--- a/js/dropdown/shared/Multiselect.svelte
+++ b/js/dropdown/shared/Multiselect.svelte
@@ -11,6 +11,7 @@
 
 	const gradio: Gradio<DropdownEvents, DropdownProps> = props.gradio;
 
+	let listbox_id = "multiselect-listbox-" + Math.random().toString(36).slice(2, 9);
 	let filter_input: HTMLElement;
 	let input_text = $state("");
 	let label = $derived(gradio.shared.label || "Multiselect");
@@ -232,6 +233,13 @@
 			{/each}
 			<div class="secondary-wrap">
 				<input
+					role="combobox"
+					aria-controls={listbox_id}
+					aria-expanded={show_options}
+					aria-haspopup="listbox"
+					aria-autocomplete={gradio.props.filterable ? "list" : "none"}
+					aria-activedescendant={active_index !== null && show_options ? `${listbox_id}-option-${active_index}` : undefined}
+					aria-label={label}
 					class="border-none"
 					class:subdued={(!choices_names.includes(input_text) &&
 						!gradio.props.allow_custom_value) ||
@@ -280,6 +288,8 @@
 			{disabled}
 			{selected_indices}
 			{active_index}
+			{listbox_id}
+			label_text={label}
 			remember_scroll={true}
 			onchange={handle_option_selected}
 		/>

--- a/js/dropdown/shared/utils.ts
+++ b/js/dropdown/shared/utils.ts
@@ -36,6 +36,7 @@ export function handle_shared_keys(
 		return [false, active_index];
 	}
 	if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+		e.preventDefault();
 		if (filtered_indices.length > 0) {
 			if (active_index === null) {
 				active_index =

--- a/js/spa/test/change_vs_input.spec.ts
+++ b/js/spa/test/change_vs_input.spec.ts
@@ -96,15 +96,15 @@ test("Radio change and input events work correctly", async ({ page }) => {
 });
 
 test("Dropdown change and input events work correctly", async ({ page }) => {
-	await page.getByRole("listbox", { name: "DD Input" }).click();
+	await page.getByRole("combobox", { name: "DD Input" }).click();
 	await page.getByRole("option", { name: "b" }).click();
 
 	await expect(page.getByLabel("Change counter")).toHaveValue("1");
 
 	await expect(
-		page.getByRole("listbox", { name: "Dropdown Input Event", exact: true })
+		page.getByRole("combobox", { name: "Dropdown Input Event", exact: true })
 	).toHaveValue("b");
 	await expect(
-		page.getByRole("listbox", { name: "Dropdown Change Event x2", exact: true })
+		page.getByRole("combobox", { name: "Dropdown Change Event x2", exact: true })
 	).toHaveValue("b");
 });

--- a/js/spa/test/dropdown_custom_value.spec.ts
+++ b/js/spa/test/dropdown_custom_value.spec.ts
@@ -4,7 +4,7 @@ test.describe("Dropdown with allow_custom_value=True", () => {
 	test("selecting an option updates the textbox with the value, not the name", async ({
 		page
 	}) => {
-		const dropdown = page.getByRole("listbox", { name: "Dropdown" });
+		const dropdown = page.getByRole("combobox", { name: "Dropdown" });
 		const output = page.getByLabel("Output");
 
 		await dropdown.click();
@@ -16,7 +16,7 @@ test.describe("Dropdown with allow_custom_value=True", () => {
 	test("blurring dropdown after selecting an option does not change the value", async ({
 		page
 	}) => {
-		const dropdown = page.getByRole("listbox", { name: "Dropdown" });
+		const dropdown = page.getByRole("combobox", { name: "Dropdown" });
 		const output = page.getByLabel("Output");
 
 		await dropdown.click();
@@ -33,7 +33,7 @@ test.describe("Dropdown with allow_custom_value=True", () => {
 	test("typing a custom value and pressing Enter updates the textbox", async ({
 		page
 	}) => {
-		const dropdown = page.getByRole("listbox", { name: "Dropdown" });
+		const dropdown = page.getByRole("combobox", { name: "Dropdown" });
 		const output = page.getByLabel("Output");
 
 		// Focus the dropdown and type a custom value
@@ -48,7 +48,7 @@ test.describe("Dropdown with allow_custom_value=True", () => {
 	test("typing a custom value and blurring updates the textbox", async ({
 		page
 	}) => {
-		const dropdown = page.getByRole("listbox", { name: "Dropdown" });
+		const dropdown = page.getByRole("combobox", { name: "Dropdown" });
 		const output = page.getByLabel("Output");
 
 		await dropdown.click();
@@ -61,7 +61,7 @@ test.describe("Dropdown with allow_custom_value=True", () => {
 	test("selecting an option after typing a custom value works correctly", async ({
 		page
 	}) => {
-		const dropdown = page.getByRole("listbox", { name: "Dropdown" });
+		const dropdown = page.getByRole("combobox", { name: "Dropdown" });
 		const output = page.getByLabel("Output");
 
 		await dropdown.click();


### PR DESCRIPTION
## Summary
Fixes #12855

The Dropdown and Multiselect components lack proper ARIA attributes, making them inaccessible to screen reader users (NVDA, JAWS, VoiceOver, Narrator). This PR implements the [WAI-ARIA Combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) to make these components fully navigable with assistive technology.

## Changes
- **Dropdown input**: Changed `role="listbox"` to `role="combobox"` (an input element should never have a listbox role per ARIA spec)
- **Added ARIA attributes to combobox input**: `aria-haspopup="listbox"`, `aria-autocomplete`, and `aria-activedescendant` to announce the currently active option during keyboard navigation
- **Listbox popup (`<ul>`)**: Added `id` attribute and `aria-label` for proper association with the combobox
- **List options (`<li>`)**: Added unique `id` attributes so `aria-activedescendant` can reference the active option
- **Multiselect input**: Added the same combobox ARIA attributes (`role`, `aria-controls`, `aria-expanded`, `aria-haspopup`, `aria-autocomplete`, `aria-activedescendant`, `aria-label`)
- **Keyboard navigation**: Added `e.preventDefault()` on ArrowUp/ArrowDown to prevent the text cursor from moving while navigating options
- **Tests**: Updated e2e tests to use the corrected `combobox` role

## Test Plan
- [x] Existing unit tests pass (13/13 in `dropdown.test.ts`)
- [x] Updated e2e tests in `change_vs_input.spec.ts` and `dropdown_custom_value.spec.ts` to match new `combobox` role
- [ ] Manual testing with NVDA/VoiceOver to verify screen readers correctly announce:
  - The combobox role and label
  - The expanded/collapsed state
  - The currently active option during arrow key navigation
  - The selected option