### PR TITLE
fix: ensure round_to_precision returns float when precision > 0

### DIFF
--- a/gradio/components/number.py
+++ b/gradio/components/number.py
@@ -124,7 +124,7 @@ class Number(FormComponent):
         elif precision == 0:
             return int(round(num, precision))
         else:
-            return round(num, precision)
+            return float(round(num, precision))
 
     @staticmethod
     def raise_if_out_of_bounds(

--- a/test/components/test_number.py
+++ b/test/components/test_number.py
@@ -151,3 +151,26 @@ class TestNumber:
         assert component.get_config().get("value") is None
         component = gr.Number(3)
         assert component.get_config().get("value") == 3.0
+
+    def test_precision_nonzero_always_returns_float(self):
+        """
+        When precision > 0, round_to_precision should always return a float,
+        even when the input is an integer.
+        """
+        numeric_input = gr.Number(precision=2, value=2.0)
+        # Integer input should be returned as float when precision > 0
+        assert numeric_input.preprocess(2) == 2.0
+        assert isinstance(numeric_input.preprocess(2), float)
+        assert numeric_input.postprocess(2) == 2.0
+        assert isinstance(numeric_input.postprocess(2), float)
+        # Float input should remain float
+        assert numeric_input.preprocess(2.0) == 2.0
+        assert isinstance(numeric_input.preprocess(2.0), float)
+        assert numeric_input.postprocess(2.0) == 2.0
+        assert isinstance(numeric_input.postprocess(2.0), float)
+
+        numeric_input = gr.Number(precision=1, value=3.0)
+        assert numeric_input.preprocess(3) == 3.0
+        assert isinstance(numeric_input.preprocess(3), float)
+        assert numeric_input.postprocess(3) == 3.0
+        assert isinstance(numeric_input.postprocess(3), float)

--- a/test/components/test_slider.py
+++ b/test/components/test_slider.py
@@ -95,3 +95,20 @@ class TestSlider:
         slider = gr.Slider(precision=0)
         assert slider.preprocess(5.1) == 5
         assert slider.api_info()["type"] == "integer"
+
+    def test_precision_nonzero_always_returns_float(self):
+        """
+        When precision > 0, Slider preprocess/postprocess should always return
+        a float, even when the input value has no fractional part.
+        """
+        slider = gr.Slider(minimum=0, maximum=10, precision=1)
+        assert slider.preprocess(2) == 2.0
+        assert isinstance(slider.preprocess(2), float)
+        assert slider.postprocess(2) == 2.0
+        assert isinstance(slider.postprocess(2), float)
+
+        slider = gr.Slider(minimum=0, maximum=10, precision=2)
+        assert slider.preprocess(5) == 5.0
+        assert isinstance(slider.preprocess(5), float)
+        assert slider.postprocess(5) == 5.0
+        assert isinstance(slider.postprocess(5), float)


### PR DESCRIPTION
## Summary

Fixes #12484

`Number.round_to_precision()` uses Python's built-in `round()`, which preserves the input type. This means `round(2, 2)` returns `int(2)` instead of `float(2.0)`. When a user sets `precision=1` (or any positive integer) on a `gr.Slider` or `gr.Number`, they expect consistent float output — but integer inputs were silently returned as integers, causing type inconsistencies between interactions.

**The fix**: wrap the return value in `float()` when `precision > 0`, so the output is always a float. This is consistent with the existing behavior for `precision=0` which explicitly casts to `int`.

### Changes

- **`gradio/components/number.py`**: Changed `return round(num, precision)` to `return float(round(num, precision))` in `round_to_precision()` for the `precision > 0` branch
- **`test/components/test_number.py`**: Added `test_precision_nonzero_always_returns_float` to verify `Number` preprocess/postprocess always return `float` when `precision > 0`
- **`test/components/test_slider.py`**: Added `test_precision_nonzero_always_returns_float` to verify `Slider` preprocess/postprocess always return `float` when `precision > 0`

### Before

```python
>>> from gradio.components.number import Number
>>> Number.round_to_precision(2, 2)
2          # int
>>> Number.round_to_precision(2, 1)
2          # int
```

### After

```python
>>> Number.round_to_precision(2, 2)
2.0        # float
>>> Number.round_to_precision(2, 1)
2.0        # float
```

## Test plan

- [x] `pytest test/components/test_number.py` — all 11 tests pass
- [x] `pytest test/components/test_slider.py` — all 8 tests pass
- [x] Verified `precision=None` still preserves original type (int stays int, float stays float)
- [x] Verified `precision=0` still returns int