### PR TITLE
fix: serve custom component assets correctly at subpath

### DIFF
--- a/js/core/src/init.svelte.ts
+++ b/js/core/src/init.svelte.ts
@@ -92,7 +92,7 @@ export class AppTree {
 		this.reactive_formatter = reactive_formatter;
 		this.#config = {
 			...config,
-			api_url: new URL(config.api_prefix, config.root).toString()
+			api_url: config.root.replace(/\/$/, "") + config.api_prefix
 		};
 		this.#component_payload = components;
 		this.#layout_payload = layout;
@@ -144,7 +144,7 @@ export class AppTree {
 		this.#component_payload = components;
 		this.#config = {
 			...config,
-			api_url: new URL(config.api_prefix, config.root).toString()
+			api_url: config.root.replace(/\/$/, "") + config.api_prefix
 		};
 		this.#dependency_payload = dependencies;
 


### PR DESCRIPTION
## Summary

- Fix custom component assets (CSS/JS) returning 404 when Gradio app is mounted at a subpath via `mount_gradio_app()`
- Replace `new URL(api_prefix, root)` with string concatenation to preserve the subpath in the constructed `api_url`
- The `new URL()` constructor was discarding the mount path because an absolute `api_prefix` (e.g. `/gradio_api`) replaces the base URL's pathname instead of appending to it

## Problem

When mounting a Gradio app at a subpath (e.g. `gr.mount_gradio_app(app, demo, path="/pdf")`), custom component assets fail to load with 404 errors:

- **Expected URL**: `http://localhost:8000/pdf/gradio_api/custom_component/...`
- **Actual URL**: `http://localhost:8000/gradio_api/custom_component/...` (missing `/pdf` prefix)

The root cause is in `js/core/src/init.svelte.ts`:

```typescript
// Before (broken): new URL("/gradio_api", "http://localhost:8000/pdf")
// produces "http://localhost:8000/gradio_api" — subpath "/pdf" is lost
api_url: new URL(config.api_prefix, config.root).toString()

// After (fixed): "http://localhost:8000/pdf" + "/gradio_api"
// produces "http://localhost:8000/pdf/gradio_api" — subpath preserved
api_url: config.root.replace(/\/$/, "") + config.api_prefix
```

## Test plan

- [ ] Mount a Gradio app with custom components at a subpath using `mount_gradio_app(app, demo, path="/subpath")`
- [ ] Verify custom component CSS and JS assets load correctly (no 404s)
- [ ] Verify the app works normally when mounted at root path (no subpath)

Closes #12802