### PR TITLE
Fix demo.load() hanging when Chatbot is in a Row with Tabs

### DIFF
--- a/.changeset/fix-chatbot-row-load.md
+++ b/.changeset/fix-chatbot-row-load.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix `demo.load()` hanging when Chatbot is in a Row with other components and Tabs are present

--- a/demo/chatbot_row_load/run.py
+++ b/demo/chatbot_row_load/run.py
@@ -1,0 +1,22 @@
+import gradio as gr
+
+with gr.Blocks() as demo:
+    with gr.Tab("Tab 1"):
+        with gr.Row():
+            gr.Chatbot()
+            with gr.Column():
+                gr.Slider()
+                gr.Slider()
+                gr.Slider()
+
+    with gr.Tab("Tab 2"):
+        textbox = gr.Textbox(label="Output")
+
+    demo.load(
+        fn=lambda: "loaded successfully",
+        inputs=None,
+        outputs=textbox,
+    )
+
+if __name__ == "__main__":
+    demo.launch()

--- a/js/core/src/init.svelte.ts
+++ b/js/core/src/init.svelte.ts
@@ -67,6 +67,7 @@ export class AppTree {
 
 	#get_callbacks = new Map<number, get_data_type>();
 	#set_callbacks = new Map<number, set_data_type>();
+	#pending_updates = new Map<number, Record<string, unknown>>();
 	#event_dispatcher: (id: number, event: string, data: unknown) => void;
 	component_ids: number[];
 	initial_tabs: Record<number, Tab[]> = {};
@@ -195,6 +196,21 @@ export class AppTree {
 		this.#set_callbacks.set(id, _set_data);
 		this.#get_callbacks.set(id, _get_data);
 		this.components_to_register.delete(id);
+
+		// Apply any pending updates that were stored while the component
+		// was not yet mounted (e.g. hidden in an inactive tab).
+		// We must apply AFTER tick() so that the Gradio class's $effect
+		// (which syncs from node props) has already run. Otherwise the
+		// $effect would overwrite the values we set here.
+		const pending = this.#pending_updates.get(id);
+		if (pending) {
+			this.#pending_updates.delete(id);
+			tick().then(() => {
+				const _set = this.#set_callbacks.get(id);
+				if (_set) _set(pending);
+			});
+		}
+
 		if (this.components_to_register.size === 0 && !this.resolved) {
 			this.resolved = true;
 			this.ready_resolve();
@@ -429,11 +445,24 @@ export class AppTree {
 			const old_value = node?.props.props.value;
 			// @ts-ignore
 			const new_props = create_props_shared_props(new_state);
-			node!.props.shared_props = {
-				...node?.props.shared_props,
-				...new_props.shared_props
-			};
-			node!.props.props = { ...node?.props.props, ...new_props.props };
+			// Modify props in-place instead of replacing the entire object.
+			// Replacing with a new object via spread can cause Svelte 5's
+			// deep $state proxy to lose track of the values during async
+			// component mounting/revival.
+			for (const key in new_props.shared_props) {
+				// @ts-ignore
+				node!.props.shared_props[key] = new_props.shared_props[key];
+			}
+			for (const key in new_props.props) {
+				// @ts-ignore
+				node!.props.props[key] = new_props.props[key];
+			}
+
+			// Also store as pending so the value can be applied via _set_data
+			// when the component eventually mounts and registers
+			const existing = this.#pending_updates.get(id) || {};
+			this.#pending_updates.set(id, { ...existing, ...new_state });
+
 			if ("value" in new_state && !dequal(old_value, new_state.value)) {
 				this.#event_dispatcher(id, "change", null);
 			}
@@ -469,15 +498,21 @@ export class AppTree {
 	}
 
 	async render_previously_invisible_children(id: number) {
-		this.root = this.traverse(this.root!, [
-			(node) => {
-				if (node.id === id) {
-					make_visible_if_not_rendered(node, this.#hidden_on_startup);
-				}
-				return node;
-			},
-			(node) => handle_visibility(node, this.#config.api_url)
-		]);
+		const node = find_node_by_id(this.root!, id);
+		if (!node) return;
+
+		// Check if this node or any of its descendants need to be made visible.
+		// If not, skip entirely to avoid unnecessary reactive updates
+		// from mutating the tree through the $state proxy.
+		if (
+			!this.#hidden_on_startup.has(node.id) &&
+			!has_hidden_descendants(node, this.#hidden_on_startup)
+		) {
+			return;
+		}
+
+		make_visible_if_not_rendered(node, this.#hidden_on_startup);
+		load_components(node, this.#config.api_url);
 	}
 }
 
@@ -491,6 +526,24 @@ function make_visible_if_not_rendered(
 	node.children.forEach((child) => {
 		make_visible_if_not_rendered(child, hidden_on_startup);
 	});
+}
+
+function has_hidden_descendants(
+	node: ProcessedComponentMeta,
+	hidden_on_startup: Set<number>
+): boolean {
+	for (const child of node.children) {
+		if (hidden_on_startup.has(child.id)) return true;
+		if (has_hidden_descendants(child, hidden_on_startup)) return true;
+	}
+	return false;
+}
+
+function load_components(node: ProcessedComponentMeta, api_url: string): void {
+	if (node.props.shared_props.visible && !node.component) {
+		node.component = get_component(node.type, node.component_class_id, api_url);
+	}
+	node.children.forEach((child) => load_components(child, api_url));
 }
 
 /**

--- a/js/spa/test/chatbot_row_load.spec.ts
+++ b/js/spa/test/chatbot_row_load.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@self/tootils";
+
+test("demo.load() fires when Chatbot is in a Row with other components", async ({
+	page
+}) => {
+	// Click on "Tab 2" to see the output textbox
+	await page.getByRole("tab", { name: "Tab 2" }).click();
+
+	// The textbox should be populated by demo.load()
+	// If the bug is present, demo.load() hangs indefinitely and the textbox stays empty
+	await expect(page.getByLabel("Output")).toHaveValue("loaded successfully", {
+		timeout: 10000
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #12849

`demo.load()` hangs indefinitely when a `gr.Chatbot` is placed inside a `gr.Row()` alongside other components when Tabs are present (introduced in v6.1.0).

### Root Cause

`render_previously_invisible_children()` performed a full tree traversal through Svelte 5's `$state` proxy, reassigning `this.root`. This triggered reactive re-renders in `MountComponents.svelte` that interrupted in-flight async component imports (particularly heavy components like Chatbot). The interrupted component never called `register_component()`, so `components_to_register` never emptied, the `ready` Promise never resolved, and `dispatch_load_events()` never fired.

### Changes

- **`render_previously_invisible_children()`**: Use direct `find_node_by_id()` + in-place mutation instead of full tree traversal/reassignment. Add early return when no descendants need visibility changes.
- **`update_state()`**: Modify props in-place (key-by-key assignment) instead of spread replacement to avoid disrupting the `$state` proxy.
- **Pending updates queue**: Store updates for components that haven't mounted yet, and apply them via `_set_data` after the component registers and `tick()` completes.
- **New helpers**: `has_hidden_descendants()` and `load_components()` for targeted, non-destructive tree operations.

### Reproduction

```python
import gradio as gr

with gr.Blocks() as demo:
    with gr.Tab('Tab 1'):
        with gr.Row():
            gr.Chatbot()
            with gr.Column():
                gr.Slider()
                gr.Slider()
                gr.Slider()
    with gr.Tab('Tab 2'):
        textbox = gr.Textbox()

    demo.load(fn=lambda: 'some text', inputs=None, outputs=textbox)

demo.launch()
```

**Before fix**: `demo.load()` hangs indefinitely, textbox stays empty.
**After fix**: Load event fires correctly, textbox gets populated.

## Test plan

- [ ] E2E test `chatbot_row_load.spec.ts` verifies `demo.load()` fires when Chatbot is in a Row with Tabs
- [ ] Existing tab, visibility, and load tests continue to pass
- [ ] Manual verification with the reproduction script from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)