### PR TITLE
fix: header checkbox only toggles its own bool column

### DIFF
--- a/.changeset/fix-dataframe-bool-header-checkbox.md
+++ b/.changeset/fix-dataframe-bool-header-checkbox.md
@@ -1,0 +1,8 @@
+---
+"@gradio/dataframe": patch
+---
+
+fix: header checkbox on bool column no longer toggles values in other selected columns
+
+- Fixed `EditableCell` blur shim to only fire when transitioning out of edit mode, not on external value changes
+- Fixed `handle_select_all` to clear cell selection before toggling bool column values

--- a/js/dataframe/shared/EditableCell.svelte
+++ b/js/dataframe/shared/EditableCell.svelte
@@ -91,9 +91,16 @@
 		handle_blur({ target: { value } } as unknown as FocusEvent);
 	}
 
-	$: if (!edit) {
-		// Shim blur on removal for Safari and Firefox
-		handle_blur({ target: { value } } as unknown as FocusEvent);
+	let prev_edit = false;
+
+	$: {
+		if (prev_edit && !edit) {
+			// Shim blur on removal for Safari and Firefox:
+			// only fire when transitioning from edit to non-edit mode,
+			// not when value changes externally (e.g. header checkbox toggle).
+			handle_blur({ target: { value } } as unknown as FocusEvent);
+		}
+		prev_edit = !!edit;
 	}
 </script>
 

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -753,6 +753,11 @@
 	}
 
 	function handle_select_all(col: number, checked: boolean): void {
+		// Clear selection to prevent interference with cells in other columns
+		df_actions.set_selected_cells([]);
+		df_actions.set_selected(false);
+		df_actions.set_editing(false);
+
 		data = data.map((row) => {
 			const new_row = [...row];
 			if (new_row[col]) {


### PR DESCRIPTION
## Summary

Fixes #12690 - The header checkbox on a bool column was also toggling values in other selected columns, causing unintended bulk edits.

**Root cause:** The `EditableCell` component had a reactive blur shim (`$: if (!edit) { handle_blur(...) }`) that fired whenever `value` changed while the cell was not in edit mode. When `handle_select_all` updated the bool column, it triggered a full `search_results` recomputation. This caused the blur shim to fire for all affected cells, potentially sending spurious `save_cell_value` calls that interfered with other selected columns.

**Changes:**

- **`EditableCell.svelte`**: Changed the blur shim reactive to track the previous `edit` state and only fire on actual edit-to-non-edit transitions (`prev_edit && !edit`), not on external value changes. This prevents spurious blur events during bulk data updates like `handle_select_all`.

- **`Table.svelte`**: Clear `selected_cells`, `selected`, and `editing` state before modifying data in `handle_select_all`, so no stale cell selection can interfere with the data update.

## Test plan

- [ ] Create a Dataframe with a bool column and other interactive columns (use the reproduction from #12690)
- [ ] Select cells across multiple columns (e.g., drag to select cells in both "Validation" and "Commentaire")
- [ ] Click the header checkbox on the bool column
- [ ] Verify only the bool column values toggle; other columns remain unchanged
- [ ] Verify that normal cell editing still works (click a cell, type, press Enter/Tab)
- [ ] Verify the header checkbox correctly shows checked/unchecked/indeterminate states