### PR TITLE
fix: Textbox preserved_by_key not persisting value

### DIFF
--- a/.changeset/fix-textbox-preserved-by-key.md
+++ b/.changeset/fix-textbox-preserved-by-key.md
@@ -1,0 +1,8 @@
+---
+"@gradio/core": patch
+"gradio": patch
+---
+
+fix:Textbox `preserved_by_key` not persisting props across re-renders in `gr.render`
+
+The `rerender` method in `init.svelte.ts` was not implementing the `preserved_by_key` logic, causing all component props to be reset to their constructor defaults on every re-render, even when `preserved_by_key` was specified. Additionally, `update_state` was not syncing prop changes back to the node tree when a component was mounted, so preserved values would be stale.

--- a/js/core/src/init.svelte.ts
+++ b/js/core/src/init.svelte.ts
@@ -362,6 +362,18 @@ export class AppTree {
 			map.set(comp.id, comp);
 			return map;
 		}, new Map<number, ComponentMeta>());
+
+		// Collect existing keyed nodes before rebuilding the subtree,
+		// so we can preserve props specified by preserved_by_key.
+		const existing_render_root = find_node_by_id(this.root!, layout.id);
+		const existing_nodes_by_key = new Map<
+			string | number,
+			ProcessedComponentMeta
+		>();
+		if (existing_render_root) {
+			collect_nodes_by_key(existing_render_root, existing_nodes_by_key);
+		}
+
 		const _subtree = this.traverse(layout, (node) => {
 			const new_node = this.create_node(
 				node,
@@ -371,6 +383,13 @@ export class AppTree {
 			);
 			return new_node;
 		});
+
+		// Apply preserved_by_key: for keyed components, preserve specified
+		// props from the existing nodes instead of using the new defaults.
+		if (existing_nodes_by_key.size > 0) {
+			apply_preserved_by_key(_subtree, existing_nodes_by_key);
+		}
+
 		gather_initial_tabs(_subtree, this.initial_tabs);
 		const subtree = this.traverse(_subtree, (node) =>
 			apply_initial_tabs(node, this.initial_tabs)
@@ -439,6 +458,20 @@ export class AppTree {
 			}
 		} else if (_set_data) {
 			_set_data(new_state);
+			// Also update the node props so that preserved_by_key can read
+			// the latest state during rerender.
+			if (node) {
+				const new_props = create_props_shared_props(
+					new_state as ComponentMeta["props"]
+				);
+				for (const key in new_props.shared_props) {
+					(node.props.shared_props as Record<string, unknown>)[key] =
+						(new_props.shared_props as Record<string, unknown>)[key];
+				}
+				for (const key in new_props.props) {
+					node.props.props[key] = new_props.props[key];
+				}
+			}
 		}
 		if (!check_visibility || already_updated_visibility) return;
 		// need to let the UI settle before traversing again
@@ -800,4 +833,64 @@ function find_parent(
 		}
 	}
 	return null;
+}
+
+/**
+ * Collects all nodes with non-null keys from a tree into a map.
+ * @param node the root of the tree to collect from
+ * @param result the map to collect into (key -> node)
+ */
+function collect_nodes_by_key(
+	node: ProcessedComponentMeta,
+	result: Map<string | number, ProcessedComponentMeta> = new Map()
+): Map<string | number, ProcessedComponentMeta> {
+	if (node.key != null) {
+		result.set(node.key, node);
+	}
+	if (node.children) {
+		for (const child of node.children) {
+			collect_nodes_by_key(child, result);
+		}
+	}
+	return result;
+}
+
+/**
+ * Applies preserved_by_key logic to a subtree: for each node with a key
+ * matching an existing node, copies over the props listed in preserved_by_key
+ * from the existing node.
+ * @param node the new subtree node
+ * @param existing_nodes_by_key map of key -> existing node
+ */
+function apply_preserved_by_key(
+	node: ProcessedComponentMeta,
+	existing_nodes_by_key: Map<string | number, ProcessedComponentMeta>
+): void {
+	if (node.key != null && existing_nodes_by_key.has(node.key)) {
+		const existing = existing_nodes_by_key.get(node.key)!;
+		const preserved_by_key = node.props.props.preserved_by_key as
+			| string[]
+			| undefined;
+		if (preserved_by_key && preserved_by_key.length > 0) {
+			for (const prop of preserved_by_key) {
+				if (
+					prop in existing.props.shared_props &&
+					prop in node.props.shared_props
+				) {
+					(node.props.shared_props as Record<string, unknown>)[prop] =
+						(existing.props.shared_props as Record<string, unknown>)[prop];
+				} else if (
+					prop in existing.props.props &&
+					prop in node.props.props
+				) {
+					node.props.props[prop] = existing.props.props[prop];
+				}
+			}
+		}
+	}
+	if (node.children) {
+		for (const child of node.children) {
+			apply_preserved_by_key(child, existing_nodes_by_key);
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #12788

The `preserved_by_key` parameter on components inside `gr.render()` was not working - all component props (including `label`, `value`, etc.) were reset to their constructor defaults on every re-render, even when `preserved_by_key` was specified.

**Root cause**: The Svelte 5 init system (`init.svelte.ts`) has a `rerender` method that rebuilds the component subtree from scratch on each render cycle. Unlike the legacy `_init.ts` (which had `preserved_by_key` logic), the new system was not implementing any prop preservation for keyed components.

Additionally, `update_state` was not syncing prop changes back to the node tree when a component was already mounted (had a `_set_data` callback), so even if preservation was attempted, the node tree would have stale values.

**Changes**:

- **`rerender` method**: Before rebuilding the subtree, collect all existing nodes by key. After creating new nodes, apply `preserved_by_key` logic - for each keyed component that matches an existing one, copy the preserved props from the old node to the new node.
- **`update_state` method**: When a component has a `_set_data` callback (mounted component), also update the node tree's props to keep them in sync. This ensures `preserved_by_key` can read the latest state during rerender.
- **Helper functions**: Added `collect_nodes_by_key` and `apply_preserved_by_key` utility functions.

## Test plan

- [ ] Run the reproduction from #12788: create textboxes with `preserved_by_key=["label", "value"]`, click "Change Label" to set a random label, then change the slider - verify that labels are preserved
- [ ] Verify that non-preserved props (like `info`) are still reset to defaults on re-render
- [ ] Verify no regressions in existing `gr.render` behavior (components without `preserved_by_key` or without keys should behave as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)