### PR TITLE
Fix: Ensure Number/Slider with precision > 0 always returns float

### DIFF
--- a/gradio/components/number.py
+++ b/gradio/components/number.py
@@ -124,7 +124,7 @@ class Number(FormComponent):
         elif precision == 0:
             return int(round(num, precision))
         else:
-            return round(num, precision)
+            return float(round(num, precision))
 
     @staticmethod
     def raise_if_out_of_bounds(

--- a/test/components/test_number.py
+++ b/test/components/test_number.py
@@ -91,6 +91,25 @@ class TestNumber:
         assert numeric_input.postprocess(2.1421) == 2.14
         assert numeric_input.postprocess(None) is None
 
+    def test_precision_returns_float(self):
+        """
+        Ensure precision > 0 always returns float, even when decimal part is 0
+        """
+        numeric_input = gr.Number(precision=1, value=2.0)
+        result = numeric_input.preprocess(2)
+        assert result == 2.0
+        assert isinstance(result, float)
+        
+        result = numeric_input.postprocess(2)
+        assert result == 2.0
+        assert isinstance(result, float)
+        
+        # Test with precision=2
+        numeric_input2 = gr.Number(precision=2, value=2.0)
+        result2 = numeric_input2.preprocess(2.0)
+        assert result2 == 2.0
+        assert isinstance(result2, float)
+
     def test_raise_if_out_of_bounds(self):
         """
         raise_if_out_of_bounds


### PR DESCRIPTION
## Fix for Issue #12484

### Problem
When setting `precision > 0` on `gr.Number` or `gr.Slider` components, the output could inconsistently return either an `int` or `float` depending on the decimal part. For example:
- `gr.Number(precision=1, value=2.0)` with input `2` would return `2` (int) instead of `2.0` (float)
- This happens because Python's `round(2.0, 1)` returns `2` not `2.0`

### Solution
Modified the `round_to_precision` method in `Number` component to explicitly cast to `float` when `precision > 0`. This ensures consistent behavior:
- `precision=None` → preserves input type (unchanged)
- `precision=0` → returns `int` (unchanged)  
- `precision>0` → **always returns `float`** (fixed)

### Testing
- Added new test `test_precision_returns_float` that verifies:
  - `preprocess(2)` with `precision=1` returns `2.0` (float)
  - `postprocess(2)` with `precision=1` returns `2.0` (float)
  - Type consistency across different precision values

### Impact
- Affects both `gr.Number` and `gr.Slider` components (both use `Number.round_to_precision`)
- Backward compatible for most use cases (float values behave the same)
- Breaking change only for code that explicitly checks `type(x) == int` after setting precision > 0

### Example
```python
# Before (inconsistent)
rep_pen = gr.Slider(value=2.0, precision=1)
# Could return: 2 (int) or 2.0 (float) unpredictably

# After (consistent)
rep_pen = gr.Slider(value=2.0, precision=1)  
# Always returns: 2.0 (float)
```

Fixes #12484