### PR TITLE
Fix type hints for gr.on triggers parameter

### DIFF
--- a/.changeset/fix-type-hints-gr-on.md
+++ b/.changeset/fix-type-hints-gr-on.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Simplify `EventListenerCallable` type to `Callable[..., Dependency]` so that type checkers correctly accept event triggers like `btn.click` and `tab.select` in `gr.on()` and `@gr.render()`

--- a/gradio/events.py
+++ b/gradio/events.py
@@ -504,31 +504,7 @@ class EventListenerMethod:
     event_name: str
 
 
-if TYPE_CHECKING:
-    EventListenerCallable = Callable[
-        [
-            Union[Callable[..., Any], None],
-            Union[Component, Sequence[Component], None],
-            Union[Block, Sequence[Block], Sequence[Component], Component, None],
-            Union[str, None, Literal[False]],
-            bool,
-            Literal["full", "minimal", "hidden"],
-            Union[Component, Sequence[Component], None],
-            Union[bool, None],
-            bool,
-            int,
-            bool,
-            bool,
-            Union[dict[str, Any], list[dict[str, Any]], None],
-            Union[float, None],
-            Union[Literal["once", "multiple", "always_last"], None],
-            Union[str, None],
-            Union[int, None, Literal["default"]],
-            Union[str, None],
-            bool,
-        ],
-        Dependency,
-    ]
+EventListenerCallable = Callable[..., Dependency]
 
 
 class EventListener(str):


### PR DESCRIPTION
Fixes #12969

## Summary
- Simplified `EventListenerCallable` type alias from a complex 19-positional-parameter `Callable` to `Callable[..., Dependency]`
- The old type was defined to match the unbound `event_trigger` function signature (including the `block` parameter), but type checkers see bound methods when users reference `btn.click`, `tab.select`, etc.
- This mismatch caused VS Code / pyright to report type errors for valid code like `gr.on(triggers=[btn.click, tab.select])`

## Details

The old `EventListenerCallable` was:
```python
Callable[
    [
        Union[Callable[..., Any], None],
        Union[Component, Sequence[Component], None],
        Union[Block, Sequence[Block], Sequence[Component], Component, None],
        # ... 16 more positional parameters
    ],
    Dependency,
]
```

This did not match the type that checkers infer for `btn.click` (a bound method with keyword-only-style parameters from the generated `.pyi` stubs). The new type `Callable[..., Dependency]` correctly accepts any callable returning `Dependency`, which all event listener methods satisfy.

## Test plan
- [x] Verified syntax is valid
- [x] Verified `EventListenerCallable` is properly defined at module level
- [x] Existing `gr.on` usage in tests (`test/test_events.py`) is compatible
- [ ] Type checker (pyright/pylance) should no longer flag `gr.on(triggers=[btn.click, tab.select])` as an error