### PR TITLE
fix Audio input in Multimodal Textbox not functional.

### DIFF
--- a/js/audio/shared/MinimalAudioPlayer.svelte
+++ b/js/audio/shared/MinimalAudioPlayer.svelte
@@ -16,10 +16,10 @@
 
 	let container: HTMLDivElement;
 	let waveform: WaveSurfer | undefined;
-	let playing = false;
-	let duration = 0;
-	let currentTime = 0;
-	let waveform_ready = false;
+	let playing = $state(false);
+	let duration = $state(0);
+	let currentTime = $state(0);
+	let waveform_ready = $state(false);
 
 	let resolved_src = $derived(value.url);
 

--- a/js/audio/shared/MinimalAudioRecorder.svelte
+++ b/js/audio/shared/MinimalAudioRecorder.svelte
@@ -33,14 +33,14 @@
 
 	let container: HTMLDivElement;
 	let waveform: WaveSurfer | undefined;
-	let record: RecordPlugin | undefined;
-	let seconds = 0;
+	let record: RecordPlugin | undefined = $state();
+	let seconds = $state(0);
 	let interval: NodeJS.Timeout;
-	let is_recording = false;
-	let has_started = false;
-	let mic_devices: MediaDeviceInfo[] = [];
-	let selected_device_id: string = "";
-	let show_device_selection = false;
+	let is_recording = $state(false);
+	let has_started = $state(false);
+	let mic_devices: MediaDeviceInfo[] = $state([]);
+	let selected_device_id: string = $state("");
+	let show_device_selection = $state(false);
 
 	const start_interval = (): void => {
 		clearInterval(interval);
@@ -170,6 +170,9 @@
 		) {
 			record.startMic({ deviceId: selected_device_id }).then(() => {
 				record?.startRecording();
+			}).catch((err) => {
+				console.error("Failed to access microphone:", err);
+				onclear?.();
 			});
 		} else if (!recording && is_recording && record) {
 			record.stopRecording();
@@ -229,7 +232,11 @@
 		<button
 			class="stop-button"
 			onclick={() => {
-				recording = false;
+				if (is_recording) {
+					recording = false;
+				} else {
+					onclear?.();
+				}
 			}}
 			aria-label="Stop recording"
 		>

--- a/js/audio/shared/MinimalAudioRecorder.svelte
+++ b/js/audio/shared/MinimalAudioRecorder.svelte
@@ -168,12 +168,15 @@
 			has_started === false &&
 			mic_devices.length <= 1
 		) {
-			record.startMic({ deviceId: selected_device_id }).then(() => {
-				record?.startRecording();
-			}).catch((err) => {
-				console.error("Failed to access microphone:", err);
-				onclear?.();
-			});
+			record
+				.startMic({ deviceId: selected_device_id })
+				.then(() => {
+					record?.startRecording();
+				})
+				.catch((err) => {
+					console.error("Failed to access microphone:", err);
+					onclear?.();
+				});
 		} else if (!recording && is_recording && record) {
 			record.stopRecording();
 			seconds = 0;


### PR DESCRIPTION
Fixes #12985

## Description

After the Svelte 5 migration, audio recording in `MultimodalTextbox` was broken. The microphone button would get stuck at 0:00 and the stop button wouldn't work.

Root cause:
In Svelte 5, plain `let` variables are not reactive, so the DOM does not update when their values change. The variables controlling recording state (`is_recording`, `seconds`, `has_started`, etc) were declared with `let` instead of `$state()`.

Changes:
- Convert reactive variables to `$state()` in  `MinimalAudioRecorder.svelte` and `MinimalAudioPlayer.svelte`
- Fix stop button logic to stop recording or clear depending on state
- Add `.catch()` to `startMic()` for safe error handling

Closes: #12985

## AI Disclosure

- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Closes #12985
