### PR TITLE
Fix Slider property update freezing UI

### DIFF
--- a/js/slider/Index.svelte
+++ b/js/slider/Index.svelte
@@ -7,14 +7,14 @@
 	import { Block, BlockTitle } from "@gradio/atoms";
 	import { StatusTracker } from "@gradio/statustracker";
 	import type { SliderEvents, SliderProps } from "./types";
-	import { tick } from "svelte";
+	import { tick, untrack } from "svelte";
 
 	let props = $props();
 	let gradio = new Gradio<SliderEvents, SliderProps>(props);
 	const INITIAL_VALUE = gradio.props.value;
 	let old_value = $state(gradio.props.value);
 
-	let range_input: HTMLInputElement;
+	let range_input: HTMLInputElement = $state() as HTMLInputElement;
 	let number_input: HTMLInputElement;
 
 	const id = `range_id_${_id++}`;
@@ -35,9 +35,8 @@
 	});
 
 	$effect(() => {
-		if (gradio.props.value == null) return;
+		if (gradio.props.value == null || !range_input) return;
 		range_input.style.setProperty("--range_progress", `${percentage}%`);
-		range_input.value = gradio.props.value.toString();
 	});
 
 	async function handle_change() {
@@ -63,7 +62,9 @@
 	// See the docs for an explanation: https://svelte.dev/docs/svelte-components#script-3-$-marks-a-statement-as-reactive
 	$effect(() => {
 		if (gradio.props.value != old_value) {
-			old_value = gradio.props.value;
+			untrack(() => {
+				old_value = gradio.props.value;
+			});
 			handle_change();
 		}
 	});
@@ -145,12 +146,12 @@
 				type="range"
 				{id}
 				name="cowbell"
-				bind:value={gradio.props.value}
-				bind:this={range_input}
 				min={gradio.props.minimum}
 				max={gradio.props.maximum}
-				on:input={handle_input}
 				step={gradio.props.step}
+				bind:value={gradio.props.value}
+				bind:this={range_input}
+				on:input={handle_input}
 				{disabled}
 				on:pointerup={handle_release}
 				aria-label={`range slider for ${gradio.shared.label}`}


### PR DESCRIPTION
## Summary
- Fixes UI freeze when updating Slider properties (visibility, min/max/value) via `gr.update()` or `gr.Slider()` constructor in callbacks
- **Root cause**: The `$effect` that synced `range_input.value` directly conflicted with Svelte's `bind:value` — when min/max changed simultaneously with value, the browser clamped to stale bounds, causing a reactive loop
- Three targeted fixes in `js/slider/Index.svelte`:
  1. Removed redundant `range_input.value` set (already handled by `bind:value`)
  2. Made `range_input` reactive (`$state`) with null guard so the CSS progress effect works correctly when visibility toggles
  3. Wrapped `old_value` write in `untrack()` to prevent unnecessary effect re-runs
  4. Reordered range input attributes so `min`/`max`/`step` are set before `bind:value`

Closes #12995

## Test plan
- [ ] Run `pnpm vitest run js/slider/` — unit tests pass
- [ ] Verify with reproduction scripts from #12995 (both `gr.update` and `gr.Slider` variants)
- [ ] Test slider still works normally: dragging, number input, reset button
- [ ] Test visibility toggle: hidden → visible with different min/max/value

🤖 Generated with [Claude Code](https://claude.com/claude-code)