### PR TITLE
fix: prevent DuplicateBlockError in multi-page apps with gr.render

### DIFF
--- a/gradio/renderable.py
+++ b/gradio/renderable.py
@@ -65,6 +65,15 @@ class Renderable:
         if blocks_config is None:
             raise ValueError("Reactive render must be inside a LocalContext.")
 
+        # Ensure Context.id is higher than any existing block ID in the session
+        # to prevent DuplicateBlockError in multi-page apps. When pages are
+        # merged, blocks from all pages share the same ID space, but Context.id
+        # may not reflect that (e.g. after a reload via `gradio app.py`).
+        if blocks_config.blocks:
+            max_existing_id = max(blocks_config.blocks.keys())
+            if Context.id <= max_existing_id:
+                Context.id = max_existing_id + 1
+
         fns_from_last_render: list[BlockFunction] = []
         for fn in blocks_config.fns.values():
             if fn.rendered_in is self:


### PR DESCRIPTION
## Summary
- Fixes `DuplicateBlockError` that occurs when using `gr.render` in multi-page apps launched via `gradio app.py`
- The root cause is that `Context.id` (the global block ID counter) can fall behind the highest block ID in the session's `blocks_config` after pages are merged, causing newly created blocks in `Renderable.apply()` to receive IDs that collide with existing blocks
- The fix ensures `Context.id` is set to at least `max(existing_block_ids) + 1` before creating new blocks in the render function

## Details
In a multi-page app, when `page1.demo.render()` and `page2.demo.render()` are called, blocks from both pages are merged into the root context's `blocks_config`. When the `load` event fires and triggers `Renderable.apply()`, new blocks are created via the user's render function (e.g. `gr.Markdown(...)`). These blocks get IDs from `Context.id`, which may not account for all merged block IDs — particularly after a module reload triggered by `gradio app.py`. This causes the `DuplicateBlockError` check in `Block.render()` to fail.

The fix adds a guard at the start of `Renderable.apply()` that bumps `Context.id` past the highest existing block ID in the session's config.

Closes #12078

## Test plan
- [ ] Create a multi-page app with `gr.render` as described in #12078
- [ ] Run with `gradio app.py` and verify no `DuplicateBlockError` on first page load
- [ ] Verify the rendered component (e.g. `gr.Markdown`) displays correctly
- [ ] Verify page refresh and code-change reloads still work correctly
- [ ] Verify single-page apps with `gr.render` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)