### PR TITLE
fix: lower clipboard icon z-index to prevent overlap with context menus

### DIFF
--- a/js/atoms/src/IconButtonWrapper.svelte
+++ b/js/atoms/src/IconButtonWrapper.svelte
@@ -46,7 +46,7 @@
 		flex-direction: row;
 		align-items: center;
 		justify-content: center;
-		z-index: var(--layer-2);
+		z-index: var(--layer-1);
 		gap: var(--spacing-sm);
 		box-shadow: var(--shadow-drop);
 		border: 1px solid var(--border-color-primary);


### PR DESCRIPTION
## Summary
- Fixes the clipboard/copy icon from `gr.JSON` and `gr.Markdown` overlapping the `gr.Dataframe` context menu
- Changed `z-index` in `IconButtonWrapper` from `var(--layer-2)` to `var(--layer-1)` to match the Dataframe CellMenu z-index level
- This aligns behavior with `gr.Textbox` and `gr.Number` copy buttons, which already render behind the context menu

Closes #11561

## Test plan
- [ ] Place a `gr.JSON(show_copy_button=True)` or `gr.Markdown(show_copy_button=True)` next to a `gr.Dataframe`
- [ ] Open the Dataframe context menu (click a cell or the 3-dot button)
- [ ] Verify the clipboard icon no longer appears above the context menu
- [ ] Verify copy button still functions correctly on JSON and Markdown components

🤖 Generated with [Claude Code](https://claude.com/claude-code)