### PR TITLE
fix: prevent duplicate select event dispatch in Dataframe component

### DIFF
--- a/js/dataframe/shared/utils/drag_utils.ts
+++ b/js/dataframe/shared/utils/drag_utils.ts
@@ -64,9 +64,7 @@ export function create_drag_handlers(
 	};
 
 	const end_drag = (event: MouseEvent): void => {
-		if (!state.is_dragging && state.drag_start) {
-			handle_cell_click(event, state.drag_start[0], state.drag_start[1]);
-		} else if (state.is_dragging && parent_element) {
+		if (state.is_dragging && parent_element) {
 			parent_element.focus();
 		}
 


### PR DESCRIPTION
## Summary

Fixes #12054

- The `select` event was being dispatched twice when clicking a Dataframe cell because `handle_cell_click` was called both on `mousedown` (in `start_drag`) and on `mouseup` (in `end_drag`) in `drag_utils.ts`
- Removed the redundant `handle_cell_click` call from `end_drag`, since `start_drag` already handles the cell click and select event dispatch for non-drag (simple click) interactions
- Drag selection behavior is preserved as `end_drag` only needs to clean up drag state and restore focus

## Test plan

- [ ] Click on a Dataframe cell and verify the `select` event handler (`fn` in `.select(fn=...)`) is called exactly once
- [ ] Verify drag-to-select multiple cells still works correctly
- [ ] Verify shift-click and ctrl/cmd-click selection still works
- [ ] Test with the reproduction script from the issue to confirm "clicked" is printed once per click