### PR TITLE
fix: prevent fill_height infinite growth with empty footer_links

### DIFF
--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -400,6 +400,7 @@
 
 	function handle_resize(): void {
 		if ("parentIFrame" in window) {
+			if (fill_height) return;
 			const box = root_container.children[0].getBoundingClientRect();
 			if (!box) return;
 			window.parentIFrame?.size(box.bottom + footer_height + 32);


### PR DESCRIPTION
## Summary

- Fixes #12992 — `fill_height` causes infinite vertical growth when `footer_links=[]` (e.g., on Hugging Face Spaces)
- Root cause: `ResizeObserver` calls `parentIFrame.size()` based on `getBoundingClientRect()`, which grows the iframe, which triggers another resize via the flex-grow layout — creating an infinite feedback loop
- When footer is present, it stabilizes the flex layout and prevents the loop; with `footer_links=[]` the footer is not rendered and nothing constrains growth
- Fix: skip `parentIFrame` resizing when `fill_height` is true, since `fill_height` semantics mean "fill available space" not "grow the container to fit content"

## Test plan

- [ ] Launch a Gradio app with `fill_height=True` (default for `ChatInterface`) and `footer_links=[]` — verify it no longer grows infinitely
- [ ] Launch a Gradio app with `fill_height=True` and default `footer_links` — verify normal behavior is preserved
- [ ] Launch a Gradio app with `fill_height=False` and `footer_links=[]` — verify iframe resizing still works
- [ ] Test on Hugging Face Spaces to confirm the fix in an iframe context

🤖 Generated with [Claude Code](https://claude.com/claude-code)