### PR TITLE
fix: skip iframe resize when fill_height is true

### DIFF
--- a/.changeset/fix-fill-height-iframe-growth.md
+++ b/.changeset/fix-fill-height-iframe-growth.md
@@ -1,0 +1,6 @@
+---
+"@gradio/core": patch
+"gradio": patch
+---
+
+fix:prevent infinite iframe growth when fill_height is true and footer_links is empty

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -400,6 +400,7 @@
 
 	function handle_resize(): void {
 		if ("parentIFrame" in window) {
+			if (fill_height) return;
 			const box = root_container.children[0].getBoundingClientRect();
 			if (!box) return;
 			window.parentIFrame?.size(box.bottom + footer_height + 32);


### PR DESCRIPTION
## Summary

- Fixes #12992
- When `fill_height=True` (default for `ChatInterface`) and `footer_links=[]`, the interface grows infinitely on HuggingFace Spaces
- Root cause: `ResizeObserver` fires `parentIFrame.size()` based on `getBoundingClientRect()`, which grows the iframe, which triggers flex layout to fill the new space, which fires the observer again -- a feedback loop. The footer normally breaks this cycle, but with no footer nothing constrains it.
- Fix: skip `parentIFrame` resizing when `fill_height` is true, since `fill_height` semantics mean "fill available space" not "grow the container to fit content"

## Test plan

- Launch with `fill_height=True` and `footer_links=[]` -- should no longer grow infinitely
- Launch with `fill_height=True` and default `footer_links` -- normal behavior preserved
- Launch with `fill_height=False` and `footer_links=[]` -- iframe resizing still works