### PR TITLE
fix: prevent infinite resize loop with `fill_height` when `footer_links=[]`

### DIFF
--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -392,6 +392,7 @@
 	let footer_height = 0;
 
 	let root_container: HTMLElement;
+	let last_reported_height: number | null = null;
 
 	function get_root_node(container: HTMLElement | null): HTMLElement | null {
 		if (!container) return null;
@@ -402,7 +403,10 @@
 		if ("parentIFrame" in window) {
 			const box = root_container.children[0].getBoundingClientRect();
 			if (!box) return;
-			window.parentIFrame?.size(box.bottom + footer_height + 32);
+			const new_height = box.bottom + footer_height + 32;
+			if (new_height === last_reported_height) return;
+			last_reported_height = new_height;
+			window.parentIFrame?.size(new_height);
 		}
 	}
 


### PR DESCRIPTION
Closing this — after further analysis I realized the height dedup approach doesn't actually stop the feedback loop, since `box.bottom` genuinely increases each cycle as the flex container stretches to fill the resized iframe. The core issue needs `parentIFrame.size()` to be skipped entirely when `fill_height` is true, not just deduplicated.

Sorry for the noise.