### PR TITLE
fix: prevent infinite resize loop when `footer_links=[]` on HuggingFace Spaces

### DIFF
--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -400,6 +400,15 @@
 
 	function handle_resize(): void {
 		if ("parentIFrame" in window) {
+			// When fill_height is active and footer is absent, skip resizing
+			// the parent iframe. fill_height means "fill available space", so
+			// asking the parent to resize creates a feedback loop: resize →
+			// iframe grows → content grows → resize again → infinite.
+			// The footer normally acts as a stable height anchor that breaks
+			// this loop, but with footer_links=[] it's removed from the DOM.
+			// See: gradio-app/gradio#12992
+			if (fill_height && footer_height === 0) return;
+
 			const box = root_container.children[0].getBoundingClientRect();
 			if (!box) return;
 			window.parentIFrame?.size(box.bottom + footer_height + 32);


### PR DESCRIPTION
## Summary

Fixes #12992 — `fill_height=True` combined with `footer_links=[]` causes the interface to grow infinitely on HuggingFace Spaces.

## Root Cause

`handle_resize()` in `Blocks.svelte` only runs when `"parentIFrame" in window` (HuggingFace Spaces iframe environment). It calculates `box.bottom + footer_height + 32` and calls `window.parentIFrame.size(new_height)` to tell HF to resize the iframe.

This creates a feedback loop:
1. `ResizeObserver` fires → calls `handle_resize()`
2. `handle_resize()` reports height → HF resizes the iframe
3. Iframe grows → `box.bottom` increases → `ResizeObserver` fires again
4. New height is bigger → reports again → infinite loop

When the footer exists, `footer_height` is bound to the footer's `clientHeight` via `bind:clientHeight={footer_height}`. The footer acts as a stable height anchor — once content + footer height settles, the resize stabilizes. But with `footer_links=[]`, the footer is removed from the DOM entirely (`{#if footer_links.length > 0}`), `footer_height` stays at 0, and there's nothing to break the feedback loop.

This explains the behavior reported in #12992:
- **Works locally** — no `parentIFrame`, so `handle_resize()` is a no-op
- **Works embedded on custom sites** — `is_embed=true` sets `fill_height=false`
- **Only breaks on HuggingFace Spaces** — `parentIFrame` exists and drives the resize

## Fix

When `fill_height` is active and there is no footer (`footer_height === 0`), skip the `parentIFrame.size()` call entirely.

This is semantically correct — `fill_height` means "fill the available space in the parent container", so asking the parent to resize to match the content height is contradictory and creates the feedback loop.

## Testing

Verified with a simulation test covering 4 scenarios:
- ✅ `fill_height=true, footer_links=[]` → resize loop prevented (0 resize cycles)
- ✅ `fill_height=true, footer present` → resize works normally
- ✅ `fill_height=false, no footer` → resize works normally  
- ✅ `fill_height=false, footer present` → completely unaffected