### PR TITLE
Fix: prevent infinite resize loop when footer_links=[] (fixes #12992)

### DIFF
--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -402,7 +402,8 @@
 		if ("parentIFrame" in window) {
 			const box = root_container.children[0].getBoundingClientRect();
 			if (!box) return;
-			window.parentIFrame?.size(box.bottom + footer_height + 32);
+			const iframe_padding = footer_links.length > 0 ? 32 : 0;
+			window.parentIFrame?.size(box.bottom + footer_height + iframe_padding);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- fix iframe resize feedback loop when `footer_links=[]` and `fill_height=True`
- only apply the extra iframe padding when footer links are actually rendered

## Root cause
`Blocks.svelte` always added an extra `+ 32` pixels when calling `window.parentIFrame.size(...)`.
With `footer_links=[]`, there is no footer, so this constant padding makes each resize event increase iframe height again, creating an infinite growth loop (especially visible on Hugging Face Spaces embeds).

## Fix
- in `js/core/src/Blocks.svelte`, compute `iframe_padding` dynamically:
  - `32` when footer links are present
  - `0` when footer is hidden (`footer_links=[]`)

## Reproduction
```python
import gradio as gr

def chatbot_response(message, history):
    return f"Hello, you said: {message}"

demo = gr.ChatInterface(chatbot_response, title="Infinite space")

if __name__ == "__main__":
    demo.launch(footer_links=[])
```

Fixes #12992
