### PR TITLE
fix: Prevent double triggering of select event for Dataframe.

### DIFF
--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -772,7 +772,8 @@
 	const drag_state: DragState = {
 		is_dragging,
 		drag_start,
-		mouse_down_pos
+		mouse_down_pos,
+		click_handled: false
 	};
 
 	$: {

--- a/js/dataframe/shared/utils/drag_utils.ts
+++ b/js/dataframe/shared/utils/drag_utils.ts
@@ -5,6 +5,7 @@ export type DragState = {
 	is_dragging: boolean;
 	drag_start: CellCoordinate | null;
 	mouse_down_pos: { x: number; y: number } | null;
+	click_handled: boolean;
 };
 
 export type DragHandlers = {
@@ -39,13 +40,13 @@ export function create_drag_handlers(
 		event.preventDefault();
 		event.stopPropagation();
 
+		state.click_handled = false;
 		state.mouse_down_pos = { x: event.clientX, y: event.clientY };
 		state.drag_start = [row, col];
 
 		if (!event.shiftKey && !event.metaKey && !event.ctrlKey) {
 			set_selected_cells([[row, col]]);
 			set_selected([row, col]);
-			handle_cell_click(event, row, col);
 		}
 	};
 
@@ -64,16 +65,27 @@ export function create_drag_handlers(
 	};
 
 	const end_drag = (event: MouseEvent): void => {
-		if (!state.is_dragging && state.drag_start) {
-			handle_cell_click(event, state.drag_start[0], state.drag_start[1]);
-		} else if (state.is_dragging && parent_element) {
-			parent_element.focus();
-		}
+		const was_dragging = state.is_dragging;
+		const drag_coords = state.drag_start;
 
 		state.is_dragging = false;
 		set_is_dragging(false);
 		state.drag_start = null;
 		state.mouse_down_pos = null;
+
+		if (drag_coords && !state.click_handled) {
+			const cell = (event.target as HTMLElement).closest("td");
+			const end_row = cell ? parseInt(cell.getAttribute("data-row") || "-1") : -1;
+			const end_col = cell ? parseInt(cell.getAttribute("data-col") || "-1") : -1;
+			const same_cell =
+				end_row === drag_coords[0] && end_col === drag_coords[1];
+			if (!was_dragging || same_cell) {
+				state.click_handled = true;
+				handle_cell_click(event, drag_coords[0], drag_coords[1]);
+			} else if (parent_element) {
+				parent_element.focus();
+			}
+		}
 	};
 
 	return {


### PR DESCRIPTION
Fixes #12054

## Description

The `select` event was being triggered twice when clicking a cell in the Dataframe component. 
Both `mousedown` and `mouseup` events were calling `handle_cell_click`, 
causing the event handler to fire twice per user interaction.

Changes:
- Introduced a `click_handled` flag in `DragState` to ensure the click
  is only processed once per user interaction
- Updated `end_drag` to check `click_handled` before calling
  `handle_cell_click`
- Added a `same_cell` check to prevent redundant calls when clicking
  on the same cell after a drag event

Closes: #12054 

## AI Disclosure

- [x] I did not use AI

## 🎯 PRs Should Target Issues

Closes #12054 