### PR TITLE
fix(dataframe): prevent freeze when selecting cell with Ctrl key

### DIFF
--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -768,11 +768,13 @@
 	let is_dragging = false;
 	let drag_start: [number, number] | null = null;
 	let mouse_down_pos: { x: number; y: number } | null = null;
+	let handled_cell_click = false;
 
 	const drag_state: DragState = {
 		is_dragging,
 		drag_start,
-		mouse_down_pos
+		mouse_down_pos,
+		handled_cell_click
 	};
 
 	$: {

--- a/js/dataframe/shared/utils/drag_utils.ts
+++ b/js/dataframe/shared/utils/drag_utils.ts
@@ -5,6 +5,7 @@ export type DragState = {
 	is_dragging: boolean;
 	drag_start: CellCoordinate | null;
 	mouse_down_pos: { x: number; y: number } | null;
+	handled_cell_click: boolean;
 };
 
 export type DragHandlers = {
@@ -41,11 +42,13 @@ export function create_drag_handlers(
 
 		state.mouse_down_pos = { x: event.clientX, y: event.clientY };
 		state.drag_start = [row, col];
+		state.handled_cell_click = false;
 
 		if (!event.shiftKey && !event.metaKey && !event.ctrlKey) {
 			set_selected_cells([[row, col]]);
 			set_selected([row, col]);
 			handle_cell_click(event, row, col);
+			state.handled_cell_click = true;
 		}
 	};
 
@@ -64,7 +67,7 @@ export function create_drag_handlers(
 	};
 
 	const end_drag = (event: MouseEvent): void => {
-		if (!state.is_dragging && state.drag_start) {
+		if (!state.is_dragging && state.drag_start && !state.handled_cell_click) {
 			handle_cell_click(event, state.drag_start[0], state.drag_start[1]);
 		} else if (state.is_dragging && parent_element) {
 			parent_element.focus();
@@ -74,6 +77,7 @@ export function create_drag_handlers(
 		set_is_dragging(false);
 		state.drag_start = null;
 		state.mouse_down_pos = null;
+		state.handled_cell_click = false;
 	};
 
 	return {


### PR DESCRIPTION
## Description

Fixes a freeze that occurred when selecting a cell in `gr.DataFrame` by clicking (mousedown), then pressing Ctrl, then releasing the mouse (mouseup).

**Root Cause:**
The \`handle_cell_click\` function was being called twice during this interaction:
1. On mousedown (without Ctrl): selected the cell
2. On mouseup (with Ctrl pressed): called again due to drag state tracking, but with \`ctrlKey=true\` in the event, causing toggle behavior that led to inconsistent state

**Fix:**
Added a \`handled_cell_click\` flag to \`DragState\` to track when \`handle_cell_click\` has already been invoked during \`start_drag\`, preventing duplicate calls in \`end_drag\`.

Closes: #13020

## AI Disclosure

- [ ] I used AI to...
- [x] I did not use AI