### PR TITLE
fix(timer): timer not updating reliably after second value change

### DIFF
--- a/.changeset/fix-timer-reliability.md
+++ b/.changeset/fix-timer-reliability.md
@@ -1,0 +1,9 @@
+---
+"@gradio/timer": patch
+---
+
+fix: Timer not updating reliably after second value change
+
+Fixed an issue where the Timer component's value could not be updated reliably
+after the second update. The fix ensures that changes to the timer's interval
+value and active state are properly tracked and applied.

--- a/js/timer/Index.svelte
+++ b/js/timer/Index.svelte
@@ -6,18 +6,36 @@
 	const props = $props();
 	const gradio = new Gradio<TimerEvents, TimerProps>(props);
 
-	let interval: NodeJS.Timeout | undefined = undefined;
+	let interval: ReturnType<typeof setInterval> | undefined = undefined;
 
+	// Use local reactive state to ensure the effect properly tracks changes
+	let timer_value = $state(gradio.props.value);
+	let timer_active = $state(gradio.props.active);
+
+	// Sync local state with gradio props when they change
 	$effect(() => {
-		if (interval) clearInterval(interval);
-		if (gradio.props.active) {
+		timer_value = gradio.props.value;
+		timer_active = gradio.props.active;
+	});
+
+	// Manage the interval based on active state and value
+	$effect(() => {
+		// Clear any existing interval
+		if (interval) {
+			clearInterval(interval);
+			interval = undefined;
+		}
+
+		// Only start a new interval if the timer is active
+		if (timer_active && timer_value > 0) {
 			interval = setInterval(() => {
 				if (document.visibilityState === "visible") {
 					gradio.dispatch("tick");
 				}
-			}, gradio.props.value * 1000);
+			}, timer_value * 1000);
 		}
 	});
+
 	onDestroy(() => {
 		if (interval) clearInterval(interval);
 	});


### PR DESCRIPTION
## Description

Fixed the Timer component not updating its interval value reliably after the second update. The issue was caused by improper reactivity tracking in Svelte 5.

Changes:
- Use explicit local `$state` variables for `timer_value` and `timer_active`
- Separate effects for syncing state from gradio props and managing the interval
- Add validation to ensure timer_value > 0 before starting interval  
- Improve cleanup by explicitly setting interval to undefined after clearing

Closes: #13022

## AI Disclosure

- [x] I used AI to assist with this contribution

## 🎯 PRs Should Target Issues

This PR targets issue #13022 which describes the Timer not updating reliably.
