### PR TITLE
fix(dataframe): prevent interface freeze on cell selection with Ctrl

### DIFF
--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -772,7 +772,8 @@
 	const drag_state: DragState = {
 		is_dragging,
 		drag_start,
-		mouse_down_pos
+		mouse_down_pos,
+		click_handled: false
 	};
 
 	$: {

--- a/js/dataframe/shared/utils/drag_utils.ts
+++ b/js/dataframe/shared/utils/drag_utils.ts
@@ -5,6 +5,7 @@ export type DragState = {
 	is_dragging: boolean;
 	drag_start: CellCoordinate | null;
 	mouse_down_pos: { x: number; y: number } | null;
+	click_handled: boolean;
 };
 
 export type DragHandlers = {
@@ -41,11 +42,13 @@ export function create_drag_handlers(
 
 		state.mouse_down_pos = { x: event.clientX, y: event.clientY };
 		state.drag_start = [row, col];
+		state.click_handled = false;
 
 		if (!event.shiftKey && !event.metaKey && !event.ctrlKey) {
 			set_selected_cells([[row, col]]);
 			set_selected([row, col]);
 			handle_cell_click(event, row, col);
+			state.click_handled = true;
 		}
 	};
 
@@ -64,7 +67,9 @@ export function create_drag_handlers(
 	};
 
 	const end_drag = (event: MouseEvent): void => {
-		if (!state.is_dragging && state.drag_start) {
+		if (!state.is_dragging && state.drag_start && !state.click_handled) {
+			// If the cell wasn't already processed during mousedown (due to modifier keys),
+			// handle it now on mouseup
 			handle_cell_click(event, state.drag_start[0], state.drag_start[1]);
 		} else if (state.is_dragging && parent_element) {
 			parent_element.focus();
@@ -74,6 +79,7 @@ export function create_drag_handlers(
 		set_is_dragging(false);
 		state.drag_start = null;
 		state.mouse_down_pos = null;
+		state.click_handled = false;
 	};
 
 	return {


### PR DESCRIPTION
## Description

Fixes #13020

When selecting a DataFrame cell with mousedown, then pressing Ctrl before mouseup, the interface would freeze. This happened because `handle_cell_click` was being called twice - once during mousedown and once during mouseup - causing conflicting selection state updates.

## Changes

- Added a `click_handled` flag to `DragState` to track whether the cell click has already been processed during mousedown
- Modified `end_drag` to only call `handle_cell_click` if it wasn't already handled during mousedown
- This prevents duplicate handling when modifier keys (Ctrl/Shift/Meta) are pressed after mousedown but before mouseup

## Testing

The fix ensures that:
1. Normal clicks work as expected (select cell, enter edit mode)
2. Ctrl+click works as expected (toggle cell selection for multi-select)
3. Pressing Ctrl after mousedown but before mouseup no longer causes a freeze

## Checklist

- [x] I have read and followed the contributing guidelines
- [x] The code follows the project's style guidelines
- [x] The changes are minimal and focused on the fix
