### PR TITLE
fix(timer): ensure reliable state updates

### DIFF
--- a/js/timer/Index.svelte
+++ b/js/timer/Index.svelte
@@ -1,24 +1,25 @@
 <script lang="ts">
-	import { onDestroy } from "svelte";
 	import type { TimerProps, TimerEvents } from "./types";
 	import { Gradio } from "@gradio/utils";
 
 	const props = $props();
 	const gradio = new Gradio<TimerEvents, TimerProps>(props);
 
-	let interval: NodeJS.Timeout | undefined = undefined;
+	let interval: NodeJS.Timeout | undefined = $state(undefined);
+	const active = $derived(gradio.props.active);
+	const value = $derived(gradio.props.value);
 
 	$effect(() => {
 		if (interval) clearInterval(interval);
-		if (gradio.props.active) {
+		if (active) {
 			interval = setInterval(() => {
 				if (document.visibilityState === "visible") {
 					gradio.dispatch("tick");
 				}
-			}, gradio.props.value * 1000);
+			}, value * 1000);
 		}
-	});
-	onDestroy(() => {
-		if (interval) clearInterval(interval);
+		return () => {
+			if (interval) clearInterval(interval);
+		};
 	});
 </script>


### PR DESCRIPTION
## Description

Fixes #13022

The Timer component's interval was not updating reliably when the value prop changed multiple times. This was due to improper reactivity tracking in Svelte 5.

## Changes

- Made interval variable reactive using `$state()`
- Added `$derived()` for `active` and `value` props to ensure explicit dependency tracking  
- Replaced `onDestroy` with effect cleanup function for proper interval cleanup on dependency changes

## Root Cause

The original implementation used a regular variable for `interval` and accessed `gradio.props.value` and `gradio.props.active` directly in the `$effect`. In Svelte 5, this didn't reliably track dependencies when the props object was mutated rather than replaced.

By using `$derived()` to create explicit reactive declarations for these values, the `$effect` now correctly re-runs whenever they change.

## Testing

The fix ensures the timer interval correctly updates every time the value or active props change, not just the first time. This matches the expected behavior described in #13022 where the timer should switch between 10s and 0.1s intervals reliably.