### PR TITLE
fix: allow Backspace/Delete in Dataframe header edit mode

### DIFF
--- a/js/dataframe/shared/utils/keyboard_utils.ts
+++ b/js/dataframe/shared/utils/keyboard_utils.ts
@@ -96,6 +96,7 @@ function handle_delete_operation(
 	const state = get(ctx.state);
 	if (!state.config.editable) return false;
 	if (event.key !== "Delete" && event.key !== "Backspace") return false;
+	if (state.ui_state.header_edit !== false) return false;
 
 	const editing = state.ui_state.editing;
 	const selected_cells = state.ui_state.selected_cells;


### PR DESCRIPTION
## Description

Pressing Backspace or Delete while editing a column header in the Dataframe component does nothing — the keypress is swallowed.

The root cause is in `handle_keydown()` in `keyboard_utils.ts`. When a header is being edited (`header_edit !== false`), the call chain goes:

1. `handle_header_navigation` returns `false` (line 55) — by design, it doesn't handle text-editing keys when `header_edit` is active
2. `handle_delete_operation` is called next and matches on Backspace/Delete (line 98)
3. Since `editing` (the *cell* editing state) is `false` during header editing, the guard block at lines 108-123 is skipped entirely
4. Execution reaches `event.preventDefault()` at line 125, which blocks the keypress from reaching the header's `<textarea>`

The fix adds one guard at the top of `handle_delete_operation`: if `header_edit` is active, return `false` immediately so the event propagates to the textarea.

### Changes

- `js/dataframe/shared/utils/keyboard_utils.ts`: Added `if (state.ui_state.header_edit !== false) return false;` after the key check in `handle_delete_operation`

Closes #12441