### PR TITLE
fix: use component default when frontend sends None on load (fixes #12095)

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1770,6 +1770,8 @@ Received inputs:
                 value_to_process = (
                     inputs[i].get("value", None) if is_prop_input else inputs[i]
                 )
+                if value_to_process is None and hasattr(block, "value") and block.value is not None:
+                    value_to_process = block.value
 
                 inputs_cached = await processing_utils.async_move_files_to_cache(
                     value_to_process,

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1241,6 +1241,23 @@ class TestUpdate:
         }
 
 
+
+@pytest.mark.asyncio
+async def test_none_input_uses_component_default_on_load():
+    """When frontend sends None (e.g. hot reload before hydration), use component default."""
+    user_data = {"user_1": "Alice", "user_2": "Bob"}
+
+    def display(user_id):
+        return user_data.get(user_id, "Unknown")
+
+    with gr.Blocks() as demo:
+        user_id = gr.Dropdown(choices=["user_1", "user_2"], value="user_1", label="User")
+        out = gr.Textbox()
+        gr.on([user_id.change, demo.load], display, user_id, out)
+
+    result = await demo.process_api(block_fn=0, inputs=[None], request=None, state=None)
+    assert result["data"][0] == "Alice"
+
 @pytest.mark.asyncio
 async def test_root_path():
     image_file = pathlib.Path(__file__).parent / "test_files" / "bus.png"


### PR DESCRIPTION
## Summary

Fixes #12095.

**Root cause:** On hot reload, the load event fires before the frontend has hydrated component values. The frontend sends `None` for input components, causing callbacks (e.g. `gr.on([demo.load, dropdown.change], fn, dropdown, output)`) to receive `None` and crash with `KeyError` when the function expects a valid value.

**Fix:** In `preprocess_data`, when the received input value is `None` and the component has a default value (`block.value`), use the component's default instead of passing `None` through.

## Changes

- `gradio/blocks.py`: Fall back to `block.value` when `value_to_process` is `None` and the component has a default
- `test/test_blocks.py`: Added `test_none_input_uses_component_default_on_load` covering the scenario

## Testing

- Verified the fix addresses the reported scenario in #12095
- Added 1 test covering: `process_api` with `None` input when component has default value
- Change is minimal and follows existing code patterns
- No unrelated changes included

Made with [Cursor](https://cursor.com)