### PR TITLE
fix: pass through dropdown value when not in choices for cascading dropdowns (fixes #12246)

### DIFF
--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -200,6 +200,9 @@ class Dropdown(FormComponent):
             return None
 
         choice_values = [value for _, value in self.choices]
+        # When value is not in choices (e.g. cascading dropdowns where parent changed
+        # options), pass through to handler instead of raising. Handler can return
+        # updated component with correct value. Fixes #12246.
         if not self.allow_custom_value:
             if isinstance(payload, list):
                 for value in payload:
@@ -208,9 +211,9 @@ class Dropdown(FormComponent):
                             f"Value: {value!r} (type: {type(value)}) is not in the list of choices: {choice_values}"
                         )
             elif payload not in choice_values:
-                raise Error(
-                    f"Value: {payload} is not in the list of choices: {choice_values}"
-                )
+                # Pass through to allow handlers to process stale values from
+                # parent-triggered updates (e.g. country/city cascading dropdowns)
+                pass
 
         if self.type == "value":
             return payload

--- a/test/components/test_dropdown.py
+++ b/test/components/test_dropdown.py
@@ -32,8 +32,8 @@ class TestDropdown:
         assert dropdown.preprocess("a") == 0
         assert dropdown.preprocess("b") == 1
         assert dropdown.value == "a"
-        with pytest.raises(gr.Error):
-            dropdown.preprocess("c")
+        # Value not in choices: pass through to handler (fixes #12246 cascading dropdowns)
+        assert dropdown.preprocess("c") is None
 
         dropdown = gr.Dropdown(choices=["a", "b"], type="index", multiselect=True)
         assert dropdown.preprocess(["a"]) == [0]


### PR DESCRIPTION
## Summary
Fixes #12246

When a parent dropdown (e.g. country) changes and triggers an update to a child dropdown (e.g. city), the child receives the previous value as input. The child's choices may have been updated from a previous response, causing preprocess to raise `Value not in list of choices`.

## Root Cause
The Dropdown `preprocess` method raised an error when the incoming value was not in the current choices. In cascading dropdowns (country/city), when the user changes country, the frontend sends the old city value. The backend's child dropdown may already have the new country's cities as choices from a previous update. Preprocess rejected the stale value before the handler could process it.

## Fix
Pass through the value to the handler when it is not in choices (single-value case). The handler can then return the updated component with the correct value.

## Changes
- gradio/components/dropdown.py: When value not in choices, pass through instead of raising (single-value case)
- test/components/test_dropdown.py: Updated test to expect pass-through behavior

Made with [Cursor](https://cursor.com)