### PR TITLE
Fix Tab interactive property not updating to True

### DIFF
--- a/js/tabs/shared/Tabs.svelte
+++ b/js/tabs/shared/Tabs.svelte
@@ -60,6 +60,7 @@
 	setContext(TABS, {
 		register_tab: (tab: Tab, order: number) => {
 			tabs[order] = tab;
+			tabs = tabs;
 
 			if ($selected_tab === false && tab.visible !== false && tab.interactive) {
 				$selected_tab = tab.id;
@@ -72,6 +73,7 @@
 				$selected_tab = tabs[0]?.id || false;
 			}
 			tabs[order] = null;
+			tabs = tabs;
 		},
 		selected_tab,
 		selected_tab_index

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -714,6 +714,36 @@ class TestBlocksPostprocessing:
             assert output["data"][1] == {"__type__": "update", "interactive": True}
 
     @pytest.mark.asyncio
+    async def test_tab_interactive_update(self):
+        """Test that Tab interactive property can be toggled from False to True."""
+
+        def unlock():
+            return gr.Tab(interactive=True)
+
+        def lock():
+            return gr.Tab(interactive=False)
+
+        with gr.Blocks() as demo:
+            with gr.Tab("tab1", id="tab1"):
+                btn_unlock = gr.Button("Unlock")
+                btn_lock = gr.Button("Lock")
+            with gr.Tab("Locked", id="tab2", interactive=False) as tab2:
+                gr.Markdown("Unlocked content")
+
+            btn_unlock.click(unlock, None, tab2)
+            btn_lock.click(lock, None, tab2)
+
+        # Unlock: interactive=False -> True
+        output = await demo.process_api(0, [], state=None)
+        assert output["data"][0]["interactive"] is True
+        assert output["data"][0]["__type__"] == "update"
+
+        # Lock: interactive=True -> False
+        output = await demo.process_api(1, [], state=None)
+        assert output["data"][0]["interactive"] is False
+        assert output["data"][0]["__type__"] == "update"
+
+    @pytest.mark.asyncio
     async def test_error_raised_if_num_outputs_is_too_low(self):
         with gr.Blocks() as demo:
             textbox1 = gr.Textbox()


### PR DESCRIPTION
## Summary
- Fixes #13033: When a `Tab` is initialized with `interactive=False`, updating it to `interactive=True` via an event handler had no effect on the UI
- **Root cause**: In `Tabs.svelte`, the `register_tab` callback mutates the `tabs` array via `tabs[order] = tab` inside a closure. Svelte's compiler does not instrument array element assignments inside closures for reactivity, so the tab buttons never re-render with the updated `interactive`/`disabled` state
- **Fix**: Added `tabs = tabs` self-assignment after mutation in both `register_tab` and `unregister_tab` to force Svelte reactivity. This is the standard Svelte pattern for triggering updates after array/object mutation

## Test plan
- [ ] Added Python test `test_tab_interactive_update` verifying the update payload is correctly produced when toggling Tab interactive between `True` and `False`
- [ ] Manual test: create a demo with `interactive=False` Tab, click button to set `interactive=True`, verify the tab becomes clickable without needing a visibility toggle workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)