### PR TITLE
fix: Tab initialized with interactive=False cannot be updated to True

### DIFF
--- a/js/tabs/shared/Tabs.svelte
+++ b/js/tabs/shared/Tabs.svelte
@@ -32,6 +32,26 @@
 
 	$: has_tabs = tabs.length > 0;
 
+	// Keep visible_tabs and overflow_tabs in sync with tabs data.
+	// handle_menu_overflow determines which tabs go into which list (based on
+	// DOM measurements), but it is async (awaits tick()) so property updates
+	// like interactive changes can be missed. This reactive block ensures the
+	// tab objects inside visible_tabs/overflow_tabs stay current.
+	$: {
+		if (tabs) {
+			visible_tabs = visible_tabs.map((vt) => {
+				if (!vt) return vt;
+				const updated = tabs.find((t) => t?.id === vt.id);
+				return updated ?? vt;
+			});
+			overflow_tabs = overflow_tabs.map((ot) => {
+				if (!ot) return ot;
+				const updated = tabs.find((t) => t?.id === ot.id);
+				return updated ?? ot;
+			});
+		}
+	}
+
 	let tab_nav_el: HTMLDivElement;
 
 	const selected_tab = writable<false | number | string>(


### PR DESCRIPTION
## Summary
- Fixes #13033: When a `gr.Tab` is created with `interactive=False`, calling `gr.Tab(interactive=True)` as an update does not work
- Root cause: the `visible_tabs` and `overflow_tabs` arrays (which the template renders from) retained stale tab objects after `register_tab` updated the canonical `tabs` array. These derived arrays are only refreshed by the async `handle_menu_overflow` function, and unlike `visible` changes, `interactive` changes don't trigger DOM structural changes that would cascade into re-running overflow logic.
- Fix: adds a synchronous reactive block that keeps `visible_tabs` and `overflow_tabs` tab objects in sync with the `tabs` array whenever any tab property changes

## Test plan
- [ ] Create a Gradio app with a Tab initialized with `interactive=False`
- [ ] Trigger an update to set `interactive=True` via button click
- [ ] Verify the tab becomes clickable without needing a visibility toggle workaround
- [ ] Verify existing tab overflow behavior is unaffected