### PR TITLE
fix: Tab interactivity not updating when changed via event handler (#13033)

### DIFF
--- a/js/tabs/shared/Tabs.svelte
+++ b/js/tabs/shared/Tabs.svelte
@@ -60,6 +60,8 @@
 	setContext(TABS, {
 		register_tab: (tab: Tab, order: number) => {
 			tabs[order] = tab;
+			// Force Svelte reactivity: create new array reference
+			tabs = [...tabs];
 
 			if ($selected_tab === false && tab.visible !== false && tab.interactive) {
 				$selected_tab = tab.id;
@@ -72,6 +74,7 @@
 				$selected_tab = tabs[0]?.id || false;
 			}
 			tabs[order] = null;
+			tabs = [...tabs];
 		},
 		selected_tab,
 		selected_tab_index


### PR DESCRIPTION
## Problem

When a Tab is initialized with `interactive=False`, it cannot be updated to `interactive=True` via an event handler. The UI remains frozen with the tab still disabled.

**Reproduction:** [#13033](https://github.com/gradio-app/gradio/issues/13033)

## Root Cause

In `js/tabs/shared/Tabs.svelte`, the `register_tab` function mutates the `tabs` array in-place (`tabs[order] = tab`). Svelte's reactivity system does not detect in-place array element mutations, so:

1. `visible_tabs` and `overflow_tabs` (derived from `tabs`) never recalculate
2. The `disabled` attribute on tab buttons remains stale

## Fix

After each in-place array mutation in `register_tab` and `unregister_tab`, create a new array reference (`tabs = [...tabs]`) to trigger Svelte's reactive dependency tracking. This ensures that when tab properties like `interactive` change, the UI properly reflects the update.

## Changes

- `js/tabs/shared/Tabs.svelte`: Add `tabs = [...tabs]` after mutations in `register_tab` and `unregister_tab`
