### PR TITLE
Add blogs to the website

### DIFF
--- a/.changeset/solid-heads-smoke.md
+++ b/.changeset/solid-heads-smoke.md
@@ -1,0 +1,5 @@
+---
+"website": minor
+---
+
+feat:Add blogs to the website

--- a/blogs/01_announcements/01_welcome-to-the-gradio-blog.md
+++ b/blogs/01_announcements/01_welcome-to-the-gradio-blog.md
@@ -1,0 +1,26 @@
+# Welcome to the Gradio Blog
+
+Author: Gradio Team
+Date: 2026-03-20
+Tags: announcement, community
+
+We're excited to launch the official Gradio blog! This is where we'll share updates, tutorials, deep dives, and community highlights from across the Gradio ecosystem.
+
+## What to Expect
+
+The Gradio blog will be your go-to source for:
+
+- **Product announcements** — new features, releases, and roadmap updates
+- **Tutorials** — step-by-step guides for building with Gradio
+- **Community spotlights** — showcasing what the community is building
+- **Technical deep dives** — behind-the-scenes looks at how Gradio works
+
+## Why a Blog?
+
+While our [Guides](/guides) cover how to use Gradio's features, the blog is a space for longer-form content that goes beyond documentation. Think of it as the place where we share our thinking, highlight interesting use cases, and connect with the broader ML community.
+
+## Stay Connected
+
+Follow us on [Twitter](https://twitter.com/Gradio) and join our [Discord](https://discord.gg/feTf9x3ZSB) to stay up to date with the latest posts.
+
+We can't wait to share what's coming next. Stay tuned!

--- a/blogs/01_announcements/02_gradio-5-launch.md
+++ b/blogs/01_announcements/02_gradio-5-launch.md
@@ -1,0 +1,47 @@
+# Gradio 5: A New Era for ML Demos
+
+Author: Gradio Team
+Date: 2026-03-21
+Tags: announcement, release, gradio-5
+
+Gradio 5 represents a major leap forward in how developers build and share machine learning applications. In this post, we'll walk through the highlights and what they mean for you.
+
+## Performance That Speaks for Itself
+
+Gradio 5 is built on a completely revamped architecture that delivers significant performance improvements:
+
+- **Faster load times** — Apps now start up to 3x faster thanks to optimized component bundling
+- **Smaller bundle sizes** — We've reduced the default JavaScript payload by over 40%
+- **Streaming improvements** — Real-time applications feel smoother with reduced latency
+
+## A Refreshed Design System
+
+The default theme in Gradio 5 has been redesigned from the ground up. Components look more polished, spacing is more consistent, and the overall feel is more modern — all while maintaining the simplicity that makes Gradio approachable.
+
+## Enhanced Developer Experience
+
+We've invested heavily in making the development workflow smoother:
+
+- **Hot reload** now works reliably across all component types
+- **Error messages** are clearer and more actionable
+- **Type hints** are comprehensive, so your editor can help you write correct code faster
+
+## Custom Components, Evolved
+
+The custom components ecosystem in Gradio 5 is more powerful than ever. Building, publishing, and sharing components is streamlined, and the API surface is cleaner.
+
+```python
+import gradio as gr
+
+demo = gr.Interface(
+    fn=lambda x: f"Hello, {x}!",
+    inputs=gr.Textbox(label="Your Name"),
+    outputs=gr.Textbox(label="Greeting"),
+)
+
+demo.launch()
+```
+
+## What's Next
+
+We're just getting started. Expect more posts diving deeper into individual features, migration guides, and community showcases. If you haven't already, [upgrade to Gradio 5](https://pypi.org/project/gradio/) and let us know what you think!

--- a/blogs/02_tutorials/01_building-ai-apps-in-minutes.md
+++ b/blogs/02_tutorials/01_building-ai-apps-in-minutes.md
@@ -1,0 +1,66 @@
+# Building AI Apps in Minutes with Gradio
+
+Author: Gradio Team
+Date: 2026-03-18
+Tags: tutorial, getting-started, beginner
+
+One of the most common questions we hear from ML practitioners is: "I have a model — how do I let people try it?" The answer is Gradio. In this post, we'll show you how to go from a Python function to a shareable web app in under five minutes.
+
+## The Simplest Possible App
+
+Let's start with the absolute basics. If you have a function, you have an app:
+
+```python
+import gradio as gr
+
+def greet(name):
+    return f"Hello, {name}! Welcome to Gradio."
+
+demo = gr.Interface(fn=greet, inputs="text", outputs="text")
+demo.launch()
+```
+
+That's it. Three lines of Gradio code and you have a working web application with a text input, a submit button, and a text output.
+
+## Adding an ML Model
+
+Now let's make it interesting. Here's a sentiment analysis app using a Hugging Face model:
+
+```python
+import gradio as gr
+from transformers import pipeline
+
+classifier = pipeline("sentiment-analysis")
+
+def analyze(text):
+    result = classifier(text)[0]
+    return f"{result['label']} ({result['score']:.2%})"
+
+demo = gr.Interface(
+    fn=analyze,
+    inputs=gr.Textbox(label="Enter text to analyze", lines=3),
+    outputs=gr.Textbox(label="Sentiment"),
+    title="Sentiment Analyzer",
+    description="Enter any text and the model will predict its sentiment."
+)
+
+demo.launch()
+```
+
+## Sharing Your App
+
+Once your app is running locally, sharing it with the world is one flag away:
+
+```python
+demo.launch(share=True)
+```
+
+This creates a public URL that anyone can access for 72 hours — no deployment, no infrastructure, no configuration.
+
+## Going Further
+
+For production deployments, you can host your Gradio apps on [Hugging Face Spaces](https://huggingface.co/spaces) for free. Just push your code to a Space repository and it will be automatically built and deployed.
+
+Check out our [Quickstart Guide](/guides/quickstart) for more details, or explore the [API documentation](/docs) to see all the components and options available to you.
+
+Happy building!

--- a/blogs/02_tutorials/02_deploying-gradio-apps-to-production.md
+++ b/blogs/02_tutorials/02_deploying-gradio-apps-to-production.md
@@ -1,0 +1,89 @@
+# Deploying Gradio Apps to Production
+
+Author: Gradio Team
+Date: 2026-03-19
+Tags: tutorial, deployment, production
+
+You've built a Gradio app and it works great locally. Now what? In this post, we'll cover the most common ways to deploy your Gradio app so that it's accessible to your users around the clock.
+
+## Option 1: Hugging Face Spaces
+
+The easiest path to production is [Hugging Face Spaces](https://huggingface.co/spaces). It's free for basic usage and requires minimal configuration.
+
+Create a `requirements.txt` with your dependencies, write your `app.py`, and push to a Space repository:
+
+```bash
+# Create a new Space
+huggingface-cli repo create my-gradio-app --type space --space-sdk gradio
+
+# Clone and add your code
+git clone https://huggingface.co/spaces/your-username/my-gradio-app
+cd my-gradio-app
+# Add your app.py and requirements.txt
+git add . && git commit -m "Initial commit" && git push
+```
+
+Your app will be live within minutes at `https://huggingface.co/spaces/your-username/my-gradio-app`.
+
+## Option 2: Docker
+
+For more control over your deployment environment, Docker is a solid choice:
+
+```dockerfile
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 7860
+CMD ["python", "app.py"]
+```
+
+Make sure your app launches on the right host and port:
+
+```python
+demo.launch(server_name="0.0.0.0", server_port=7860)
+```
+
+## Option 3: Cloud Platforms
+
+Gradio apps are standard Python web applications under the hood, so they work anywhere you can run Python:
+
+- **AWS** — Deploy on EC2, ECS, or Lambda (with some constraints)
+- **GCP** — Cloud Run is a great fit for containerized Gradio apps
+- **Azure** — App Service or Container Instances both work well
+
+## Production Considerations
+
+When moving to production, keep these in mind:
+
+### Authentication
+
+Gradio supports basic authentication out of the box:
+
+```python
+demo.launch(auth=("admin", "your-secure-password"))
+```
+
+For more sophisticated auth, consider putting Gradio behind a reverse proxy like Nginx with your own authentication layer.
+
+### Scaling
+
+Gradio apps handle concurrent users well, but for high-traffic applications:
+
+- Use the `max_threads` parameter to control concurrency
+- Consider running multiple replicas behind a load balancer
+- Enable request queuing with `demo.queue()` for long-running predictions
+
+### Monitoring
+
+Keep an eye on your app's health by checking the built-in `/info` endpoint and integrating with your existing monitoring tools.
+
+## Wrapping Up
+
+There's no single "right" way to deploy a Gradio app — it depends on your scale, budget, and infrastructure preferences. For most use cases, Hugging Face Spaces is the fastest path. For enterprise deployments, Docker with your cloud provider of choice gives you the most flexibility.
+
+Check out the [Sharing Your App guide](/guides/sharing-your-app) for more details on deployment options.

--- a/js/_website/generate_jsons/generate.py
+++ b/js/_website/generate_jsons/generate.py
@@ -6,7 +6,7 @@ import boto3
 from botocore import UNSIGNED
 from botocore.client import Config
 
-from src import changelog, demos, docs, guides
+from src import blogs, changelog, demos, docs, guides
 
 WEBSITE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 GRADIO_DIR = os.path.abspath(os.path.join(WEBSITE_DIR, "..", "..", "gradio"))
@@ -109,8 +109,10 @@ def create_dir_if_not_exists(path):
 
 
 create_dir_if_not_exists(make_dir(WEBSITE_DIR, "src/lib/json"))
+create_dir_if_not_exists(make_dir(WEBSITE_DIR, "src/lib/json/blogs"))
 create_dir_if_not_exists(make_dir(WEBSITE_DIR, "src/lib/json/guides"))
 
+blogs.generate(make_dir(WEBSITE_DIR, "src/lib/json/blogs/") + "/")
 demos.generate(make_dir(WEBSITE_DIR, "src/lib/json/demos.json"))
 guides.generate(make_dir(WEBSITE_DIR, "src/lib/json/guides/") + "/")
 SYSTEM_PROMPT, FALLBACK_PROMPT = docs.generate(

--- a/js/_website/generate_jsons/src/blogs/__init__.py
+++ b/js/_website/generate_jsons/src/blogs/__init__.py
@@ -1,0 +1,153 @@
+import json
+import os
+import re
+import markdown
+
+DIR = os.path.dirname(__file__)
+BLOGS_DIR = os.path.abspath(os.path.join(DIR, "../../../../../blogs"))
+
+
+def format_name(blog_name):
+    index = None
+    if re.match("^[0-9]+_", blog_name):
+        index = int(blog_name[: blog_name.index("_")])
+        blog_name = blog_name[blog_name.index("_") + 1 :]
+    if blog_name.lower().endswith(".md"):
+        blog_name = blog_name[:-3]
+    pretty_blog_name = " ".join(
+        [word[0].upper() + word[1:] for word in blog_name.split("-")]
+    )
+    return index, blog_name, pretty_blog_name
+
+
+blog_folders = sorted(
+    [
+        f
+        for f in os.listdir(BLOGS_DIR)
+        if os.path.isdir(os.path.join(BLOGS_DIR, f)) and re.match(r"^\d+_", f)
+    ]
+)
+
+blogs = []
+blogs_by_category = []
+blog_names = []
+blog_urls = []
+absolute_index = 0
+for blog_folder in blog_folders:
+    blog_list = sorted(os.listdir(os.path.join(BLOGS_DIR, blog_folder)))
+    blog_list = [f for f in blog_list if f.endswith(".md")]
+    _, blog_category, pretty_blog_category = format_name(blog_folder)
+    blogs_by_category.append({"category": pretty_blog_category, "blogs": []})
+    blog_names.append({"category": pretty_blog_category, "blogs": []})
+    for blog_file in blog_list:
+        blog_index, blog_name, pretty_blog_name = format_name(blog_file)
+        with open(os.path.join(BLOGS_DIR, blog_folder, blog_file)) as f:
+            blog_content = f.read()
+
+        title = blog_content.split("\n")[0]
+
+        metadata_labels = []
+
+        def get_labeled_metadata(label, is_list=True):
+            global blog_content
+            metadata_labels.append(label)
+            full_label = label + " "
+            metadata = [] if is_list else None
+            if full_label in blog_content:
+                metadata = blog_content.split(full_label)[1].split("\n")[0]
+                blog_content = blog_content.replace(full_label + metadata, "")
+                if is_list:
+                    metadata = metadata.split(", ")
+            return metadata
+
+        tags = get_labeled_metadata("Tags:")
+        author = get_labeled_metadata("Author:", is_list=False)
+        date = get_labeled_metadata("Date:", is_list=False)
+
+        url = f"/blog/{blog_name}/"
+
+        blog_content = re.sub(
+            r"\n\nTip: (.*?)(?=\n\n|$)",
+            lambda x: f"""
+            <div class='tip'>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/>
+                    <path d="M9 18h6"/>
+                    <path d="M10 22h4"/>
+                </svg>
+                <div>{markdown.markdown(x.group(1))}</div>
+            </div>
+                """,
+            blog_content,
+        )
+
+        blog_content = re.sub(
+            r"(\n\nWarning: )(.*?)(?=\n\n|$)",
+            lambda x: f"""
+            <div class='warning'>
+                <span class="inline-flex" style="align-items: baseline">
+                    <svg class="self-center w-5 h-5 mx-1" xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' fill='currentColor' version='1.1' width='800px' height='800px' viewBox='0 0 554.2 554.199' xml:space='preserve'>
+                        <path d='M538.5,386.199L356.5,70.8c-16.4-28.4-46.7-45.9-79.501-45.9c-32.8,0-63.1,17.5-79.5,45.9L12.3,391.6   c-16.4,28.4-16.4,63.4,0,91.8C28.7,511.8,59,529.3,91.8,529.3H462.2c0.101,0,0.2,0,0.2,0c50.7,0,91.8-41.101,91.8-91.8   C554.2,418.5,548.4,400.8,538.5,386.199z M316.3,416.899c0,21.7-16.7,38.3-39.2,38.3s-39.2-16.6-39.2-38.3V416   c0-21.601,16.7-38.301,39.2-38.301S316.3,394.3,316.3,416V416.899z M317.2,158.7L297.8,328.1c-1.3,12.2-9.4,19.8-20.7,19.8   s-19.4-7.7-20.7-19.8L237,158.6c-1.3-13.1,5.801-23,18-23H299.1C311.3,135.7,318.5,145.6,317.2,158.7z'/>
+                    </svg>
+                <span><strong>Warning:</strong></span>
+                </span>
+                {markdown.markdown(x.group(2))}
+            </div>
+                """,
+            blog_content,
+        )
+
+        content_no_html = blog_content
+
+        blog_content = "\n".join(
+            [
+                line
+                for i, line in enumerate(blog_content.split("\n"))
+                if not any(line.startswith(label) for label in metadata_labels)
+            ]
+        )
+
+        blog_content = re.sub(
+            r"```([a-z]+)\n",
+            lambda x: f"<div class='codeblock'><pre><code class='lang-{x.group(1)}'>",
+            blog_content,
+        )
+        blog_content = re.sub(r"```", "</code></pre></div>", blog_content)
+
+        blog_data = {
+            "name": blog_name,
+            "category": blog_category,
+            "pretty_category": pretty_blog_category,
+            "blog_index": blog_index,
+            "absolute_index": absolute_index,
+            "pretty_name": pretty_blog_name,
+            "content": content_no_html,
+            "tags": tags,
+            "author": author,
+            "date": date,
+            "url": url,
+        }
+        blogs.append(blog_data)
+        blogs_by_category[-1]["blogs"].append(blog_data)
+        blog_names[-1]["blogs"].append(
+            {"name": blog_name, "pretty_name": pretty_blog_name, "url": url}
+        )
+        blog_urls.append(blog_name)
+        absolute_index += 1
+
+
+def generate(json_path):
+    if not os.path.isdir(json_path):
+        os.mkdir(json_path)
+    with open(json_path + "blogs_by_category.json", "w+") as f:
+        json.dump(
+            {
+                "blogs_by_category": blogs_by_category,
+            },
+            f,
+        )
+    for blog in blogs:
+        with open(json_path + blog["name"] + ".json", "w+") as f:
+            json.dump({"blog": blog}, f)
+    with open(json_path + "blog_names.json", "w+") as f:
+        json.dump({"blog_names": blog_names, "blog_urls": blog_urls}, f)

--- a/js/_website/src/lib/assets/theme.css
+++ b/js/_website/src/lib/assets/theme.css
@@ -14,6 +14,7 @@
 
 :root {
 	--name: default;
+	--custom-css: ;
 	--primary-50: #fff7ed;
 	--primary-100: #ffedd5;
 	--primary-200: #ffddb3;
@@ -156,6 +157,8 @@
 	--checkbox-label-gap: var(--spacing-lg);
 	--checkbox-label-padding: var(--spacing-md) calc(2 * var(--spacing-md));
 	--checkbox-label-shadow: none;
+	--checkbox-label-shadow-hover: var(--checkbox-label-shadow);
+	--checkbox-label-shadow-active: var(--checkbox-label-shadow);
 	--checkbox-label-text-size: var(--text-md);
 	--checkbox-label-text-weight: 400;
 	--checkbox-check: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
@@ -298,6 +301,9 @@
 	--checkbox-label-border-color-hover: var(--checkbox-label-border-color);
 	--checkbox-label-border-color-selected: var(--checkbox-label-border-color);
 	--checkbox-label-border-width: var(--input-border-width);
+	--checkbox_label_shadow: None;
+	--checkbox_label_shadow_hover: None;
+	--checkbox_label_shadow_active: None;
 	--checkbox-label-text-color: var(--body-text-color);
 	--checkbox-label-text-color-selected: var(--checkbox-label-text-color);
 	--error-background-fill: var(--neutral-900);
@@ -358,6 +364,7 @@
 	--button-secondary-shadow-hover: var(--button-secondary-shadow);
 	--button-secondary-shadow-active: var(--button-secondary-shadow);
 	--name: default;
+	--custom-css: ;
 	--primary-50: #fff7ed;
 	--primary-100: #ffedd5;
 	--primary-200: #ffddb3;
@@ -456,6 +463,8 @@
 	--checkbox-label-gap: var(--spacing-lg);
 	--checkbox-label-padding: var(--spacing-md) calc(2 * var(--spacing-md));
 	--checkbox-label-shadow: none;
+	--checkbox-label-shadow-hover: var(--checkbox-label-shadow);
+	--checkbox-label-shadow-active: var(--checkbox-label-shadow);
 	--checkbox-label-text-size: var(--text-md);
 	--checkbox-label-text-weight: 400;
 	--checkbox-check: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");

--- a/js/_website/src/lib/components/Header.svelte
+++ b/js/_website/src/lib/components/Header.svelte
@@ -13,6 +13,7 @@
 	const nav_links = [
 		{ label: "API", href: "/docs" },
 		{ label: "Guides", href: "/guides" },
+		{ label: "Blog", href: "/blog" },
 		{ label: "Themes", href: "/themes/gallery" },
 		{ label: "Custom Components", href: "/custom-components/gallery" },
 		{ label: "HTML Components", href: "/custom-components/html-gallery" }

--- a/js/_website/src/routes/blog/+layout.server.ts
+++ b/js/_website/src/routes/blog/+layout.server.ts
@@ -1,0 +1,35 @@
+export const prerender = true;
+
+let cache = new Map();
+
+async function load_main_blog_names() {
+	if (cache.has(`main_blog_names`)) {
+		return cache.get(`main_blog_names`);
+	}
+	let blog_names_json = await import(`../../lib/json/blogs/blog_names.json`);
+	cache.set(`main_blog_names`, blog_names_json);
+	return blog_names_json;
+}
+
+async function load_main_blogs(blog_urls: string[]) {
+	if (cache.has(`main_blogs`)) {
+		return cache.get(`main_blogs`);
+	}
+	let blogs: { [key: string]: any } = {};
+	for (const blog_url of blog_urls) {
+		let blog_json = await import(`../../lib/json/blogs/${blog_url}.json`);
+		blogs[blog_url] = blog_json;
+	}
+	cache.set(`main_blogs`, blogs);
+	return blogs;
+}
+
+export async function load({ params, url }) {
+	let blog_names_json = await load_main_blog_names();
+	let blogs = await load_main_blogs(blog_names_json.blog_urls);
+
+	return {
+		blog_names_json,
+		blogs
+	};
+}

--- a/js/_website/src/routes/blog/+page.server.ts
+++ b/js/_website/src/routes/blog/+page.server.ts
@@ -1,0 +1,11 @@
+async function load_main_blog_categories() {
+	return await import(`../../lib/json/blogs/blogs_by_category.json`);
+}
+
+export async function load({ params, parent }) {
+	let blogs_by_category_json = await load_main_blog_categories();
+
+	return {
+		blogs_by_category: blogs_by_category_json.blogs_by_category
+	};
+}

--- a/js/_website/src/routes/blog/+page.svelte
+++ b/js/_website/src/routes/blog/+page.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+	import MetaTags from "$lib/components/MetaTags.svelte";
+	import { page } from "$app/stores";
+
+	export let data: {
+		[key: string]: any;
+	};
+</script>
+
+<MetaTags
+	title="Gradio Blog"
+	url={$page.url.pathname}
+	canonical={$page.url.pathname}
+	description="News, tutorials, and updates from the Gradio team."
+/>
+
+<div class="container mx-auto px-4 relative pt-8 mb-12">
+	<div class="flex gap-8">
+		<nav
+			class="hidden lg:block w-64 flex-shrink-0 sticky top-8 self-start max-h-[calc(100vh-4rem)] overflow-y-auto"
+		>
+			<div class="space-y-8">
+				{#each data.blogs_by_category as { category, blogs } (category)}
+					<div>
+						<h2
+							class="text-xs font-bold uppercase tracking-wide text-gray-900 dark:text-gray-100 mb-3"
+						>
+							{category}
+						</h2>
+						<ul class="space-y-2">
+							{#each blogs as blog (blog.name)}
+								<li>
+									<a
+										href=".{blog.url}"
+										class="block text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors py-1"
+									>
+										{blog.pretty_name}
+									</a>
+								</li>
+							{/each}
+						</ul>
+					</div>
+				{/each}
+			</div>
+		</nav>
+
+		<div class="flex-1">
+			<h1
+				class="mb-8 flex items-center text-4xl font-bold text-gray-900 dark:text-gray-100"
+			>
+				Blog
+			</h1>
+
+			<div class="prose dark:prose-invert max-w-none">
+				<p class="text-xl text-gray-600 dark:text-gray-400 mb-8">
+					News, tutorials, and updates from the Gradio team.
+				</p>
+			</div>
+
+			<div class="space-y-6 mt-8">
+				{#each data.blogs_by_category as { category, blogs } (category)}
+					{#each blogs as blog (blog.name)}
+						<a
+							href=".{blog.url}"
+							class="block p-6 rounded-lg border border-gray-200 dark:border-neutral-700 hover:border-orange-300 dark:hover:border-orange-600 transition-colors group"
+						>
+							<h3
+								class="text-lg font-semibold text-gray-900 dark:text-gray-100 group-hover:text-orange-600 dark:group-hover:text-orange-400 transition-colors"
+							>
+								{blog.pretty_name}
+							</h3>
+							<div
+								class="flex gap-3 mt-2 text-sm text-gray-500 dark:text-gray-400"
+							>
+								{#if blog.author}
+									<span>{blog.author}</span>
+								{/if}
+								{#if blog.date}
+									<span>{blog.date}</span>
+								{/if}
+							</div>
+							{#if blog.tags && blog.tags.length > 0}
+								<div class="flex flex-wrap gap-2 mt-3">
+									{#each blog.tags as tag}
+										<span
+											class="px-2 py-0.5 text-xs rounded-full bg-gray-100 dark:bg-neutral-800 text-gray-600 dark:text-gray-400"
+										>
+											{tag}
+										</span>
+									{/each}
+								</div>
+							{/if}
+						</a>
+					{/each}
+				{/each}
+			</div>
+		</div>
+	</div>
+</div>

--- a/js/_website/src/routes/blog/[blog]/+page.server.ts
+++ b/js/_website/src/routes/blog/[blog]/+page.server.ts
@@ -1,0 +1,82 @@
+import { compile } from "mdsvex";
+import { highlight } from "$lib/prism";
+import anchor from "$lib/assets/img/anchor.svg";
+import { make_slug_processor } from "$lib/utils";
+import { toString as to_string } from "hast-util-to-string";
+import { error } from "@sveltejs/kit";
+
+export const prerender = true;
+
+async function load_main_blogs(blog: string) {
+	return await import(`../../lib/json/blogs/${blog}.json`);
+}
+
+export async function load({ params, parent }) {
+	const { blog_names_json, blogs } = await parent();
+
+	if (!blog_names_json.blog_urls.some((blog: string) => blog === params.blog)) {
+		throw error(404);
+	}
+
+	let blog_json = blogs[params.blog];
+
+	let blog = blog_json.blog;
+	const blog_slug: object[] = [];
+
+	const get_slug = make_slug_processor();
+	function plugin() {
+		return function transform(tree: any) {
+			tree.children.forEach((n: any) => {
+				if (
+					n.type === "element" &&
+					["h2", "h3", "h4", "h5", "h6"].includes(n.tagName)
+				) {
+					const str_of_heading = to_string(n);
+					const slug = get_slug(str_of_heading);
+
+					blog_slug.push({
+						text: str_of_heading,
+						href: `#${slug}`,
+						level: parseInt(n.tagName.replace("h", ""))
+					});
+
+					if (!n.children) n.children = [];
+					n.properties.className = ["group"];
+					n.properties.id = [slug];
+					n.children.push({
+						type: "element",
+						tagName: "a",
+						properties: {
+							href: `#${slug}`,
+							className: ["invisible", "group-hover-visible"]
+						},
+						children: [
+							{
+								type: "element",
+								tagName: "img",
+								properties: {
+									src: anchor,
+									className: ["anchor-img"]
+								},
+								children: []
+							}
+						]
+					});
+				}
+			});
+		};
+	}
+
+	const compiled = await compile(blog.content, {
+		rehypePlugins: [plugin],
+		highlight: { highlighter: highlight },
+		smartypants: false
+	});
+	blog.new_html = compiled?.code;
+
+	return {
+		blog,
+		blog_slug,
+		blog_names: blog_names_json.blog_names
+	};
+}

--- a/js/_website/src/routes/blog/[blog]/+page.svelte
+++ b/js/_website/src/routes/blog/[blog]/+page.svelte
@@ -1,0 +1,413 @@
+<script lang="ts">
+	// @ts-nocheck
+	import MetaTags from "$lib/components/MetaTags.svelte";
+	import { page } from "$app/stores";
+	import { tick } from "svelte";
+	import FancyDetails from "$lib/components/Details.svelte";
+	import { onNavigate } from "$app/navigation";
+	import { clickOutside } from "$lib/components/clickOutside.js";
+	import CopyMarkdown from "$lib/components/CopyMarkdown.svelte";
+
+	export let data: {
+		blog: any;
+		blog_slug: {
+			text: string;
+			href: string;
+			level: number;
+		}[];
+		blog_names: {
+			category: string;
+			blogs: {
+				name: string;
+				pretty_name: string;
+				url: string;
+			}[];
+		}[];
+	};
+	let blog_page = data.blog;
+	let blog_names = data.blog_names;
+	let blog_slug = data.blog_slug;
+
+	let header_targets: { [key: string]: HTMLElement } = {};
+	let current_header_id: string = "";
+
+	$: if (y !== undefined && blog_slug.length > 0) {
+		for (const slug of blog_slug) {
+			const id = slug.href.slice(1);
+			const el = document.getElementById(id);
+			if (el && y >= el.offsetTop - 100) {
+				current_header_id = id;
+			}
+		}
+	}
+
+	let show_nav = false;
+	let sidebar: HTMLElement;
+	let target_link: HTMLElement;
+	let y: number;
+	let content_el: HTMLDivElement;
+
+	let flattened_blogs = blog_names.map((category) => category.blogs).flat();
+	let prev_blog: any;
+	let next_blog: any;
+
+	$: if (sidebar) {
+		if (
+			target_link?.previousElementSibling?.classList.contains("category-link")
+		) {
+			target_link = target_link.previousElementSibling as HTMLElement;
+		}
+		sidebar.scrollTop = target_link?.offsetTop;
+	}
+	$: blog_page = data.blog;
+	$: blog_slug = data.blog_slug;
+	$: flattened_blogs = blog_names.map((category) => category.blogs).flat();
+	$: prev_blog =
+		flattened_blogs[
+			flattened_blogs.findIndex((blog) => blog.url === blog_page.url) - 1
+		];
+	$: next_blog =
+		flattened_blogs[
+			flattened_blogs.findIndex((blog) => blog.url === blog_page.url) + 1
+		];
+	$: blog_names = data.blog_names;
+
+	let _details: (FancyDetails | void)[] = [];
+
+	async function make_details() {
+		_details.forEach((c) => c?.$destroy());
+		await tick();
+		const details = document.querySelectorAll("details");
+		if (details.length === 0) return;
+
+		_details = Array.from(details).map((detail) => {
+			const summary_text = detail.querySelector("summary")?.innerHTML;
+			const detail_children = detail.querySelectorAll(
+				"details > *:not(summary)"
+			);
+
+			let detail_text = "";
+			detail_children.forEach((child, i) => {
+				detail_text += `<p>${child.innerHTML}</p>`;
+			});
+
+			if (!summary_text || !detail_text) return;
+
+			const new_el = document.createElement("div");
+			const comp = new FancyDetails({
+				target: new_el,
+				props: {
+					summary: summary_text,
+					content: detail_text
+				}
+			});
+			detail.replaceWith(new_el);
+
+			return comp;
+		});
+	}
+
+	$: content_el && data.blog.new_html && make_details();
+
+	onNavigate(() => {
+		show_nav = false;
+	});
+
+	$: show_nav;
+
+	function get_category(name: string) {
+		if (blog_names) {
+			for (let category of blog_names) {
+				for (let blog of category.blogs) {
+					if (blog.name === name) {
+						return [category.category, blog.pretty_name];
+					}
+				}
+			}
+		}
+	}
+
+	let category_and_name: any[] | undefined = get_category(blog_page.name);
+
+	$: category_and_name = get_category(blog_page.name);
+</script>
+
+<MetaTags
+	title={blog_page.pretty_name}
+	url={$page.url.pathname}
+	canonical={$page.url.pathname}
+	description="A blog post from the Gradio team"
+/>
+<div class="container mx-auto px-4 pt-8 flex relative w-full">
+	<!-- Mobile menu -->
+
+	<div
+		class:hidden={!show_nav}
+		class="fixed inset-0 bg-black/20 backdrop-blur-md lg:hidden z-50"
+	>
+		<div
+			use:clickOutside
+			on:click_outside={() => (show_nav = false)}
+			class:hidden={!show_nav}
+			class="max-w-max min-w-[75%] shadow overflow-y-auto fixed backdrop-blur-lg z-50 bg-white dark:bg-neutral-900 px-6 py-4 h-full inset-0"
+			id="mobile-nav"
+		>
+			<button
+				on:click={() => (show_nav = false)}
+				type="button"
+				class="absolute z-10 top-4 right-4 w-2/12 h-4 flex items-center justify-center text-grey-500 hover:text-slate-600 dark:text-slate-400 dark:hover:text-slate-300 p-4"
+				tabindex="0"
+			>
+				<svg viewBox="0 0 10 10" class="overflow-visible" style="width: 10px"
+					><path
+						d="M0 0L10 10M10 0L0 10"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+					></path></svg
+				>
+			</button>
+
+			<div class="space-y-6 mt-12">
+				{#each blog_names as { category, blogs } (category)}
+					<div>
+						<h2
+							class="text-xs font-bold uppercase tracking-wide text-gray-900 dark:text-gray-100 mb-3"
+						>
+							{category}
+						</h2>
+						<ul class="space-y-2">
+							{#each blogs as blog (blog.name)}
+								<li>
+									<a
+										href="..{blog.url}"
+										class="block text-sm transition-colors py-1 {blog.name ===
+										blog_page.name
+											? 'text-orange-600 dark:text-orange-400 font-semibold'
+											: 'text-gray-600 dark:text-gray-400'}"
+									>
+										{blog.pretty_name}
+									</a>
+								</li>
+							{/each}
+						</ul>
+					</div>
+				{/each}
+			</div>
+		</div>
+	</div>
+
+	<nav
+		bind:this={sidebar}
+		class="w-64 flex-shrink-0 sticky top-8 self-start max-h-[calc(100vh-4rem)] overflow-y-auto hidden lg:block pr-8"
+	>
+		<div class="space-y-8">
+			{#each blog_names as { category, blogs } (category)}
+				<div>
+					<h2
+						class="text-xs font-bold uppercase tracking-wide text-gray-900 dark:text-gray-100 mb-3"
+					>
+						{category}
+					</h2>
+					<ul class="space-y-2">
+						{#each blogs as blog (blog.name)}
+							<li>
+								{#if blog.name === blog_page.name}
+									<a
+										bind:this={target_link}
+										href="..{blog.url}"
+										class="block text-sm transition-colors py-1 text-orange-600 dark:text-orange-400 font-semibold"
+									>
+										{blog.pretty_name}
+									</a>
+								{:else}
+									<a
+										href="..{blog.url}"
+										class="block text-sm transition-colors py-1 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+									>
+										{blog.pretty_name}
+									</a>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				</div>
+			{/each}
+		</div>
+	</nav>
+	<div class="w-full lg:w-8/12 lg:min-w-0 lg:pl-8">
+		<div
+			class="flex items-center p-4 border-b border-t border-slate-900/10 lg:hidden dark:border-slate-50/[0.06]"
+		>
+			<button
+				on:click={() => (show_nav = !show_nav)}
+				type="button"
+				class="text-slate-500 hover:text-slate-600 dark:text-slate-400 dark:hover:text-slate-300"
+			>
+				<svg width="24" height="24"
+					><path
+						d="M5 6h14M5 12h14M5 18h14"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+					></path></svg
+				>
+			</button>
+			{#if category_and_name}
+				<ol class="ml-4 flex text-sm leading-6 whitespace-nowrap min-w-0">
+					<li class="flex items-center">
+						{category_and_name[0]}
+						<svg
+							width="3"
+							height="6"
+							aria-hidden="true"
+							class="mx-3 overflow-visible text-slate-400"
+							><path
+								d="M0 0L3 3L0 6"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="1.5"
+								stroke-linecap="round"
+							></path></svg
+						>
+					</li>
+					<li class="font-semibold text-slate-900 truncate dark:text-slate-200">
+						{category_and_name[1]}
+					</li>
+				</ol>
+			{/if}
+		</div>
+
+		{#if blog_page.author || blog_page.date}
+			<div
+				class="mb-6 flex flex-wrap items-center gap-3 text-sm text-gray-500 dark:text-gray-400"
+			>
+				{#if blog_page.author}
+					<span class="flex items-center gap-1">
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							class="w-4 h-4"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+							<circle cx="12" cy="7" r="4" />
+						</svg>
+						{blog_page.author}
+					</span>
+				{/if}
+				{#if blog_page.date}
+					<span class="flex items-center gap-1">
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							class="w-4 h-4"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+							<line x1="16" y1="2" x2="16" y2="6" />
+							<line x1="8" y1="2" x2="8" y2="6" />
+							<line x1="3" y1="10" x2="21" y2="10" />
+						</svg>
+						{blog_page.date}
+					</span>
+				{/if}
+			</div>
+		{/if}
+
+		{#if blog_page.tags && blog_page.tags.length > 0}
+			<div class="flex flex-wrap gap-2 mb-6">
+				{#each blog_page.tags as tag}
+					<span
+						class="px-2 py-0.5 text-xs rounded-full bg-gray-100 dark:bg-neutral-800 text-gray-600 dark:text-gray-400"
+					>
+						{tag}
+					</span>
+				{/each}
+			</div>
+		{/if}
+
+		<div
+			class="prose text-lg max-w-full dark:prose-invert"
+			bind:this={content_el}
+		>
+			<CopyMarkdown markdown_content={blog_page.content} />
+			{@html blog_page.new_html}
+		</div>
+		<div class="w-full flex flex-wrap justify-between mt-12 mb-8">
+			{#if prev_blog}
+				<a
+					href="..{prev_blog.url}"
+					class="text-left px-4 py-1 bg-gray-50 dark:bg-neutral-800 rounded-full text-gray-900 dark:text-gray-100 hover:underline max-w-[48%]"
+				>
+					<div class="flex text-lg">
+						<span class="text-orange-500 mr-1">&#8592;</span>
+						<p class="whitespace-nowrap overflow-hidden text-ellipsis">
+							{prev_blog.pretty_name}
+						</p>
+					</div>
+				</a>
+			{:else}
+				<div />
+			{/if}
+			{#if next_blog}
+				<a
+					href="..{next_blog.url}"
+					class="text-right px-4 py-1 bg-gray-50 dark:bg-neutral-800 rounded-full text-gray-900 dark:text-gray-100 max-w-1/2 hover:underline max-w-[48%]"
+				>
+					<div class="flex text-lg">
+						<p class="whitespace-nowrap overflow-hidden text-ellipsis">
+							{next_blog.pretty_name}
+						</p>
+						<span class="text-orange-500 ml-1">&#8594;</span>
+					</div>
+				</a>
+			{:else}
+				<div />
+			{/if}
+		</div>
+	</div>
+
+	{#if blog_slug.length > 0}
+		<div
+			class="float-right top-8 hidden sticky h-screen overflow-y-auto lg:block lg:w-2/12"
+		>
+			<div class="mx-8">
+				<a
+					class="text-sm tracking-wider font-semibold text-gray-600 dark:text-gray-300 py-2 block"
+					href="#"
+				>
+					{blog_page.pretty_name}
+				</a>
+				<ul class="space-y-2 list-none">
+					{#each blog_slug as slug}
+						<li style="padding-left: {(slug.level - 2) * 0.75}rem">
+							<a
+								bind:this={header_targets[slug.href.slice(1)]}
+								href={slug.href}
+								class="block text-sm transition-colors py-1 {current_header_id ===
+								slug.href.slice(1)
+									? 'text-orange-500 font-medium'
+									: 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100'}"
+							>
+								{slug.text}
+							</a>
+						</li>
+					{/each}
+				</ul>
+			</div>
+		</div>
+	{/if}
+</div>
+
+<svelte:window bind:scrollY={y} />


### PR DESCRIPTION
Draft PR to show how the blogs can be structured. They work the same way as the guides: written in markdown in the repo and categorized the same way. But since we don't really care about version vs main here, we don't need to load them from AWS. added some metadata for the author, tags etc. Also had claude generate sample blogs so you can see what it looks like. Design could be way cooler though! 