### PR TITLE
fix: Tab interactivity not updating when changed dynamically

### DIFF
--- a/js/tabs/shared/Tabs.svelte
+++ b/js/tabs/shared/Tabs.svelte
@@ -60,6 +60,7 @@
 	setContext(TABS, {
 		register_tab: (tab: Tab, order: number) => {
 			tabs[order] = tab;
+			tabs = tabs; // Trigger Svelte reactivity on array mutation
 
 			if ($selected_tab === false && tab.visible !== false && tab.interactive) {
 				$selected_tab = tab.id;
@@ -72,6 +73,7 @@
 				$selected_tab = tabs[0]?.id || false;
 			}
 			tabs[order] = null;
+			tabs = tabs; // Trigger Svelte reactivity on array mutation
 		},
 		selected_tab,
 		selected_tab_index


### PR DESCRIPTION
## Description

Fixes #13033

When a Tab's `interactive` property is updated at runtime (e.g. from `False` to `True`), the UI does not reflect the change. The root cause is that `tabs[order] = tab` is a **mutation**, not an **assignment** — Svelte's reactivity system does not detect array index mutations.

### Changes

Added `tabs = tabs` after each array index mutation in `register_tab` and `unregister_tab` to force Svelte to re-evaluate reactive statements that depend on `tabs`. This ensures:

1. Tab buttons update their `disabled` state when `interactive` changes
2. The `change_tab` function sees the updated tab data
3. The `handle_menu_overflow` reactive correctly reflects tab state

### Reproduction (from issue)

```python
import gradio as gr

def unlock_logic(text):
    if text == "open":
        return gr.Tab(interactive=True)
    return gr.Tab(interactive=False)

with gr.Blocks() as demo:
    with gr.Tab("tab1", id="tab1"):
        inp = gr.Textbox(label="Enter 'open' to unlock")
        btn = gr.Button("Click to Unlock")
    with gr.Tab("Locked", id="tab2", interactive=False) as tab2:
        gr.Markdown("Tab content here")
    btn.click(unlock_logic, inputs=inp, outputs=tab2)

demo.launch()
```

Before this fix, clicking the button with "open" would not unlock the tab. After this fix, the tab becomes interactive as expected.
