### PR TITLE
fix: replace bare except with except BaseException in depth estimation demo

### DIFF
--- a/demo/depth_estimation/run.py
+++ b/demo/depth_estimation/run.py
@@ -43,7 +43,7 @@ def process_image(image_path):
             np.array(image), depth_image, image_path, depth=8)
         img = Image.fromarray(depth_image)
         return [img, gltf_path, gltf_path]
-    except:
+    except BaseException:
         print("Error reconstructing 3D model")
         raise Exception("Error reconstructing 3D model")
 


### PR DESCRIPTION
## Summary

Replace bare `except:` clause with `except BaseException:` in `demo/depth_estimation/run.py`.

Per PEP 8, bare `except:` clauses should specify an exception type. Since this handler re-raises (via `raise Exception(...)`), `except BaseException:` preserves the original behavior while being explicit about what is caught.

**Change:**
```python
# Before
except:
    print("Error reconstructing 3D model")
    raise Exception("Error reconstructing 3D model")

# After
except BaseException:
    print("Error reconstructing 3D model")
    raise Exception("Error reconstructing 3D model")
```

## Testing
No behavior change — style/correctness fix only.