### PR TITLE
fix #12054: Prevent Dataframe select event from firing twice on click

### DIFF
--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -772,7 +772,8 @@
 	const drag_state: DragState = {
 		is_dragging,
 		drag_start,
-		mouse_down_pos
+		mouse_down_pos,
+		click_handled: false
 	};
 
 	$: {

--- a/js/dataframe/shared/utils/drag_utils.ts
+++ b/js/dataframe/shared/utils/drag_utils.ts
@@ -5,6 +5,7 @@ export type DragState = {
 	is_dragging: boolean;
 	drag_start: CellCoordinate | null;
 	mouse_down_pos: { x: number; y: number } | null;
+	click_handled: boolean;
 };
 
 export type DragHandlers = {
@@ -39,13 +40,13 @@ export function create_drag_handlers(
 		event.preventDefault();
 		event.stopPropagation();
 
+		state.click_handled = false;
 		state.mouse_down_pos = { x: event.clientX, y: event.clientY };
 		state.drag_start = [row, col];
 
 		if (!event.shiftKey && !event.metaKey && !event.ctrlKey) {
 			set_selected_cells([[row, col]]);
 			set_selected([row, col]);
-			handle_cell_click(event, row, col);
 		}
 	};
 
@@ -64,16 +65,27 @@ export function create_drag_handlers(
 	};
 
 	const end_drag = (event: MouseEvent): void => {
-		if (!state.is_dragging && state.drag_start) {
-			handle_cell_click(event, state.drag_start[0], state.drag_start[1]);
-		} else if (state.is_dragging && parent_element) {
-			parent_element.focus();
-		}
+		const was_dragging = state.is_dragging;
+		const drag_coords = state.drag_start;
 
 		state.is_dragging = false;
 		set_is_dragging(false);
 		state.drag_start = null;
 		state.mouse_down_pos = null;
+
+		if (drag_coords && !state.click_handled) {
+			const cell = (event.target as HTMLElement).closest("td");
+			const end_row = cell ? parseInt(cell.getAttribute("data-row") || "-1") : -1;
+			const end_col = cell ? parseInt(cell.getAttribute("data-col") || "-1") : -1;
+			const same_cell =
+				end_row === drag_coords[0] && end_col === drag_coords[1];
+			if (!was_dragging || same_cell) {
+				state.click_handled = true;
+				handle_cell_click(event, drag_coords[0], drag_coords[1]);
+			} else if (parent_element) {
+				parent_element.focus();
+			}
+		}
 	};
 
 	return {

--- a/patches/@gradio__dataframe@0.20.1.patch
+++ b/patches/@gradio__dataframe@0.20.1.patch
@@ -1,0 +1,109 @@
+diff --git a/dist/shared/utils/drag_utils.js b/dist/shared/utils/drag_utils.js
+index 7d7ec212ff66b7423694d6921c71794cb67a9b1c..d1a93583c751f78ac8fb0ace3391ef4005079005 100644
+--- a/dist/shared/utils/drag_utils.js
++++ b/dist/shared/utils/drag_utils.js
+@@ -11,12 +11,12 @@ export function create_drag_handlers(state, set_is_dragging, set_selected_cells,
+             return;
+         event.preventDefault();
+         event.stopPropagation();
++        state.click_handled = false;
+         state.mouse_down_pos = { x: event.clientX, y: event.clientY };
+         state.drag_start = [row, col];
+         if (!event.shiftKey && !event.metaKey && !event.ctrlKey) {
+             set_selected_cells([[row, col]]);
+             set_selected([row, col]);
+-            handle_cell_click(event, row, col);
+         }
+     };
+     const update_selection = (event) => {
+@@ -32,16 +32,25 @@ export function create_drag_handlers(state, set_is_dragging, set_selected_cells,
+         set_selected([row, col]);
+     };
+     const end_drag = (event) => {
+-        if (!state.is_dragging && state.drag_start) {
+-            handle_cell_click(event, state.drag_start[0], state.drag_start[1]);
+-        }
+-        else if (state.is_dragging && parent_element) {
+-            parent_element.focus();
+-        }
++        const was_dragging = state.is_dragging;
++        const drag_coords = state.drag_start;
+         state.is_dragging = false;
+         set_is_dragging(false);
+         state.drag_start = null;
+         state.mouse_down_pos = null;
++        if (drag_coords && !state.click_handled) {
++            const cell = event.target.closest("td");
++            const end_row = cell ? parseInt(cell.getAttribute("data-row") || "-1") : -1;
++            const end_col = cell ? parseInt(cell.getAttribute("data-col") || "-1") : -1;
++            const same_cell = end_row === drag_coords[0] && end_col === drag_coords[1];
++            if (!was_dragging || same_cell) {
++                state.click_handled = true;
++                handle_cell_click(event, drag_coords[0], drag_coords[1]);
++            }
++            else if (parent_element) {
++                parent_element.focus();
++            }
++        }
+     };
+     return {
+         handle_mouse_down: start_drag,
+diff --git a/shared/utils/drag_utils.ts b/shared/utils/drag_utils.ts
+index d1c1ec091441305554f15c47b89bfb650d25e49c..5e5cdde1e5fde95daff6ab488e32d495a1272e30 100644
+--- a/shared/utils/drag_utils.ts
++++ b/shared/utils/drag_utils.ts
+@@ -5,6 +5,7 @@ export type DragState = {
+ 	is_dragging: boolean;
+ 	drag_start: CellCoordinate | null;
+ 	mouse_down_pos: { x: number; y: number } | null;
++	click_handled: boolean;
+ };
+ 
+ export type DragHandlers = {
+@@ -39,13 +40,13 @@ export function create_drag_handlers(
+ 		event.preventDefault();
+ 		event.stopPropagation();
+ 
++		state.click_handled = false;
+ 		state.mouse_down_pos = { x: event.clientX, y: event.clientY };
+ 		state.drag_start = [row, col];
+ 
+ 		if (!event.shiftKey && !event.metaKey && !event.ctrlKey) {
+ 			set_selected_cells([[row, col]]);
+ 			set_selected([row, col]);
+-			handle_cell_click(event, row, col);
+ 		}
+ 	};
+ 
+@@ -64,16 +65,26 @@ export function create_drag_handlers(
+ 	};
+ 
+ 	const end_drag = (event: MouseEvent): void => {
+-		if (!state.is_dragging && state.drag_start) {
+-			handle_cell_click(event, state.drag_start[0], state.drag_start[1]);
+-		} else if (state.is_dragging && parent_element) {
+-			parent_element.focus();
+-		}
++		const was_dragging = state.is_dragging;
++		const drag_coords = state.drag_start;
+ 
+ 		state.is_dragging = false;
+ 		set_is_dragging(false);
+ 		state.drag_start = null;
+ 		state.mouse_down_pos = null;
++
++		if (drag_coords && !state.click_handled) {
++			const cell = (event.target as HTMLElement).closest("td");
++			const end_row = cell ? parseInt(cell.getAttribute("data-row") || "-1") : -1;
++			const end_col = cell ? parseInt(cell.getAttribute("data-col") || "-1") : -1;
++			const same_cell = end_row === drag_coords[0] && end_col === drag_coords[1];
++			if (!was_dragging || same_cell) {
++				state.click_handled = true;
++				handle_cell_click(event, drag_coords[0], drag_coords[1]);
++			} else if (parent_element) {
++				parent_element.focus();
++			}
++		}
+ 	};
+ 
+ 	return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
+  '@gradio/dataframe@0.20.1':
+    hash: 7afbe373086914d45e90d5b867cf3ddb4509d91dcae52b9c2e02c1d301f315f5
+    path: patches/@gradio__dataframe@0.20.1.patch
   '@sveltejs/package':
     hash: 4bf60d897bf9a1418645763e4338b3223b9458b10046bd6cde08601581f05183
     path: patches/@sveltejs__package.patch
@@ -1249,7 +1252,7 @@ importers:
         version: 1.19.0(@types/node@24.10.9)
       '@gradio/dataframe-npm':
         specifier: npm:@gradio/dataframe@0.20.1
-        version: '@gradio/dataframe@0.20.1(@types/node@24.10.9)(svelte@4.2.20)'
+        version: '@gradio/dataframe@0.20.1(patch_hash=7afbe373086914d45e90d5b867cf3ddb4509d91dcae52b9c2e02c1d301f315f5)(@types/node@24.10.9)(svelte@4.2.20)'
       '@gradio/icons':
         specifier: npm:@gradio/icons@0.14.0
         version: 0.14.0(svelte@4.2.20)
@@ -9679,7 +9682,7 @@ snapshots:
       - '@types/node'
       - utf-8-validate
 
-  '@gradio/dataframe@0.20.1(@types/node@24.10.9)(svelte@4.2.20)':
+  '@gradio/dataframe@0.20.1(patch_hash=7afbe373086914d45e90d5b867cf3ddb4509d91dcae52b9c2e02c1d301f315f5)(@types/node@24.10.9)(svelte@4.2.20)':
     dependencies:
       '@gradio/atoms': 0.18.1(svelte@4.2.20)
       '@gradio/button': 0.5.13(@types/node@24.10.9)(svelte@4.2.20)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,4 +6,5 @@ packages:
   - js/preview/test/**/*
 
 patchedDependencies:
+  '@gradio/dataframe@0.20.1': patches/@gradio__dataframe@0.20.1.patch
   '@sveltejs/package': patches/@sveltejs__package.patch


### PR DESCRIPTION
Fixes #12054

## Description

The select event on the Dataframe component was firing twice on each cell click. handle_cell_click was being called on both mousedown and mouseup in drag_utils.ts, causing the event handler to fire twice per user interaction.

Changes:

- Introduced a click_handled flag in DragState to ensure the click is only processed once per user interaction

- Updated end_drag to check click_handled before calling handle_cell_click

- Added a same_cell check to prevent redundant calls when releasing the mouse on the same cell after a drag

- Applied the same fix as a pnpm patch (patches/@gradio__dataframe@0.20.1.patch) to cover the npm-pinned version used at runtime

Closes: #12054 

## AI Disclosure

- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Closes: #12054