### PR TITLE
docs: Improve DuplicateButton docstring for clarity

### DIFF
--- a/gradio/components/duplicate_button.py
+++ b/gradio/components/duplicate_button.py
@@ -18,10 +18,8 @@ if TYPE_CHECKING:
 
 @document()
 class DuplicateButton(Button):
-    """
-    Button that triggers a Spaces Duplication, when the demo is on Hugging Face Spaces. Does nothing locally.
-    """
-
+    """A button that duplicates the current Hugging Face Space. Functional only when deployed on Hugging Face Spaces; no-op in local environments."""
+    
     is_template = True
 
     def __init__(


### PR DESCRIPTION
Description:
Updated the docstring for the DuplicateButton component to provide clearer technical guidance.

Changes:

Clarified that the button is specifically for duplicating the current Hugging Face Space.

Explicitly noted that the button is functional only when deployed on Hugging Face Spaces.

Added a note that the component performs no action (no-op) when run in local environments to prevent user confusion during local development.