### PR TITLE
Fix gr.Group residual layout gap

### DIFF
--- a/js/group/Index.svelte
+++ b/js/group/Index.svelte
@@ -45,6 +45,6 @@
 		border-radius: 0;
 	}
 	.hide {
-		display: none;
+		display: none !important;
 	}
 </style>


### PR DESCRIPTION
Description:

Description
This PR addresses Issue #13128 where a gr.Group component leaves a residual 1px layout gap even when visible=False is passed.

The Problem: When visible=False is set, Gradio attaches the .hide class (display: none;) to the Group component. However, occasionally this can be overridden by other CSS flex properties or specificity issues in the DOM, causing the container to still participate in the parent's flex layout calculation (resulting in stray layout gaps).

The Fix: I updated the .hide CSS declaration in 

gradio/js/group/Index.svelte
 to use display: none !important;. This ensures that when a gr.Group is explicitly marked as hidden, it is strictly removed from the layout flow and its gap completely collapses.

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to draft this PR
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

