### PR TITLE
Add "Common Patterns" section to Textbox docs

### DIFF
--- a/.changeset/better-textbox-docs.md
+++ b/.changeset/better-textbox-docs.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+docs: Add "Common Patterns" section to Textbox component docs

--- a/js/_website/src/lib/templates/gradio/03_components/textbox.svx
+++ b/js/_website/src/lib/templates/gradio/03_components/textbox.svx
@@ -44,6 +44,41 @@ gradio.Textbox(···)
 ### Shortcuts
 <ShortcutTable shortcuts={obj.string_shortcuts} />
 {/if}
+### Common Patterns
+
+#### Multi-line text input
+
+By default, `gr.Textbox` renders as a single-line input. For longer text such as paragraphs or code, set `lines` to show multiple rows and optionally `max_lines` to cap the height:
+
+```python
+import gradio as gr
+
+def summarize(text):
+    return f"Received {len(text.split())} words."
+
+demo = gr.Interface(
+    fn=summarize,
+    inputs=gr.Textbox(lines=5, max_lines=10, label="Paste your text here"),
+    outputs="text",
+)
+```
+
+#### Password and sensitive input
+
+Set `type="password"` to mask characters as the user types. The value is passed as plain text to your function — masking is display-only:
+
+```python
+import gradio as gr
+
+def check(password):
+    return "Access granted" if password == "secret" else "Wrong password"
+
+demo = gr.Interface(
+    fn=check,
+    inputs=gr.Textbox(type="password", label="Enter password"),
+    outputs="text",
+)
+```
 
 {#if obj.demos && obj.demos.length > 0}
 <!--- Demos -->


### PR DESCRIPTION
## Summary

Add a "Common Patterns" section to the `gr.Textbox` component docs page with two practical recipes.

## What's added

**Multi-line text input** — `gr.Textbox` defaults to a single line. Shows how to use `lines` and `max_lines` for longer text input such as paragraphs or code.

**Password and sensitive input** — Shows how to use `type="password"` to mask characters while passing plain text to the function.

## Approach

Same pattern as #12755 (Row docs), #12922 (Image docs), and #12923 (Slider docs) — custom markdown section in the `.svx` file, no docstring changes.

Closes #12748