### PR TITLE
Add missing stacklevel=2 to 62 warnings.warn() calls

### DIFF
--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -425,7 +425,8 @@ class Client:
                 )
             if secrets is not None:
                 warnings.warn(
-                    "Secrets are only used when the Space is duplicated for the first time, and are not updated if the duplicated Space already exists."
+                    "Secrets are only used when the Space is duplicated for the first time, and are not updated if the duplicated Space already exists.",
+                    stacklevel=2,
                 )
         except RepositoryNotFoundError:
             if verbose:
@@ -1150,7 +1151,7 @@ class Endpoint:
 
         def _cancel():
             if cancel_msg:
-                warnings.warn(cancel_msg)
+                warnings.warn(cancel_msg, stacklevel=2)
             if cancellable:
                 httpx.post(
                     url,

--- a/client/python/gradio_client/documentation.py
+++ b/client/python/gradio_client/documentation.py
@@ -106,7 +106,7 @@ def document(*fns, inherit=False, documentation_group=None):
                     # Then this is likely a custom Gradio component that we do not include in the documentation
                     pass
             except Exception as exc:
-                warnings.warn(f"Could not get documentation group for {cls}: {exc}")
+                warnings.warn(f"Could not get documentation group for {cls}: {exc}", stacklevel=2)
         classes_to_document[documentation_group].append((cls, functions))
         return cls
 

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -321,6 +321,7 @@ def is_valid_url(possible_url: str) -> bool:
     warnings.warn(
         "is_valid_url should not be used. "
         "Use is_http_url_like() and probe_url(), as suitable, instead.",
+        stacklevel=2,
     )
     return is_http_url_like(possible_url) and probe_url(possible_url)
 
@@ -1300,7 +1301,8 @@ def handle_file(filepath_or_url: str | Path):
 
 def file(filepath_or_url: str | Path):
     warnings.warn(
-        "file() is deprecated and will be removed in a future version. Use handle_file() instead."
+        "file() is deprecated and will be removed in a future version. Use handle_file() instead.",
+        stacklevel=2,
     )
     return handle_file(filepath_or_url)
 

--- a/gradio/_simple_templates/simpledropdown.py
+++ b/gradio/_simple_templates/simpledropdown.py
@@ -106,7 +106,8 @@ class SimpleDropdown(FormComponent):
     def _warn_if_invalid_choice(self, y):
         if y not in [value for _, value in self.choices]:
             warnings.warn(
-                f"The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: {y}."
+                f"The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: {y}.",
+                stacklevel=2,
             )
 
     def postprocess(self, value):

--- a/gradio/analytics.py
+++ b/gradio/analytics.py
@@ -93,12 +93,13 @@ def version_check():
             warnings.warn(
                 f"IMPORTANT: You are using gradio version {current_pkg_version}, "
                 f"however version {latest_pkg_version} is available, please upgrade. \n"
-                f"--------"
+                f"--------",
+                stacklevel=2,
             )
     except json.decoder.JSONDecodeError:  # type: ignore
-        warnings.warn("unable to parse version details from package URL.")
+        warnings.warn("unable to parse version details from package URL.", stacklevel=2)
     except KeyError:
-        warnings.warn("package URL does not contain version info.")
+        warnings.warn("package URL does not contain version info.", stacklevel=2)
     except Exception:
         pass
 

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1853,7 +1853,8 @@ Received inputs:
     Output components:
         [{wanted}]
     Output values returned:
-        [{received}]"""
+        [{received}]""",
+                    stacklevel=2,
                 )
 
     async def postprocess_data(
@@ -2493,6 +2494,7 @@ Received inputs:
             warnings.warn(
                 "SSR mode is not supported with multi-page apps when mounting on a FastAPI app. Disabling SSR mode.",
                 UserWarning,
+                stacklevel=2,
             )
             return False
         return (
@@ -2662,11 +2664,13 @@ Received inputs:
         if self.auth and not callable(self.auth):
             if any(not authenticable[0] for authenticable in self.auth):  # type: ignore
                 warnings.warn(
-                    "You have provided an empty username in `auth`. Please provide a valid username."
+                    "You have provided an empty username in `auth`. Please provide a valid username.",
+                    stacklevel=2,
                 )
             if any(not authenticable[1] for authenticable in self.auth):  # type: ignore
                 warnings.warn(
-                    "You have provided an empty password in `auth`. Please provide a valid password."
+                    "You have provided an empty password in `auth`. Please provide a valid password.",
+                    stacklevel=2,
                 )
 
         self.auth_message = auth_message
@@ -2864,7 +2868,7 @@ Received inputs:
                 )
 
         if self.share and self.space_id:
-            warnings.warn("Setting share=True is not supported on Hugging Face Spaces")
+            warnings.warn("Setting share=True is not supported on Hugging Face Spaces", stacklevel=2)
             self.share = False
 
         if self.share:

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -321,7 +321,8 @@ class ChatInterface(Blocks):
             self.chatbot = cast(Chatbot, get_component_instance(chatbot, render=True))
             if self.chatbot.examples and self.examples_messages:
                 warnings.warn(
-                    "The ChatInterface already has examples set. The examples provided in the chatbot will be ignored."
+                    "The ChatInterface already has examples set. The examples provided in the chatbot will be ignored.",
+                    stacklevel=2,
                 )
             self.chatbot.examples = (
                 self.examples_messages

--- a/gradio/components/base.py
+++ b/gradio/components/base.py
@@ -180,16 +180,14 @@ class Component(ComponentBase, Block):
         self.info = info
         if not container:
             if show_label:
-                warnings.warn("show_label has no effect when container is False.")
+                warnings.warn("show_label has no effect when container is False.", stacklevel=2)
             show_label = False
         if show_label is None:
             show_label = True
         self.show_label = show_label
         self.container = container
         if scale is not None and scale != round(scale):
-            warnings.warn(
-                f"'scale' value should be an integer. Using {scale} will cause issues."
-            )
+            warnings.warn(f"'scale' value should be an integer. Using {scale} will cause issues.", stacklevel=2)
         self.scale = scale
         self.min_width = min_width
         self.interactive = interactive

--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -183,6 +183,7 @@ class Dataframe(Component):
             warnings.warn(
                 "The `row_limits` parameter is not yet implemented.",
                 UserWarning,
+                stacklevel=2,
             )
         self.row_limits = row_limits
         self.column_count = self.col_count = self.__process_counts(
@@ -192,11 +193,13 @@ class Dataframe(Component):
             warnings.warn(
                 "The `col_count` parameter is deprecated and will be removed. Please use `column_count` instead.",
                 UserWarning,
+                stacklevel=2,
             )
         if column_limits is not None:
             warnings.warn(
                 "The `column_limits` parameter is not yet implemented.",
                 UserWarning,
+                stacklevel=2,
             )
         self.column_limits = column_limits
         self.static_columns = static_columns or []
@@ -495,7 +498,8 @@ class Dataframe(Component):
             )
         if isinstance(value, Styler) and self.interactive:
             warnings.warn(
-                "Cannot display Styler object in interactive mode. Will display as a regular pandas dataframe instead."
+                "Cannot display Styler object in interactive mode. Will display as a regular pandas dataframe instead.",
+                stacklevel=2,
             )
 
         headers = self.get_headers(value) or self.headers

--- a/gradio/components/dataset.py
+++ b/gradio/components/dataset.py
@@ -191,7 +191,8 @@ class Dataset(Component):
                 index = None
                 warnings.warn(
                     "The `Dataset` component does not support updating the dataset data by providing "
-                    "a set of list values. Instead, you should return a new Dataset(samples=...) object."
+                    "a set of list values. Instead, you should return a new Dataset(samples=...) object.",
+                    stacklevel=2,
                 )
             return index
 

--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -130,13 +130,12 @@ class Dropdown(FormComponent):
             value = [value]
 
         if not multiselect and max_choices is not None:
-            warnings.warn(
-                "The `max_choices` parameter is ignored when `multiselect` is False."
-            )
+            warnings.warn("The `max_choices` parameter is ignored when `multiselect` is False.", stacklevel=2)
         if not filterable and allow_custom_value:
             filterable = True
             warnings.warn(
-                "The `filterable` parameter cannot be set to False when `allow_custom_value` is True. Setting `filterable` to True."
+                "The `filterable` parameter cannot be set to False when `allow_custom_value` is True. Setting `filterable` to True.",
+                stacklevel=2,
             )
         self.max_choices = max_choices
         self.allow_custom_value = allow_custom_value
@@ -233,7 +232,8 @@ class Dropdown(FormComponent):
         if self.allow_custom_value or value in [value for _, value in self.choices]:
             return
         warnings.warn(
-            f"The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: {value} or set allow_custom_value=True."
+            f"The value passed into gr.Dropdown() is not in the list of choices. Please update the list of choices to include: {value} or set allow_custom_value=True.",
+            stacklevel=2,
         )
 
     def postprocess(

--- a/gradio/components/json_component.py
+++ b/gradio/components/json_component.py
@@ -140,6 +140,7 @@ class JSON(Component):
                 f"JSON component received unexpected type {type(value)}. "
                 "Expected a string (including a valid JSON string), dict, list, or Callable.",
                 UserWarning,
+                stacklevel=2,
             )
 
         if isinstance(value, str):

--- a/gradio/components/textbox.py
+++ b/gradio/components/textbox.py
@@ -137,12 +137,14 @@ class Textbox(FormComponent):
         if type in ["password", "email"]:
             if lines != 1:
                 warnings.warn(
-                    "The `lines` parameter must be 1 for `type` of 'password' or 'email'. Setting `lines` to 1."
+                    "The `lines` parameter must be 1 for `type` of 'password' or 'email'. Setting `lines` to 1.",
+                    stacklevel=2,
                 )
                 lines = 1
             if max_lines not in [None, 1]:
                 warnings.warn(
-                    "The `max_lines` parameter must be None or 1 for `type` of 'password' or 'email'. Setting `max_lines` to 1."
+                    "The `max_lines` parameter must be None or 1 for `type` of 'password' or 'email'. Setting `max_lines` to 1.",
+                    stacklevel=2,
                 )
                 max_lines = 1
         self.lines = lines

--- a/gradio/components/upload_button.py
+++ b/gradio/components/upload_button.py
@@ -90,9 +90,7 @@ class UploadButton(Component):
         self.type = type
         self.file_count = file_count
         if file_count == "directory" and file_types is not None:
-            warnings.warn(
-                "The `file_types` parameter is ignored when `file_count` is 'directory'."
-            )
+            warnings.warn("The `file_types` parameter is ignored when `file_count` is 'directory'.", stacklevel=2)
         if file_types is not None and not isinstance(file_types, list):
             raise ValueError(
                 f"Parameter file_types must be a list. Received {file_types.__class__.__name__}"

--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -300,9 +300,7 @@ class Video(StreamingOutput, Component):
             processing_utils.ffmpeg_installed()
             and not processing_utils.video_is_playable(video)
         ):
-            warnings.warn(
-                "Video does not have browser-compatible container or codec. Converting to mp4."
-            )
+            warnings.warn("Video does not have browser-compatible container or codec. Converting to mp4.", stacklevel=2)
             with trace_phase_sync("postprocess_video_convert_video_to_playable_mp4"):
                 video = processing_utils.convert_video_to_playable_mp4(video)
         # Recalculate the format in case convert_video_to_playable_mp4 already made it the selected format

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -178,7 +178,8 @@ def load_blocks_from_huggingface(
     if token is not None:
         if Context.token is not None and Context.token != token:
             warnings.warn(
-                """You are loading a model/Space with a different access token than the one you used to load a previous model/Space. This is not recommended, as it may cause unexpected behavior."""
+                """You are loading a model/Space with a different access token than the one you used to load a previous model/Space. This is not recommended, as it may cause unexpected behavior.""",
+                stacklevel=2,
             )
         Context.token = token
 
@@ -520,7 +521,8 @@ def from_spaces(
 ) -> Blocks:
     if provider is not None:
         warnings.warn(
-            "The `provider` parameter is not supported when loading Spaces. It will be ignored."
+            "The `provider` parameter is not supported when loading Spaces. It will be ignored.",
+            stacklevel=2,
         )
 
     space_url = f"https://huggingface.co/spaces/{space_name}"
@@ -570,7 +572,8 @@ def from_spaces(
                 "You cannot override parameters for this Space by passing in kwargs. "
                 "Instead, please load the Space as a function and use it to create a "
                 "Blocks or Interface locally. You may find this Guide helpful: "
-                "https://gradio.app/using_blocks_like_functions/"
+                "https://gradio.app/using_blocks_like_functions/",
+                stacklevel=2,
             )
         return from_spaces_blocks(space=space_name, token=token)
 

--- a/gradio/external_utils.py
+++ b/gradio/external_utils.py
@@ -43,7 +43,7 @@ def get_model_info(model_name, token=None):
 def get_tabular_examples(model_name: str) -> dict[str, list[float]]:
     readme = httpx.get(f"https://huggingface.co/{model_name}/resolve/main/README.md")
     if readme.status_code != 200:
-        warnings.warn(f"Cannot load examples from README for {model_name}", UserWarning)
+        warnings.warn(f"Cannot load examples from README for {model_name}", UserWarning, stacklevel=2)
         example_data = {}
     else:
         yaml_regex = re.search(

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -150,6 +150,7 @@ class Examples:
         if _initiated_directly:
             warnings.warn(
                 "Please use gr.Examples(...) instead of gr.helpers.Examples(...) to create the Examples.",
+                stacklevel=2,
             )
 
         self.cache_examples = False
@@ -178,7 +179,8 @@ class Examples:
                 cache_mode = "eager"
                 warnings.warn(
                     "The `GRADIO_CACHE_MODE` environment variable must be either 'eager' or 'lazy'. "
-                    "Defaulting to 'eager'."
+                    "Defaulting to 'eager'.",
+                    stacklevel=2,
                 )
 
         if self.cache_examples and cache_mode == "lazy":
@@ -467,7 +469,8 @@ class Examples:
                     )
         else:
             warnings.warn(
-                f"If an Examples object is created outside a Blocks Context, make sure to call `examples.dataset.render()`{'and `examples.create()`' if self.cache_examples else ''} to render the examples in the interface."
+                f"If an Examples object is created outside a Blocks Context, make sure to call `examples.dataset.render()`{'and `examples.create()`' if self.cache_examples else ''} to render the examples in the interface.",
+                stacklevel=2,
             )
 
     async def _postprocess_output(self, output) -> list:
@@ -503,7 +506,8 @@ class Examples:
                         "example values. This may result in an exception being thrown by "
                         "your function. If you do get an error while caching examples, make "
                         "sure all of your inputs have example values for all of your examples "
-                        "or you provide default values for those particular parameters in your function."
+                        "or you provide default values for those particular parameters in your function.",
+                        stacklevel=2,
                     )
                     break
         if self.cache_examples is True:
@@ -986,6 +990,7 @@ def special_args(
                         warnings.warn(
                             "Empty session being created. Install gradio[oauth] and add a gr.LoginButton to your app to enable OAuth login.",
                             UserWarning,
+                            stacklevel=2,
                         )
                         session = {}
                     else:
@@ -1065,7 +1070,7 @@ def special_args(
             i = len(inputs)
             param = positional_args[i]
             if param.default == param.empty:
-                warnings.warn("Unexpected argument. Filling with None.")
+                warnings.warn("Unexpected argument. Filling with None.", stacklevel=2)
                 inputs.append(None)
             else:
                 inputs.append(param.default)
@@ -1146,7 +1151,7 @@ def log_message(
         if level in ("info", "success"):
             print(message)
         elif level == "warning":
-            warnings.warn(message)
+            warnings.warn(message, stacklevel=2)
         return
     blocks._queue.log_message(
         event_id=event_id,

--- a/gradio/i18n.py
+++ b/gradio/i18n.py
@@ -112,6 +112,7 @@ class I18n:
                     f"Invalid locale code: '{locale}'. Locale codes should follow BCP 47 format (e.g., 'en', 'en-US'). "
                     f"This locale will still be included, but may not work correctly.",
                     UserWarning,
+                    stacklevel=2,
                 )
             self.translations[locale] = translation_dict
 

--- a/gradio/image_utils.py
+++ b/gradio/image_utils.py
@@ -307,7 +307,7 @@ def preprocess_image(
         try:
             im = ImageOps.exif_transpose(im)
         except Exception:
-            warnings.warn(f"Failed to transpose image {file_path} based on EXIF data.")
+            warnings.warn(f"Failed to transpose image {file_path} based on EXIF data.", stacklevel=2)
     if suffix.lower() != "gif" and im is not None:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -270,7 +270,8 @@ class Interface(Blocks):
             if cache_examples:
                 warnings.warn(
                     "Cache examples cannot be used with state inputs and outputs. "
-                    "Setting cache_examples to False."
+                    "Setting cache_examples to False.",
+                    stacklevel=2,
                 )
             self.cache_examples = False
 
@@ -738,9 +739,7 @@ class Interface(Blocks):
 
             for component in self.input_components:  # type: ignore
                 if getattr(component, "streaming", None):
-                    warnings.warn(
-                        "Streaming components are only supported in live interfaces."
-                    )
+                    warnings.warn("Streaming components are only supported in live interfaces.", stacklevel=2)
 
             if _stop_btn:
                 extra_output = [_submit_btn, _stop_btn]

--- a/gradio/layouts/column.py
+++ b/gradio/layouts/column.py
@@ -56,9 +56,7 @@ class Column(BlockContext, metaclass=ComponentMeta):
             preserved_by_key: A list of parameters from this component's constructor. Inside a gr.render() function, if a component is re-rendered with the same key, these (and only these) parameters will be preserved in the UI (if they have been changed by the user or an event listener) instead of re-rendered based on the values provided during constructor.
         """
         if scale != round(scale):
-            warnings.warn(
-                f"'scale' value should be an integer. Using {scale} will cause issues."
-            )
+            warnings.warn(f"'scale' value should be an integer. Using {scale} will cause issues.", stacklevel=2)
 
         self.scale = scale
         self.min_width = min_width

--- a/gradio/layouts/row.py
+++ b/gradio/layouts/row.py
@@ -66,9 +66,7 @@ class Row(BlockContext, metaclass=ComponentMeta):
         self.max_height = max_height
         self.min_height = min_height
         if scale and scale != round(scale):
-            warnings.warn(
-                f"'scale' value should be an integer. Using {scale} will cause issues."
-            )
+            warnings.warn(f"'scale' value should be an integer. Using {scale} will cause issues.", stacklevel=2)
 
         self.scale = scale
 

--- a/gradio/mcp.py
+++ b/gradio/mcp.py
@@ -207,7 +207,8 @@ class GradioMCPServer:
                 warnings.warn(
                     "This MCP server includes a tool that has a gr.State input, which will not be "
                     "updated between tool calls. The original, default value of the State will be "
-                    "used each time."
+                    "used each time.",
+                    stacklevel=2,
                 )
 
     def _get_or_create_client(self) -> Client:

--- a/gradio/node_server.py
+++ b/gradio/node_server.py
@@ -134,9 +134,7 @@ def start_node_process(
         except OSError:
             continue
         except Exception as e:
-            warnings.warn(
-                f"Unexpected error while starting Node server: {e}. Trying next port..."
-            )
+            warnings.warn(f"Unexpected error while starting Node server: {e}. Trying next port...", stacklevel=2)
             if node_process:
                 node_process.terminate()
                 node_process = None

--- a/gradio/oauth.py
+++ b/gradio/oauth.py
@@ -162,7 +162,8 @@ def _add_mocked_oauth_routes(app: fastapi.FastAPI) -> None:
     warnings.warn(
         "Gradio does not support OAuth features outside of a Space environment. To help"
         " you debug your app locally, the login and logout buttons are mocked with your"
-        " profile. To make it work, your machine must be logged in to Huggingface."
+        " profile. To make it work, your machine must be logged in to Huggingface.",
+        stacklevel=2,
     )
     mocked_oauth_info = _get_mocked_oauth_info()
 

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -695,26 +695,26 @@ def convert_to_16_bit_wav(data):
     # Based on: https://docs.scipy.org/doc/scipy/reference/generated/scipy.io.wavfile.write.html
     warning = "Trying to convert audio automatically from {} to 16-bit int format."
     if data.dtype in [np.float64, np.float32, np.float16]:
-        warnings.warn(warning.format(data.dtype))
+        warnings.warn(warning.format(data.dtype), stacklevel=2)
         data = data / np.abs(data).max()
         data = data * 32767
         data = data.astype(np.int16)
     elif data.dtype == np.int32:
-        warnings.warn(warning.format(data.dtype))
+        warnings.warn(warning.format(data.dtype), stacklevel=2)
         data = data / 65536
         data = data.astype(np.int16)
     elif data.dtype == np.int16:
         pass
     elif data.dtype == np.uint16:
-        warnings.warn(warning.format(data.dtype))
+        warnings.warn(warning.format(data.dtype), stacklevel=2)
         data = data - 32768
         data = data.astype(np.int16)
     elif data.dtype == np.uint8:
-        warnings.warn(warning.format(data.dtype))
+        warnings.warn(warning.format(data.dtype), stacklevel=2)
         data = data * 257 - 32768
         data = data.astype(np.int16)
     elif data.dtype == np.int8:
-        warnings.warn(warning.format(data.dtype))
+        warnings.warn(warning.format(data.dtype), stacklevel=2)
         data = data * 256
         data = data.astype(np.int16)
     else:

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -2598,7 +2598,8 @@ def mount_gradio_app(
     if favicon_path is not None and path != "/":
         warnings.warn(
             "The 'favicon_path' parameter is set but will be ignored because 'path' is not '/'. "
-            "Please add the favicon directly to your FastAPI app."
+            "Please add the favicon directly to your FastAPI app.",
+            stacklevel=2,
         )
 
     blocks.dev_mode = False

--- a/gradio/themes/base.py
+++ b/gradio/themes/base.py
@@ -102,7 +102,7 @@ class ThemeClass:
     def _get_computed_value(self, property: str, depth=0) -> str:
         max_depth = 100
         if depth > max_depth:
-            warnings.warn(f"Cannot resolve '{property}' - circular reference detected.")
+            warnings.warn(f"Cannot resolve '{property}' - circular reference detected.", stacklevel=2)
             return ""
         is_dark = property.endswith("_dark")
         if is_dark:
@@ -163,7 +163,8 @@ class ThemeClass:
                     warnings.warn(
                         f"This theme was created for Gradio {theme_gradio_version}, "
                         f"but you are using Gradio {__version__}. "
-                        "Some styles may not work as expected."
+                        "Some styles may not work as expected.",
+                        stacklevel=2,
                     )
             except (ValueError, IndexError):
                 pass

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -579,7 +579,7 @@ def get_theme(theme: Theme | str | None) -> Theme:
             try:
                 theme = Theme.from_hub(theme)
             except Exception as e:
-                warnings.warn(f"Cannot load {theme}. Caught Exception: {str(e)}")
+                warnings.warn(f"Cannot load {theme}. Caught Exception: {str(e)}", stacklevel=2)
                 theme = DefaultTheme()
     return theme
 
@@ -1197,17 +1197,11 @@ def check_function_inputs_match(fn: Callable, inputs: Sequence, inputs_as_dict: 
             return f"Keyword-only args must have default values for function {fn}"
     arg_count = 1 if inputs_as_dict else len(inputs)
     if min_args == max_args and max_args != arg_count:
-        warnings.warn(
-            f"Expected {max_args} arguments for function {fn}, received {arg_count}."
-        )
+        warnings.warn(f"Expected {max_args} arguments for function {fn}, received {arg_count}.", stacklevel=2)
     if arg_count < min_args:
-        warnings.warn(
-            f"Expected at least {min_args} arguments for function {fn}, received {arg_count}."
-        )
+        warnings.warn(f"Expected at least {min_args} arguments for function {fn}, received {arg_count}.", stacklevel=2)
     if max_args != infinity and arg_count > max_args:
-        warnings.warn(
-            f"Expected maximum {max_args} arguments for function {fn}, received {arg_count}."
-        )
+        warnings.warn(f"Expected maximum {max_args} arguments for function {fn}, received {arg_count}.", stacklevel=2)
 
 
 class TupleNoPrint(tuple):


### PR DESCRIPTION
## Description

Without `stacklevel`, `warnings.warn()` reports the location of the `warn()` call itself rather than the caller's location, making it harder for users to identify the source of the warning in their own code.

This adds `stacklevel=2` to all 62 `warnings.warn()` calls across 30 files in both `gradio/` and `client/python/gradio_client/` that were missing it.

### Changes

- **30 files modified** across `gradio/`, `gradio/components/`, `gradio/layouts/`, `gradio/themes/`, `gradio/_simple_templates/`, and `client/python/gradio_client/`
- **62 `warnings.warn()` calls** now include `stacklevel=2`
- No functional changes — only the warning source location reported to users is affected

### Why this matters

When a user calls e.g. `gr.Dropdown(multiselect=False, max_choices=5)`, the warning currently points to `gradio/components/dropdown.py:133` instead of the user's own code. With `stacklevel=2`, the warning correctly points to the line in the user's script, making it much easier to find and fix the issue.

### Files changed

<details>
<summary>Full list of 30 files</summary>

- `gradio/analytics.py`
- `gradio/blocks.py`
- `gradio/chat_interface.py`
- `gradio/components/base.py`
- `gradio/components/dataframe.py`
- `gradio/components/dataset.py`
- `gradio/components/dropdown.py`
- `gradio/components/json_component.py`
- `gradio/components/textbox.py`
- `gradio/components/upload_button.py`
- `gradio/components/video.py`
- `gradio/external.py`
- `gradio/external_utils.py`
- `gradio/helpers.py`
- `gradio/i18n.py`
- `gradio/image_utils.py`
- `gradio/interface.py`
- `gradio/layouts/column.py`
- `gradio/layouts/row.py`
- `gradio/mcp.py`
- `gradio/node_server.py`
- `gradio/oauth.py`
- `gradio/processing_utils.py`
- `gradio/routes.py`
- `gradio/themes/base.py`
- `gradio/utils.py`
- `gradio/_simple_templates/simpledropdown.py`
- `client/python/gradio_client/client.py`
- `client/python/gradio_client/documentation.py`
- `client/python/gradio_client/utils.py`

</details>