### PR TITLE
Fix flakey crypto-js test

### DIFF
--- a/js/browserstate/crypto.test.ts
+++ b/js/browserstate/crypto.test.ts
@@ -71,12 +71,6 @@ describe("decrypt", () => {
 		expect(result).not.toBe(original);
 	});
 
-	test("wrong key returns an empty string (CryptoJS padding failure)", () => {
-		const encrypted = encrypt("hello", "correct-key");
-		// CryptoJS returns "" when AES-CBC decryption fails padding validation
-		expect(decrypt(encrypted, "wrong-key")).toBe("");
-	});
-
 	test("completely malformed input (no IV separator) does not return the input as-is", () => {
 		// CryptoJS may throw or return "" — either is acceptable; it must not echo the input
 		try {


### PR DESCRIPTION
# How to fix flaky tests 101

Delete them.

---

Jokes aside, the test had two issues:

- it was testing Cryptojs implementation details, which is not our responsibility, nor can we do anything about it.
- it was assuming cryptojs treatment of wrong keys in this context is deterministic, which it isn't sometimes garbage bytes through and you get the malformed UTF data errors.