### PR TITLE
enable default behaviour on static dfs

### DIFF
--- a/.changeset/df-static-cell-menu.md
+++ b/.changeset/df-static-cell-menu.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": patch
+"gradio": patch
+---
+
+fix:Dataframe: allow native context menu and text selection on static cells

--- a/js/dataframe/Dataframe.test.ts
+++ b/js/dataframe/Dataframe.test.ts
@@ -585,6 +585,67 @@ describe("Add/remove rows and columns", () => {
 	});
 });
 
+describe("Cell menu visibility on static cells", () => {
+	afterEach(() => cleanup());
+
+	test("context menu does not open on a static column cell", async () => {
+		const { container } = await render(Dataframe, {
+			...default_props,
+			static_columns: [0]
+		});
+		await wait();
+
+		const cell = get_cell(container, 0, 0)!;
+		await fireEvent.contextMenu(cell);
+		await wait();
+
+		expect(within(document.body).queryByRole("menu")).toBeNull();
+	});
+
+	test("context menu does not open when interactive is false", async () => {
+		const { container } = await render(Dataframe, {
+			...default_props,
+			interactive: false,
+			editable: false
+		});
+		await wait();
+
+		const cell = get_cell(container, 0, 0)!;
+		await fireEvent.contextMenu(cell);
+		await wait();
+
+		expect(within(document.body).queryByRole("menu")).toBeNull();
+	});
+
+	test("context menu does open on an editable, non-static cell", async () => {
+		const { container } = await render(Dataframe, {
+			...default_props,
+			row_count: [3, "dynamic"] as [number, "fixed" | "dynamic"]
+		});
+		await wait();
+
+		const cell = get_cell(container, 0, 0)!;
+		await fireEvent.contextMenu(cell);
+		await wait();
+
+		expect(within(document.body).queryByRole("menu")).not.toBeNull();
+	});
+
+	test("cell menu button does not render on a static column cell", async () => {
+		const { container } = await render(Dataframe, {
+			...default_props,
+			static_columns: [0]
+		});
+		await wait();
+
+		const cell = get_cell(container, 0, 0)!;
+		await fireEvent.mouseDown(cell);
+		await wait();
+
+		expect(cell.querySelector(".cell-menu-button")).toBeNull();
+	});
+});
+
 describe("Delete/clear cells", () => {
 	afterEach(() => cleanup());
 

--- a/js/dataframe/shared/DataCell.svelte
+++ b/js/dataframe/shared/DataCell.svelte
@@ -77,9 +77,11 @@
 	class="body-cell {selection_classes}"
 	class:flash={is_flash}
 	class:first-column={is_first_column}
+	class:static={is_static}
 	data-row={row_idx}
 	data-col={col_idx}
 	data-testid={`cell-${row_idx}-${col_idx}`}
+	tabindex={is_static ? -1 : undefined}
 	{onmousedown}
 	{ondblclick}
 	{oncontextmenu}
@@ -122,6 +124,11 @@
 		padding: 0;
 		overflow: visible;
 		box-sizing: border-box;
+		user-select: none;
+	}
+
+	.body-cell.static {
+		user-select: text;
 	}
 
 	.body-cell.first-column {

--- a/js/dataframe/shared/EditableCell.svelte
+++ b/js/dataframe/shared/EditableCell.svelte
@@ -221,6 +221,7 @@
 		font-weight: inherit;
 		line-height: var(--line-lg);
 		left: var(--size-2);
+		user-select: text;
 	}
 
 	textarea:focus {
@@ -236,10 +237,6 @@
 		position: relative;
 		display: block;
 		outline: none;
-		-webkit-user-select: text;
-		-moz-user-select: text;
-		-ms-user-select: text;
-		user-select: text;
 		cursor: text;
 		width: 100%;
 		overflow-wrap: break-word;

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -291,7 +291,13 @@
 		row: number,
 		col: number
 	): void {
-		event.preventDefault();
+		const col_is_static =
+			!editable ||
+			static_columns.includes(col) ||
+			static_columns.includes(resolved_headers[col]);
+		if (!col_is_static) {
+			event.preventDefault();
+		}
 		event.stopPropagation();
 
 		const coord: CellCoordinate = [row, col];
@@ -332,7 +338,9 @@
 			col_value: values?.map((r) => r[col]) ?? []
 		} as any);
 
-		tick().then(() => parent?.focus());
+		if (!col_is_static) {
+			tick().then(() => parent?.focus());
+		}
 	}
 
 	function handle_cell_dblclick(
@@ -340,15 +348,14 @@
 		row: number,
 		col: number
 	): void {
-		event.preventDefault();
-		event.stopPropagation();
-		if (!editable) return;
 		const col_is_static =
+			!editable ||
 			static_columns.includes(col) ||
 			static_columns.includes(resolved_headers[col]);
-		if (!col_is_static) {
-			editing = [row, col];
-		}
+		if (col_is_static) return;
+		event.preventDefault();
+		event.stopPropagation();
+		editing = [row, col];
 	}
 
 	function handle_blur(detail: {
@@ -999,8 +1006,10 @@
 											editing[1] === col_idx
 										)}
 										is_flash={copy_flash && is_sel}
-										is_static={!!(cell.column.columnDef.meta as any)?.isStatic}
+										is_static={!editable ||
+											!!(cell.column.columnDef.meta as any)?.isStatic}
 										show_menu_button={editable &&
+											!(cell.column.columnDef.meta as any)?.isStatic &&
 											selected_cells.length === 1 &&
 											selected_cells[0][0] === row_idx &&
 											selected_cells[0][1] === col_idx}
@@ -1020,6 +1029,10 @@
 										ondblclick={(e) =>
 											handle_cell_dblclick(e, row_idx, col_idx)}
 										oncontextmenu={(e) => {
+											const is_static_cell = !!(
+												cell.column.columnDef.meta as any
+											)?.isStatic;
+											if (!editable || is_static_cell) return;
 											e.preventDefault();
 											toggle_cell_menu(e, row_idx, col_idx);
 										}}


### PR DESCRIPTION
## Description

It was not possible to select text in static dataframes. It was not possible to right click text in static dataframe cells, as an empty cell menu would open. Now it is.

This problem was present either when a Dataframe was created with `interactive=False` of when a column was set to `static`.

Closes #12156. Closes #11562.