### PR TITLE
fix flaky render test

### DIFF
--- a/.changeset/red-frogs-nail.md
+++ b/.changeset/red-frogs-nail.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataset": minor
+"gradio": minor
+---
+
+feat:render

--- a/.changeset/red-frogs-nail.md
+++ b/.changeset/red-frogs-nail.md
@@ -3,4 +3,4 @@
 "gradio": minor
 ---
 
-feat:render
+feat:fix flaky render test

--- a/js/dataset/Dataset.svelte
+++ b/js/dataset/Dataset.svelte
@@ -195,8 +195,10 @@
 								selected={current_hover === i}
 								type="gallery"
 							/>
-						{:else if component_meta.length}
-							{#await Promise.all( [component_meta[0][0].component, component_meta[0][0].runtime] ) then [component, runtime]}
+						{:else if component_meta.length && component_meta[0]?.length}
+							{#await Promise.all( [component_meta[0][0].component, component_meta[0][0].runtime] )}
+								{sample_row[0]}
+							{:then [component, runtime]}
 								{#key sample_row[0]}
 									<MountExample
 										{component}
@@ -210,7 +212,11 @@
 										{root}
 									/>
 								{/key}
+							{:catch}
+								{sample_row[0]}
 							{/await}
+						{:else}
+							{sample_row[0]}
 						{/if}
 					</button>
 				{/if}

--- a/js/spa/test/render_tests.spec.ts
+++ b/js/spa/test/render_tests.spec.ts
@@ -53,15 +53,19 @@ test("Test examples work in render", async ({ page }) => {
 	await input.waitFor();
 	const testButton = page.getByRole("button", { name: "test" });
 	await testButton.waitFor();
-	await testButton.click();
-	await expect(input).toHaveValue("test", { timeout: 10000 });
+	await expect(async () => {
+		await testButton.click();
+		await expect(input).toHaveValue("test", { timeout: 2000 });
+	}).toPass({ timeout: 10000 });
 
 	const little_textbox = page.getByLabel("little textbox", { exact: true });
 	await little_textbox.waitFor();
 	const defButton = page.getByRole("button", { name: "def", exact: true });
 	await defButton.waitFor();
-	await defButton.click();
-	await expect(little_textbox).toHaveValue("def", { timeout: 10000 });
+	await expect(async () => {
+		await defButton.click();
+		await expect(little_textbox).toHaveValue("def", { timeout: 2000 });
+	}).toPass({ timeout: 10000 });
 });
 
 test("Test keyed event listeners in render", async ({ page }) => {

--- a/js/spa/test/render_tests.spec.ts
+++ b/js/spa/test/render_tests.spec.ts
@@ -49,16 +49,10 @@ test("Test event/selection data can trigger render", async ({ page }) => {
 });
 
 test("Test examples work in render", async ({ page }) => {
-	const testButton = page.getByRole("button", { name: "test" });
-	try {
-		await testButton.waitFor({ timeout: 10000 });
-	} catch {
-		await page.reload();
-		await page.waitForLoadState("load");
-		await testButton.waitFor({ timeout: 10000 });
-	}
-
 	const input = page.getByLabel("input", { exact: true });
+	await input.waitFor();
+	const testButton = page.getByRole("button", { name: "test" });
+	await testButton.waitFor();
 	await testButton.click();
 	await expect(input).toHaveValue("test", { timeout: 10000 });
 

--- a/js/spa/test/render_tests.spec.ts
+++ b/js/spa/test/render_tests.spec.ts
@@ -49,23 +49,25 @@ test("Test event/selection data can trigger render", async ({ page }) => {
 });
 
 test("Test examples work in render", async ({ page }) => {
-	const input = page.getByLabel("input", { exact: true });
-	await input.waitFor();
 	const testButton = page.getByRole("button", { name: "test" });
-	await testButton.waitFor();
-	await expect(async () => {
-		await testButton.click();
-		await expect(input).toHaveValue("test", { timeout: 2000 });
-	}).toPass({ timeout: 10000 });
+	try {
+		await testButton.waitFor({ timeout: 10000 });
+	} catch {
+		await page.reload();
+		await page.waitForLoadState("load");
+		await testButton.waitFor({ timeout: 10000 });
+	}
+
+	const input = page.getByLabel("input", { exact: true });
+	await testButton.click();
+	await expect(input).toHaveValue("test", { timeout: 10000 });
 
 	const little_textbox = page.getByLabel("little textbox", { exact: true });
 	await little_textbox.waitFor();
 	const defButton = page.getByRole("button", { name: "def", exact: true });
 	await defButton.waitFor();
-	await expect(async () => {
-		await defButton.click();
-		await expect(little_textbox).toHaveValue("def", { timeout: 2000 });
-	}).toPass({ timeout: 10000 });
+	await defButton.click();
+	await expect(little_textbox).toHaveValue("def", { timeout: 10000 });
 });
 
 test("Test keyed event listeners in render", async ({ page }) => {


### PR DESCRIPTION
## Description

i thought #13235 broke it but i was wrong.

 ~anyways this seems to maybe fix it? seems dynamic import don't always complete on time when there are multiple playwright workers running so this reload is a safety net.~

the example button was showing blank while waiting for the dynamic import to load, now it shows plain text instead of nothing

Closes: #(issue)

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

