### PR TITLE
Add docs for gr.cache and gr.Cache

### DIFF
--- a/.changeset/yummy-paths-attack.md
+++ b/.changeset/yummy-paths-attack.md
@@ -1,0 +1,5 @@
+---
+"website": minor
+---
+
+feat:Add docs for gr.cache and gr.Cache

--- a/js/_website/generate_jsons/src/docs/__init__.py
+++ b/js/_website/generate_jsons/src/docs/__init__.py
@@ -171,13 +171,20 @@ def organize_docs(d):
                     if "default" in p:
                         p["default"] = str(p["default"])
             if mode == "component":
-                organized["gradio"]["components"][c["name"].lower()] = c
+                target = organized["gradio"]["components"]
             elif mode == "py-client":
-                organized["python-client"][c["name"].lower()] = c
+                target = organized["python-client"]
             elif mode in ["helpers", "routes", "chatinterface", "modals"]:
-                organized["gradio"][mode][c["name"].lower()] = c                
+                target = organized["gradio"][mode]
             else:
-                organized["gradio"]["building"][c["name"].lower()] = c
+                target = organized["gradio"]["building"]
+            key = c["name"].lower()
+            if key in target:
+                if c["name"] != c["name"].lower():
+                    key = key + "-class"
+                else:
+                    target[key + "-class"] = target.pop(key)
+            target[key] = c
     
 
     def format_name(page_name):

--- a/js/_website/src/lib/templates/gradio/04_helpers/cache-class.svx
+++ b/js/_website/src/lib/templates/gradio/04_helpers/cache-class.svx
@@ -1,0 +1,70 @@
+
+<script lang="ts">
+    import {get_object} from "../../process_json.ts";
+    import ParamTable from "$lib/components/ParamTable.svelte";
+    import ShortcutTable from "$lib/components/ShortcutTable.svelte";
+    import DemosSection from "$lib/components/DemosSection.svelte";
+    import FunctionsSection from "$lib/components/FunctionsSection.svelte";
+    import GuidesSection from "$lib/components/GuidesSection.svelte";
+    import CopyButton from "$lib/components/CopyButton.svelte";
+    import { style_formatted_text } from "$lib/text";
+
+    let obj = get_object("cache-class");
+
+    obj.guides = [{
+        "url": "/guides/caching",
+        "pretty_name": "Caching"
+    }]
+</script>
+
+<!--- Title -->
+# {obj.name}
+
+<!--- Usage -->
+```python
+gradio.Cache(···)
+```
+
+<!--- Description -->
+### Description
+## {@html style_formatted_text(obj.description)}
+
+<!-- Example Usage -->
+
+{#if obj.example}
+### Example Usage
+```python
+import gradio as gr
+
+def generate(prompt, c=gr.Cache(per_session=True)):
+    hit = c.get(prompt)
+    if hit is not None:
+        return hit["result"]
+    result = llm(prompt)
+    c.set(prompt, result=result)
+    return result
+```
+{/if}
+
+<!--- Initialization -->
+### Initialization
+<ParamTable parameters={obj.parameters} anchor_links={obj.name}/>
+
+
+{#if obj.demos && obj.demos.length > 0}
+<!--- Demos -->
+### Demos
+<DemosSection demos={obj.demos} />
+{/if}
+
+{#if obj.fns && obj.fns.length > 0}
+<!--- Methods -->
+### Methods
+<FunctionsSection fns={obj.fns} event_listeners={false} />
+{/if}
+
+{#if obj.guides && obj.guides.length > 0}
+<!--- Guides -->
+<!--- the guide section below is still necessary to scrape the guides on the side navigation -->
+<GuidesSection guides={obj.guides}/>
+{/if}

--- a/js/_website/src/lib/templates/gradio/04_helpers/cache.svx
+++ b/js/_website/src/lib/templates/gradio/04_helpers/cache.svx
@@ -22,7 +22,6 @@
 
 <!--- Usage -->
 ```python
-@gradio.cache
 @gradio.cache(···)
 ```
 

--- a/js/_website/src/lib/templates/gradio/04_helpers/cache.svx
+++ b/js/_website/src/lib/templates/gradio/04_helpers/cache.svx
@@ -1,0 +1,71 @@
+
+<script lang="ts">
+    import {get_object} from "../../process_json.ts";
+    import ParamTable from "$lib/components/ParamTable.svelte";
+    import ShortcutTable from "$lib/components/ShortcutTable.svelte";
+    import DemosSection from "$lib/components/DemosSection.svelte";
+    import FunctionsSection from "$lib/components/FunctionsSection.svelte";
+    import GuidesSection from "$lib/components/GuidesSection.svelte";
+    import CopyButton from "$lib/components/CopyButton.svelte";
+    import { style_formatted_text } from "$lib/text";
+
+    let obj = get_object("cache");
+
+    obj.guides = [{
+        "url": "/guides/caching",
+        "pretty_name": "Caching"
+    }]
+</script>
+
+<!--- Title -->
+# {obj.name}
+
+<!--- Usage -->
+```python
+@gradio.cache
+@gradio.cache(···)
+```
+
+<!--- Description -->
+### Description
+## {@html style_formatted_text(obj.description)}
+
+<!-- Example Usage -->
+
+{#if obj.example}
+### Example Usage
+```python
+import gradio as gr
+
+@gr.cache
+def classify(image):
+    return model.predict(image)
+
+@gr.cache(max_size=256, per_session=True)
+def generate(prompt):
+    return llm(prompt)
+```
+{/if}
+
+<!--- Initialization -->
+### Initialization
+<ParamTable parameters={obj.parameters} anchor_links={obj.name}/>
+
+
+{#if obj.demos && obj.demos.length > 0}
+<!--- Demos -->
+### Demos
+<DemosSection demos={obj.demos} />
+{/if}
+
+{#if obj.fns && obj.fns.length > 0}
+<!--- Methods -->
+### Methods
+<FunctionsSection fns={obj.fns} event_listeners={false} />
+{/if}
+
+{#if obj.guides && obj.guides.length > 0}
+<!--- Guides -->
+<!--- the guide section below is still necessary to scrape the guides on the side navigation -->
+<GuidesSection guides={obj.guides}/>
+{/if}


### PR DESCRIPTION
This PR adds `.svx` doc pages for `@gr.cache` (decorator) and `gr.Cache` (manual cache class). The problem is that we currently use the lower case name for the class/method for the .svx, so I tweaked the docs generation so that if a collision is detected, the class entry gets a `-class` suffix (e.g. `"cache-class"`).

verified this works by visiting the built site, e.g. https://99a9d3f1.gradio-website.pages.dev/main/docs/gradio/cache-class