### PR TITLE
add untraced param to storybook workflow

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -103,6 +103,7 @@ jobs:
           onlyChanged: true
           exitOnceUploaded: true
           storybookBuildDir: storybook-static
+          untraced: "package.json pnpm-lock.yaml .github/** **/*.py **/*.md"
 
   comment-chromatic-end:
     uses: "./.github/workflows/comment-queue.yml"


### PR DESCRIPTION
## Description

this should hopefully reduce snapshots by preventing chromatic from caring about the package.json we create in the storybook workflow file, therefore not disabling turbosnap

