### PR TITLE
fix: replace dead-code bare except with nested try/except in depth estimation demo

### DIFF
--- a/demo/depth_estimation/run.py
+++ b/demo/depth_estimation/run.py
@@ -39,13 +39,19 @@ def process_image(image_path):
         img = Image.fromarray(depth_image)
         return [img, gltf_path, gltf_path]
     except Exception:
-        gltf_path = create_3d_obj(
-            np.array(image), depth_image, image_path, depth=8)
-        img = Image.fromarray(depth_image)
-        return [img, gltf_path, gltf_path]
-    except:
-        print("Error reconstructing 3D model")
-        raise Exception("Error reconstructing 3D model")
+        # Retry with a lower Poisson depth to produce a coarser but more
+        # robust mesh when the first attempt fails (e.g. too many vertices).
+        # The previous bare `except:` after this block was dead code: in Python
+        # only one except clause per try block can match, so the second handler
+        # never ran.  Nest the fallback in its own try/except instead.
+        try:
+            gltf_path = create_3d_obj(
+                np.array(image), depth_image, image_path, depth=8)
+            img = Image.fromarray(depth_image)
+            return [img, gltf_path, gltf_path]
+        except Exception:
+            print("Error reconstructing 3D model")
+            raise
 
 def create_3d_obj(rgb_image, depth_image, image_path, depth=10):
     depth_o3d = o3d.geometry.Image(depth_image)


### PR DESCRIPTION
## Summary

Fixes #13282

The `process_image` function in `demo/depth_estimation/run.py` has a Python exception-handling bug that makes the fallback error reporting dead code.

## Problem

```python
try:
    gltf_path = create_3d_obj(np.array(image), depth_image, image_path)
    ...
except Exception:           # ← first handler: retry with lower depth
    gltf_path = create_3d_obj(
        np.array(image), depth_image, image_path, depth=8)
    ...
except:                     # ← DEAD CODE: never executes
    print("Error reconstructing 3D model")
    raise Exception("Error reconstructing 3D model")
```

In Python, `except` clauses belong to a single `try` block and are tested **in order** — only the **first** matching clause executes. Once `except Exception:` matches the original exception, the subsequent `except:` clause is never evaluated. If the retry call inside `except Exception:` also raises, the exception propagates **uncaught** and the error message is never printed.

## Fix

Nest the fallback `create_3d_obj` call inside its own `try/except`:

```python
try:
    gltf_path = create_3d_obj(np.array(image), depth_image, image_path)
    ...
except Exception:
    try:
        gltf_path = create_3d_obj(
            np.array(image), depth_image, image_path, depth=8)
        ...
    except Exception:
        print("Error reconstructing 3D model")
        raise
```

Now if the lower-depth retry also fails, the error message is printed and the exception re-raised as intended.