### PR TITLE
Fix Dataset gallery view component metadata indexing and broken pagination

### DIFF
--- a/.changeset/fix-dataset-gallery-component-meta.md
+++ b/.changeset/fix-dataset-gallery-component-meta.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataset": patch
+"gradio": patch
+---
+
+fix:Dataset: fix gallery view using wrong component metadata index and fix broken pagination after Svelte 5 migration

--- a/js/dataset/Dataset.svelte
+++ b/js/dataset/Dataset.svelte
@@ -61,9 +61,10 @@
 
 	// page resets to 0 whenever effective_samples changes,
 	// but can still be overwritten by user clicks
-	let page = $derived.by(() => {
+	let page = $state(0);
+	$effect(() => {
 		effective_samples;
-		return 0;
+		page = 0;
 	});
 
 	let paginate = $derived(effective_samples.length > samples_per_page);
@@ -195,8 +196,8 @@
 								selected={current_hover === i}
 								type="gallery"
 							/>
-						{:else if component_meta.length}
-							{#await Promise.all( [component_meta[0][0].component, component_meta[0][0].runtime] ) then [component, runtime]}
+						{:else if component_meta.length && component_meta[i]}
+							{#await Promise.all( [component_meta[i][0].component, component_meta[i][0].runtime] ) then [component, runtime]}
 								{#key sample_row[0]}
 									<MountExample
 										{component}


### PR DESCRIPTION
## Description

Two bugs in `Dataset.svelte` introduced during the Svelte 5 migration (PR #13150 and related work):

### 1. Wrong component metadata index in gallery view

The gallery view used `component_meta[0][0]` for every example row instead of `component_meta[i][0]`. This caused all rows to reference the first row's component metadata (promise + runtime), rather than each row using its own. When components like `gr.Dropdown` or `gr.Radio` are used as inputs alongside `gr.Dataframe` outputs, this incorrect indexing leads to rendering issues and browser freezes.

**Before:**
```svelte
{:else if component_meta.length}
    {#await Promise.all( [component_meta[0][0].component, component_meta[0][0].runtime] ) ...}
```

**After:**
```svelte
{:else if component_meta.length && component_meta[i]}
    {#await Promise.all( [component_meta[i][0].component, component_meta[i][0].runtime] ) ...}
```

Also added a bounds check (`component_meta[i]`) to guard against the case where `selected_samples` and `component_meta` have different lengths during async loading.

### 2. Broken pagination (Svelte 5 migration)

`page` was declared as `$derived` (read-only in Svelte 5) but the pagination click handler attempted to assign to it (`page = visible_page`). This made pagination completely non-functional. Changed to `$state` with a resetting `$effect` to restore the original behavior.

Closes: #13270

## AI Disclosure

- [x] I did not use AI

## Testing

- Verified the reproduction case from the issue no longer freezes the browser
- Verified each gallery example row renders using its own component metadata
- Verified pagination click handler correctly changes the displayed page