### PR TITLE
fix(slider): prevent ValueError when minimum equals maximum

### DIFF
--- a/gradio/components/slider.py
+++ b/gradio/components/slider.py
@@ -85,8 +85,11 @@ class Slider(FormComponent):
         self.precision = precision
         if step is None:
             difference = maximum - minimum
-            power = math.floor(math.log10(difference) - 2)
-            self.step = 10**power
+            if difference <= 0:
+                self.step = 1
+            else:
+                power = math.floor(math.log10(difference) - 2)
+                self.step = 10**power
         else:
             self.step = step
         self.buttons = buttons


### PR DESCRIPTION
## Bug

`gr.Slider` crashes with `ValueError: math domain error` when `minimum == maximum` and no explicit `step` is provided. The auto-step calculation computes `math.log10(0)`.

```python
gr.Slider(minimum=5, maximum=5)  # crashes
```

## Fix

Guard against zero or negative difference in the auto-step calculation. When `minimum == maximum`, default `step` to `1`.

Closes #13293