### PR TITLE
fix(dataframe): prevent IndexError in set_auto_datatype for empty lists and 1D arrays

### DIFF
--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -562,6 +562,8 @@ class Dataframe(Component):
             ]
 
         elif isinstance(value, np.ndarray):
+            if value.ndim == 1:
+                value = value.reshape(1, -1)
             self.datatype = [
                 dtype_mapping.get(
                     numbers_re.sub(
@@ -573,15 +575,18 @@ class Dataframe(Component):
             ]
 
         elif isinstance(value, list):
-            self.datatype = [
-                dtype_mapping.get(
-                    numbers_re.sub(
-                        "", brackets_re.sub("", str(type(val).__name__))
-                    ).lower(),
-                    "str",
-                )
-                for val in value[0]
-            ]
+            if len(value) == 0:
+                self.datatype = "str"
+            else:
+                self.datatype = [
+                    dtype_mapping.get(
+                        numbers_re.sub(
+                            "", brackets_re.sub("", str(type(val).__name__))
+                        ).lower(),
+                        "str",
+                    )
+                    for val in value[0]
+                ]
 
         elif _is_polars_available():
             pl = _import_polars()


### PR DESCRIPTION
## Bug

`gr.Dataframe(datatype="auto")` crashes with `IndexError` on two edge cases:

1. **Empty list**: `value[0]` raises `IndexError: list index out of range`
2. **1D numpy array**: `value[0, i]` raises `IndexError: too many indices for array`

## Fix

- For 1D numpy arrays, reshape to `(1, N)` before inferring column types
- For empty lists, default datatype to `"str"`

Closes #13294