### PR TITLE
fix(video): remove duplicated arrow in SRT-to-VTT subtitle conversion

### DIFF
--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -419,7 +419,7 @@ class Video(StreamingOutput, Component):
                     subtitle_lines = subtitle_block.split("\n")
                     subtitle_timing = subtitle_lines[1].replace(",", ".")
                     subtitle_text = "\n".join(subtitle_lines[2:])
-                    vtt_file.write(f"{subtitle_timing} --> {subtitle_timing}\n")
+                    vtt_file.write(f"{subtitle_timing}\n")
                     vtt_file.write(f"{subtitle_text}\n\n")
 
         file_path = Path(subtitle)  # type: ignore


### PR DESCRIPTION
## Bug

The `srt_to_vtt` function produces invalid VTT timing lines. SRT timing lines already contain `-->` (e.g. `00:00:01,000 --> 00:00:05,000`). After converting commas to dots, the result is a valid VTT timing line. But line 422 writes it twice with an extra `-->` between them:

```
00:00:01.000 --> 00:00:05.000 --> 00:00:01.000 --> 00:00:05.000
```

Browsers cannot parse this, so subtitles silently fail to display.

## Fix

Write `subtitle_timing` once — it's already a complete VTT timing line after the comma-to-dot replacement.

Closes #13292