### PR TITLE
feat(dropdown): add placeholder parameter to gr.Dropdown

### DIFF
--- a/gradio/components/dropdown.py
+++ b/gradio/components/dropdown.py
@@ -65,6 +65,7 @@ class Dropdown(FormComponent):
         filterable: bool = True,
         label: str | I18nData | None = None,
         info: str | I18nData | None = None,
+        placeholder: str | I18nData | None = None,
         every: Timer | float | None = None,
         inputs: Component | Sequence[Component] | set[Component] | None = None,
         show_label: bool | None = None,
@@ -91,6 +92,7 @@ class Dropdown(FormComponent):
             filterable: if True, user will be able to type into the dropdown and filter the choices by typing. Can only be set to False if `allow_custom_value` is False.
             label: the label for this component, displayed above the component if `show_label` is `True` and is also used as the header if there are a table of examples for this component. If None and used in a `gr.Interface`, the label will be the name of the parameter this component corresponds to.
             info: additional component description, appears below the label in smaller font. Supports markdown / HTML syntax.
+            placeholder: placeholder hint to provide behind the dropdown input field. Only applies when no value is selected.
             every: continously calls `value` to recalculate it if `value` is a function (has no effect otherwise). Can provide a Timer whose tick resets `value`, or a float that provides the regular interval for the reset Timer.
             inputs: components that are used as inputs to calculate `value` if `value` is a function (has no effect otherwise). `value` is recalculated any time the inputs change.
             show_label: if True, will display label.
@@ -160,6 +162,7 @@ class Dropdown(FormComponent):
             value=value,
         )
         self.buttons = set_default_buttons(buttons, None)
+        self.placeholder = placeholder
         self._value_description = f"one{' or more' if multiselect else ''} of {[c[1] if isinstance(c, tuple) else c for c in self.choices]}"
 
     def api_info(self) -> dict[str, Any]:

--- a/js/dropdown/Index.svelte
+++ b/js/dropdown/Index.svelte
@@ -39,6 +39,7 @@
 		<Dropdown
 			label={gradio.shared.label}
 			info={gradio.props.info}
+			placeholder={gradio.props.placeholder}
 			bind:value={gradio.props.value}
 			choices={gradio.props.choices}
 			interactive={gradio.shared.interactive}

--- a/js/dropdown/shared/Dropdown.svelte
+++ b/js/dropdown/shared/Dropdown.svelte
@@ -15,6 +15,7 @@
 	let {
 		label = "Dropdown",
 		info = undefined,
+		placeholder = undefined,
 		value = $bindable<string | number | null>(),
 		choices = [],
 		interactive = true,
@@ -41,6 +42,7 @@
 		allow_custom_value: boolean;
 		filterable: boolean;
 		buttons: (string | CustomButtonType)[] | null;
+		placeholder?: string;
 		oncustom_button_click?: ((id: number) => void) | null;
 		on_change?: (value: string | number | null) => void;
 		on_input?: () => void;
@@ -182,6 +184,9 @@
 			on_change?.(value);
 		}
 	});
+
+	// Show placeholder only when no text is entered
+	let resolved_placeholder = $derived(input_text === "" ? placeholder : undefined);
 </script>
 
 <div class:container>
@@ -208,6 +213,7 @@
 					{disabled}
 					bind:value={input_text}
 					bind:this={filter_input}
+					placeholder={resolved_placeholder}
 					onkeydown={handle_key_down}
 					onkeyup={(e) => {
 						on_key_up?.({

--- a/js/dropdown/types.ts
+++ b/js/dropdown/types.ts
@@ -11,6 +11,7 @@ export interface DropdownProps {
 	info: string;
 	filterable: boolean;
 	buttons: (string | CustomButton)[] | null;
+	placeholder?: string;
 }
 
 export interface DropdownEvents {


### PR DESCRIPTION
Good day

## Summary

This PR adds a  parameter to the  component, addressing feature request #12128.

## Changes

### Python ()
- Added  parameter to 
- Added documentation for the  parameter
- Stored  as instance attribute

### JavaScript/TypeScript
- : Added  to 
- : Passed  to the Dropdown component
- :
  - Added  to props destructuring
  - Added  to the type declaration
  - Added  derived state that shows placeholder only when input is empty
  - Added  attribute to the input element

## Behavior

The  parameter displays hint text inside the dropdown field when:
1. No value is selected (the dropdown is empty)
2. The placeholder text disappears once the user selects a value

This is consistent with how placeholders work in  and follows common UX patterns in modern web forms.

## Example usage

```python
import gradio as gr

with gr.Blocks() as demo:
    dropdown = gr.Dropdown(
        choices=["Python", "JavaScript", "Java", "C++", "Go"],
        label="Select Programming Language",
        placeholder="e.g., Python or JavaScript",
        info="Choose your preferred language"
    )

demo.launch()
```

## Testing

The existing tests should continue to pass. The  attribute is automatically serialized via  since it follows the standard pattern of being a constructor parameter stored as an instance attribute.

---

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof