### PR TITLE
fix(video): emit valid VTT timing lines

### DIFF
--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -419,7 +419,7 @@ class Video(StreamingOutput, Component):
                     subtitle_lines = subtitle_block.split("\n")
                     subtitle_timing = subtitle_lines[1].replace(",", ".")
                     subtitle_text = "\n".join(subtitle_lines[2:])
-                    vtt_file.write(f"{subtitle_timing} --> {subtitle_timing}\n")
+                    vtt_file.write(f"{subtitle_timing}\n")
                     vtt_file.write(f"{subtitle_text}\n\n")
 
         file_path = Path(subtitle)  # type: ignore

--- a/test/components/test_video.py
+++ b/test/components/test_video.py
@@ -152,6 +152,30 @@ class TestVideo:
             output = output.model_dump()
             assert processing_utils.video_is_playable(output["path"])
 
+    def test_video_subtitles_srt_converts_to_valid_vtt(self):
+        srt_content = """1
+00:00:01,000 --> 00:00:05,000
+Hello world
+
+2
+00:00:06,000 --> 00:00:10,000
+This is a test
+"""
+
+        with tempfile.NamedTemporaryFile(suffix=".srt", delete=False) as tmp_srt:
+            tmp_srt.write(srt_content.encode("utf-8"))
+            subtitle_path = tmp_srt.name
+
+        subtitle_file = gr.Video(subtitles=subtitle_path).subtitles
+        assert subtitle_file is not None
+
+        with open(subtitle_file.path, encoding="utf-8") as converted:
+            converted_content = converted.read()
+
+        assert "WEBVTT" in converted_content
+        assert "00:00:01.000 --> 00:00:05.000\n" in converted_content
+        assert "00:00:01.000 --> 00:00:05.000 -->" not in converted_content
+
     @patch("pathlib.Path.exists", MagicMock(return_value=False))
     @patch("gradio.components.video.FFmpeg")
     def test_video_preprocessing_flips_video_for_webcam(self, mock_ffmpeg, media_data):


### PR DESCRIPTION
Summary
- write the converted SRT timing line directly instead of duplicating the arrow-separated range
- add a regression test covering SRT to VTT conversion output

Closes #13292.

Testing
- attempted: python3 -m pytest test/components/test_video.py -q
- blocked locally because test/conftest.py requires gradio_client, which is not installed in the current environment
