### PR TITLE
10x~35x Faster Video Trimming Without Re-encoding

### DIFF
--- a/.changeset/twelve-sloths-create.md
+++ b/.changeset/twelve-sloths-create.md
@@ -1,0 +1,6 @@
+---
+"@gradio/video": patch
+"gradio": patch
+---
+
+fix:Faster Video Trimming Without Re-encoding

--- a/js/video/shared/utils.ts
+++ b/js/video/shared/utils.ts
@@ -86,11 +86,12 @@ export async function trimVideo(
 		);
 
 		let command = [
+			"-ss",
+            startTime.toString(),
 			"-i",
 			inputName,
-			...(startTime !== 0 ? ["-ss", startTime.toString()] : []),
-			...(endTime !== 0 ? ["-to", endTime.toString()] : []),
-			"-c:a",
+			...(endTime !== 0 ? ["-to", (endTime - startTime).toString()] : []),
+			"-c",
 			"copy",
 			outputName
 		];

--- a/js/video/shared/utils.ts
+++ b/js/video/shared/utils.ts
@@ -87,7 +87,7 @@ export async function trimVideo(
 
 		let command = [
 			"-ss",
-            startTime.toString(),
+			startTime.toString(),
 			"-i",
 			inputName,
 			...(endTime !== 0 ? ["-to", (endTime - startTime).toString()] : []),


### PR DESCRIPTION
## Description

This is a follow-up to #11110, which tried to fix slow video trimming by passing `-c copy` to avoid re-encoding. That approach failed for H264 (and other interframe codecs) since `-c copy` requires the trim start to land on a keyframe. When it doesn't, the output is corrupted.

The fix here moves `-ss` before the `-i` flag. According to the [ffmpeg docs](https://ffmpeg.org/ffmpeg.html), when `-ss` is used as an input option, ffmpeg seeks to the nearest keyframe before the requested position. This means `-c copy` will work correctly because we're always starting from a keyframe.

The tradeoff is that if the user selects a start time or an end time that falls between keyframes, the trim may begin slightly earlier or end slightly earlier than requested. 

From [ffmpeg docs on input seeking](https://trac.ffmpeg.org/wiki/Seeking):
> Using "-ss" with "-c copy" alike may not be accurate: since `ffmpeg` may only split on I-frame (keyframe independently decodable) alike.

So this would be very fast but might be inaccurate, depending on the keyframe interval GOP size. There is no way to get around this as of my understanding, if we want fast trimming it will be slightly inaccurate. If this is not acceptable we can have two trimming options "fast and inaccurate", and "slow and accurate" falling back to the old method of re-encoding the video stream.

Tested with the sample video in #11110 and H264 encoded videos. Both trim correctly without issues.

Note: the `-to` value was changed to `(endTime - startTime)` since after input-side seeking it becomes a duration relative to the seek point, not an absolute timestamp.

Closes: #6664

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to verify my solution.
- [ ] I did not use AI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FFmpeg trimming flags to seek before decoding and stream-copy output, which can alter trim accuracy and behavior across codecs/keyframe intervals.
> 
> **Overview**
> Improves `trimVideo` by moving `-ss` before `-i` and using `-c copy` so trims can be performed via fast stream copy without re-encoding (reducing corruption for interframe codecs).
> 
> Adjusts `-to` to be a duration (`endTime - startTime`) relative to the seek point, and adds a changeset bump for `@gradio/video` and `gradio`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59bbdc8488df6c96084736fd7059c2b00523559a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->