### PR TITLE
Fix cancel to remove queued pending events

### DIFF
--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -639,11 +639,20 @@ class Queue:
                 )
                 self.event_ids_to_events.pop(event._id, None)
 
-            if session_hash and session_hash in self.pending_event_ids_session:
-                removed_ids = {e._id for e in events_to_remove}
-                self.pending_event_ids_session[session_hash] -= removed_ids
-                if not self.pending_event_ids_session[session_hash]:
-                    self.pending_event_ids_session.pop(session_hash, None)
+            removed_ids = {e._id for e in events_to_remove}
+            if event_id:
+                removed_ids.add(event_id)
+            if removed_ids:
+                sessions = (
+                    [session_hash]
+                    if session_hash
+                    else list(self.pending_event_ids_session)
+                )
+                for session in sessions:
+                    if session in self.pending_event_ids_session:
+                        self.pending_event_ids_session[session] -= removed_ids
+                        if not self.pending_event_ids_session[session]:
+                            self.pending_event_ids_session.pop(session, None)
 
     async def notify_clients(self) -> None:
         """

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1582,6 +1582,7 @@ class App(FastAPI):
                 body.event_id
                 in blocks._queue.pending_event_ids_session.get(body.session_hash, {})
             )
+            await blocks._queue.clean_events(event_id=body.event_id)
             if session_open and event_running:
                 message = ProcessCompletedMessage(
                     output={}, success=True, event_id=body.event_id
@@ -1697,30 +1698,23 @@ class App(FastAPI):
                                 isinstance(message, ProcessCompletedMessage)
                                 and message.event_id
                             ):
+                                pending_event_ids = (
+                                    blocks._queue.pending_event_ids_session.get(
+                                        session_hash, set()
+                                    )
+                                )
                                 # It's possible that the event_id has already been removed
                                 # for example, the user sent two duplicate `/cancel` requests.
                                 # The first one would have removed the event_id from pending_event_ids_session
-                                if (
-                                    message.event_id
-                                    in (
-                                        blocks._queue.pending_event_ids_session[
-                                            session_hash
-                                        ]
-                                    )
-                                ):
-                                    blocks._queue.pending_event_ids_session[
-                                        session_hash
-                                    ].remove(message.event_id)
+                                if message.event_id in pending_event_ids:
+                                    pending_event_ids.remove(message.event_id)
+                                    if not pending_event_ids:
+                                        blocks._queue.pending_event_ids_session.pop(
+                                            session_hash, None
+                                        )
                                 if message.msg == ServerMessage.server_stopped or (
                                     message.msg == ServerMessage.process_completed
-                                    and (
-                                        len(
-                                            blocks._queue.pending_event_ids_session[
-                                                session_hash
-                                            ]
-                                        )
-                                        == 0
-                                    )
+                                    and not pending_event_ids
                                 ):
                                     message = CloseStreamMessage()
                                     response = process_msg(message)

--- a/test/test_queueing.py
+++ b/test/test_queueing.py
@@ -224,6 +224,66 @@ def test_heartbeat_task_cancelled_after_stream_completes():
     demo.close()
 
 
+def test_cancel_removes_pending_event_from_queue():
+    from gradio.routes import App
+
+    with gr.Blocks() as demo:
+        start = gr.Button()
+        output = gr.Textbox()
+
+        def wait():
+            time.sleep(1)
+            return "done"
+
+        start.click(wait, None, output)
+
+    demo.queue(default_concurrency_limit=1)
+    app = App.create_app(demo)
+    client = TestClient(app)
+
+    first = client.post(
+        f"{API_PREFIX}/queue/join",
+        json={
+            "data": [],
+            "fn_index": 0,
+            "event_data": None,
+            "session_hash": "test_session",
+            "trigger_id": None,
+        },
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        f"{API_PREFIX}/queue/join",
+        json={
+            "data": [],
+            "fn_index": 0,
+            "event_data": None,
+            "session_hash": "test_session",
+            "trigger_id": None,
+        },
+    )
+    assert second.status_code == 200
+    assert len(demo._queue) == 2
+
+    response = client.post(
+        f"{API_PREFIX}/cancel",
+        json={
+            "session_hash": "test_session",
+            "fn_index": 0,
+            "event_id": second.json()["event_id"],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"]
+    assert len(demo._queue) == 1
+    assert second.json()["event_id"] not in demo._queue.event_ids_to_events
+    assert second.json()["event_id"] not in demo._queue.pending_event_ids_session[
+        "test_session"
+    ]
+
+
 def test_analytics_summary(monkeypatch):
     """Test that the analytics summary endpoint is correctly being computed every N requests,
     where N is set by the GRADIO_ANALYTICS_CACHE_FREQUENCY environment variable."""


### PR DESCRIPTION
- clean queued events by event_id in /cancel route

- keep pending_event_ids_session consistent when removing by event_id

- avoid KeyError in SSE cleanup when event already removed

- add regression test for cancelling a pending queued event

## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

