### PR TITLE
fix(events): tolerate missing select event value

### DIFF
--- a/gradio/events.py
+++ b/gradio/events.py
@@ -224,7 +224,7 @@ class SelectData(EventData):
         """
         The index of the selected item. Is a tuple if the component is two dimensional or selection is a range.
         """
-        self.value: Any = data["value"]
+        self.value: Any = data.get("value")
         """
         The value of the selected item.
         """

--- a/js/gallery/Gallery.test.ts
+++ b/js/gallery/Gallery.test.ts
@@ -996,6 +996,7 @@ describe("Regression: #13170 — selected_index points to newly appended image",
 		expect(select).toHaveBeenCalled();
 		const last_call = select.mock.calls[select.mock.calls.length - 1][0];
 		expect(last_call.index).toBe(2);
+		expect(last_call.value).toEqual(img("c"));
 	});
 
 	test("rapidly appending images with selected_index tracking last always shows the latest", async () => {

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -43,6 +43,12 @@ class TestEvent:
         assert resp.status_code == 200
         assert resp.json()["data"][0] == "1"
 
+    def test_select_event_data_without_value(self):
+        event_data = gr.SelectData(None, {"index": 1})
+
+        assert event_data.index == 1
+        assert event_data.value is None
+
     def test_consecutive_events(self):
         def double(x):
             return x + x


### PR DESCRIPTION
## Description

`SelectData` currently requires every select event payload to include a `value` field. Gallery selection payloads can omit that field when `selected_index` changes during an update, which raises `KeyError: 'value'` before the listener runs.

This changes `SelectData.value` to default to `None` when the payload omits `value`, matching the existing behavior for select payloads that explicitly send `"value": null`. It also adds a regression test for missing `value` data and tightens the Gallery regression test to assert the selected item value is present when available.

Closes: #13314

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to inspect the issue, make the small code/test change, and self-review the diff.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

Ran:

- `python -m pytest test/test_events.py::TestEvent::test_select_event_data_without_value -q`
- `python -m compileall -q gradio/events.py test/test_events.py`
- `pnpm vitest run --config .config/vitest.config.ts js/gallery/Gallery.test.ts -t "selected_index pointing to newly appended item dispatches select with correct data"`

Note: running the existing `test_event_data` endpoint test locally from the source checkout failed because the frontend templates were not built (`frontend/index.html` missing), which is unrelated to this change.
