### PR TITLE
Remove Event From Queue When Cancelled

### DIFF
--- a/.changeset/silent-toys-rescue.md
+++ b/.changeset/silent-toys-rescue.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Remove Event From Queue When Cancelled

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -467,6 +467,22 @@ class Queue:
         self.broadcast_estimations(event.concurrency_id, len(event_queue.queue) - 1)
         return True, event._id, "success"
 
+    async def remove_from_queue(self, event_id: str):
+        event = self.event_ids_to_events.get(event_id)
+        if event:
+            async with self.delete_lock:
+                q = self.event_queue_per_concurrency_id[event.concurrency_id]
+                try:
+                    q.queue.remove(event)
+                except ValueError:
+                    pass
+                self.event_ids_to_events.pop(event_id, None)
+                session_hash = event.session_hash
+                if session_hash in self.pending_event_ids_session:
+                    self.pending_event_ids_session[session_hash].discard(event_id)
+                    if not self.pending_event_ids_session[session_hash]:
+                        self.pending_event_ids_session.pop(session_hash, None)
+
     def _cancel_asyncio_tasks(self):
         for task in self._asyncio_tasks:
             task.cancel()

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -474,14 +474,9 @@ class Queue:
                 q = self.event_queue_per_concurrency_id[event.concurrency_id]
                 try:
                     q.queue.remove(event)
+                    self.event_ids_to_events.pop(event_id, None)
                 except ValueError:
                     pass
-                self.event_ids_to_events.pop(event_id, None)
-                session_hash = event.session_hash
-                if session_hash in self.pending_event_ids_session:
-                    self.pending_event_ids_session[session_hash].discard(event_id)
-                    if not self.pending_event_ids_session[session_hash]:
-                        self.pending_event_ids_session.pop(session_hash, None)
 
     def _cancel_asyncio_tasks(self):
         for task in self._asyncio_tasks:

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1582,6 +1582,7 @@ class App(FastAPI):
                 body.event_id
                 in blocks._queue.pending_event_ids_session.get(body.session_hash, {})
             )
+            await blocks._queue.remove_from_queue(body.event_id)
             if session_open and event_running:
                 message = ProcessCompletedMessage(
                     output={}, success=True, event_id=body.event_id

--- a/test/test_queueing.py
+++ b/test/test_queueing.py
@@ -224,6 +224,65 @@ def test_heartbeat_task_cancelled_after_stream_completes():
     demo.close()
 
 
+def test_cancel_removes_pending_event_from_queue():
+    """Cancelling a queued (not yet running) event should remove it from the queue."""
+    with gr.Blocks() as demo:
+        start = gr.Button()
+        output = gr.Textbox()
+
+        def slow():
+            time.sleep(5)
+            return "done"
+
+        start.click(slow, None, output)
+
+    demo.queue(default_concurrency_limit=1)
+    app, _, _ = demo.launch(prevent_thread_lock=True)
+    test_client = TestClient(app)
+
+    join_payload = {
+        "data": [],
+        "fn_index": 0,
+        "event_data": None,
+        "session_hash": "sess1",
+        "trigger_id": None,
+    }
+
+    try:
+        first = test_client.post(f"{API_PREFIX}/queue/join", json=join_payload)
+        second = test_client.post(f"{API_PREFIX}/queue/join", json=join_payload)
+        third = test_client.post(f"{API_PREFIX}/queue/join", json=join_payload)
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert third.status_code == 200
+
+        second_event_id = second.json()["event_id"]
+        third_event_id = third.json()["event_id"]
+
+        # First event gets picked up by the worker; second and third are queued
+        assert len(demo._queue) == 2
+        assert second_event_id in demo._queue.event_ids_to_events
+        assert second_event_id in demo._queue.pending_event_ids_session["sess1"]
+
+        # Cancel the second (pending/queued) event
+        resp = test_client.post(
+            f"{API_PREFIX}/cancel",
+            json={
+                "session_hash": "sess1",
+                "fn_index": 0,
+                "event_id": second_event_id,
+            },
+        )
+        assert resp.status_code == 200
+
+        assert len(demo._queue) == 1
+        assert second_event_id not in demo._queue.event_ids_to_events
+        assert second_event_id not in demo._queue.pending_event_ids_session["sess1"]
+        assert third_event_id in demo._queue.event_ids_to_events
+    finally:
+        demo.close()
+
+
 def test_analytics_summary(monkeypatch):
     """Test that the analytics summary endpoint is correctly being computed every N requests,
     where N is set by the GRADIO_ANALYTICS_CACHE_FREQUENCY environment variable."""

--- a/test/test_queueing.py
+++ b/test/test_queueing.py
@@ -231,7 +231,7 @@ def test_cancel_removes_pending_event_from_queue():
         output = gr.Textbox()
 
         def slow():
-            time.sleep(5)
+            time.sleep(2)
             return "done"
 
         start.click(slow, None, output)
@@ -274,11 +274,21 @@ def test_cancel_removes_pending_event_from_queue():
             },
         )
         assert resp.status_code == 200
+        assert third_event_id in demo._queue.event_ids_to_events
 
         assert len(demo._queue) == 1
-        assert second_event_id not in demo._queue.event_ids_to_events
+        r = test_client.get(f"{API_PREFIX}/queue/data?session_hash=sess1")
+
+        # Verify we got a process_completed message
+        got_completed = False
+        for line in r.iter_lines():
+            if "data" in line:
+                data = json.loads(line[5:])
+                if data["msg"] == "process_completed":
+                    got_completed = True
+        assert got_completed
         assert second_event_id not in demo._queue.pending_event_ids_session["sess1"]
-        assert third_event_id in demo._queue.event_ids_to_events
+        assert second_event_id not in demo._queue.event_ids_to_events
     finally:
         demo.close()
 


### PR DESCRIPTION
## Description

Closes: #13323 

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core queue cancellation behavior and mutates shared queue state; mistakes could lead to stuck jobs or inconsistent tracking under concurrency.
> 
> **Overview**
> Fixes queue cancellation so a *pending/queued* event is actually removed from the server-side queue when `/cancel` is called, instead of only signalling completion to the client.
> 
> Adds `Queue.remove_from_queue()` to delete the `Event` from the per-concurrency queue under `delete_lock` and drop its `event_id` mapping, wires it into the `/cancel` route, and includes a regression test ensuring queue length and internal tracking (`event_ids_to_events` / `pending_event_ids_session`) update correctly after cancelling a not-yet-running job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cf7051657bd3828410dc89aa1bc9f235d32174d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->