### PR TITLE
Prevent Gallery Select Event From Triggering When Value Updated Programmatically

### DIFF
--- a/.changeset/two-eels-attend.md
+++ b/.changeset/two-eels-attend.md
@@ -1,0 +1,6 @@
+---
+"@gradio/gallery": minor
+"gradio": minor
+---
+
+feat:Prevent Gallery Select Event From Triggering When Value Updated Programmatically

--- a/.changeset/two-eels-attend.md
+++ b/.changeset/two-eels-attend.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/gallery": minor
-"gradio": minor
+"@gradio/gallery": patch
+"gradio": patch
 ---
 
-feat:Prevent Gallery Select Event From Triggering When Value Updated Programmatically
+fix:Prevent Gallery Select Event From Triggering When Value Updated Programmatically

--- a/js/gallery/Gallery.test.ts
+++ b/js/gallery/Gallery.test.ts
@@ -627,7 +627,7 @@ describe("Events: select", () => {
 		expect(select).toHaveBeenCalledWith(expect.objectContaining({ index: 1 }));
 	});
 
-	test("select: fired when selected_index changes via set_data", async () => {
+	test("select: not fired when selected_index changes via set_data", async () => {
 		const { listen, set_data } = await render(Gallery, {
 			...default_props,
 			preview: true,
@@ -639,8 +639,25 @@ describe("Events: select", () => {
 
 		await set_data({ selected_index: 2 });
 
-		expect(select).toHaveBeenCalled();
-		expect(select).toHaveBeenCalledWith(expect.objectContaining({ index: 2 }));
+		expect(select).not.toHaveBeenCalled();
+	});
+
+	test("select: not fired when value and selected_index update together via set_data", async () => {
+		const { listen, set_data } = await render(Gallery, {
+			...default_props,
+			preview: true,
+			selected_index: 0,
+			value: [img("a"), img("b")]
+		});
+
+		const select = listen("select");
+
+		await set_data({
+			value: [img("a"), img("b"), img("c")],
+			selected_index: 2
+		});
+
+		expect(select).not.toHaveBeenCalled();
 	});
 });
 
@@ -976,7 +993,7 @@ describe("Regression: #13170 — selected_index points to newly appended image",
 		expect(preview_img.src).toBe("https://example.com/img3.png");
 	});
 
-	test("selected_index pointing to newly appended item dispatches select with correct data", async () => {
+	test("selected_index pointing to newly appended item does not dispatch select", async () => {
 		const initial_value = [img("a"), img("b")];
 
 		const { set_data, listen } = await render(Gallery, {
@@ -993,9 +1010,7 @@ describe("Regression: #13170 — selected_index points to newly appended image",
 			selected_index: 2
 		});
 
-		expect(select).toHaveBeenCalled();
-		const last_call = select.mock.calls[select.mock.calls.length - 1][0];
-		expect(last_call.index).toBe(2);
+		expect(select).not.toHaveBeenCalled();
 	});
 
 	test("rapidly appending images with selected_index tracking last always shows the latest", async () => {

--- a/js/gallery/shared/Gallery.svelte
+++ b/js/gallery/shared/Gallery.svelte
@@ -160,7 +160,6 @@
 	if (selected_index == null && preview && value?.length) {
 		selected_index = 0;
 	}
-	let old_selected_index: number | null = $state(selected_index);
 
 	$effect(() => {
 		if (!dequal(prev_value, value)) {
@@ -195,6 +194,15 @@
 		() => ((selected_index ?? 0) + 1) % (resolved_value?.length ?? 0)
 	);
 
+	function dispatch_select(index: number): void {
+		if (resolved_value !== null) {
+			onselect({
+				index,
+				value: resolved_value?.[index]
+			});
+		}
+	}
+
 	function handle_preview_click(event: MouseEvent): void {
 		const element = event.target as HTMLElement;
 		const x = event.offsetX;
@@ -206,6 +214,7 @@
 		} else {
 			selected_index = next;
 		}
+		dispatch_select(selected_index);
 	}
 
 	function on_keydown(e: KeyboardEvent): void {
@@ -218,31 +227,17 @@
 			case "ArrowLeft":
 				e.preventDefault();
 				selected_index = previous;
+				dispatch_select(selected_index);
 				break;
 			case "ArrowRight":
 				e.preventDefault();
 				selected_index = next;
+				dispatch_select(selected_index);
 				break;
 			default:
 				break;
 		}
 	}
-
-	$effect(() => {
-		// Only trigger the effect if the selected_index has actually changed
-		if (selected_index !== old_selected_index) {
-			old_selected_index = selected_index;
-
-			// Ensure we have a valid selection and data to work with
-			if (selected_index !== null && resolved_value !== null) {
-				// Notify the parent component or listener about the updated selection
-				onselect({
-					index: selected_index,
-					value: resolved_value?.[selected_index]
-				});
-			}
-		}
-	});
 
 	$effect(() => {
 		if (allow_preview && container_element) {
@@ -495,7 +490,10 @@
 					{#each resolved_value as media, i}
 						<button
 							bind:this={el[i]}
-							on:click={() => (selected_index = i)}
+							on:click={() => {
+								selected_index = i;
+								dispatch_select(i);
+							}}
 							class="thumbnail-item thumbnail-small"
 							class:selected={selected_index === i && mode !== "minimal"}
 							aria-label={"Thumbnail " +
@@ -616,6 +614,7 @@
 									onpreview_open();
 								}
 								selected_index = i;
+								dispatch_select(i);
 							}}
 							aria-label={"Thumbnail " +
 								(i + 1) +


### PR DESCRIPTION
## Description

Closes: #13314

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the observable semantics of the `select` event; consumers that relied on `select` firing on programmatic updates may see behavior changes, though the change is localized to the Gallery frontend component.
> 
> **Overview**
> Prevents `Gallery` from emitting `select` when `selected_index` (or `value` + `selected_index`) changes programmatically via prop updates, so `select` now represents *user-driven* selection only.
> 
> Implementation removes the reactive `selected_index` watcher that auto-dispatched `onselect`, and instead explicitly calls a new `dispatch_select()` from click/keyboard/preview navigation handlers. Tests are updated to assert no `select` on `set_data`, and a patch changeset is added for `@gradio/gallery` and `gradio`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c68a4832fcde4dd7ae7c9227ce7a4a240032941f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->