### PR TITLE
fix ffmpeg action via bump

### DIFF
--- a/.github/actions/install-all-deps/action.yml
+++ b/.github/actions/install-all-deps/action.yml
@@ -80,7 +80,7 @@ runs:
       run: |
         uv venv --allow-existing venv --python=${{ inputs.python_version }}
     - name: Install ffmpeg
-      uses: FedericoCarboni/setup-ffmpeg@583042d32dd1cabb8bd09df03bde06080da5c87c # @v2
+      uses: FedericoCarboni/setup-ffmpeg@37062fbf7149fc5578d6c57e08aed62458b375d6 # @v3.1
     - name: Install test dependencies
       if: inputs.test == 'true' && steps.cache.outputs.cache-hit != 'true'
       shell: bash


### PR DESCRIPTION
We have been seeing flake in the `install-all-deps` action because of an upstream issue in the ffmepg action. This was fixed in v3 of that action which this PR bumps to. Needs a merge to main to take effect.

Basically v2 discovered the ffmpeg tag by querying the GitHub Releases API on the action's own repo, then downloading binaries from the matching release. The intermittent errors are that API call flaking.

v3 was rewritten to download binaries directly from upstream.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI-only dependency bump; main risk is ffmpeg installation behavior changing across environments, potentially breaking workflows if v3 differs from v2.
> 
> **Overview**
> Updates the `install-all-deps` composite GitHub Action to use `FedericoCarboni/setup-ffmpeg` `v3.1` (pinned by commit) instead of the older `v2` pin, aiming to reduce CI flakiness during ffmpeg installation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e78ac6557c9268ec3f6dd68149932b3fa2341a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->