### PR TITLE
ci: install ffmpeg via apt/choco instead of FedericoCarboni/setup-ffmpeg

### DIFF
--- a/.github/actions/install-all-deps/action.yml
+++ b/.github/actions/install-all-deps/action.yml
@@ -79,8 +79,17 @@ runs:
       shell: bash
       run: |
         uv venv --allow-existing venv --python=${{ inputs.python_version }}
-    - name: Install ffmpeg
-      uses: FedericoCarboni/setup-ffmpeg@37062fbf7149fc5578d6c57e08aed62458b375d6 # @v3.1
+    - name: Install ffmpeg (linux)
+      if: ${{ inputs.os == 'ubuntu-latest' }}
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y --no-install-recommends ffmpeg
+    - name: Install ffmpeg (windows)
+      if: ${{ inputs.os == 'windows-latest' }}
+      shell: bash
+      run: |
+        choco install ffmpeg -y --no-progress
     - name: Install test dependencies
       if: inputs.test == 'true' && steps.cache.outputs.cache-hit != 'true'
       shell: bash


### PR DESCRIPTION
The previous action depended on a third-party server: v2 hit the GitHub Releases API on the action's own repo (which started flaking), v3+ pulls binaries directly from johnvansickle.com / gyan.dev / evermeet.cx and is now failing with `TypeError: fetch failed`.

Both flavours leave us at the mercy of an external service. The OS package managers already ship a working ffmpeg — apt on linux runners, chocolatey on windows runners — so install from there and remove the external dependency.

## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI dependency installation changes could affect runner compatibility, install time, or ffmpeg version differences across OS images, potentially causing test/build failures.
> 
> **Overview**
> Switches the composite CI action `.github/actions/install-all-deps/action.yml` from using `FedericoCarboni/setup-ffmpeg` to **installing `ffmpeg` via the runner package managers**: `apt-get` on `ubuntu-latest` and `choco` on `windows-latest`.
> 
> This removes an external download dependency and makes ffmpeg provisioning explicit and OS-conditional in the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49ff9c4dd75a55e40835f77478abf2f5970d70e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->