### PR TITLE
Revert "10x~35x Faster Video Trimming Without Re-encoding"

### DIFF
--- a/.changeset/twelve-sloths-create.md
+++ b/.changeset/twelve-sloths-create.md
@@ -1,6 +1,0 @@
----
-"@gradio/video": patch
-"gradio": patch
----
-
-fix:Faster Video Trimming Without Re-encoding

--- a/js/video/shared/utils.ts
+++ b/js/video/shared/utils.ts
@@ -86,12 +86,11 @@ export async function trimVideo(
 		);
 
 		let command = [
-			"-ss",
-			startTime.toString(),
 			"-i",
 			inputName,
-			...(endTime !== 0 ? ["-to", (endTime - startTime).toString()] : []),
-			"-c",
+			...(startTime !== 0 ? ["-ss", startTime.toString()] : []),
+			...(endTime !== 0 ? ["-to", endTime.toString()] : []),
+			"-c:a",
 			"copy",
 			outputName
 		];


### PR DESCRIPTION
Reverts gradio-app/gradio#13325

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FFmpeg trim command arguments, which can alter trim accuracy/behavior and may impact output compatibility for some videos. Scope is small but touches core client-side video processing.
> 
> **Overview**
> Reverts the prior “faster trimming” release note by removing the `.changeset` entry.
> 
> Adjusts `trimVideo` FFmpeg invocation in `js/video/shared/utils.ts` by moving `-ss` after `-i`, switching `-to` to use the absolute `endTime` (instead of a derived duration), and changing stream copy flags from `-c copy` to `-c:a copy`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c26f2769cc5315f50712d12ae13512ec87c446b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->