### PR TITLE
install ffmpeg manually in ci

### DIFF
--- a/.github/actions/install-all-deps/action.yml
+++ b/.github/actions/install-all-deps/action.yml
@@ -79,17 +79,31 @@ runs:
       shell: bash
       run: |
         uv venv --allow-existing venv --python=${{ inputs.python_version }}
+    - name: Cache ffmpeg
+      id: cache-ffmpeg
+      uses: actions/cache@v4
+      with:
+        path: ffmpeg-bin
+        key: ffmpeg-${{ inputs.os }}-7.0.2-v1
     - name: Install ffmpeg (linux)
-      if: ${{ inputs.os == 'ubuntu-latest' }}
+      if: ${{ inputs.os == 'ubuntu-latest' && steps.cache-ffmpeg.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends ffmpeg
+        mkdir -p ffmpeg-bin
+        curl -fsSL https://johnvansickle.com/ffmpeg/releases/ffmpeg-7.0.2-amd64-static.tar.xz -o /tmp/ffmpeg.tar.xz
+        tar -xf /tmp/ffmpeg.tar.xz -C /tmp
+        cp /tmp/ffmpeg-7.0.2-amd64-static/ffmpeg /tmp/ffmpeg-7.0.2-amd64-static/ffprobe ffmpeg-bin/
     - name: Install ffmpeg (windows)
-      if: ${{ inputs.os == 'windows-latest' }}
+      if: ${{ inputs.os == 'windows-latest' && steps.cache-ffmpeg.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
-        choco install ffmpeg -y --no-progress
+        mkdir -p ffmpeg-bin
+        curl -fsSL https://github.com/GyanD/codexffmpeg/releases/download/7.0.2/ffmpeg-7.0.2-essentials_build.zip -o ffmpeg.zip
+        unzip -q ffmpeg.zip
+        mv ffmpeg-7.0.2-essentials_build/bin/ffmpeg.exe ffmpeg-7.0.2-essentials_build/bin/ffprobe.exe ffmpeg-bin/
+    - name: Add ffmpeg to PATH
+      shell: bash
+      run: echo "$GITHUB_WORKSPACE/ffmpeg-bin" >> "$GITHUB_PATH"
     - name: Install test dependencies
       if: inputs.test == 'true' && steps.cache.outputs.cache-hit != 'true'
       shell: bash


### PR DESCRIPTION
Install ffmpeg manually in CI and cache forever.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI dependency installation for `ffmpeg` on both Linux and Windows; failures or upstream download changes could break workflows or alter media-related test behavior.
> 
> **Overview**
> Updates the `install-all-deps` composite GitHub Action to **stop installing system `ffmpeg`** via `apt`/`choco` and instead **download pinned `ffmpeg`/`ffprobe` 7.0.2 binaries** into a local `ffmpeg-bin` directory.
> 
> Adds an `actions/cache` layer for `ffmpeg-bin` keyed by OS/version and prepends the cached directory to `PATH`, so subsequent CI runs reuse the same `ffmpeg` install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5491f2b4090f33faf874942bcba79f967be32b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->