### PR TITLE
Fix gr.List refresh after upload updates reused value

### DIFF
--- a/js/dataframe/Dataframe.test.ts
+++ b/js/dataframe/Dataframe.test.ts
@@ -731,6 +731,33 @@ describe("Events", () => {
 		expect(change).toHaveBeenCalled();
 	});
 
+	test("regression: UI refreshes when set_data reuses the same value object reference", async () => {
+		const value_object = {
+			data: [["file_1"]],
+			headers: ["File Name"],
+			metadata: null
+		};
+		const { set_data, container } = await render(Dataframe, {
+			...default_props,
+			value: value_object,
+			interactive: false,
+			editable: false,
+			col_count: [1, "fixed"] as [number, "fixed" | "dynamic"],
+			row_count: [1, "dynamic"] as [number, "fixed" | "dynamic"]
+		});
+		await wait();
+
+		expect(get_cell(container, 0, 0)?.textContent).toContain("file_1");
+
+		// Simulate a same-reference update where nested data changes in place.
+		value_object.data.push(["file_2"]);
+		await set_data({ value: value_object });
+		await wait();
+
+		expect(get_rows(container).length).toBe(2);
+		expect(get_cell(container, 1, 0)?.textContent).toContain("file_2");
+	});
+
 	test("select: emitted when cell is clicked", async () => {
 		const { container, listen } = await render(Dataframe, default_props);
 		await wait();

--- a/js/dataframe/Index.svelte
+++ b/js/dataframe/Index.svelte
@@ -16,6 +16,14 @@
 	const gradio = new Gradio<DataframeEvents, DataframeProps>(_props);
 
 	let fullscreen = $state(gradio.props.fullscreen ?? false);
+	let rendered_value = $state(structuredClone(gradio.props.value) ?? null);
+
+	$effect(() => {
+		const next_value = gradio.props.value;
+		if (!dequal(next_value, rendered_value)) {
+			rendered_value = structuredClone(next_value) ?? null;
+		}
+	});
 
 	// align datatype array to current value headers using the original
 	// config-time header→datatype mapping.
@@ -91,10 +99,10 @@
 		{...gradio.shared.loading_status}
 	/>
 	<Table
-		headers={gradio.props.value?.headers ?? []}
-		values={gradio.props.value?.data ?? []}
-		display_value={gradio.props.value?.metadata?.display_value ?? null}
-		styling={gradio.props.value?.metadata?.styling ?? null}
+		headers={rendered_value?.headers ?? []}
+		values={rendered_value?.data ?? []}
+		display_value={rendered_value?.metadata?.display_value ?? null}
+		styling={rendered_value?.metadata?.styling ?? null}
 		col_count={gradio.props.col_count}
 		row_count={gradio.props.row_count}
 		label={gradio.shared.label}


### PR DESCRIPTION
## Summary
- snapshot dataframe values before passing them into the table component
- detect deep mutations even when the outer value object reference is reused
- add a regression test covering UploadButton-style same-reference updates

Closes #13339

## Testing
- Not run locally: pnpm is not installed in this environment
- corepack pnpm was also unavailable due network restrictions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the dataframe snapshots and compares `value` before rendering, which could affect update frequency and performance for large tables. Functional scope is small but touches core rendering state.
> 
> **Overview**
> Fixes a dataframe refresh regression where `set_data` updates that *reuse the same `value` object reference* (but mutate nested `data` in place) would not update the UI.
> 
> `Index.svelte` now keeps a `rendered_value` snapshot (via `structuredClone`) and updates it only when a deep equality check (`dequal`) detects actual content changes, and the `Table` is rendered from this snapshot.
> 
> Adds a regression test covering UploadButton-style same-reference updates to ensure new rows/cells appear after in-place mutations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aef9f9b6d790003c124c143399110b71ad6a6ea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->