### PR TITLE
Fix dataframe auto datatype for empty and 1D inputs

### DIFF
--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -562,6 +562,9 @@ class Dataframe(Component):
             ]
 
         elif isinstance(value, np.ndarray):
+            if value.ndim < 2 or value.size == 0:
+                self.datatype = "str"
+                return
             self.datatype = [
                 dtype_mapping.get(
                     numbers_re.sub(
@@ -573,6 +576,9 @@ class Dataframe(Component):
             ]
 
         elif isinstance(value, list):
+            if len(value) == 0:
+                self.datatype = "str"
+                return
             self.datatype = [
                 dtype_mapping.get(
                     numbers_re.sub(

--- a/test/components/test_dataframe.py
+++ b/test/components/test_dataframe.py
@@ -391,6 +391,13 @@ class TestDataframe:
         assert not df.is_empty(pd.DataFrame({"a": [1, 2]}))
         assert not df.is_empty(pd.DataFrame({"a": [1, 2]}).style)
 
+    def test_auto_datatype_handles_empty_list_and_1d_ndarray(self):
+        dataframe_empty_list = gr.Dataframe(value=[], datatype="auto")
+        assert dataframe_empty_list.datatype == "str"
+
+        dataframe_1d_array = gr.Dataframe(value=np.array([1, 2, 3]), datatype="auto")
+        assert dataframe_1d_array.datatype == "str"
+
     def test_get_headers(self):
         """Test get_headers method with various data types"""
         df = gr.Dataframe()


### PR DESCRIPTION
## Summary
- guard `set_auto_datatype()` against empty lists and 1D numpy arrays
- fall back to `"str"` instead of indexing into unsupported shapes
- add regression tests covering both empty list and 1D ndarray inputs

Closes #13294

## Testing
- `python -m pytest test/components/test_dataframe.py -k "auto_datatype_handles_empty_list_and_1d_ndarray or is_empty"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds simple guards in `set_auto_datatype()` to avoid indexing errors on empty/1D inputs, plus focused regression tests.
> 
> **Overview**
> Fixes `gr.Dataframe(datatype="auto")` inference for unsupported/empty shapes by treating **empty lists** and **1D/empty numpy arrays** as a single `"str"` datatype instead of indexing into missing columns.
> 
> Adds regression tests ensuring `datatype` falls back to `"str"` for these inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c565e800bbc0d38cc7fc8a8b01f8698c0c7c107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->