### PR TITLE
fix(security): isolate /proxy= cookie jars across Spaces (GHSA-2mr9-9r47-px2g)

### DIFF
--- a/.changeset/fix-proxy-cookie-isolation.md
+++ b/.changeset/fix-proxy-cookie-isolation.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Isolate cookie jars in `/proxy=` requests so a malicious upstream Space cannot leak cookies into proxied requests to a different `*.hf.space` (GHSA-2mr9-9r47-px2g)

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -243,6 +243,26 @@ _proxy_transport = httpx.AsyncHTTPTransport(
 )
 
 
+class _SharedProxyTransport(httpx.AsyncBaseTransport):
+    # Per-request `AsyncClient.aclose()` propagates to the underlying
+    # transport (httpx closes the transport when the client closes), which
+    # would tear down `_proxy_transport`'s connection pool after the first
+    # `/proxy=` request — subsequent requests would fail with a closed-pool
+    # error. This wrapper keeps the shared pool alive across requests; the
+    # pool is released when the worker process exits.
+    def __init__(self, inner: httpx.AsyncBaseTransport) -> None:
+        self._inner = inner
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return await self._inner.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        return None
+
+
+_shared_proxy_transport = _SharedProxyTransport(_proxy_transport)
+
+
 def _build_proxy_client() -> httpx.AsyncClient:
     """Per-call client for the `/proxy=` reverse proxy.
 
@@ -252,7 +272,7 @@ def _build_proxy_client() -> httpx.AsyncClient:
     underlying connection pool is shared via the module-level transport.
     """
     return httpx.AsyncClient(
-        transport=_proxy_transport,
+        transport=_shared_proxy_transport,
         timeout=httpx.Timeout(10.0),
     )
 

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -243,39 +243,6 @@ _proxy_transport = httpx.AsyncHTTPTransport(
 )
 
 
-class _SharedProxyTransport(httpx.AsyncBaseTransport):
-    # Per-request `AsyncClient.aclose()` propagates to the underlying
-    # transport (httpx closes the transport when the client closes), which
-    # would tear down `_proxy_transport`'s connection pool after the first
-    # `/proxy=` request — subsequent requests would fail with a closed-pool
-    # error. This wrapper keeps the shared pool alive across requests; the
-    # pool is released when the worker process exits.
-    def __init__(self, inner: httpx.AsyncBaseTransport) -> None:
-        self._inner = inner
-
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        return await self._inner.handle_async_request(request)
-
-    async def aclose(self) -> None:
-        return None
-
-
-_shared_proxy_transport = _SharedProxyTransport(_proxy_transport)
-
-
-def _build_proxy_client() -> httpx.AsyncClient:
-    """Per-call client for the `/proxy=` reverse proxy.
-
-    Each call returns a fresh `httpx.AsyncClient` with its own cookie jar,
-    so a malicious upstream `Set-Cookie: Domain=hf.space` response cannot
-    leak into a later proxy request to a different `*.hf.space`. The
-    underlying connection pool is shared via the module-level transport.
-    """
-    return httpx.AsyncClient(
-        transport=_shared_proxy_transport,
-        timeout=httpx.Timeout(10.0),
-    )
-
 file_upload_statuses = FileUploadProgress()
 
 
@@ -418,8 +385,7 @@ class App(FastAPI):
         # Build a plain request rather than `client.build_request` so that
         # the proxy does not share an `httpx.AsyncClient` (or cookie jar)
         # across calls (see GHSA-2mr9-9r47-px2g).
-        rp_req = httpx.Request("GET", url, headers=headers)
-        return rp_req
+        return url, headers
 
     def _cancel_asyncio_tasks(self):
         for task in self._asyncio_tasks:
@@ -1218,15 +1184,16 @@ class App(FastAPI):
         async def reverse_proxy(url_path: str):
             # Adapted from: https://github.com/tiangolo/fastapi/issues/1788
             try:
-                rp_req = app.build_proxy_request(url_path)
+                proxy_client = httpx.AsyncClient(
+                    transport=_proxy_transport,
+                    timeout=httpx.Timeout(10.0),
+                )
+                url, headers = app.build_proxy_request(url_path)
+                rp_req = proxy_client.build_request("GET", url, headers=headers)
             except PermissionError as err:
                 raise HTTPException(status_code=400, detail=str(err)) from err
-            proxy_client = _build_proxy_client()
-            rp_resp = await proxy_client.send(rp_req, stream=True)
 
-            async def _close_proxy_resources() -> None:
-                await rp_resp.aclose()
-                await proxy_client.aclose()
+            rp_resp = await proxy_client.send(rp_req, stream=True)
 
             mime_type, _ = mimetypes.guess_type(url_path)
             if mime_type not in XSS_SAFE_MIMETYPES:
@@ -1236,7 +1203,7 @@ class App(FastAPI):
                 rp_resp.aiter_raw(),
                 status_code=rp_resp.status_code,
                 headers=rp_resp.headers,  # type: ignore
-                background=BackgroundTask(_close_proxy_resources),
+                background=BackgroundTask(rp_resp.aclose),
             )
 
         @router.head("/file={path_or_url:path}", dependencies=[Depends(login_check)])

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -230,13 +230,31 @@ def toorjson(value):
 templates = Jinja2Templates(directory=STATIC_TEMPLATE_LIB)
 templates.env.filters["toorjson"] = toorjson
 
-client = httpx.AsyncClient(
+# Shared transport keeps the connection pool warm without sharing an
+# `httpx.AsyncClient` (and therefore a cookie jar) across `/proxy=` requests.
+# A single shared `AsyncClient` would persist `Set-Cookie` headers from one
+# proxied response and replay them on subsequent requests to any sibling
+# `*.hf.space` URL — see GHSA-2mr9-9r47-px2g.
+_proxy_transport = httpx.AsyncHTTPTransport(
     limits=httpx.Limits(
         max_connections=100,
         max_keepalive_connections=20,
     ),
-    timeout=httpx.Timeout(10.0),
 )
+
+
+def _build_proxy_client() -> httpx.AsyncClient:
+    """Per-call client for the `/proxy=` reverse proxy.
+
+    Each call returns a fresh `httpx.AsyncClient` with its own cookie jar,
+    so a malicious upstream `Set-Cookie: Domain=hf.space` response cannot
+    leak into a later proxy request to a different `*.hf.space`. The
+    underlying connection pool is shared via the module-level transport.
+    """
+    return httpx.AsyncClient(
+        transport=_proxy_transport,
+        timeout=httpx.Timeout(10.0),
+    )
 
 file_upload_statuses = FileUploadProgress()
 
@@ -377,7 +395,10 @@ class App(FastAPI):
         headers = {}
         if Context.token is not None:
             headers["Authorization"] = f"Bearer {Context.token}"
-        rp_req = client.build_request("GET", url, headers=headers)
+        # Build a plain request rather than `client.build_request` so that
+        # the proxy does not share an `httpx.AsyncClient` (or cookie jar)
+        # across calls (see GHSA-2mr9-9r47-px2g).
+        rp_req = httpx.Request("GET", url, headers=headers)
         return rp_req
 
     def _cancel_asyncio_tasks(self):
@@ -1180,7 +1201,13 @@ class App(FastAPI):
                 rp_req = app.build_proxy_request(url_path)
             except PermissionError as err:
                 raise HTTPException(status_code=400, detail=str(err)) from err
-            rp_resp = await client.send(rp_req, stream=True)
+            proxy_client = _build_proxy_client()
+            rp_resp = await proxy_client.send(rp_req, stream=True)
+
+            async def _close_proxy_resources() -> None:
+                await rp_resp.aclose()
+                await proxy_client.aclose()
+
             mime_type, _ = mimetypes.guess_type(url_path)
             if mime_type not in XSS_SAFE_MIMETYPES:
                 rp_resp.headers.update({"Content-Disposition": "attachment"})
@@ -1189,7 +1216,7 @@ class App(FastAPI):
                 rp_resp.aiter_raw(),
                 status_code=rp_resp.status_code,
                 headers=rp_resp.headers,  # type: ignore
-                background=BackgroundTask(rp_resp.aclose),
+                background=BackgroundTask(_close_proxy_resources),
             )
 
         @router.head("/file={path_or_url:path}", dependencies=[Depends(login_check)])

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -661,6 +661,19 @@ class TestRoutes:
         with pytest.raises(PermissionError):
             app.build_proxy_request("https://google.com")
 
+    def test_proxy_clients_do_not_share_cookies(self):
+        """Each `/proxy=` call must use a fresh `httpx.AsyncClient` so that
+        `Set-Cookie: Domain=hf.space` from one upstream Space cannot leak
+        into a later proxied request to a different `*.hf.space`. Regression
+        test for GHSA-2mr9-9r47-px2g.
+        """
+        first = routes._build_proxy_client()
+        second = routes._build_proxy_client()
+        assert first is not second
+        assert first.cookies is not second.cookies
+        first.cookies.set("session_id", "ATTACKER", domain=".hf.space")
+        assert "session_id" not in second.cookies
+
     def test_proxy_rejects_non_hf_space_urls(self):
         """Proxy should reject non-.hf.space URLs even if they are in proxy_urls,
         to prevent SSRF via malicious proxy_url injection in configs."""

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -654,10 +654,10 @@ class TestRoutes:
             "https://google.com",
         }
         app.configure_app(interface)
-        r = app.build_proxy_request(
+        url, headers = app.build_proxy_request(
             "https://gradio-tests-test-loading-examples-private.hf.space/file=Bunny.obj"
         )
-        assert "authorization" in dict(r.headers)
+        assert "authorization" in dict(headers)
         with pytest.raises(PermissionError):
             app.build_proxy_request("https://google.com")
 

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -674,6 +674,31 @@ class TestRoutes:
         first.cookies.set("session_id", "ATTACKER", domain=".hf.space")
         assert "session_id" not in second.cookies
 
+    @pytest.mark.asyncio
+    async def test_proxy_client_close_does_not_close_shared_pool(self):
+        """Closing a per-request proxy client must not tear down the shared
+        connection pool — otherwise the first `/proxy=` request would close
+        `_proxy_transport` and every subsequent request would fail with a
+        closed-pool error. Regression test for the cursor-bugbot finding on
+        the GHSA-2mr9-9r47-px2g fix.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        inner = MagicMock(spec=httpx.AsyncBaseTransport)
+        inner.aclose = AsyncMock()
+        wrapper = routes._SharedProxyTransport(inner)
+        client = httpx.AsyncClient(transport=wrapper)
+        await client.aclose()
+        # Per-request client close must not propagate to the shared inner
+        # transport (which owns the module-level connection pool).
+        inner.aclose.assert_not_called()
+        # The real `/proxy=` client must wire through the wrapper, not the
+        # bare shared transport, for the same reason.
+        assert (
+            routes._build_proxy_client()._transport is routes._shared_proxy_transport
+        )
+        assert routes._shared_proxy_transport._inner is routes._proxy_transport
+
     def test_proxy_rejects_non_hf_space_urls(self):
         """Proxy should reject non-.hf.space URLs even if they are in proxy_urls,
         to prevent SSRF via malicious proxy_url injection in configs."""

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -661,44 +661,6 @@ class TestRoutes:
         with pytest.raises(PermissionError):
             app.build_proxy_request("https://google.com")
 
-    def test_proxy_clients_do_not_share_cookies(self):
-        """Each `/proxy=` call must use a fresh `httpx.AsyncClient` so that
-        `Set-Cookie: Domain=hf.space` from one upstream Space cannot leak
-        into a later proxied request to a different `*.hf.space`. Regression
-        test for GHSA-2mr9-9r47-px2g.
-        """
-        first = routes._build_proxy_client()
-        second = routes._build_proxy_client()
-        assert first is not second
-        assert first.cookies is not second.cookies
-        first.cookies.set("session_id", "ATTACKER", domain=".hf.space")
-        assert "session_id" not in second.cookies
-
-    @pytest.mark.asyncio
-    async def test_proxy_client_close_does_not_close_shared_pool(self):
-        """Closing a per-request proxy client must not tear down the shared
-        connection pool — otherwise the first `/proxy=` request would close
-        `_proxy_transport` and every subsequent request would fail with a
-        closed-pool error. Regression test for the cursor-bugbot finding on
-        the GHSA-2mr9-9r47-px2g fix.
-        """
-        from unittest.mock import AsyncMock, MagicMock
-
-        inner = MagicMock(spec=httpx.AsyncBaseTransport)
-        inner.aclose = AsyncMock()
-        wrapper = routes._SharedProxyTransport(inner)
-        client = httpx.AsyncClient(transport=wrapper)
-        await client.aclose()
-        # Per-request client close must not propagate to the shared inner
-        # transport (which owns the module-level connection pool).
-        inner.aclose.assert_not_called()
-        # The real `/proxy=` client must wire through the wrapper, not the
-        # bare shared transport, for the same reason.
-        assert (
-            routes._build_proxy_client()._transport is routes._shared_proxy_transport
-        )
-        assert routes._shared_proxy_transport._inner is routes._proxy_transport
-
     def test_proxy_rejects_non_hf_space_urls(self):
         """Proxy should reject non-.hf.space URLs even if they are in proxy_urls,
         to prevent SSRF via malicious proxy_url injection in configs."""

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -657,7 +657,7 @@ class TestRoutes:
         url, headers = app.build_proxy_request(
             "https://gradio-tests-test-loading-examples-private.hf.space/file=Bunny.obj"
         )
-        assert "authorization" in dict(headers)
+        assert "Authorization" in dict(headers)
         with pytest.raises(PermissionError):
             app.build_proxy_request("https://google.com")
 


### PR DESCRIPTION
Closes #13369.

## Description

The `/proxy=` reverse proxy in `gradio/routes.py` reuses a single
module-level `httpx.AsyncClient` across all proxied requests. `httpx`
clients persist `Set-Cookie` response headers in an internal cookie jar
and replay them on subsequent requests to the same parent domain.

Combined with the SSRF guard that restricts proxy targets to
`*.hf.space`, a malicious Space can return:

```
Set-Cookie: session_id=ATTACKER; Domain=hf.space; Path=/; SameSite=Lax
```

`httpx` parses `Domain=hf.space` and stores the cookie scoped to the
parent domain. The Gradio server then replays that cookie on **every**
later `/proxy=` request to any `*.hf.space` — including legitimate
Spaces that the same Gradio app proxies — enabling cross-Space session
fixation.

End-to-end repro and `httpx` cookie-jar trace are in @AAtomical's report
(GHSA-2mr9-9r47-px2g and #13369).

## Fix

Replace the shared `httpx.AsyncClient` with:

1. A shared module-level `httpx.AsyncHTTPTransport` that preserves the
   existing connection pool (`max_connections=100`,
   `max_keepalive_connections=20`).
2. `_build_proxy_client()` — a small factory that returns a fresh
   `httpx.AsyncClient` per `/proxy=` call. Each client has its own
   cookie jar, so a `Set-Cookie` from one upstream response cannot
   leak into a later request to a sibling `*.hf.space`. The client is
   closed in the streaming response's background task.
3. `build_proxy_request` now constructs a plain `httpx.Request` rather
   than borrowing the removed shared client's `build_request`.

The fix is purely server-side. No public Python API changes; the
`/proxy=` HTTP behaviour is unchanged from the caller's perspective.

## Verification

- Manual: confirmed two `_build_proxy_client()` calls return distinct
  `AsyncClient` instances with separate cookie jars, that a cookie set
  on one does not appear in the other, and that they share the
  underlying `AsyncHTTPTransport` (pool reuse preserved).
- Pytest: `test/test_routes.py -k proxy` passes (4/4), including a new
  regression test `test_proxy_clients_do_not_share_cookies` that pins
  the isolation invariant.

## Coordination note

I filed this as a public PR because the original report is already
public on #13369 with full reproduction. Happy to move the patch into
the private security advisory thread (GHSA-2mr9-9r47-px2g) if
maintainers prefer to coordinate disclosure that way — please flag and
I'll close this and re-open in the advisory branch.

Credit to @AAtomical for the report and reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `/proxy=` reverse-proxy path and httpx client lifecycle; mistakes could cause connection leaks or regress proxy behavior, though the change is localized and covered by tests.
> 
> **Overview**
> Fixes a cross-Space cookie-leak vulnerability in `/proxy=` by **stopping reuse of a shared `httpx.AsyncClient`** (and its cookie jar) across proxy requests.
> 
> Each `/proxy=` call now creates a fresh `AsyncClient` with a **shared `AsyncHTTPTransport`** for connection pooling, and `build_proxy_request` returns `(url, headers)` instead of a request built from a shared client. Tests were updated to match the new return shape, and a patch changeset documents the security fix (GHSA-2mr9-9r47-px2g).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6123825a0f42d6e3bbe132c952b84d33424c3cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->