### PR TITLE
Limit generated PWA icon size

### DIFF
--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -156,6 +156,7 @@ BUILD_PATH_LIB = cast(
     .as_posix(),  # type: ignore
 )
 VERSION = get_package_version()
+MAX_PWA_ICON_SIZE = 512
 XSS_SAFE_MIMETYPES = {
     "image/jpeg",
     "image/png",
@@ -2019,14 +2020,19 @@ class App(FastAPI):
 
             if size is None:
                 return FileResponse(favicon_path)
+            if size <= 0 or size > MAX_PWA_ICON_SIZE:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Icon size must be between 1 and {MAX_PWA_ICON_SIZE}.",
+                )
 
             import PIL.Image
 
-            img = PIL.Image.open(favicon_path)
-            img = img.resize((size, size))
+            with PIL.Image.open(favicon_path) as img:
+                img = img.resize((size, size))
 
-            img_byte_array = io.BytesIO()
-            img.save(img_byte_array, format="PNG")
+                img_byte_array = io.BytesIO()
+                img.save(img_byte_array, format="PNG")
             img_byte_array.seek(0)
 
             return StreamingResponse(
@@ -2068,8 +2074,8 @@ class App(FastAPI):
                         "purpose": "any",
                     },
                     {
-                        "src": app.url_path_for("pwa_icon", size=512),
-                        "sizes": "512x512",
+                        "src": app.url_path_for("pwa_icon", size=MAX_PWA_ICON_SIZE),
+                        "sizes": f"{MAX_PWA_ICON_SIZE}x{MAX_PWA_ICON_SIZE}",
                         "type": "image/png",
                         "purpose": "any",
                     },

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -74,6 +74,25 @@ class TestRoutes:
         response = test_client.get("/favicon.ico")
         assert response.status_code == 200
 
+    @pytest.mark.parametrize(
+        ("size", "expected_status"),
+        [
+            (0, 400),
+            (-1, 400),
+            (routes.MAX_PWA_ICON_SIZE, 200),
+            (routes.MAX_PWA_ICON_SIZE + 1, 400),
+        ],
+    )
+    def test_pwa_icon_validates_resize_size(self, size, expected_status):
+        io = Interface(lambda x: x + x, "text", "text")
+        io.favicon_path = "test/test_files/bus.png"
+        app = routes.App.create_app(io)
+        client = TestClient(app)
+
+        response = client.get(f"/pwa_icon/{size}")
+
+        assert response.status_code == expected_status
+
     def test_openapi_route(self, test_client):
         response = test_client.get(f"{API_PREFIX}/openapi.json")
         assert response.status_code == 200


### PR DESCRIPTION
## Summary
- bound generated PWA icon resize requests to the largest size advertised in the manifest
- reject non-positive and oversized icon sizes before opening/resizing the favicon
- add regression coverage for oversized `/pwa_icon/{size}` requests

## Test
```powershell
$env:PYTHONPATH='.'; ..\.venv-gradio\Scripts\python -m pytest test\test_routes.py::TestRoutes::test_pwa_icon_rejects_oversized_resize -q
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to a single route that rejects invalid/oversized icon resize requests and adds test coverage; only affects clients requesting out-of-range sizes.
> 
> **Overview**
> Adds a `MAX_PWA_ICON_SIZE` constant (512) and uses it to **cap `/pwa_icon/{size}` resize requests**, returning `400` for non-positive or oversized sizes before any image processing.
> 
> Updates `manifest.json` generation to reference the same max size, and adds a parametrized regression test ensuring out-of-range sizes are rejected while the max allowed size succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc6ef2dacad04326d0885b905327b0294da42764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->