### PR TITLE
fix(heartbeat): check client disconnect after each heartbeat sleep

### DIFF
--- a/.changeset/thick-words-sneeze.md
+++ b/.changeset/thick-words-sneeze.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:fix(heartbeat): check client disconnect after each heartbeat sleep

--- a/.changeset/thick-words-sneeze.md
+++ b/.changeset/thick-words-sneeze.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:fix(heartbeat): check client disconnect after each heartbeat sleep
+fix:fix(heartbeat): check client disconnect after each heartbeat sleep

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1405,6 +1405,8 @@ class App(FastAPI):
                         )
                         if stop_stream_task in done:
                             raise asyncio.CancelledError()
+                        if await request.is_disconnected():
+                            raise asyncio.CancelledError()
                     except asyncio.CancelledError:
                         if not stop_stream_task.done():
                             stop_stream_task.cancel()


### PR DESCRIPTION
## Summary

The `/heartbeat/{session_hash}` SSE generator only triggers unload callbacks when the ASGI framework raises `CancelledError` on the streaming task. Behind Kubernetes load balancers or nginx with TCP keepalives, the underlying TCP connection stays open after the browser disconnects — so the ASGI layer never cancels the generator. Session unload callbacks can be delayed up to 30 minutes in these environments.

## Fix

Add `await request.is_disconnected()` check after every `asyncio.wait()` in the heartbeat loop, raising `CancelledError` immediately if the client has gone away:

```python
# BEFORE
if stop_stream_task in done:
    raise asyncio.CancelledError()

# AFTER
if stop_stream_task in done:
    raise asyncio.CancelledError()
if await request.is_disconnected():
    raise asyncio.CancelledError()
```

This matches the pattern already used by the `/dev/reload` SSE endpoint at line 561 and other streaming endpoints in `routes.py`. Unload now fires within one `heartbeat_rate` interval (15 s by default) of the client disconnecting, regardless of whether the transport layer keeps the TCP connection alive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to the `/heartbeat/{session_hash}` SSE loop to detect client disconnects sooner; main impact is timing of session unload/cleanup callbacks.
> 
> **Overview**
> **Fixes delayed session cleanup for disconnected clients.** The `/heartbeat/{session_hash}` SSE iterator now checks `request.is_disconnected()` after each heartbeat sleep and cancels the stream immediately, ensuring unload callbacks and session cleanup run promptly even when proxies/load balancers keep the TCP connection open.
> 
> Adds a patch changeset for the Gradio release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02607f0e01514f923ac4ef2605339e3456bb7360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->