### PR TITLE
fix: support point-cloud Model3D files

### DIFF
--- a/.changeset/model3d-point-cloud.md
+++ b/.changeset/model3d-point-cloud.md
@@ -1,0 +1,5 @@
+---
+"@gradio/model3d": patch
+---
+
+Support point-only OBJ files and generic PLY point-cloud files in Model3D.

--- a/.changeset/model3d-point-cloud.md
+++ b/.changeset/model3d-point-cloud.md
@@ -2,4 +2,4 @@
 "@gradio/model3d": patch
 ---
 
-Support point-only OBJ files and generic PLY point-cloud files in Model3D.
+Support generic PLY point-cloud files in Model3D.

--- a/js/model3D/shared/Canvas3D.node-test.ts
+++ b/js/model3D/shared/Canvas3D.node-test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const source = readFileSync(
+	resolve(dirname(fileURLToPath(import.meta.url)), "Canvas3D.svelte"),
+	"utf-8"
+);
+
+describe("Canvas3D point cloud dependencies", () => {
+	test("loads Babylon point-cloud classes dynamically", () => {
+		expect(source).not.toMatch(
+			/import\s+\{[^}]*\b(?:Color4|PointsCloudSystem|Vector3)\b[^}]*\}\s+from\s+["']@babylonjs\/core["']/
+		);
+		expect(source).toMatch(/await\s+import\(\s*["']@babylonjs\/core["']\s*\)/);
+	});
+});

--- a/js/model3D/shared/Canvas3D.svelte
+++ b/js/model3D/shared/Canvas3D.svelte
@@ -4,7 +4,7 @@
 	import type { Viewer, ViewerDetails } from "@babylonjs/viewer";
 	import { Color4, PointsCloudSystem, Vector3 } from "@babylonjs/core";
 	import type { Camera, Mesh, Observer } from "@babylonjs/core";
-	import { load_obj_point_cloud, type PointCloudData } from "./point-cloud";
+	import type { PointCloudData } from "./point-cloud";
 
 	let BABYLON_VIEWER: typeof import("@babylonjs/viewer");
 
@@ -87,20 +87,6 @@
 		pointCloudMesh = undefined;
 	}
 
-	function is_obj_url(url: string): boolean {
-		return url.toLowerCase().split(/[?#]/)[0].endsWith(".obj");
-	}
-
-	async function try_load_obj_point_cloud(
-		url: string
-	): Promise<PointCloudData | null> {
-		try {
-			return await load_obj_point_cloud(url);
-		} catch {
-			return null;
-		}
-	}
-
 	async function render_point_cloud(
 		point_cloud: PointCloudData,
 		currentToken: number
@@ -167,9 +153,7 @@
 			}
 
 			clear_point_cloud();
-			const parsedPointCloud =
-				point_cloud ??
-				(is_obj_url(url) ? await try_load_obj_point_cloud(url) : null);
+			const parsedPointCloud = point_cloud;
 			if (currentToken !== loadToken) return;
 			if (parsedPointCloud) {
 				await render_point_cloud(parsedPointCloud, currentToken);

--- a/js/model3D/shared/Canvas3D.svelte
+++ b/js/model3D/shared/Canvas3D.svelte
@@ -3,7 +3,7 @@
 	import type { FileData } from "@gradio/client";
 	import type { Viewer, ViewerDetails } from "@babylonjs/viewer";
 	import { Color4, PointsCloudSystem, Vector3 } from "@babylonjs/core";
-	import type { Mesh } from "@babylonjs/core";
+	import type { Camera, Mesh, Observer } from "@babylonjs/core";
 	import { load_obj_point_cloud, type PointCloudData } from "./point-cloud";
 
 	let BABYLON_VIEWER: typeof import("@babylonjs/viewer");
@@ -34,6 +34,8 @@
 	let mounted = $state(false);
 	let pointCloudSystem: PointsCloudSystem | undefined;
 	let pointCloudMesh: Mesh | undefined;
+	let cameraSensitivityObserver: Observer<Camera> | null = null;
+	let cameraSensitivityCamera: Camera | null = null;
 	let loadToken = 0;
 
 	onMount(() => {
@@ -56,13 +58,20 @@
 		initViewer();
 
 		return () => {
+			if (cameraSensitivityCamera && cameraSensitivityObserver) {
+				cameraSensitivityCamera.onAfterCheckInputsObservable.remove(
+					cameraSensitivityObserver
+				);
+			}
 			viewer?.dispose();
+			cameraSensitivityObserver = null;
+			cameraSensitivityCamera = null;
 		};
 	});
 
 	$effect(() => {
 		if (mounted) {
-			load_model(url);
+			void load_model(url);
 		}
 	});
 
@@ -148,39 +157,43 @@
 
 	async function load_model(url: string | undefined): Promise<void> {
 		const currentToken = ++loadToken;
-		if (viewer) {
-			if (url) {
-				clear_point_cloud();
-				const parsedPointCloud =
-					point_cloud ??
-					(is_obj_url(url) ? await try_load_obj_point_cloud(url) : null);
-				if (currentToken !== loadToken) return;
-				if (parsedPointCloud) {
-					await render_point_cloud(parsedPointCloud, currentToken);
-					return;
-				}
+		if (!viewer) return;
 
-				viewer
-					.loadModel(url, {
-						pluginOptions: {
-							obj: {
-								importVertexColors: true
-							}
-						}
-					})
-					.then(() => {
-						if (currentToken !== loadToken) return;
-						if (display_mode === "point_cloud") {
-							setRenderingMode(true, false);
-						} else if (display_mode === "wireframe") {
-							setRenderingMode(false, true);
-						} else {
-							update_camera(camera_position, zoom_speed, pan_speed);
-						}
-					});
-			} else {
+		try {
+			if (!url) {
 				clear_point_cloud();
 				viewer.resetModel();
+				return;
+			}
+
+			clear_point_cloud();
+			const parsedPointCloud =
+				point_cloud ??
+				(is_obj_url(url) ? await try_load_obj_point_cloud(url) : null);
+			if (currentToken !== loadToken) return;
+			if (parsedPointCloud) {
+				await render_point_cloud(parsedPointCloud, currentToken);
+				return;
+			}
+
+			await viewer.loadModel(url, {
+				pluginOptions: {
+					obj: {
+						importVertexColors: true
+					}
+				}
+			});
+			if (currentToken !== loadToken) return;
+			if (display_mode === "point_cloud") {
+				setRenderingMode(true, false);
+			} else if (display_mode === "wireframe") {
+				setRenderingMode(false, true);
+			} else {
+				update_camera(camera_position, zoom_speed, pan_speed);
+			}
+		} catch {
+			if (currentToken === loadToken) {
+				clear_point_cloud();
 			}
 		}
 	}
@@ -207,7 +220,15 @@
 			camera.panningSensibility = (10000 * pan_speed) / camera.radius;
 		};
 		updateCameraSensibility();
-		camera.onAfterCheckInputsObservable.add(updateCameraSensibility);
+		if (cameraSensitivityCamera && cameraSensitivityObserver) {
+			cameraSensitivityCamera.onAfterCheckInputsObservable.remove(
+				cameraSensitivityObserver
+			);
+		}
+		cameraSensitivityObserver = camera.onAfterCheckInputsObservable.add(
+			updateCameraSensibility
+		);
+		cameraSensitivityCamera = camera;
 	}
 
 	export function reset_camera_position(): void {

--- a/js/model3D/shared/Canvas3D.svelte
+++ b/js/model3D/shared/Canvas3D.svelte
@@ -2,8 +2,12 @@
 	import { onMount } from "svelte";
 	import type { FileData } from "@gradio/client";
 	import type { Viewer, ViewerDetails } from "@babylonjs/viewer";
-	import { Color4, PointsCloudSystem, Vector3 } from "@babylonjs/core";
-	import type { Camera, Mesh, Observer } from "@babylonjs/core";
+	import type {
+		Camera,
+		Mesh,
+		Observer,
+		PointsCloudSystem
+	} from "@babylonjs/core";
 	import type { PointCloudData } from "./point-cloud";
 
 	let BABYLON_VIEWER: typeof import("@babylonjs/viewer");
@@ -92,6 +96,9 @@
 		currentToken: number
 	): Promise<void> {
 		if (!viewerDetails || !viewer) return;
+		const { Color4, PointsCloudSystem, Vector3 } =
+			await import("@babylonjs/core");
+		if (currentToken !== loadToken) return;
 
 		viewer.resetModel();
 		clear_point_cloud();

--- a/js/model3D/shared/Canvas3D.svelte
+++ b/js/model3D/shared/Canvas3D.svelte
@@ -2,6 +2,9 @@
 	import { onMount } from "svelte";
 	import type { FileData } from "@gradio/client";
 	import type { Viewer, ViewerDetails } from "@babylonjs/viewer";
+	import { Color4, PointsCloudSystem, Vector3 } from "@babylonjs/core";
+	import type { Mesh } from "@babylonjs/core";
+	import { load_obj_point_cloud, type PointCloudData } from "./point-cloud";
 
 	let BABYLON_VIEWER: typeof import("@babylonjs/viewer");
 
@@ -11,7 +14,8 @@
 		clear_color,
 		camera_position,
 		zoom_speed,
-		pan_speed
+		pan_speed,
+		point_cloud = null
 	}: {
 		value: FileData;
 		display_mode: "solid" | "point_cloud" | "wireframe";
@@ -19,6 +23,7 @@
 		camera_position: [number | null, number | null, number | null];
 		zoom_speed: number;
 		pan_speed: number;
+		point_cloud?: PointCloudData | null;
 	} = $props();
 
 	let url = $derived(value.url);
@@ -27,6 +32,9 @@
 	let viewer = $state<Viewer>();
 	let viewerDetails = $state<Readonly<ViewerDetails>>();
 	let mounted = $state(false);
+	let pointCloudSystem: PointsCloudSystem | undefined;
+	let pointCloudMesh: Mesh | undefined;
+	let loadToken = 0;
 
 	onMount(() => {
 		const initViewer = async (): Promise<void> => {
@@ -64,9 +72,94 @@
 		viewerDetails.scene.forceWireframe = wireframe;
 	}
 
-	function load_model(url: string | undefined): void {
+	function clear_point_cloud(): void {
+		pointCloudSystem?.dispose();
+		pointCloudSystem = undefined;
+		pointCloudMesh = undefined;
+	}
+
+	function is_obj_url(url: string): boolean {
+		return url.toLowerCase().split(/[?#]/)[0].endsWith(".obj");
+	}
+
+	async function try_load_obj_point_cloud(
+		url: string
+	): Promise<PointCloudData | null> {
+		try {
+			return await load_obj_point_cloud(url);
+		} catch {
+			return null;
+		}
+	}
+
+	async function render_point_cloud(
+		point_cloud: PointCloudData,
+		currentToken: number
+	): Promise<void> {
+		if (!viewerDetails || !viewer) return;
+
+		viewer.resetModel();
+		clear_point_cloud();
+
+		const scene = viewerDetails.scene;
+		const points = point_cloud.positions.length / 3;
+		const system = new PointsCloudSystem("gradio-point-cloud", 2, scene, {
+			updatable: false
+		});
+
+		system.addPoints(points, (particle: any, index: number) => {
+			const position_index = index * 3;
+			particle.position = new Vector3(
+				point_cloud.positions[position_index],
+				point_cloud.positions[position_index + 1],
+				point_cloud.positions[position_index + 2]
+			);
+
+			if (point_cloud.colors) {
+				const color_index = index * 4;
+				particle.color = new Color4(
+					point_cloud.colors[color_index],
+					point_cloud.colors[color_index + 1],
+					point_cloud.colors[color_index + 2],
+					point_cloud.colors[color_index + 3]
+				);
+			}
+		});
+
+		pointCloudSystem = system;
+		const mesh = await system.buildMeshAsync();
+		if (currentToken !== loadToken) {
+			system.dispose();
+			return;
+		}
+		pointCloudMesh = mesh;
+
+		const bounds = pointCloudMesh.getBoundingInfo().boundingBox;
+		const center = Vector3.Center(bounds.minimumWorld, bounds.maximumWorld);
+		const radius = Math.max(
+			Vector3.Distance(bounds.minimumWorld, bounds.maximumWorld),
+			1
+		);
+
+		viewerDetails.camera.setTarget(center);
+		viewerDetails.camera.radius = radius * 1.5;
+		update_camera(camera_position, zoom_speed, pan_speed);
+	}
+
+	async function load_model(url: string | undefined): Promise<void> {
+		const currentToken = ++loadToken;
 		if (viewer) {
 			if (url) {
+				clear_point_cloud();
+				const parsedPointCloud =
+					point_cloud ??
+					(is_obj_url(url) ? await try_load_obj_point_cloud(url) : null);
+				if (currentToken !== loadToken) return;
+				if (parsedPointCloud) {
+					await render_point_cloud(parsedPointCloud, currentToken);
+					return;
+				}
+
 				viewer
 					.loadModel(url, {
 						pluginOptions: {
@@ -76,6 +169,7 @@
 						}
 					})
 					.then(() => {
+						if (currentToken !== loadToken) return;
 						if (display_mode === "point_cloud") {
 							setRenderingMode(true, false);
 						} else if (display_mode === "wireframe") {
@@ -85,6 +179,7 @@
 						}
 					});
 			} else {
+				clear_point_cloud();
 				viewer.resetModel();
 			}
 		}

--- a/js/model3D/shared/Canvas3DGS.svelte
+++ b/js/model3D/shared/Canvas3DGS.svelte
@@ -14,6 +14,7 @@
 	} = $props();
 
 	let url = $derived(value.url);
+	let path = $derived(value?.path);
 
 	let canvas: HTMLCanvasElement;
 	let scene: SPLAT.Scene;
@@ -55,9 +56,10 @@
 				throw new Error("No resolved URL");
 			}
 			loading = true;
-			if (url.endsWith(".ply")) {
+			const model_path = path ?? url;
+			if (model_path.endsWith(".ply")) {
 				await SPLAT.PLYLoader.LoadAsync(url, scene, undefined);
-			} else if (url.endsWith(".splat")) {
+			} else if (model_path.endsWith(".splat")) {
 				await SPLAT.Loader.LoadAsync(url, scene, undefined);
 			} else {
 				throw new Error("Unsupported file type");
@@ -97,8 +99,6 @@
 			}
 		};
 	});
-
-	let path = $derived(value?.path);
 
 	$effect(() => {
 		if (canvas && mounted && path) {

--- a/js/model3D/shared/Canvas3DPLY.svelte
+++ b/js/model3D/shared/Canvas3DPLY.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import type { FileData } from "@gradio/client";
-	import { onDestroy } from "svelte";
 	import { load_ply_point_cloud, type PointCloudData } from "./point-cloud";
 	import {
 		loadCanvas3D,
@@ -76,6 +75,11 @@
 		reset_camera_available = false;
 
 		void load_renderer(load_url, currentToken);
+
+		return () => {
+			loadToken++;
+			revoke_fallback_url();
+		};
 	});
 
 	async function load_renderer(
@@ -125,8 +129,6 @@
 			reset_camera_available = false;
 		}
 	}
-
-	onDestroy(revoke_fallback_url);
 
 	export function update_camera(
 		camera_position: [number | null, number | null, number | null],

--- a/js/model3D/shared/Canvas3DPLY.svelte
+++ b/js/model3D/shared/Canvas3DPLY.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	import type { FileData } from "@gradio/client";
+	import type Canvas3D from "./Canvas3D.svelte";
+	import Canvas3DComponent from "./Canvas3D.svelte";
+	import Canvas3DGSComponent from "./Canvas3DGS.svelte";
+	import { load_ply_point_cloud, type PointCloudData } from "./point-cloud";
+
+	let {
+		value,
+		display_mode,
+		clear_color,
+		camera_position,
+		zoom_speed,
+		pan_speed
+	}: {
+		value: FileData;
+		display_mode: "solid" | "point_cloud" | "wireframe";
+		clear_color: [number, number, number, number];
+		camera_position: [number | null, number | null, number | null];
+		zoom_speed: number;
+		pan_speed: number;
+	} = $props();
+
+	let canvas3d = $state<Canvas3D | undefined>();
+	let point_cloud = $state<PointCloudData | null>(null);
+	let renderer = $state<"loading" | "point_cloud" | "gs">("loading");
+	let loaded_url: string | undefined;
+
+	$effect(() => {
+		if (!value?.url || value.url === loaded_url) return;
+
+		loaded_url = value.url;
+		renderer = "loading";
+		point_cloud = null;
+
+		load_ply_point_cloud(value.url)
+			.then((loaded_point_cloud) => {
+				if (loaded_url !== value.url) return;
+				point_cloud = loaded_point_cloud;
+				renderer = loaded_point_cloud ? "point_cloud" : "gs";
+			})
+			.catch(() => {
+				if (loaded_url === value.url) {
+					renderer = "gs";
+				}
+			});
+	});
+
+	export function update_camera(
+		camera_position: [number | null, number | null, number | null],
+		zoom_speed: number,
+		pan_speed: number
+	): void {
+		canvas3d?.update_camera(camera_position, zoom_speed, pan_speed);
+	}
+
+	export function reset_camera_position(): void {
+		canvas3d?.reset_camera_position();
+	}
+</script>
+
+{#if renderer === "point_cloud" && point_cloud}
+	<Canvas3DComponent
+		bind:this={canvas3d}
+		{value}
+		{display_mode}
+		{clear_color}
+		{camera_position}
+		{zoom_speed}
+		{pan_speed}
+		{point_cloud}
+	/>
+{:else if renderer === "gs"}
+	<Canvas3DGSComponent {value} {zoom_speed} {pan_speed} />
+{/if}

--- a/js/model3D/shared/Canvas3DPLY.svelte
+++ b/js/model3D/shared/Canvas3DPLY.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { FileData } from "@gradio/client";
 	import type Canvas3D from "./Canvas3D.svelte";
-	import Canvas3DComponent from "./Canvas3D.svelte";
-	import Canvas3DGSComponent from "./Canvas3DGS.svelte";
+	import type Canvas3DGS from "./Canvas3DGS.svelte";
 	import { load_ply_point_cloud, type PointCloudData } from "./point-cloud";
 
 	let {
@@ -24,33 +23,72 @@
 	} = $props();
 
 	let canvas3d = $state<Canvas3D | undefined>();
+	let Canvas3DComponent = $state<typeof Canvas3D>();
+	let Canvas3DGSComponent = $state<typeof Canvas3DGS>();
 	let point_cloud = $state<PointCloudData | null>(null);
 	let renderer = $state<"loading" | "point_cloud" | "gs">("loading");
 	let loaded_url: string | undefined;
+	let loadToken = 0;
+
+	async function loadCanvas3D(): Promise<typeof Canvas3D> {
+		const module = await import("./Canvas3D.svelte");
+		return module.default;
+	}
+
+	async function loadCanvas3DGS(): Promise<typeof Canvas3DGS> {
+		const module = await import("./Canvas3DGS.svelte");
+		return module.default;
+	}
 
 	$effect(() => {
-		if (!value?.url || value.url === loaded_url) return;
+		if (!value?.url) {
+			loadToken++;
+			loaded_url = undefined;
+			renderer = "loading";
+			point_cloud = null;
+			reset_camera_available = false;
+			return;
+		}
+		if (value.url === loaded_url) return;
 
 		const load_url = value.url;
+		const currentToken = ++loadToken;
 		loaded_url = load_url;
 		renderer = "loading";
 		point_cloud = null;
 		reset_camera_available = false;
 
-		load_ply_point_cloud(load_url)
-			.then((loaded_point_cloud) => {
-				if (loaded_url !== load_url) return;
-				point_cloud = loaded_point_cloud;
-				renderer = loaded_point_cloud ? "point_cloud" : "gs";
-				reset_camera_available = renderer === "point_cloud";
-			})
-			.catch(() => {
-				if (loaded_url === load_url) {
-					renderer = "gs";
-					reset_camera_available = false;
-				}
-			});
+		void load_renderer(load_url, currentToken);
 	});
+
+	async function load_renderer(
+		load_url: string,
+		currentToken: number
+	): Promise<void> {
+		try {
+			const loaded_point_cloud = await load_ply_point_cloud(load_url);
+			if (currentToken !== loadToken) return;
+
+			point_cloud = loaded_point_cloud;
+			if (loaded_point_cloud) {
+				Canvas3DComponent ??= await loadCanvas3D();
+				if (currentToken !== loadToken) return;
+				renderer = "point_cloud";
+				reset_camera_available = true;
+			} else {
+				Canvas3DGSComponent ??= await loadCanvas3DGS();
+				if (currentToken !== loadToken) return;
+				renderer = "gs";
+				reset_camera_available = false;
+			}
+		} catch {
+			if (currentToken !== loadToken) return;
+			Canvas3DGSComponent ??= await loadCanvas3DGS();
+			if (currentToken !== loadToken) return;
+			renderer = "gs";
+			reset_camera_available = false;
+		}
+	}
 
 	export function update_camera(
 		camera_position: [number | null, number | null, number | null],
@@ -65,8 +103,9 @@
 	}
 </script>
 
-{#if renderer === "point_cloud" && point_cloud}
-	<Canvas3DComponent
+{#if renderer === "point_cloud" && point_cloud && Canvas3DComponent}
+	<svelte:component
+		this={Canvas3DComponent}
 		bind:this={canvas3d}
 		{value}
 		{display_mode}
@@ -76,6 +115,11 @@
 		{pan_speed}
 		{point_cloud}
 	/>
-{:else if renderer === "gs"}
-	<Canvas3DGSComponent {value} {zoom_speed} {pan_speed} />
+{:else if renderer === "gs" && Canvas3DGSComponent}
+	<svelte:component
+		this={Canvas3DGSComponent}
+		{value}
+		{zoom_speed}
+		{pan_speed}
+	/>
 {/if}

--- a/js/model3D/shared/Canvas3DPLY.svelte
+++ b/js/model3D/shared/Canvas3DPLY.svelte
@@ -29,18 +29,19 @@
 	$effect(() => {
 		if (!value?.url || value.url === loaded_url) return;
 
-		loaded_url = value.url;
+		const load_url = value.url;
+		loaded_url = load_url;
 		renderer = "loading";
 		point_cloud = null;
 
-		load_ply_point_cloud(value.url)
+		load_ply_point_cloud(load_url)
 			.then((loaded_point_cloud) => {
-				if (loaded_url !== value.url) return;
+				if (loaded_url !== load_url) return;
 				point_cloud = loaded_point_cloud;
 				renderer = loaded_point_cloud ? "point_cloud" : "gs";
 			})
 			.catch(() => {
-				if (loaded_url === value.url) {
+				if (loaded_url === load_url) {
 					renderer = "gs";
 				}
 			});

--- a/js/model3D/shared/Canvas3DPLY.svelte
+++ b/js/model3D/shared/Canvas3DPLY.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
 	import type { FileData } from "@gradio/client";
 	import { onDestroy } from "svelte";
-	import type Canvas3D from "./Canvas3D.svelte";
-	import type Canvas3DGS from "./Canvas3DGS.svelte";
 	import { load_ply_point_cloud, type PointCloudData } from "./point-cloud";
+	import {
+		loadCanvas3D,
+		loadCanvas3DGS,
+		type Canvas3DComponentType,
+		type Canvas3DGSComponentType,
+		type Canvas3DLike
+	} from "./renderer-loader";
 
 	let {
 		value,
@@ -23,25 +28,15 @@
 		reset_camera_available?: boolean;
 	} = $props();
 
-	let canvas3d = $state<Canvas3D | undefined>();
-	let Canvas3DComponent = $state<typeof Canvas3D>();
-	let Canvas3DGSComponent = $state<typeof Canvas3DGS>();
+	let canvas3d = $state<Canvas3DLike | undefined>();
+	let Canvas3DComponent = $state<Canvas3DComponentType>();
+	let Canvas3DGSComponent = $state<Canvas3DGSComponentType>();
 	let point_cloud = $state<PointCloudData | null>(null);
 	let gs_value = $state<FileData | undefined>();
 	let renderer = $state<"loading" | "point_cloud" | "gs">("loading");
 	let loaded_url: string | undefined;
 	let fallback_url: string | undefined;
 	let loadToken = 0;
-
-	async function loadCanvas3D(): Promise<typeof Canvas3D> {
-		const module = await import("./Canvas3D.svelte");
-		return module.default;
-	}
-
-	async function loadCanvas3DGS(): Promise<typeof Canvas3DGS> {
-		const module = await import("./Canvas3DGS.svelte");
-		return module.default;
-	}
 
 	function revoke_object_url(url: string | undefined): void {
 		if (

--- a/js/model3D/shared/Canvas3DPLY.svelte
+++ b/js/model3D/shared/Canvas3DPLY.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { FileData } from "@gradio/client";
+	import { onDestroy } from "svelte";
 	import type Canvas3D from "./Canvas3D.svelte";
 	import type Canvas3DGS from "./Canvas3DGS.svelte";
 	import { load_ply_point_cloud, type PointCloudData } from "./point-cloud";
@@ -26,8 +27,10 @@
 	let Canvas3DComponent = $state<typeof Canvas3D>();
 	let Canvas3DGSComponent = $state<typeof Canvas3DGS>();
 	let point_cloud = $state<PointCloudData | null>(null);
+	let gs_value = $state<FileData | undefined>();
 	let renderer = $state<"loading" | "point_cloud" | "gs">("loading");
 	let loaded_url: string | undefined;
+	let fallback_url: string | undefined;
 	let loadToken = 0;
 
 	async function loadCanvas3D(): Promise<typeof Canvas3D> {
@@ -40,10 +43,27 @@
 		return module.default;
 	}
 
+	function revoke_object_url(url: string | undefined): void {
+		if (
+			url &&
+			typeof URL !== "undefined" &&
+			typeof URL.revokeObjectURL === "function"
+		) {
+			URL.revokeObjectURL(url);
+		}
+	}
+
+	function revoke_fallback_url(): void {
+		revoke_object_url(fallback_url);
+		fallback_url = undefined;
+	}
+
 	$effect(() => {
 		if (!value?.url) {
 			loadToken++;
 			loaded_url = undefined;
+			revoke_fallback_url();
+			gs_value = undefined;
 			renderer = "loading";
 			point_cloud = null;
 			reset_camera_available = false;
@@ -54,6 +74,8 @@
 		const load_url = value.url;
 		const currentToken = ++loadToken;
 		loaded_url = load_url;
+		revoke_fallback_url();
+		gs_value = value;
 		renderer = "loading";
 		point_cloud = null;
 		reset_camera_available = false;
@@ -65,23 +87,42 @@
 		load_url: string,
 		currentToken: number
 	): Promise<void> {
+		let pending_fallback_url: string | undefined;
 		try {
-			const loaded_point_cloud = await load_ply_point_cloud(load_url);
-			if (currentToken !== loadToken) return;
+			const loaded = await load_ply_point_cloud(load_url);
+			pending_fallback_url = loaded.fallback_url;
+			if (currentToken !== loadToken) {
+				revoke_object_url(pending_fallback_url);
+				pending_fallback_url = undefined;
+				return;
+			}
 
-			point_cloud = loaded_point_cloud;
-			if (loaded_point_cloud) {
+			point_cloud = loaded.point_cloud;
+			if (loaded.point_cloud) {
 				Canvas3DComponent ??= await loadCanvas3D();
 				if (currentToken !== loadToken) return;
 				renderer = "point_cloud";
 				reset_camera_available = true;
 			} else {
 				Canvas3DGSComponent ??= await loadCanvas3DGS();
-				if (currentToken !== loadToken) return;
+				if (currentToken !== loadToken) {
+					revoke_object_url(pending_fallback_url);
+					pending_fallback_url = undefined;
+					return;
+				}
+				if (loaded.fallback_url) {
+					revoke_fallback_url();
+					fallback_url = loaded.fallback_url;
+					pending_fallback_url = undefined;
+					gs_value = { ...value, url: loaded.fallback_url };
+				} else {
+					gs_value = value;
+				}
 				renderer = "gs";
 				reset_camera_available = false;
 			}
 		} catch {
+			revoke_object_url(pending_fallback_url);
 			if (currentToken !== loadToken) return;
 			Canvas3DGSComponent ??= await loadCanvas3DGS();
 			if (currentToken !== loadToken) return;
@@ -89,6 +130,8 @@
 			reset_camera_available = false;
 		}
 	}
+
+	onDestroy(revoke_fallback_url);
 
 	export function update_camera(
 		camera_position: [number | null, number | null, number | null],
@@ -115,10 +158,10 @@
 		{pan_speed}
 		{point_cloud}
 	/>
-{:else if renderer === "gs" && Canvas3DGSComponent}
+{:else if renderer === "gs" && Canvas3DGSComponent && gs_value}
 	<svelte:component
 		this={Canvas3DGSComponent}
-		{value}
+		value={gs_value}
 		{zoom_speed}
 		{pan_speed}
 	/>

--- a/js/model3D/shared/Canvas3DPLY.svelte
+++ b/js/model3D/shared/Canvas3DPLY.svelte
@@ -11,7 +11,8 @@
 		clear_color,
 		camera_position,
 		zoom_speed,
-		pan_speed
+		pan_speed,
+		reset_camera_available = $bindable(false)
 	}: {
 		value: FileData;
 		display_mode: "solid" | "point_cloud" | "wireframe";
@@ -19,6 +20,7 @@
 		camera_position: [number | null, number | null, number | null];
 		zoom_speed: number;
 		pan_speed: number;
+		reset_camera_available?: boolean;
 	} = $props();
 
 	let canvas3d = $state<Canvas3D | undefined>();
@@ -33,16 +35,19 @@
 		loaded_url = load_url;
 		renderer = "loading";
 		point_cloud = null;
+		reset_camera_available = false;
 
 		load_ply_point_cloud(load_url)
 			.then((loaded_point_cloud) => {
 				if (loaded_url !== load_url) return;
 				point_cloud = loaded_point_cloud;
 				renderer = loaded_point_cloud ? "point_cloud" : "gs";
+				reset_camera_available = renderer === "point_cloud";
 			})
 			.catch(() => {
 				if (loaded_url === load_url) {
 					renderer = "gs";
+					reset_camera_available = false;
 				}
 			});
 	});

--- a/js/model3D/shared/Model3D.svelte
+++ b/js/model3D/shared/Model3D.svelte
@@ -4,19 +4,16 @@
 	import { File, Download, Undo } from "@gradio/icons";
 	import type { I18nFormatter } from "@gradio/utils";
 	import { dequal } from "dequal";
-	import type Canvas3DGS from "./Canvas3DGS.svelte";
-	import type Canvas3DPLY from "./Canvas3DPLY.svelte";
-	import type Canvas3D from "./Canvas3D.svelte";
 	import {
 		load_renderer_component,
-		renderer_for_model3d_path
+		model3d_renderer_loaders,
+		renderer_for_model3d_path,
+		type Canvas3DComponentType,
+		type Canvas3DGSComponentType,
+		type Canvas3DLike,
+		type Canvas3DPLYComponentType,
+		type Model3DCanvasComponent
 	} from "./renderer-loader";
-
-	type Canvas3DLike = Canvas3D | Canvas3DPLY;
-	type Model3DCanvasComponent =
-		| typeof Canvas3D
-		| typeof Canvas3DGS
-		| typeof Canvas3DPLY;
 
 	let {
 		value,
@@ -45,24 +42,11 @@
 	let current_settings = $state({ camera_position, zoom_speed, pan_speed });
 	let use_3dgs = $state(false);
 	let use_ply = $state(false);
-	let Canvas3DGSComponent = $state<typeof Canvas3DGS>();
-	let Canvas3DPLYComponent = $state<typeof Canvas3DPLY>();
-	let Canvas3DComponent = $state<typeof Canvas3D>();
+	let Canvas3DGSComponent = $state<Canvas3DGSComponentType>();
+	let Canvas3DPLYComponent = $state<Canvas3DPLYComponentType>();
+	let Canvas3DComponent = $state<Canvas3DComponentType>();
 	let canvas3d = $state<Canvas3DLike | undefined>();
 	let reset_camera_available = $state(false);
-
-	async function loadCanvas3D(): Promise<typeof Canvas3D> {
-		const module = await import("./Canvas3D.svelte");
-		return module.default;
-	}
-	async function loadCanvas3DGS(): Promise<typeof Canvas3DGS> {
-		const module = await import("./Canvas3DGS.svelte");
-		return module.default;
-	}
-	async function loadCanvas3DPLY(): Promise<typeof Canvas3DPLY> {
-		const module = await import("./Canvas3DPLY.svelte");
-		return module.default;
-	}
 
 	$effect(() => {
 		if (!value) {
@@ -79,18 +63,14 @@
 
 		return load_renderer_component<Model3DCanvasComponent>(
 			renderer,
-			{
-				mesh: loadCanvas3D,
-				ply: loadCanvas3DPLY,
-				splat: loadCanvas3DGS
-			},
+			model3d_renderer_loaders,
 			(renderer, component) => {
 				if (renderer === "ply") {
-					Canvas3DPLYComponent = component as typeof Canvas3DPLY;
+					Canvas3DPLYComponent = component as Canvas3DPLYComponentType;
 				} else if (renderer === "splat") {
-					Canvas3DGSComponent = component as typeof Canvas3DGS;
+					Canvas3DGSComponent = component as Canvas3DGSComponentType;
 				} else {
-					Canvas3DComponent = component as typeof Canvas3D;
+					Canvas3DComponent = component as Canvas3DComponentType;
 				}
 			}
 		);

--- a/js/model3D/shared/Model3D.svelte
+++ b/js/model3D/shared/Model3D.svelte
@@ -7,8 +7,16 @@
 	import type Canvas3DGS from "./Canvas3DGS.svelte";
 	import type Canvas3DPLY from "./Canvas3DPLY.svelte";
 	import type Canvas3D from "./Canvas3D.svelte";
+	import {
+		load_renderer_component,
+		renderer_for_model3d_path
+	} from "./renderer-loader";
 
 	type Canvas3DLike = Canvas3D | Canvas3DPLY;
+	type Model3DCanvasComponent =
+		| typeof Canvas3D
+		| typeof Canvas3DGS
+		| typeof Canvas3DPLY;
 
 	let {
 		value,
@@ -64,24 +72,28 @@
 			return;
 		}
 
-		use_ply = value.path.endsWith(".ply");
-		use_3dgs = value.path.endsWith(".splat") || use_ply;
+		const renderer = renderer_for_model3d_path(value.path);
+		use_ply = renderer === "ply";
+		use_3dgs = renderer !== "mesh";
 		reset_camera_available = false;
-		if (use_3dgs) {
-			if (use_ply) {
-				loadCanvas3DPLY().then((component) => {
-					Canvas3DPLYComponent = component;
-				});
-			} else {
-				loadCanvas3DGS().then((component) => {
-					Canvas3DGSComponent = component;
-				});
+
+		return load_renderer_component<Model3DCanvasComponent>(
+			renderer,
+			{
+				mesh: loadCanvas3D,
+				ply: loadCanvas3DPLY,
+				splat: loadCanvas3DGS
+			},
+			(renderer, component) => {
+				if (renderer === "ply") {
+					Canvas3DPLYComponent = component as typeof Canvas3DPLY;
+				} else if (renderer === "splat") {
+					Canvas3DGSComponent = component as typeof Canvas3DGS;
+				} else {
+					Canvas3DComponent = component as typeof Canvas3D;
+				}
 			}
-		} else {
-			loadCanvas3D().then((component) => {
-				Canvas3DComponent = component;
-			});
-		}
+		);
 	});
 
 	function handle_undo(): void {

--- a/js/model3D/shared/Model3D.svelte
+++ b/js/model3D/shared/Model3D.svelte
@@ -41,6 +41,7 @@
 	let Canvas3DPLYComponent = $state<typeof Canvas3DPLY>();
 	let Canvas3DComponent = $state<typeof Canvas3D>();
 	let canvas3d = $state<Canvas3DLike | undefined>();
+	let reset_camera_available = $state(false);
 
 	async function loadCanvas3D(): Promise<typeof Canvas3D> {
 		const module = await import("./Canvas3D.svelte");
@@ -56,24 +57,30 @@
 	}
 
 	$effect(() => {
-		if (value) {
-			use_ply = value.path.endsWith(".ply");
-			use_3dgs = value.path.endsWith(".splat") || use_ply;
-			if (use_3dgs) {
-				if (use_ply) {
-					loadCanvas3DPLY().then((component) => {
-						Canvas3DPLYComponent = component;
-					});
-				} else {
-					loadCanvas3DGS().then((component) => {
-						Canvas3DGSComponent = component;
-					});
-				}
+		if (!value) {
+			use_ply = false;
+			use_3dgs = false;
+			reset_camera_available = false;
+			return;
+		}
+
+		use_ply = value.path.endsWith(".ply");
+		use_3dgs = value.path.endsWith(".splat") || use_ply;
+		reset_camera_available = false;
+		if (use_3dgs) {
+			if (use_ply) {
+				loadCanvas3DPLY().then((component) => {
+					Canvas3DPLYComponent = component;
+				});
 			} else {
-				loadCanvas3D().then((component) => {
-					Canvas3DComponent = component;
+				loadCanvas3DGS().then((component) => {
+					Canvas3DGSComponent = component;
 				});
 			}
+		} else {
+			loadCanvas3D().then((component) => {
+				Canvas3DComponent = component;
+			});
 		}
 	});
 
@@ -101,7 +108,7 @@
 {#if value}
 	<div class="model3D" data-testid="model3d">
 		<IconButtonWrapper>
-			{#if !use_3dgs || use_ply}
+			{#if !use_3dgs || (use_ply && reset_camera_available)}
 				<!-- Canvas3DGS is the only renderer here without reset_camera_position. -->
 				<IconButton
 					Icon={Undo}
@@ -130,6 +137,7 @@
 				{camera_position}
 				{zoom_speed}
 				{pan_speed}
+				bind:reset_camera_available
 			/>
 		{:else if use_3dgs}
 			<svelte:component

--- a/js/model3D/shared/Model3D.svelte
+++ b/js/model3D/shared/Model3D.svelte
@@ -101,8 +101,8 @@
 {#if value}
 	<div class="model3D" data-testid="model3d">
 		<IconButtonWrapper>
-			{#if !use_3dgs}
-				<!-- Canvas3DGS doesn't implement the undo method (reset_camera_position) -->
+			{#if !use_3dgs || use_ply}
+				<!-- Canvas3DGS is the only renderer here without reset_camera_position. -->
 				<IconButton
 					Icon={Undo}
 					label="Undo"

--- a/js/model3D/shared/Model3D.svelte
+++ b/js/model3D/shared/Model3D.svelte
@@ -5,7 +5,10 @@
 	import type { I18nFormatter } from "@gradio/utils";
 	import { dequal } from "dequal";
 	import type Canvas3DGS from "./Canvas3DGS.svelte";
+	import type Canvas3DPLY from "./Canvas3DPLY.svelte";
 	import type Canvas3D from "./Canvas3D.svelte";
+
+	type Canvas3DLike = Canvas3D | Canvas3DPLY;
 
 	let {
 		value,
@@ -33,9 +36,11 @@
 
 	let current_settings = $state({ camera_position, zoom_speed, pan_speed });
 	let use_3dgs = $state(false);
+	let use_ply = $state(false);
 	let Canvas3DGSComponent = $state<typeof Canvas3DGS>();
+	let Canvas3DPLYComponent = $state<typeof Canvas3DPLY>();
 	let Canvas3DComponent = $state<typeof Canvas3D>();
-	let canvas3d = $state<Canvas3D | undefined>();
+	let canvas3d = $state<Canvas3DLike | undefined>();
 
 	async function loadCanvas3D(): Promise<typeof Canvas3D> {
 		const module = await import("./Canvas3D.svelte");
@@ -45,14 +50,25 @@
 		const module = await import("./Canvas3DGS.svelte");
 		return module.default;
 	}
+	async function loadCanvas3DPLY(): Promise<typeof Canvas3DPLY> {
+		const module = await import("./Canvas3DPLY.svelte");
+		return module.default;
+	}
 
 	$effect(() => {
 		if (value) {
-			use_3dgs = value.path.endsWith(".splat") || value.path.endsWith(".ply");
+			use_ply = value.path.endsWith(".ply");
+			use_3dgs = value.path.endsWith(".splat") || use_ply;
 			if (use_3dgs) {
-				loadCanvas3DGS().then((component) => {
-					Canvas3DGSComponent = component;
-				});
+				if (use_ply) {
+					loadCanvas3DPLY().then((component) => {
+						Canvas3DPLYComponent = component;
+					});
+				} else {
+					loadCanvas3DGS().then((component) => {
+						Canvas3DGSComponent = component;
+					});
+				}
 			} else {
 				loadCanvas3D().then((component) => {
 					Canvas3DComponent = component;
@@ -104,7 +120,18 @@
 			</a>
 		</IconButtonWrapper>
 
-		{#if use_3dgs}
+		{#if use_ply}
+			<svelte:component
+				this={Canvas3DPLYComponent}
+				bind:this={canvas3d}
+				{value}
+				{display_mode}
+				{clear_color}
+				{camera_position}
+				{zoom_speed}
+				{pan_speed}
+			/>
+		{:else if use_3dgs}
 			<svelte:component
 				this={Canvas3DGSComponent}
 				{value}

--- a/js/model3D/shared/Model3DUpload.svelte
+++ b/js/model3D/shared/Model3DUpload.svelte
@@ -146,7 +146,7 @@
 {:else}
 	<div class="input-model">
 		<ModifyUpload
-			undoable={!use_3dgs}
+			undoable={!use_3dgs || use_ply}
 			onclear={handle_clear}
 			{i18n}
 			onundo={handle_undo}

--- a/js/model3D/shared/Model3DUpload.svelte
+++ b/js/model3D/shared/Model3DUpload.svelte
@@ -6,7 +6,10 @@
 	import { File } from "@gradio/icons";
 	import type { I18nFormatter } from "@gradio/utils";
 	import type Canvas3DGS from "./Canvas3DGS.svelte";
+	import type Canvas3DPLY from "./Canvas3DPLY.svelte";
 	import type Canvas3D from "./Canvas3D.svelte";
+
+	type Canvas3DLike = Canvas3D | Canvas3DPLY;
 
 	let {
 		value = $bindable(),
@@ -53,9 +56,11 @@
 	} = $props();
 
 	let use_3dgs = $state(false);
+	let use_ply = $state(false);
 	let Canvas3DGSComponent = $state<typeof Canvas3DGS>();
+	let Canvas3DPLYComponent = $state<typeof Canvas3DPLY>();
 	let Canvas3DComponent = $state<typeof Canvas3D>();
-	let canvas3d = $state<Canvas3D | undefined>();
+	let canvas3d = $state<Canvas3DLike | undefined>();
 	let dragging = $state(false);
 
 	async function loadCanvas3D(): Promise<typeof Canvas3D> {
@@ -66,14 +71,25 @@
 		const module = await import("./Canvas3DGS.svelte");
 		return module.default;
 	}
+	async function loadCanvas3DPLY(): Promise<typeof Canvas3DPLY> {
+		const module = await import("./Canvas3DPLY.svelte");
+		return module.default;
+	}
 
 	$effect(() => {
 		if (value) {
-			use_3dgs = value.path.endsWith(".splat") || value.path.endsWith(".ply");
+			use_ply = value.path.endsWith(".ply");
+			use_3dgs = value.path.endsWith(".splat") || use_ply;
 			if (use_3dgs) {
-				loadCanvas3DGS().then((component) => {
-					Canvas3DGSComponent = component;
-				});
+				if (use_ply) {
+					loadCanvas3DPLY().then((component) => {
+						Canvas3DPLYComponent = component;
+					});
+				} else {
+					loadCanvas3DGS().then((component) => {
+						Canvas3DGSComponent = component;
+					});
+				}
 			} else {
 				loadCanvas3D().then((component) => {
 					Canvas3DComponent = component;
@@ -136,7 +152,18 @@
 			onundo={handle_undo}
 		/>
 
-		{#if use_3dgs}
+		{#if use_ply}
+			<svelte:component
+				this={Canvas3DPLYComponent}
+				bind:this={canvas3d}
+				{value}
+				{display_mode}
+				{clear_color}
+				{camera_position}
+				{zoom_speed}
+				{pan_speed}
+			/>
+		{:else if use_3dgs}
 			<svelte:component
 				this={Canvas3DGSComponent}
 				{value}

--- a/js/model3D/shared/Model3DUpload.svelte
+++ b/js/model3D/shared/Model3DUpload.svelte
@@ -8,8 +8,16 @@
 	import type Canvas3DGS from "./Canvas3DGS.svelte";
 	import type Canvas3DPLY from "./Canvas3DPLY.svelte";
 	import type Canvas3D from "./Canvas3D.svelte";
+	import {
+		load_renderer_component,
+		renderer_for_model3d_path
+	} from "./renderer-loader";
 
 	type Canvas3DLike = Canvas3D | Canvas3DPLY;
+	type Model3DCanvasComponent =
+		| typeof Canvas3D
+		| typeof Canvas3DGS
+		| typeof Canvas3DPLY;
 
 	let {
 		value = $bindable(),
@@ -85,24 +93,28 @@
 			return;
 		}
 
-		use_ply = value.path.endsWith(".ply");
-		use_3dgs = value.path.endsWith(".splat") || use_ply;
+		const renderer = renderer_for_model3d_path(value.path);
+		use_ply = renderer === "ply";
+		use_3dgs = renderer !== "mesh";
 		reset_camera_available = false;
-		if (use_3dgs) {
-			if (use_ply) {
-				loadCanvas3DPLY().then((component) => {
-					Canvas3DPLYComponent = component;
-				});
-			} else {
-				loadCanvas3DGS().then((component) => {
-					Canvas3DGSComponent = component;
-				});
+
+		return load_renderer_component<Model3DCanvasComponent>(
+			renderer,
+			{
+				mesh: loadCanvas3D,
+				ply: loadCanvas3DPLY,
+				splat: loadCanvas3DGS
+			},
+			(renderer, component) => {
+				if (renderer === "ply") {
+					Canvas3DPLYComponent = component as typeof Canvas3DPLY;
+				} else if (renderer === "splat") {
+					Canvas3DGSComponent = component as typeof Canvas3DGS;
+				} else {
+					Canvas3DComponent = component as typeof Canvas3D;
+				}
 			}
-		} else {
-			loadCanvas3D().then((component) => {
-				Canvas3DComponent = component;
-			});
-		}
+		);
 	});
 
 	$effect(() => {

--- a/js/model3D/shared/Model3DUpload.svelte
+++ b/js/model3D/shared/Model3DUpload.svelte
@@ -61,6 +61,7 @@
 	let Canvas3DPLYComponent = $state<typeof Canvas3DPLY>();
 	let Canvas3DComponent = $state<typeof Canvas3D>();
 	let canvas3d = $state<Canvas3DLike | undefined>();
+	let reset_camera_available = $state(false);
 	let dragging = $state(false);
 
 	async function loadCanvas3D(): Promise<typeof Canvas3D> {
@@ -77,24 +78,30 @@
 	}
 
 	$effect(() => {
-		if (value) {
-			use_ply = value.path.endsWith(".ply");
-			use_3dgs = value.path.endsWith(".splat") || use_ply;
-			if (use_3dgs) {
-				if (use_ply) {
-					loadCanvas3DPLY().then((component) => {
-						Canvas3DPLYComponent = component;
-					});
-				} else {
-					loadCanvas3DGS().then((component) => {
-						Canvas3DGSComponent = component;
-					});
-				}
+		if (!value) {
+			use_ply = false;
+			use_3dgs = false;
+			reset_camera_available = false;
+			return;
+		}
+
+		use_ply = value.path.endsWith(".ply");
+		use_3dgs = value.path.endsWith(".splat") || use_ply;
+		reset_camera_available = false;
+		if (use_3dgs) {
+			if (use_ply) {
+				loadCanvas3DPLY().then((component) => {
+					Canvas3DPLYComponent = component;
+				});
 			} else {
-				loadCanvas3D().then((component) => {
-					Canvas3DComponent = component;
+				loadCanvas3DGS().then((component) => {
+					Canvas3DGSComponent = component;
 				});
 			}
+		} else {
+			loadCanvas3D().then((component) => {
+				Canvas3DComponent = component;
+			});
 		}
 	});
 
@@ -146,7 +153,7 @@
 {:else}
 	<div class="input-model">
 		<ModifyUpload
-			undoable={!use_3dgs || use_ply}
+			undoable={!use_3dgs || (use_ply && reset_camera_available)}
 			onclear={handle_clear}
 			{i18n}
 			onundo={handle_undo}
@@ -162,6 +169,7 @@
 				{camera_position}
 				{zoom_speed}
 				{pan_speed}
+				bind:reset_camera_available
 			/>
 		{:else if use_3dgs}
 			<svelte:component

--- a/js/model3D/shared/Model3DUpload.svelte
+++ b/js/model3D/shared/Model3DUpload.svelte
@@ -5,19 +5,16 @@
 	import { BlockLabel } from "@gradio/atoms";
 	import { File } from "@gradio/icons";
 	import type { I18nFormatter } from "@gradio/utils";
-	import type Canvas3DGS from "./Canvas3DGS.svelte";
-	import type Canvas3DPLY from "./Canvas3DPLY.svelte";
-	import type Canvas3D from "./Canvas3D.svelte";
 	import {
 		load_renderer_component,
-		renderer_for_model3d_path
+		model3d_renderer_loaders,
+		renderer_for_model3d_path,
+		type Canvas3DComponentType,
+		type Canvas3DGSComponentType,
+		type Canvas3DLike,
+		type Canvas3DPLYComponentType,
+		type Model3DCanvasComponent
 	} from "./renderer-loader";
-
-	type Canvas3DLike = Canvas3D | Canvas3DPLY;
-	type Model3DCanvasComponent =
-		| typeof Canvas3D
-		| typeof Canvas3DGS
-		| typeof Canvas3DPLY;
 
 	let {
 		value = $bindable(),
@@ -65,25 +62,12 @@
 
 	let use_3dgs = $state(false);
 	let use_ply = $state(false);
-	let Canvas3DGSComponent = $state<typeof Canvas3DGS>();
-	let Canvas3DPLYComponent = $state<typeof Canvas3DPLY>();
-	let Canvas3DComponent = $state<typeof Canvas3D>();
+	let Canvas3DGSComponent = $state<Canvas3DGSComponentType>();
+	let Canvas3DPLYComponent = $state<Canvas3DPLYComponentType>();
+	let Canvas3DComponent = $state<Canvas3DComponentType>();
 	let canvas3d = $state<Canvas3DLike | undefined>();
 	let reset_camera_available = $state(false);
 	let dragging = $state(false);
-
-	async function loadCanvas3D(): Promise<typeof Canvas3D> {
-		const module = await import("./Canvas3D.svelte");
-		return module.default;
-	}
-	async function loadCanvas3DGS(): Promise<typeof Canvas3DGS> {
-		const module = await import("./Canvas3DGS.svelte");
-		return module.default;
-	}
-	async function loadCanvas3DPLY(): Promise<typeof Canvas3DPLY> {
-		const module = await import("./Canvas3DPLY.svelte");
-		return module.default;
-	}
 
 	$effect(() => {
 		if (!value) {
@@ -100,18 +84,14 @@
 
 		return load_renderer_component<Model3DCanvasComponent>(
 			renderer,
-			{
-				mesh: loadCanvas3D,
-				ply: loadCanvas3DPLY,
-				splat: loadCanvas3DGS
-			},
+			model3d_renderer_loaders,
 			(renderer, component) => {
 				if (renderer === "ply") {
-					Canvas3DPLYComponent = component as typeof Canvas3DPLY;
+					Canvas3DPLYComponent = component as Canvas3DPLYComponentType;
 				} else if (renderer === "splat") {
-					Canvas3DGSComponent = component as typeof Canvas3DGS;
+					Canvas3DGSComponent = component as Canvas3DGSComponentType;
 				} else {
-					Canvas3DComponent = component as typeof Canvas3D;
+					Canvas3DComponent = component as Canvas3DComponentType;
 				}
 			}
 		);

--- a/js/model3D/shared/point-cloud.test.ts
+++ b/js/model3D/shared/point-cloud.test.ts
@@ -255,6 +255,31 @@ end_header
 		await expect(load_ply_point_cloud("/missing.ply")).resolves.toBeNull();
 	});
 
+	test("does not read an entire streamed OBJ mesh before returning null", async () => {
+		const bytes = new TextEncoder().encode("v 1 2 3\nf 1 2 3\n");
+		const text = vi.fn(async () => {
+			throw new Error("full response body should not be read");
+		});
+		const fetch_mock = vi.fn(
+			async () =>
+				({
+					ok: true,
+					body: new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(bytes);
+							controller.close();
+						}
+					}),
+					text
+				}) as unknown as Response
+		);
+
+		vi.stubGlobal("fetch", fetch_mock);
+
+		await expect(load_obj_point_cloud("/mesh.obj")).resolves.toBeNull();
+		expect(text).not.toHaveBeenCalled();
+	});
+
 	test("fetches the full PLY after a point-cloud header probe", async () => {
 		const point_cloud_header = ascii_buffer(`ply
 format ascii 1.0

--- a/js/model3D/shared/point-cloud.test.ts
+++ b/js/model3D/shared/point-cloud.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "vitest";
+
+import { parse_obj_point_cloud, parse_ply_point_cloud } from "./point-cloud";
+
+function ascii_buffer(value: string): ArrayBuffer {
+	return new TextEncoder().encode(value).buffer;
+}
+
+function float32(values: number[]): number[] {
+	return Array.from(new Float32Array(values));
+}
+
+function binary_little_endian_ply(): ArrayBuffer {
+	const header = [
+		"ply",
+		"format binary_little_endian 1.0",
+		"element vertex 2",
+		"property double x",
+		"property double y",
+		"property double z",
+		"property uchar red",
+		"property uchar green",
+		"property uchar blue",
+		"end_header",
+		""
+	].join("\n");
+	const header_bytes = new TextEncoder().encode(header);
+	const point_bytes = new ArrayBuffer(54);
+	const view = new DataView(point_bytes);
+	let offset = 0;
+
+	for (const point of [
+		{ position: [1, 2, 3], color: [255, 128, 0] },
+		{ position: [-1, -2, -3], color: [0, 64, 255] }
+	]) {
+		for (const coordinate of point.position) {
+			view.setFloat64(offset, coordinate, true);
+			offset += 8;
+		}
+		for (const channel of point.color) {
+			view.setUint8(offset, channel);
+			offset += 1;
+		}
+	}
+
+	const bytes = new Uint8Array(
+		header_bytes.byteLength + point_bytes.byteLength
+	);
+	bytes.set(header_bytes, 0);
+	bytes.set(new Uint8Array(point_bytes), header_bytes.byteLength);
+	return bytes.buffer;
+}
+
+describe("point cloud parsing", () => {
+	test("parses OBJ vertices with colors when no faces are present", () => {
+		const point_cloud = parse_obj_point_cloud(`
+v 1 2 3 0.25 0.5 0.75
+v -1 -2 -3 255 128 0
+`);
+
+		expect(Array.from(point_cloud?.positions ?? [])).toEqual([
+			1, 2, 3, -1, -2, -3
+		]);
+		expect(Array.from(point_cloud?.colors ?? [])).toEqual(
+			float32([0.25, 0.5, 0.75, 1, 1, 128 / 255, 0, 1])
+		);
+	});
+
+	test("does not claim OBJ meshes that contain faces", () => {
+		const point_cloud = parse_obj_point_cloud(`
+v 1 2 3
+v 4 5 6
+v 7 8 9
+f 1 2 3
+`);
+
+		expect(point_cloud).toBeNull();
+	});
+
+	test("parses ASCII PLY vertices with RGB colors", () => {
+		const point_cloud = parse_ply_point_cloud(
+			ascii_buffer(`ply
+format ascii 1.0
+element vertex 2
+property float x
+property float y
+property float z
+property uchar red
+property uchar green
+property uchar blue
+end_header
+1 2 3 255 128 0
+-1 -2 -3 0 64 255
+`)
+		);
+
+		expect(Array.from(point_cloud?.positions ?? [])).toEqual([
+			1, 2, 3, -1, -2, -3
+		]);
+		expect(Array.from(point_cloud?.colors ?? [])).toEqual(
+			float32([1, 128 / 255, 0, 1, 0, 64 / 255, 1, 1])
+		);
+	});
+
+	test("parses binary little-endian PLY vertices with RGB colors", () => {
+		const point_cloud = parse_ply_point_cloud(binary_little_endian_ply());
+
+		expect(Array.from(point_cloud?.positions ?? [])).toEqual([
+			1, 2, 3, -1, -2, -3
+		]);
+		expect(Array.from(point_cloud?.colors ?? [])).toEqual(
+			float32([1, 128 / 255, 0, 1, 0, 64 / 255, 1, 1])
+		);
+	});
+
+	test("leaves Gaussian splat PLY files for the existing GS renderer", () => {
+		const point_cloud = parse_ply_point_cloud(
+			ascii_buffer(`ply
+format ascii 1.0
+element vertex 1
+property float x
+property float y
+property float z
+property float f_dc_0
+property float opacity
+property float scale_0
+property float rot_0
+end_header
+0 0 0 0 1 1 0
+`)
+		);
+
+		expect(point_cloud).toBeNull();
+	});
+});

--- a/js/model3D/shared/point-cloud.test.ts
+++ b/js/model3D/shared/point-cloud.test.ts
@@ -148,6 +148,26 @@ end_header
 		]);
 	});
 
+	test("parses ASCII PLY vertices after malformed data lines", () => {
+		const point_cloud = parse_ply_point_cloud(
+			ascii_buffer(`ply
+format ascii 1.0
+element vertex 2
+property float x
+property float y
+property float z
+end_header
+1 2 3
+not a vertex
+4 5 6
+`)
+		);
+
+		expect(Array.from(point_cloud?.positions ?? [])).toEqual([
+			1, 2, 3, 4, 5, 6
+		]);
+	});
+
 	test("normalizes uchar PLY color value one as 1/255", () => {
 		const point_cloud = parse_ply_point_cloud(
 			ascii_buffer(`ply

--- a/js/model3D/shared/point-cloud.test.ts
+++ b/js/model3D/shared/point-cloud.test.ts
@@ -1,11 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import {
-	load_obj_point_cloud,
-	load_ply_point_cloud,
-	parse_obj_point_cloud,
-	parse_ply_point_cloud
-} from "./point-cloud";
+import { load_ply_point_cloud, parse_ply_point_cloud } from "./point-cloud";
 
 function ascii_buffer(value: string): ArrayBuffer {
 	return new TextEncoder().encode(value).buffer;
@@ -59,31 +54,6 @@ function binary_little_endian_ply(): ArrayBuffer {
 describe("point cloud parsing", () => {
 	afterEach(() => {
 		vi.unstubAllGlobals();
-	});
-
-	test("parses OBJ vertices with colors when no faces are present", () => {
-		const point_cloud = parse_obj_point_cloud(`
-v 1 2 3 0.25 0.5 0.75
-v -1 -2 -3 255 128 0
-`);
-
-		expect(Array.from(point_cloud?.positions ?? [])).toEqual([
-			1, 2, 3, -1, -2, -3
-		]);
-		expect(Array.from(point_cloud?.colors ?? [])).toEqual(
-			float32([0.25, 0.5, 0.75, 1, 1, 128 / 255, 0, 1])
-		);
-	});
-
-	test("does not claim OBJ meshes that contain faces", () => {
-		const point_cloud = parse_obj_point_cloud(`
-v 1 2 3
-v 4 5 6
-v 7 8 9
-f 1 2 3
-`);
-
-		expect(point_cloud).toBeNull();
 	});
 
 	test("parses ASCII PLY vertices with RGB colors", () => {
@@ -291,33 +261,7 @@ end_header
 			vi.fn(async () => failed_response)
 		);
 
-		await expect(load_obj_point_cloud("/missing.obj")).resolves.toBeNull();
 		await expect(load_ply_point_cloud("/missing.ply")).resolves.toBeNull();
-	});
-
-	test("does not read an entire streamed OBJ mesh before returning null", async () => {
-		const bytes = new TextEncoder().encode("v 1 2 3\nf 1 2 3\n");
-		const text = vi.fn(async () => {
-			throw new Error("full response body should not be read");
-		});
-		const fetch_mock = vi.fn(
-			async () =>
-				({
-					ok: true,
-					body: new ReadableStream<Uint8Array>({
-						start(controller) {
-							controller.enqueue(bytes);
-							controller.close();
-						}
-					}),
-					text
-				}) as unknown as Response
-		);
-
-		vi.stubGlobal("fetch", fetch_mock);
-
-		await expect(load_obj_point_cloud("/mesh.obj")).resolves.toBeNull();
-		expect(text).not.toHaveBeenCalled();
 	});
 
 	test("fetches the full PLY after a point-cloud header probe", async () => {

--- a/js/model3D/shared/point-cloud.test.ts
+++ b/js/model3D/shared/point-cloud.test.ts
@@ -149,6 +149,28 @@ end_header
 		);
 	});
 
+	test("normalizes 16-bit integer PLY color channels", () => {
+		const point_cloud = parse_ply_point_cloud(
+			ascii_buffer(`ply
+format ascii 1.0
+element vertex 1
+property float x
+property float y
+property float z
+property ushort red
+property uint16 green
+property ushort blue
+property uint16 alpha
+end_header
+1 2 3 65535 32768 1 65535
+`)
+		);
+
+		expect(Array.from(point_cloud?.colors ?? [])).toEqual(
+			float32([1, 32768 / 65535, 1 / 65535, 1])
+		);
+	});
+
 	test("parses binary little-endian PLY vertices with RGB colors", () => {
 		const point_cloud = parse_ply_point_cloud(binary_little_endian_ply());
 

--- a/js/model3D/shared/point-cloud.test.ts
+++ b/js/model3D/shared/point-cloud.test.ts
@@ -232,4 +232,76 @@ end_header
 		await expect(load_obj_point_cloud("/missing.obj")).resolves.toBeNull();
 		await expect(load_ply_point_cloud("/missing.ply")).resolves.toBeNull();
 	});
+
+	test("fetches the full PLY after a point-cloud header probe", async () => {
+		const point_cloud_header = ascii_buffer(`ply
+format ascii 1.0
+element vertex 1
+property float x
+property float y
+property float z
+end_header
+`);
+		const point_cloud_ply = ascii_buffer(`ply
+format ascii 1.0
+element vertex 1
+property float x
+property float y
+property float z
+end_header
+1 2 3
+`);
+		const fetch_mock = vi
+			.fn()
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 206,
+				arrayBuffer: async () => point_cloud_header
+			} as unknown as Response)
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				arrayBuffer: async () => point_cloud_ply
+			} as unknown as Response);
+
+		vi.stubGlobal("fetch", fetch_mock);
+
+		const point_cloud = await load_ply_point_cloud("/model.ply");
+		expect(Array.from(point_cloud?.positions ?? [])).toEqual([1, 2, 3]);
+		expect(fetch_mock).toHaveBeenNthCalledWith(1, "/model.ply", {
+			headers: { Range: "bytes=0-65535" }
+		});
+		expect(fetch_mock).toHaveBeenNthCalledWith(2, "/model.ply");
+	});
+
+	test("does not fetch a full Gaussian splat PLY before GS rendering", async () => {
+		const gaussian_splat_header = ascii_buffer(`ply
+format ascii 1.0
+element vertex 1
+property float x
+property float y
+property float z
+property float f_dc_0
+property float opacity
+property float scale_0
+property float rot_0
+end_header
+`);
+		const fetch_mock = vi.fn(
+			async () =>
+				({
+					ok: true,
+					status: 206,
+					arrayBuffer: async () => gaussian_splat_header
+				}) as unknown as Response
+		);
+
+		vi.stubGlobal("fetch", fetch_mock);
+
+		await expect(load_ply_point_cloud("/model.ply")).resolves.toBeNull();
+		expect(fetch_mock).toHaveBeenCalledOnce();
+		expect(fetch_mock).toHaveBeenCalledWith("/model.ply", {
+			headers: { Range: "bytes=0-65535" }
+		});
+	});
 });

--- a/js/model3D/shared/point-cloud.test.ts
+++ b/js/model3D/shared/point-cloud.test.ts
@@ -128,6 +128,26 @@ end_header
 		expect(Array.from(point_cloud?.positions ?? [])).toEqual([1, 2, 3]);
 	});
 
+	test("parses ASCII PLY vertices after blank data lines", () => {
+		const point_cloud = parse_ply_point_cloud(
+			ascii_buffer(`ply
+format ascii 1.0
+element vertex 2
+property float x
+property float y
+property float z
+end_header
+1 2 3
+
+4 5 6
+`)
+		);
+
+		expect(Array.from(point_cloud?.positions ?? [])).toEqual([
+			1, 2, 3, 4, 5, 6
+		]);
+	});
+
 	test("normalizes uchar PLY color value one as 1/255", () => {
 		const point_cloud = parse_ply_point_cloud(
 			ascii_buffer(`ply

--- a/js/model3D/shared/point-cloud.test.ts
+++ b/js/model3D/shared/point-cloud.test.ts
@@ -102,6 +102,27 @@ end_header
 		);
 	});
 
+	test("normalizes uchar PLY color value one as 1/255", () => {
+		const point_cloud = parse_ply_point_cloud(
+			ascii_buffer(`ply
+format ascii 1.0
+element vertex 1
+property float x
+property float y
+property float z
+property uchar red
+property uchar green
+property uchar blue
+end_header
+1 2 3 1 1 1
+`)
+		);
+
+		expect(Array.from(point_cloud?.colors ?? [])).toEqual(
+			float32([1 / 255, 1 / 255, 1 / 255, 1])
+		);
+	});
+
 	test("parses binary little-endian PLY vertices with RGB colors", () => {
 		const point_cloud = parse_ply_point_cloud(binary_little_endian_ply());
 

--- a/js/model3D/shared/point-cloud.test.ts
+++ b/js/model3D/shared/point-cloud.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { parse_obj_point_cloud, parse_ply_point_cloud } from "./point-cloud";
+import {
+	load_obj_point_cloud,
+	load_ply_point_cloud,
+	parse_obj_point_cloud,
+	parse_ply_point_cloud
+} from "./point-cloud";
 
 function ascii_buffer(value: string): ArrayBuffer {
 	return new TextEncoder().encode(value).buffer;
@@ -52,6 +57,10 @@ function binary_little_endian_ply(): ArrayBuffer {
 }
 
 describe("point cloud parsing", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
 	test("parses OBJ vertices with colors when no faces are present", () => {
 		const point_cloud = parse_obj_point_cloud(`
 v 1 2 3 0.25 0.5 0.75
@@ -102,6 +111,23 @@ end_header
 		);
 	});
 
+	test("parses ASCII PLY data after multibyte header comments", () => {
+		const point_cloud = parse_ply_point_cloud(
+			ascii_buffer(`ply
+format ascii 1.0
+comment café
+element vertex 1
+property float x
+property float y
+property float z
+end_header
+1 2 3
+`)
+		);
+
+		expect(Array.from(point_cloud?.positions ?? [])).toEqual([1, 2, 3]);
+	});
+
 	test("normalizes uchar PLY color value one as 1/255", () => {
 		const point_cloud = parse_ply_point_cloud(
 			ascii_buffer(`ply
@@ -134,6 +160,43 @@ end_header
 		);
 	});
 
+	test("ignores malformed PLY element counts", () => {
+		expect(
+			parse_ply_point_cloud(
+				ascii_buffer(`ply
+format ascii 1.0
+element vertex nope
+property float x
+property float y
+property float z
+end_header
+1 2 3
+`)
+			)
+		).toBeNull();
+		expect(
+			parse_ply_point_cloud(
+				ascii_buffer(`ply
+format ascii 1.0
+element vertex 1
+property float x
+property float y
+property float z
+element face NaN
+end_header
+1 2 3
+`)
+			)
+		).toBeNull();
+	});
+
+	test("ignores truncated binary PLY data", () => {
+		const buffer = binary_little_endian_ply();
+		expect(
+			parse_ply_point_cloud(buffer.slice(0, buffer.byteLength - 1))
+		).toBeNull();
+	});
+
 	test("leaves Gaussian splat PLY files for the existing GS renderer", () => {
 		const point_cloud = parse_ply_point_cloud(
 			ascii_buffer(`ply
@@ -152,5 +215,21 @@ end_header
 		);
 
 		expect(point_cloud).toBeNull();
+	});
+
+	test("does not parse failed fetch responses", async () => {
+		const failed_response = {
+			ok: false,
+			arrayBuffer: async () => new ArrayBuffer(0),
+			text: async () => ""
+		} as unknown as Response;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => failed_response)
+		);
+
+		await expect(load_obj_point_cloud("/missing.obj")).resolves.toBeNull();
+		await expect(load_ply_point_cloud("/missing.ply")).resolves.toBeNull();
 	});
 });

--- a/js/model3D/shared/point-cloud.test.ts
+++ b/js/model3D/shared/point-cloud.test.ts
@@ -51,6 +51,31 @@ function binary_little_endian_ply(): ArrayBuffer {
 	return bytes.buffer;
 }
 
+function streamed_response(
+	chunks: ArrayBuffer[],
+	on_cancel: () => void,
+	array_buffer: () => Promise<ArrayBuffer>
+): Response {
+	let index = 0;
+	return {
+		ok: true,
+		status: 200,
+		body: new ReadableStream<Uint8Array>({
+			pull(controller): void {
+				if (index < chunks.length) {
+					controller.enqueue(new Uint8Array(chunks[index]));
+					index += 1;
+				}
+				if (index === chunks.length) {
+					controller.close();
+				}
+			},
+			cancel: on_cancel
+		}),
+		arrayBuffer: array_buffer
+	} as unknown as Response;
+}
+
 describe("point cloud parsing", () => {
 	afterEach(() => {
 		vi.unstubAllGlobals();
@@ -261,7 +286,9 @@ end_header
 			vi.fn(async () => failed_response)
 		);
 
-		await expect(load_ply_point_cloud("/missing.ply")).resolves.toBeNull();
+		await expect(load_ply_point_cloud("/missing.ply")).resolves.toEqual({
+			point_cloud: null
+		});
 	});
 
 	test("fetches the full PLY after a point-cloud header probe", async () => {
@@ -297,8 +324,8 @@ end_header
 
 		vi.stubGlobal("fetch", fetch_mock);
 
-		const point_cloud = await load_ply_point_cloud("/model.ply");
-		expect(Array.from(point_cloud?.positions ?? [])).toEqual([1, 2, 3]);
+		const loaded = await load_ply_point_cloud("/model.ply");
+		expect(Array.from(loaded.point_cloud?.positions ?? [])).toEqual([1, 2, 3]);
 		expect(fetch_mock).toHaveBeenNthCalledWith(1, "/model.ply", {
 			headers: { Range: "bytes=0-65535" }
 		});
@@ -329,10 +356,88 @@ end_header
 
 		vi.stubGlobal("fetch", fetch_mock);
 
-		await expect(load_ply_point_cloud("/model.ply")).resolves.toBeNull();
+		await expect(load_ply_point_cloud("/model.ply")).resolves.toEqual({
+			point_cloud: null
+		});
 		expect(fetch_mock).toHaveBeenCalledOnce();
 		expect(fetch_mock).toHaveBeenCalledWith("/model.ply", {
 			headers: { Range: "bytes=0-65535" }
 		});
+	});
+
+	test("reuses full Gaussian splat PLY responses when range is unsupported", async () => {
+		const gaussian_splat_ply = ascii_buffer(`ply
+format ascii 1.0
+element vertex 1
+property float x
+property float y
+property float z
+property float f_dc_0
+property float opacity
+property float scale_0
+property float rot_0
+end_header
+0 0 0 0 1 1 0
+`);
+		const createObjectURL = vi.fn(() => "blob:gaussian-splat-ply");
+		vi.stubGlobal("URL", {
+			...URL,
+			createObjectURL,
+			revokeObjectURL: vi.fn()
+		});
+		const fetch_mock = vi.fn(
+			async () =>
+				({
+					ok: true,
+					status: 200,
+					arrayBuffer: async () => gaussian_splat_ply
+				}) as unknown as Response
+		);
+
+		vi.stubGlobal("fetch", fetch_mock);
+
+		await expect(load_ply_point_cloud("/model.ply")).resolves.toEqual({
+			point_cloud: null,
+			fallback_url: "blob:gaussian-splat-ply"
+		});
+		expect(createObjectURL).toHaveBeenCalledOnce();
+		expect(fetch_mock).toHaveBeenCalledOnce();
+	});
+
+	test("cancels a non-range Gaussian splat PLY response after reading its header", async () => {
+		const gaussian_splat_header = ascii_buffer(`ply
+format ascii 1.0
+element vertex 1
+property float x
+property float y
+property float z
+property float f_dc_0
+property float opacity
+property float scale_0
+property float rot_0
+end_header
+`);
+		let cancelled = false;
+		const read_full_body = vi.fn(async () => {
+			throw new Error("should not read the full response body");
+		});
+		const fetch_mock = vi.fn(async () =>
+			streamed_response(
+				[gaussian_splat_header, new ArrayBuffer(1024)],
+				() => {
+					cancelled = true;
+				},
+				read_full_body
+			)
+		);
+
+		vi.stubGlobal("fetch", fetch_mock);
+
+		await expect(load_ply_point_cloud("/model.ply")).resolves.toEqual({
+			point_cloud: null
+		});
+		expect(fetch_mock).toHaveBeenCalledOnce();
+		expect(read_full_body).not.toHaveBeenCalled();
+		expect(cancelled).toBe(true);
 	});
 });

--- a/js/model3D/shared/point-cloud.ts
+++ b/js/model3D/shared/point-cloud.ts
@@ -398,6 +398,13 @@ function parse_ascii_ply(
 		if (values.length < properties.length) {
 			continue;
 		}
+		if (
+			values
+				.slice(0, properties.length)
+				.some((value) => !Number.isFinite(value))
+		) {
+			continue;
+		}
 
 		positions.push(values[x_index], values[y_index], values[z_index]);
 		if (red_index !== -1 && green_index !== -1 && blue_index !== -1) {

--- a/js/model3D/shared/point-cloud.ts
+++ b/js/model3D/shared/point-cloud.ts
@@ -388,7 +388,12 @@ function parse_ascii_ply(
 		return null;
 	}
 
-	for (const line of body_text.split(/\r?\n/).slice(0, header.vertex_count)) {
+	let parsed_vertices = 0;
+	for (const line of body_text.split(/\r?\n/)) {
+		if (parsed_vertices >= header.vertex_count) {
+			break;
+		}
+
 		const values = line.trim().split(/\s+/).map(Number);
 		if (values.length < properties.length) {
 			continue;
@@ -408,6 +413,7 @@ function parse_ascii_ply(
 				alpha_index === -1 ? undefined : properties[alpha_index].type
 			);
 		}
+		parsed_vertices += 1;
 	}
 
 	return build_point_cloud(positions, colors);

--- a/js/model3D/shared/point-cloud.ts
+++ b/js/model3D/shared/point-cloud.ts
@@ -283,92 +283,6 @@ function build_point_cloud(
 	};
 }
 
-export function parse_obj_point_cloud(text: string): PointCloudData | null {
-	const positions: number[] = [];
-	const colors: number[] = [];
-
-	for (const raw_line of text.split(/\r?\n/)) {
-		if (parse_obj_line(raw_line, positions, colors)) {
-			return null;
-		}
-	}
-
-	return build_point_cloud(positions, colors);
-}
-
-function parse_obj_line(
-	raw_line: string,
-	positions: number[],
-	colors: number[]
-): boolean {
-	const line = raw_line.trim();
-	if (!line || line.startsWith("#")) {
-		return false;
-	}
-
-	const parts = line.split(/\s+/);
-	if (parts[0] === "f") {
-		return true;
-	}
-
-	if (parts[0] !== "v" || parts.length < 4) {
-		return false;
-	}
-
-	const position = parts.slice(1, 4).map(Number);
-	if (position.some((coordinate) => Number.isNaN(coordinate))) {
-		return false;
-	}
-	positions.push(...position);
-
-	if (
-		parts.length >= 7 &&
-		!parts.slice(4, 7).some((channel) => Number.isNaN(Number(channel)))
-	) {
-		const color = parts.slice(4, 7).map(Number);
-		push_color(colors, color[0], color[1], color[2]);
-	} else {
-		push_color(colors, 1, 1, 1);
-	}
-
-	return false;
-}
-
-async function parse_obj_point_cloud_stream(
-	body: ReadableStream<Uint8Array>
-): Promise<PointCloudData | null> {
-	const reader = body.getReader();
-	const decoder = new TextDecoder("utf-8");
-	const positions: number[] = [];
-	const colors: number[] = [];
-	let pending = "";
-
-	while (true) {
-		const { value, done } = await reader.read();
-		if (done) {
-			break;
-		}
-
-		pending += decoder.decode(value, { stream: true });
-		const lines = pending.split(/\r?\n/);
-		pending = lines.pop() ?? "";
-
-		for (const line of lines) {
-			if (parse_obj_line(line, positions, colors)) {
-				await reader.cancel();
-				return null;
-			}
-		}
-	}
-
-	pending += decoder.decode();
-	if (pending && parse_obj_line(pending, positions, colors)) {
-		return null;
-	}
-
-	return build_point_cloud(positions, colors);
-}
-
 function parse_ascii_ply(
 	body_text: string,
 	header: PlyHeader
@@ -518,19 +432,6 @@ export function parse_ply_point_cloud(
 	} catch {
 		return null;
 	}
-}
-
-export async function load_obj_point_cloud(
-	url: string
-): Promise<PointCloudData | null> {
-	const response = await fetch(url);
-	if (!response.ok) {
-		return null;
-	}
-	if (response.body) {
-		return parse_obj_point_cloud_stream(response.body);
-	}
-	return parse_obj_point_cloud(await response.text());
 }
 
 export async function load_ply_point_cloud(

--- a/js/model3D/shared/point-cloud.ts
+++ b/js/model3D/shared/point-cloud.ts
@@ -53,11 +53,25 @@ const PLY_TYPE_SIZES: Record<string, number> = {
 const PLY_HEADER_PROBE_BYTES = 64 * 1024;
 type PlyContentKind = "point_cloud" | "gaussian_splat" | "unsupported";
 
-const BYTE_COLOR_TYPES = new Set(["uchar", "uint8"]);
+const INTEGER_COLOR_MAX_VALUES: Record<string, number> = {
+	char: 127,
+	int8: 127,
+	uchar: 255,
+	uint8: 255,
+	short: 32767,
+	int16: 32767,
+	ushort: 65535,
+	uint16: 65535,
+	int: 2147483647,
+	int32: 2147483647,
+	uint: 4294967295,
+	uint32: 4294967295
+};
 
 function normalize_channel(value: number, type?: string): number {
-	if (type && BYTE_COLOR_TYPES.has(type)) {
-		return value / 255;
+	const max_value = type ? INTEGER_COLOR_MAX_VALUES[type] : undefined;
+	if (max_value) {
+		return value / max_value;
 	}
 	return value > 1 ? value / 255 : value;
 }

--- a/js/model3D/shared/point-cloud.ts
+++ b/js/model3D/shared/point-cloud.ts
@@ -50,7 +50,12 @@ const PLY_TYPE_SIZES: Record<string, number> = {
 	float64: 8
 };
 
-function normalize_channel(value: number): number {
+const BYTE_COLOR_TYPES = new Set(["uchar", "uint8"]);
+
+function normalize_channel(value: number, type?: string): number {
+	if (type && BYTE_COLOR_TYPES.has(type)) {
+		return value / 255;
+	}
 	return value > 1 ? value / 255 : value;
 }
 
@@ -66,13 +71,17 @@ function push_color(
 	red: number | undefined,
 	green: number | undefined,
 	blue: number | undefined,
-	alpha = 1
+	alpha = 1,
+	red_type?: string,
+	green_type?: string,
+	blue_type?: string,
+	alpha_type?: string
 ): void {
 	colors.push(
-		normalize_channel(red ?? 1),
-		normalize_channel(green ?? 1),
-		normalize_channel(blue ?? 1),
-		normalize_channel(alpha)
+		normalize_channel(red ?? 1, red_type),
+		normalize_channel(green ?? 1, green_type),
+		normalize_channel(blue ?? 1, blue_type),
+		normalize_channel(alpha, alpha_type)
 	);
 }
 
@@ -302,7 +311,11 @@ function parse_ascii_ply(
 				values[red_index],
 				values[green_index],
 				values[blue_index],
-				alpha_index === -1 ? 1 : values[alpha_index]
+				alpha_index === -1 ? 1 : values[alpha_index],
+				properties[red_index].type,
+				properties[green_index].type,
+				properties[blue_index].type,
+				alpha_index === -1 ? undefined : properties[alpha_index].type
 			);
 		}
 	}
@@ -361,7 +374,11 @@ function parse_binary_ply(
 				values[red_index],
 				values[green_index],
 				values[blue_index],
-				alpha_index === -1 ? 1 : values[alpha_index]
+				alpha_index === -1 ? 1 : values[alpha_index],
+				properties[red_index].type,
+				properties[green_index].type,
+				properties[blue_index].type,
+				alpha_index === -1 ? undefined : properties[alpha_index].type
 			);
 		}
 

--- a/js/model3D/shared/point-cloud.ts
+++ b/js/model3D/shared/point-cloud.ts
@@ -66,6 +66,11 @@ function color_property_index(
 	return properties.findIndex((property) => names.includes(property.name));
 }
 
+function parse_ply_count(value: string | undefined): number | null {
+	const count = Number(value);
+	return Number.isInteger(count) && count >= 0 ? count : null;
+}
+
 function push_color(
 	colors: number[],
 	red: number | undefined,
@@ -153,9 +158,17 @@ function parse_ply_header(buffer: ArrayBuffer): PlyHeader | null {
 		} else if (parts[0] === "element") {
 			current_element = parts[1] ?? null;
 			if (current_element === "vertex") {
-				vertex_count = Number(parts[2] ?? 0);
+				const count = parse_ply_count(parts[2]);
+				if (count === null) {
+					return null;
+				}
+				vertex_count = count;
 			} else if (current_element === "face") {
-				face_count = Number(parts[2] ?? 0);
+				const count = parse_ply_count(parts[2]);
+				if (count === null) {
+					return null;
+				}
+				face_count = count;
 			}
 		} else if (
 			parts[0] === "property" &&
@@ -277,7 +290,7 @@ export function parse_obj_point_cloud(text: string): PointCloudData | null {
 }
 
 function parse_ascii_ply(
-	text: string,
+	body_text: string,
 	header: PlyHeader
 ): PointCloudData | null {
 	const positions: number[] = [];
@@ -295,10 +308,7 @@ function parse_ascii_ply(
 		return null;
 	}
 
-	for (const line of text
-		.slice(header.header_length)
-		.split(/\r?\n/)
-		.slice(0, header.vertex_count)) {
+	for (const line of body_text.split(/\r?\n/).slice(0, header.vertex_count)) {
 		const values = line.trim().split(/\s+/).map(Number);
 		if (values.length < properties.length) {
 			continue;
@@ -342,13 +352,19 @@ function parse_binary_ply(
 		return null;
 	}
 
-	const stride = properties.reduce(
-		(size, property) => size + (PLY_TYPE_SIZES[property.type] ?? 0),
-		0
-	);
+	const property_offsets: number[] = [];
+	let stride = 0;
+	for (const property of properties) {
+		const size = PLY_TYPE_SIZES[property.type];
+		if (!size) {
+			return null;
+		}
+		property_offsets.push(stride);
+		stride += size;
+	}
 	if (
 		stride === 0 ||
-		properties.some((property) => !PLY_TYPE_SIZES[property.type])
+		buffer.byteLength < header.header_length + header.vertex_count * stride
 	) {
 		return null;
 	}
@@ -356,25 +372,23 @@ function parse_binary_ply(
 	const view = new DataView(buffer);
 	const little_endian = header.format === "binary_little_endian";
 	let row_offset = header.header_length;
+	const value_at = (index: number): number =>
+		ply_property_value(
+			view,
+			row_offset + property_offsets[index],
+			properties[index].type,
+			little_endian
+		);
 
 	for (let row = 0; row < header.vertex_count; row++) {
-		const values: number[] = [];
-		let property_offset = row_offset;
-		for (const property of properties) {
-			values.push(
-				ply_property_value(view, property_offset, property.type, little_endian)
-			);
-			property_offset += PLY_TYPE_SIZES[property.type];
-		}
-
-		positions.push(values[x_index], values[y_index], values[z_index]);
+		positions.push(value_at(x_index), value_at(y_index), value_at(z_index));
 		if (red_index !== -1 && green_index !== -1 && blue_index !== -1) {
 			push_color(
 				colors,
-				values[red_index],
-				values[green_index],
-				values[blue_index],
-				alpha_index === -1 ? 1 : values[alpha_index],
+				value_at(red_index),
+				value_at(green_index),
+				value_at(blue_index),
+				alpha_index === -1 ? 1 : value_at(alpha_index),
 				properties[red_index].type,
 				properties[green_index].type,
 				properties[blue_index].type,
@@ -402,19 +416,24 @@ export function parse_ply_point_cloud(
 	}
 
 	if (header.format === "ascii") {
-		return parse_ascii_ply(
-			new TextDecoder("utf-8").decode(array_buffer),
-			header
-		);
+		const body = new Uint8Array(array_buffer, header.header_length);
+		return parse_ascii_ply(new TextDecoder("utf-8").decode(body), header);
 	}
 
-	return parse_binary_ply(array_buffer, header);
+	try {
+		return parse_binary_ply(array_buffer, header);
+	} catch {
+		return null;
+	}
 }
 
 export async function load_obj_point_cloud(
 	url: string
 ): Promise<PointCloudData | null> {
 	const response = await fetch(url);
+	if (!response.ok) {
+		return null;
+	}
 	return parse_obj_point_cloud(await response.text());
 }
 
@@ -422,5 +441,8 @@ export async function load_ply_point_cloud(
 	url: string
 ): Promise<PointCloudData | null> {
 	const response = await fetch(url);
+	if (!response.ok) {
+		return null;
+	}
 	return parse_ply_point_cloud(await response.arrayBuffer());
 }

--- a/js/model3D/shared/point-cloud.ts
+++ b/js/model3D/shared/point-cloud.ts
@@ -286,42 +286,87 @@ function build_point_cloud(
 export function parse_obj_point_cloud(text: string): PointCloudData | null {
 	const positions: number[] = [];
 	const colors: number[] = [];
-	let has_faces = false;
 
 	for (const raw_line of text.split(/\r?\n/)) {
-		const line = raw_line.trim();
-		if (!line || line.startsWith("#")) {
-			continue;
-		}
-
-		const parts = line.split(/\s+/);
-		if (parts[0] === "f") {
-			has_faces = true;
-			break;
-		}
-
-		if (parts[0] !== "v" || parts.length < 4) {
-			continue;
-		}
-
-		const position = parts.slice(1, 4).map(Number);
-		if (position.some((coordinate) => Number.isNaN(coordinate))) {
-			continue;
-		}
-		positions.push(...position);
-
-		if (
-			parts.length >= 7 &&
-			!parts.slice(4, 7).some((channel) => Number.isNaN(Number(channel)))
-		) {
-			const color = parts.slice(4, 7).map(Number);
-			push_color(colors, color[0], color[1], color[2]);
-		} else {
-			push_color(colors, 1, 1, 1);
+		if (parse_obj_line(raw_line, positions, colors)) {
+			return null;
 		}
 	}
 
-	return has_faces ? null : build_point_cloud(positions, colors);
+	return build_point_cloud(positions, colors);
+}
+
+function parse_obj_line(
+	raw_line: string,
+	positions: number[],
+	colors: number[]
+): boolean {
+	const line = raw_line.trim();
+	if (!line || line.startsWith("#")) {
+		return false;
+	}
+
+	const parts = line.split(/\s+/);
+	if (parts[0] === "f") {
+		return true;
+	}
+
+	if (parts[0] !== "v" || parts.length < 4) {
+		return false;
+	}
+
+	const position = parts.slice(1, 4).map(Number);
+	if (position.some((coordinate) => Number.isNaN(coordinate))) {
+		return false;
+	}
+	positions.push(...position);
+
+	if (
+		parts.length >= 7 &&
+		!parts.slice(4, 7).some((channel) => Number.isNaN(Number(channel)))
+	) {
+		const color = parts.slice(4, 7).map(Number);
+		push_color(colors, color[0], color[1], color[2]);
+	} else {
+		push_color(colors, 1, 1, 1);
+	}
+
+	return false;
+}
+
+async function parse_obj_point_cloud_stream(
+	body: ReadableStream<Uint8Array>
+): Promise<PointCloudData | null> {
+	const reader = body.getReader();
+	const decoder = new TextDecoder("utf-8");
+	const positions: number[] = [];
+	const colors: number[] = [];
+	let pending = "";
+
+	while (true) {
+		const { value, done } = await reader.read();
+		if (done) {
+			break;
+		}
+
+		pending += decoder.decode(value, { stream: true });
+		const lines = pending.split(/\r?\n/);
+		pending = lines.pop() ?? "";
+
+		for (const line of lines) {
+			if (parse_obj_line(line, positions, colors)) {
+				await reader.cancel();
+				return null;
+			}
+		}
+	}
+
+	pending += decoder.decode();
+	if (pending && parse_obj_line(pending, positions, colors)) {
+		return null;
+	}
+
+	return build_point_cloud(positions, colors);
 }
 
 function parse_ascii_ply(
@@ -468,6 +513,9 @@ export async function load_obj_point_cloud(
 	const response = await fetch(url);
 	if (!response.ok) {
 		return null;
+	}
+	if (response.body) {
+		return parse_obj_point_cloud_stream(response.body);
 	}
 	return parse_obj_point_cloud(await response.text());
 }

--- a/js/model3D/shared/point-cloud.ts
+++ b/js/model3D/shared/point-cloud.ts
@@ -50,6 +50,9 @@ const PLY_TYPE_SIZES: Record<string, number> = {
 	float64: 8
 };
 
+const PLY_HEADER_PROBE_BYTES = 64 * 1024;
+type PlyContentKind = "point_cloud" | "gaussian_splat" | "unsupported";
+
 const BYTE_COLOR_TYPES = new Set(["uchar", "uint8"]);
 
 function normalize_channel(value: number, type?: string): number {
@@ -196,6 +199,24 @@ function is_gaussian_splat_ply(properties: PlyProperty[]): boolean {
 	return properties.some((property) =>
 		GAUSSIAN_SPLAT_PROPERTIES.has(property.name)
 	);
+}
+
+function classify_ply_content(buffer: ArrayBufferLike): PlyContentKind | null {
+	const array_buffer = trim_array_buffer(buffer);
+	const has_complete_header =
+		find_ply_header_end(new Uint8Array(array_buffer)) !== -1;
+	const header = parse_ply_header(array_buffer);
+
+	if (!header) {
+		return has_complete_header ? "unsupported" : null;
+	}
+	if (is_gaussian_splat_ply(header.vertex_properties)) {
+		return "gaussian_splat";
+	}
+	if (header.face_count > 0) {
+		return "unsupported";
+	}
+	return "point_cloud";
 }
 
 function ply_property_value(
@@ -440,9 +461,27 @@ export async function load_obj_point_cloud(
 export async function load_ply_point_cloud(
 	url: string
 ): Promise<PointCloudData | null> {
+	const probe_response = await fetch(url, {
+		headers: { Range: `bytes=0-${PLY_HEADER_PROBE_BYTES - 1}` }
+	});
+	if (!probe_response.ok) {
+		return null;
+	}
+
+	const probe_buffer = await probe_response.arrayBuffer();
+	if (probe_response.status !== 206) {
+		return parse_ply_point_cloud(probe_buffer);
+	}
+
+	const content_kind = classify_ply_content(probe_buffer);
+	if (content_kind === "gaussian_splat" || content_kind === "unsupported") {
+		return null;
+	}
+
 	const response = await fetch(url);
 	if (!response.ok) {
 		return null;
 	}
+
 	return parse_ply_point_cloud(await response.arrayBuffer());
 }

--- a/js/model3D/shared/point-cloud.ts
+++ b/js/model3D/shared/point-cloud.ts
@@ -3,6 +3,11 @@ export interface PointCloudData {
 	colors?: Float32Array;
 }
 
+export interface PlyPointCloudLoadResult {
+	point_cloud: PointCloudData | null;
+	fallback_url?: string;
+}
+
 interface PlyProperty {
 	name: string;
 	type: string;
@@ -233,6 +238,92 @@ function classify_ply_content(buffer: ArrayBufferLike): PlyContentKind | null {
 	return "point_cloud";
 }
 
+function create_ply_blob_url(buffer: ArrayBuffer): string | undefined {
+	if (
+		typeof Blob === "undefined" ||
+		typeof URL === "undefined" ||
+		typeof URL.createObjectURL !== "function"
+	) {
+		return undefined;
+	}
+
+	return URL.createObjectURL(
+		new Blob([buffer], { type: "application/octet-stream" })
+	);
+}
+
+function merge_chunks(chunks: Uint8Array[], byte_length: number): ArrayBuffer {
+	const bytes = new Uint8Array(byte_length);
+	let offset = 0;
+	for (const chunk of chunks) {
+		bytes.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return bytes.buffer;
+}
+
+async function load_full_ply_response(
+	response: Response
+): Promise<PlyPointCloudLoadResult> {
+	const buffer = await response.arrayBuffer();
+	const content_kind = classify_ply_content(buffer);
+	if (content_kind === "gaussian_splat") {
+		return {
+			point_cloud: null,
+			fallback_url: create_ply_blob_url(buffer)
+		};
+	}
+	return { point_cloud: parse_ply_point_cloud(buffer) };
+}
+
+async function load_streamed_ply_response(
+	response: Response
+): Promise<PlyPointCloudLoadResult> {
+	if (!response.body) {
+		return load_full_ply_response(response);
+	}
+
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let byte_length = 0;
+	let content_kind: PlyContentKind | null = null;
+
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) {
+			break;
+		}
+
+		chunks.push(value);
+		byte_length += value.byteLength;
+		content_kind = classify_ply_content(merge_chunks(chunks, byte_length));
+		if (content_kind === "gaussian_splat" || content_kind === "unsupported") {
+			await reader.cancel();
+			return { point_cloud: null };
+		}
+		if (content_kind === "point_cloud") {
+			break;
+		}
+	}
+
+	if (content_kind !== "point_cloud") {
+		return { point_cloud: null };
+	}
+
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) {
+			break;
+		}
+		chunks.push(value);
+		byte_length += value.byteLength;
+	}
+
+	return {
+		point_cloud: parse_ply_point_cloud(merge_chunks(chunks, byte_length))
+	};
+}
+
 function ply_property_value(
 	view: DataView,
 	offset: number,
@@ -436,28 +527,28 @@ export function parse_ply_point_cloud(
 
 export async function load_ply_point_cloud(
 	url: string
-): Promise<PointCloudData | null> {
+): Promise<PlyPointCloudLoadResult> {
 	const probe_response = await fetch(url, {
 		headers: { Range: `bytes=0-${PLY_HEADER_PROBE_BYTES - 1}` }
 	});
 	if (!probe_response.ok) {
-		return null;
+		return { point_cloud: null };
+	}
+
+	if (probe_response.status !== 206) {
+		return load_streamed_ply_response(probe_response);
 	}
 
 	const probe_buffer = await probe_response.arrayBuffer();
-	if (probe_response.status !== 206) {
-		return parse_ply_point_cloud(probe_buffer);
-	}
-
 	const content_kind = classify_ply_content(probe_buffer);
 	if (content_kind === "gaussian_splat" || content_kind === "unsupported") {
-		return null;
+		return { point_cloud: null };
 	}
 
 	const response = await fetch(url);
 	if (!response.ok) {
-		return null;
+		return { point_cloud: null };
 	}
 
-	return parse_ply_point_cloud(await response.arrayBuffer());
+	return { point_cloud: parse_ply_point_cloud(await response.arrayBuffer()) };
 }

--- a/js/model3D/shared/point-cloud.ts
+++ b/js/model3D/shared/point-cloud.ts
@@ -1,0 +1,409 @@
+export interface PointCloudData {
+	positions: Float32Array;
+	colors?: Float32Array;
+}
+
+interface PlyProperty {
+	name: string;
+	type: string;
+}
+
+interface PlyHeader {
+	format: "ascii" | "binary_little_endian" | "binary_big_endian";
+	header_length: number;
+	vertex_count: number;
+	vertex_properties: PlyProperty[];
+	face_count: number;
+}
+
+const COLOR_NAMES = {
+	red: ["red", "diffuse_red", "r"],
+	green: ["green", "diffuse_green", "g"],
+	blue: ["blue", "diffuse_blue", "b"],
+	alpha: ["alpha", "diffuse_alpha", "a"]
+};
+
+const GAUSSIAN_SPLAT_PROPERTIES = new Set([
+	"f_dc_0",
+	"f_rest_0",
+	"opacity",
+	"scale_0",
+	"rot_0"
+]);
+
+const PLY_TYPE_SIZES: Record<string, number> = {
+	char: 1,
+	int8: 1,
+	uchar: 1,
+	uint8: 1,
+	short: 2,
+	int16: 2,
+	ushort: 2,
+	uint16: 2,
+	int: 4,
+	int32: 4,
+	uint: 4,
+	uint32: 4,
+	float: 4,
+	float32: 4,
+	double: 8,
+	float64: 8
+};
+
+function normalize_channel(value: number): number {
+	return value > 1 ? value / 255 : value;
+}
+
+function color_property_index(
+	properties: PlyProperty[],
+	names: string[]
+): number {
+	return properties.findIndex((property) => names.includes(property.name));
+}
+
+function push_color(
+	colors: number[],
+	red: number | undefined,
+	green: number | undefined,
+	blue: number | undefined,
+	alpha = 1
+): void {
+	colors.push(
+		normalize_channel(red ?? 1),
+		normalize_channel(green ?? 1),
+		normalize_channel(blue ?? 1),
+		normalize_channel(alpha)
+	);
+}
+
+function trim_array_buffer(buffer: ArrayBufferLike): ArrayBuffer {
+	if (buffer instanceof ArrayBuffer) {
+		return buffer;
+	}
+	const copy = new Uint8Array(buffer.byteLength);
+	copy.set(new Uint8Array(buffer));
+	return copy.buffer;
+}
+
+function find_ply_header_end(bytes: Uint8Array): number {
+	const marker = new TextEncoder().encode("end_header");
+	for (let i = 0; i <= bytes.length - marker.length; i++) {
+		let matched = true;
+		for (let j = 0; j < marker.length; j++) {
+			if (bytes[i + j] !== marker[j]) {
+				matched = false;
+				break;
+			}
+		}
+		if (matched) {
+			let end = i + marker.length;
+			while (end < bytes.length && bytes[end] !== 10) {
+				end += 1;
+			}
+			return end < bytes.length ? end + 1 : end;
+		}
+	}
+	return -1;
+}
+
+function parse_ply_header(buffer: ArrayBuffer): PlyHeader | null {
+	const bytes = new Uint8Array(buffer);
+	const header_length = find_ply_header_end(bytes);
+	if (header_length === -1) {
+		return null;
+	}
+
+	const header_text = new TextDecoder("ascii").decode(
+		bytes.slice(0, header_length)
+	);
+	const lines = header_text.split(/\r?\n/).map((line) => line.trim());
+	if (lines[0] !== "ply") {
+		return null;
+	}
+
+	let format: PlyHeader["format"] | null = null;
+	let vertex_count = 0;
+	let face_count = 0;
+	let current_element: string | null = null;
+	const vertex_properties: PlyProperty[] = [];
+
+	for (const line of lines.slice(1)) {
+		if (!line || line.startsWith("comment")) {
+			continue;
+		}
+
+		const parts = line.split(/\s+/);
+		if (parts[0] === "format") {
+			if (
+				parts[1] === "ascii" ||
+				parts[1] === "binary_little_endian" ||
+				parts[1] === "binary_big_endian"
+			) {
+				format = parts[1];
+			}
+		} else if (parts[0] === "element") {
+			current_element = parts[1] ?? null;
+			if (current_element === "vertex") {
+				vertex_count = Number(parts[2] ?? 0);
+			} else if (current_element === "face") {
+				face_count = Number(parts[2] ?? 0);
+			}
+		} else if (
+			parts[0] === "property" &&
+			current_element === "vertex" &&
+			parts[1] !== "list"
+		) {
+			vertex_properties.push({ type: parts[1], name: parts[2] });
+		}
+	}
+
+	if (!format || vertex_count <= 0) {
+		return null;
+	}
+
+	return {
+		format,
+		header_length,
+		vertex_count,
+		vertex_properties,
+		face_count
+	};
+}
+
+function is_gaussian_splat_ply(properties: PlyProperty[]): boolean {
+	return properties.some((property) =>
+		GAUSSIAN_SPLAT_PROPERTIES.has(property.name)
+	);
+}
+
+function ply_property_value(
+	view: DataView,
+	offset: number,
+	type: string,
+	little_endian: boolean
+): number {
+	switch (type) {
+		case "char":
+		case "int8":
+			return view.getInt8(offset);
+		case "uchar":
+		case "uint8":
+			return view.getUint8(offset);
+		case "short":
+		case "int16":
+			return view.getInt16(offset, little_endian);
+		case "ushort":
+		case "uint16":
+			return view.getUint16(offset, little_endian);
+		case "int":
+		case "int32":
+			return view.getInt32(offset, little_endian);
+		case "uint":
+		case "uint32":
+			return view.getUint32(offset, little_endian);
+		case "float":
+		case "float32":
+			return view.getFloat32(offset, little_endian);
+		case "double":
+		case "float64":
+			return view.getFloat64(offset, little_endian);
+		default:
+			throw new Error(`Unsupported PLY property type: ${type}`);
+	}
+}
+
+function build_point_cloud(
+	positions: number[],
+	colors: number[]
+): PointCloudData | null {
+	if (positions.length === 0) {
+		return null;
+	}
+
+	return {
+		positions: new Float32Array(positions),
+		colors: colors.length > 0 ? new Float32Array(colors) : undefined
+	};
+}
+
+export function parse_obj_point_cloud(text: string): PointCloudData | null {
+	const positions: number[] = [];
+	const colors: number[] = [];
+	let has_faces = false;
+
+	for (const raw_line of text.split(/\r?\n/)) {
+		const line = raw_line.trim();
+		if (!line || line.startsWith("#")) {
+			continue;
+		}
+
+		const parts = line.split(/\s+/);
+		if (parts[0] === "f") {
+			has_faces = true;
+			break;
+		}
+
+		if (parts[0] !== "v" || parts.length < 4) {
+			continue;
+		}
+
+		const position = parts.slice(1, 4).map(Number);
+		if (position.some((coordinate) => Number.isNaN(coordinate))) {
+			continue;
+		}
+		positions.push(...position);
+
+		if (
+			parts.length >= 7 &&
+			!parts.slice(4, 7).some((channel) => Number.isNaN(Number(channel)))
+		) {
+			const color = parts.slice(4, 7).map(Number);
+			push_color(colors, color[0], color[1], color[2]);
+		} else {
+			push_color(colors, 1, 1, 1);
+		}
+	}
+
+	return has_faces ? null : build_point_cloud(positions, colors);
+}
+
+function parse_ascii_ply(
+	text: string,
+	header: PlyHeader
+): PointCloudData | null {
+	const positions: number[] = [];
+	const colors: number[] = [];
+	const properties = header.vertex_properties;
+	const x_index = properties.findIndex((property) => property.name === "x");
+	const y_index = properties.findIndex((property) => property.name === "y");
+	const z_index = properties.findIndex((property) => property.name === "z");
+	const red_index = color_property_index(properties, COLOR_NAMES.red);
+	const green_index = color_property_index(properties, COLOR_NAMES.green);
+	const blue_index = color_property_index(properties, COLOR_NAMES.blue);
+	const alpha_index = color_property_index(properties, COLOR_NAMES.alpha);
+
+	if (x_index === -1 || y_index === -1 || z_index === -1) {
+		return null;
+	}
+
+	for (const line of text
+		.slice(header.header_length)
+		.split(/\r?\n/)
+		.slice(0, header.vertex_count)) {
+		const values = line.trim().split(/\s+/).map(Number);
+		if (values.length < properties.length) {
+			continue;
+		}
+
+		positions.push(values[x_index], values[y_index], values[z_index]);
+		if (red_index !== -1 && green_index !== -1 && blue_index !== -1) {
+			push_color(
+				colors,
+				values[red_index],
+				values[green_index],
+				values[blue_index],
+				alpha_index === -1 ? 1 : values[alpha_index]
+			);
+		}
+	}
+
+	return build_point_cloud(positions, colors);
+}
+
+function parse_binary_ply(
+	buffer: ArrayBuffer,
+	header: PlyHeader
+): PointCloudData | null {
+	const positions: number[] = [];
+	const colors: number[] = [];
+	const properties = header.vertex_properties;
+	const x_index = properties.findIndex((property) => property.name === "x");
+	const y_index = properties.findIndex((property) => property.name === "y");
+	const z_index = properties.findIndex((property) => property.name === "z");
+	const red_index = color_property_index(properties, COLOR_NAMES.red);
+	const green_index = color_property_index(properties, COLOR_NAMES.green);
+	const blue_index = color_property_index(properties, COLOR_NAMES.blue);
+	const alpha_index = color_property_index(properties, COLOR_NAMES.alpha);
+
+	if (x_index === -1 || y_index === -1 || z_index === -1) {
+		return null;
+	}
+
+	const stride = properties.reduce(
+		(size, property) => size + (PLY_TYPE_SIZES[property.type] ?? 0),
+		0
+	);
+	if (
+		stride === 0 ||
+		properties.some((property) => !PLY_TYPE_SIZES[property.type])
+	) {
+		return null;
+	}
+
+	const view = new DataView(buffer);
+	const little_endian = header.format === "binary_little_endian";
+	let row_offset = header.header_length;
+
+	for (let row = 0; row < header.vertex_count; row++) {
+		const values: number[] = [];
+		let property_offset = row_offset;
+		for (const property of properties) {
+			values.push(
+				ply_property_value(view, property_offset, property.type, little_endian)
+			);
+			property_offset += PLY_TYPE_SIZES[property.type];
+		}
+
+		positions.push(values[x_index], values[y_index], values[z_index]);
+		if (red_index !== -1 && green_index !== -1 && blue_index !== -1) {
+			push_color(
+				colors,
+				values[red_index],
+				values[green_index],
+				values[blue_index],
+				alpha_index === -1 ? 1 : values[alpha_index]
+			);
+		}
+
+		row_offset += stride;
+	}
+
+	return build_point_cloud(positions, colors);
+}
+
+export function parse_ply_point_cloud(
+	buffer: ArrayBufferLike
+): PointCloudData | null {
+	const array_buffer = trim_array_buffer(buffer);
+	const header = parse_ply_header(array_buffer);
+	if (
+		!header ||
+		header.face_count > 0 ||
+		is_gaussian_splat_ply(header.vertex_properties)
+	) {
+		return null;
+	}
+
+	if (header.format === "ascii") {
+		return parse_ascii_ply(
+			new TextDecoder("utf-8").decode(array_buffer),
+			header
+		);
+	}
+
+	return parse_binary_ply(array_buffer, header);
+}
+
+export async function load_obj_point_cloud(
+	url: string
+): Promise<PointCloudData | null> {
+	const response = await fetch(url);
+	return parse_obj_point_cloud(await response.text());
+}
+
+export async function load_ply_point_cloud(
+	url: string
+): Promise<PointCloudData | null> {
+	const response = await fetch(url);
+	return parse_ply_point_cloud(await response.arrayBuffer());
+}

--- a/js/model3D/shared/renderer-loader.test.ts
+++ b/js/model3D/shared/renderer-loader.test.ts
@@ -102,4 +102,14 @@ describe("Canvas3DPLY renderer loaders", () => {
 			/function\s+loadCanvas3D(?:GS)?\s*\(/
 		);
 	});
+
+	test("invalidates pending loads during effect cleanup", () => {
+		const cleanup = canvas3d_ply_source.match(
+			/\$effect\(\(\) => \{[\s\S]*?void load_renderer\(load_url, currentToken\);\s*return \(\) => \{([\s\S]*?)\};\s*\}\);/
+		)?.[1];
+
+		expect(cleanup).toBeDefined();
+		expect(cleanup ?? "").toContain("loadToken++");
+		expect(cleanup ?? "").toContain("revoke_fallback_url()");
+	});
 });

--- a/js/model3D/shared/renderer-loader.test.ts
+++ b/js/model3D/shared/renderer-loader.test.ts
@@ -1,9 +1,17 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 
 import {
 	load_renderer_component,
 	renderer_for_model3d_path
 } from "./renderer-loader";
+
+const canvas3d_ply_source = readFileSync(
+	resolve(dirname(fileURLToPath(import.meta.url)), "Canvas3DPLY.svelte"),
+	"utf-8"
+);
 
 function deferred<T>(): {
 	promise: Promise<T>;
@@ -82,5 +90,16 @@ describe("load_renderer_component", () => {
 
 		expect(assigned).toEqual([]);
 		expect(errors).toEqual([error]);
+	});
+});
+
+describe("Canvas3DPLY renderer loaders", () => {
+	test("uses shared dynamic renderer loader functions", () => {
+		expect(canvas3d_ply_source).toContain(`from "./renderer-loader"`);
+		expect(canvas3d_ply_source).toContain("loadCanvas3D");
+		expect(canvas3d_ply_source).toContain("loadCanvas3DGS");
+		expect(canvas3d_ply_source).not.toMatch(
+			/function\s+loadCanvas3D(?:GS)?\s*\(/
+		);
 	});
 });

--- a/js/model3D/shared/renderer-loader.test.ts
+++ b/js/model3D/shared/renderer-loader.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	load_renderer_component,
+	renderer_for_model3d_path
+} from "./renderer-loader";
+
+function deferred<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+} {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+describe("renderer_for_model3d_path", () => {
+	test("routes PLY files to the PLY renderer", () => {
+		expect(renderer_for_model3d_path("model.ply")).toBe("ply");
+	});
+
+	test("routes splat files to the Gaussian splat renderer", () => {
+		expect(renderer_for_model3d_path("model.splat")).toBe("splat");
+	});
+
+	test("routes other files to the mesh renderer", () => {
+		expect(renderer_for_model3d_path("model.gltf")).toBe("mesh");
+	});
+});
+
+describe("load_renderer_component", () => {
+	test("ignores stale component loads after cleanup", async () => {
+		const ply = deferred<string>();
+		const assigned: string[] = [];
+		const cleanup = load_renderer_component(
+			"ply",
+			{
+				mesh: async () => "mesh-component",
+				ply: () => ply.promise,
+				splat: async () => "splat-component"
+			},
+			(renderer, component) => {
+				assigned.push(`${renderer}:${component}`);
+			}
+		);
+
+		cleanup();
+		ply.resolve("ply-component");
+		await ply.promise;
+		await Promise.resolve();
+
+		expect(assigned).toEqual([]);
+	});
+});

--- a/js/model3D/shared/renderer-loader.test.ts
+++ b/js/model3D/shared/renderer-loader.test.ts
@@ -16,6 +16,10 @@ function deferred<T>(): {
 	return { promise, resolve };
 }
 
+function flushPromises(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("renderer_for_model3d_path", () => {
 	test("routes PLY files to the PLY renderer", () => {
 		expect(renderer_for_model3d_path("model.ply")).toBe("ply");
@@ -52,5 +56,31 @@ describe("load_renderer_component", () => {
 		await Promise.resolve();
 
 		expect(assigned).toEqual([]);
+	});
+
+	test("handles component loader rejections", async () => {
+		const error = new Error("chunk failed");
+		const assigned: string[] = [];
+		const errors: unknown[] = [];
+
+		load_renderer_component(
+			"ply",
+			{
+				mesh: async () => "mesh-component",
+				ply: () => Promise.reject(error),
+				splat: async () => "splat-component"
+			},
+			(renderer, component) => {
+				assigned.push(`${renderer}:${component}`);
+			},
+			(error) => {
+				errors.push(error);
+			}
+		);
+
+		await flushPromises();
+
+		expect(assigned).toEqual([]);
+		expect(errors).toEqual([error]);
 	});
 });

--- a/js/model3D/shared/renderer-loader.ts
+++ b/js/model3D/shared/renderer-loader.ts
@@ -1,4 +1,40 @@
+import type Canvas3D from "./Canvas3D.svelte";
+import type Canvas3DGS from "./Canvas3DGS.svelte";
+import type Canvas3DPLY from "./Canvas3DPLY.svelte";
+
 export type Model3DRenderer = "mesh" | "ply" | "splat";
+export type Canvas3DLike = Canvas3D | Canvas3DPLY;
+export type Canvas3DComponentType = typeof Canvas3D;
+export type Canvas3DGSComponentType = typeof Canvas3DGS;
+export type Canvas3DPLYComponentType = typeof Canvas3DPLY;
+export type Model3DCanvasComponent =
+	| Canvas3DComponentType
+	| Canvas3DGSComponentType
+	| Canvas3DPLYComponentType;
+
+export async function loadCanvas3D(): Promise<Canvas3DComponentType> {
+	const module = await import("./Canvas3D.svelte");
+	return module.default;
+}
+
+export async function loadCanvas3DGS(): Promise<Canvas3DGSComponentType> {
+	const module = await import("./Canvas3DGS.svelte");
+	return module.default;
+}
+
+export async function loadCanvas3DPLY(): Promise<Canvas3DPLYComponentType> {
+	const module = await import("./Canvas3DPLY.svelte");
+	return module.default;
+}
+
+export const model3d_renderer_loaders: Record<
+	Model3DRenderer,
+	() => Promise<Model3DCanvasComponent>
+> = {
+	mesh: loadCanvas3D,
+	ply: loadCanvas3DPLY,
+	splat: loadCanvas3DGS
+};
 
 export function renderer_for_model3d_path(path: string): Model3DRenderer {
 	if (path.endsWith(".ply")) {

--- a/js/model3D/shared/renderer-loader.ts
+++ b/js/model3D/shared/renderer-loader.ts
@@ -13,15 +13,22 @@ export function renderer_for_model3d_path(path: string): Model3DRenderer {
 export function load_renderer_component<T>(
 	renderer: Model3DRenderer,
 	loaders: Record<Model3DRenderer, () => Promise<T>>,
-	assign: (renderer: Model3DRenderer, component: T) => void
+	assign: (renderer: Model3DRenderer, component: T) => void,
+	on_error?: (error: unknown) => void
 ): () => void {
 	let active = true;
 
-	loaders[renderer]().then((component) => {
-		if (active) {
-			assign(renderer, component);
-		}
-	});
+	loaders[renderer]()
+		.then((component) => {
+			if (active) {
+				assign(renderer, component);
+			}
+		})
+		.catch((error) => {
+			if (active) {
+				on_error?.(error);
+			}
+		});
 
 	return () => {
 		active = false;

--- a/js/model3D/shared/renderer-loader.ts
+++ b/js/model3D/shared/renderer-loader.ts
@@ -1,0 +1,29 @@
+export type Model3DRenderer = "mesh" | "ply" | "splat";
+
+export function renderer_for_model3d_path(path: string): Model3DRenderer {
+	if (path.endsWith(".ply")) {
+		return "ply";
+	}
+	if (path.endsWith(".splat")) {
+		return "splat";
+	}
+	return "mesh";
+}
+
+export function load_renderer_component<T>(
+	renderer: Model3DRenderer,
+	loaders: Record<Model3DRenderer, () => Promise<T>>,
+	assign: (renderer: Model3DRenderer, component: T) => void
+): () => void {
+	let active = true;
+
+	loaders[renderer]().then((component) => {
+		if (active) {
+			assign(renderer, component);
+		}
+	});
+
+	return () => {
+		active = false;
+	};
+}


### PR DESCRIPTION
## Description

Adds a focused PLY point-cloud path for `Model3D` files that contain vertices but no mesh faces.

Closes: #8826

The change probes `.ply` files before choosing the renderer:
- Gaussian-splat PLY files stay on the existing `Canvas3DGS` renderer.
- Regular vertex-only PLY point clouds are parsed into Babylon point clouds and rendered through `Canvas3D`.
- Other model types continue through the existing renderer paths.

## AI Disclosure

- [x] I used AI assistance to help draft and self-review this patch. kumquat
- [ ] I did not use AI

## PRs Should Target Issues

This targets #8826.

## Testing and Formatting Your Code

- `corepack pnpm install --frozen-lockfile --store-dir /private/tmp/gradio-13407-pnpm-store`
- `PLAYWRIGHT_BROWSERS_PATH=/private/tmp/gradio-13407-ms-playwright corepack pnpm exec playwright install chromium`
- `PLAYWRIGHT_BROWSERS_PATH=/private/tmp/gradio-13407-ms-playwright corepack pnpm exec vitest run --config .config/vitest.config.ts js/model3D/shared/point-cloud.test.ts`
- `PLAYWRIGHT_BROWSERS_PATH=/private/tmp/gradio-13407-ms-playwright corepack pnpm exec vitest run --config .config/vitest.config.ts js/model3D/Model3D.test.ts -t "ply"`
- `CI=1 PLAYWRIGHT_BROWSERS_PATH=/private/tmp/gradio-13407-ms-playwright corepack pnpm exec vitest run --config .config/vitest.config.ts js/model3D/Model3D.test.ts`
- `corepack pnpm exec prettier --ignore-path .config/.prettierignore --check --config .config/.prettierrc.json --plugin prettier-plugin-svelte js/model3D/shared/point-cloud.ts js/model3D/shared/point-cloud.test.ts js/model3D/shared/Canvas3D.svelte js/model3D/shared/Canvas3DPLY.svelte js/model3D/shared/Model3D.svelte js/model3D/shared/Model3DUpload.svelte .changeset/model3d-point-cloud.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New client-side PLY parsing and fetch/range logic on a hot UI path; regressions could mis-route `.ply` between gsplat and Babylon or affect large-file loading behavior.
> 
> **Overview**
> **Model3D** now supports generic vertex-only **PLY point clouds**, not only meshes and Gaussian splats.
> 
> `.ply` files go through a new **`Canvas3DPLY`** path that **range-probes** the file, classifies it, then either parses vertices into a Babylon **PointsCloudSystem** (`Canvas3D`) or keeps the existing **gsplat** renderer. Gaussian-splat PLYs are detected by splat-specific properties; faced meshes are rejected for the point-cloud parser. **`renderer-loader`** centralizes mesh / ply / splat routing and stale-safe dynamic imports; **`Model3D`** / **`Model3DUpload`** wire PLY-specific camera undo when Babylon reset is available.
> 
> Load races use **load tokens**, blob URLs are revoked on cleanup, and Babylon core point-cloud APIs are **dynamically imported** to limit bundle impact. Broad **vitest** coverage covers PLY parsing, fetch probing, and renderer selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb04912cff7441e00b895400ce2e1e41b4f9f4c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->