### PR TITLE
Add gr.VideoEditor for drawing masks on video

### DIFF
--- a/.agents/skills/gradio/references/event-listeners.md
+++ b/.agents/skills/gradio/references/event-listeners.md
@@ -128,3 +128,5 @@ component.event_name(
 - **UploadButton**: click, upload
 
 - **Video**: change, clear, start_recording, stop_recording, stop, play, pause, end, upload, input
+
+- **VideoEditor**: change, upload, clear

--- a/.changeset/eager-otters-paint.md
+++ b/.changeset/eager-otters-paint.md
@@ -1,0 +1,6 @@
+---
+"@gradio/videoeditor": minor
+"gradio": minor
+---
+
+feat:Add `gr.VideoEditor` component for drawing masks on video frames

--- a/demo/video_editor_mask/run.py
+++ b/demo/video_editor_mask/run.py
@@ -1,0 +1,25 @@
+import gradio as gr
+
+
+def process(value):
+    if value is None:
+        return None, None
+    return value.get("video"), value.get("mask")
+
+
+with gr.Blocks() as demo:
+    gr.Markdown("## VideoEditor: draw a mask on a video frame")
+
+    editor = gr.VideoEditor(label="Upload a video and draw a mask")
+
+    btn = gr.Button("Submit", variant="primary")
+
+    with gr.Row():
+        video_out = gr.Video(label="Video")
+        mask_out = gr.Image(label="Mask (PNG)")
+
+    btn.click(fn=process, inputs=editor, outputs=[video_out, mask_out])
+
+
+if __name__ == "__main__":
+    demo.launch()

--- a/gradio/__init__.py
+++ b/gradio/__init__.py
@@ -67,6 +67,7 @@ from gradio.components import (
     Timer,
     UploadButton,
     Video,
+    VideoEditor,
     component,
 )
 from gradio.components.audio import WaveformOptions
@@ -253,6 +254,7 @@ __all__ = [
     "UndoData",
     "UploadButton",
     "Video",
+    "VideoEditor",
     "Walkthrough",
     "Step",
     "Warning",

--- a/gradio/components/__init__.py
+++ b/gradio/components/__init__.py
@@ -52,6 +52,7 @@ from gradio.components.textbox import InputHTMLAttributes, Textbox
 from gradio.components.timer import Timer
 from gradio.components.upload_button import UploadButton
 from gradio.components.video import Video
+from gradio.components.video_editor import VideoEditor
 from gradio.layouts import Form
 
 Text = Textbox
@@ -120,6 +121,7 @@ __all__ = [
     "Timer",
     "UploadButton",
     "Video",
+    "VideoEditor",
     "StreamingInput",
     "StreamingOutput",
     "ImageEditor",

--- a/gradio/components/video_editor.py
+++ b/gradio/components/video_editor.py
@@ -1,0 +1,181 @@
+"""gr.VideoEditor() component."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, Sequence
+
+import numpy as np
+import PIL.Image
+from gradio_client import handle_file
+from gradio_client.documentation import document
+
+from gradio import image_utils
+from gradio.components.base import Component
+from gradio.data_classes import FileData, GradioModel
+from gradio.events import Events
+from gradio.exceptions import Error
+from gradio.i18n import I18nData
+
+if TYPE_CHECKING:
+    from gradio.components import Timer
+
+
+class VideoEditorData(GradioModel):
+    video: FileData
+    mask: FileData | None = None
+
+
+@document()
+class VideoEditor(Component):
+    """
+    Creates a video editor component that allows users to upload a video and draw a mask
+    on top of the displayed frame. The mask is returned as a PNG image alongside the
+    uploaded video. If the browser cannot play the uploaded video, an error message is
+    shown in place of the player.
+
+    Demos: video_editor_mask
+    """
+
+    EVENTS = [
+        Events.change,
+        Events.upload,
+        Events.clear,
+    ]
+
+    data_model = VideoEditorData
+
+    def __init__(
+        self,
+        value: str | Path | None = None,
+        *,
+        sources: list[Literal["upload"]] | None = None,
+        height: int | str | None = None,
+        label: str | I18nData | None = None,
+        every: Timer | float | None = None,
+        inputs: Component | Sequence[Component] | set[Component] | None = None,
+        show_label: bool | None = None,
+        container: bool = True,
+        scale: int | None = None,
+        min_width: int = 160,
+        interactive: bool | None = None,
+        visible: bool | Literal["hidden"] = True,
+        elem_id: str | None = None,
+        elem_classes: list[str] | str | None = None,
+        render: bool = True,
+        key: int | str | tuple[int | str, ...] | None = None,
+        preserved_by_key: list[str] | str | None = "value",
+        brush_color: str = "rgba(255, 0, 0, 0.5)",
+        brush_size: int = 20,
+    ):
+        """
+        Parameters:
+            value: path or URL for the default video to display.
+            sources: list of sources permitted. Currently only "upload" is supported.
+            height: The height of the component, specified in pixels if a number is passed, or in CSS units if a string is passed.
+            label: the label for this component. Appears above the component and is also used as the header if there are a table of examples for this component. If None and used in a `gr.Interface`, the label will be the name of the parameter this component is assigned to.
+            every: Continously calls `value` to recalculate it if `value` is a function (has no effect otherwise). Can provide a Timer whose tick resets `value`, or a float that provides the regular interval for the reset Timer.
+            inputs: Components that are used as inputs to calculate `value` if `value` is a function (has no effect otherwise). `value` is recalculated any time the inputs change.
+            show_label: if True, will display label.
+            container: If True, will place the component in a container - providing some extra padding around the border.
+            scale: relative size compared to adjacent Components. For example if Components A and B are in a Row, and A has scale=2, and B has scale=1, A will be twice as wide as B. Should be an integer. scale applies in Rows, and to top-level Components in Blocks where fill_height=True.
+            min_width: minimum pixel width, will wrap if not sufficient screen space to satisfy this value. If a certain scale value results in this Component being narrower than min_width, the min_width parameter will be respected first.
+            interactive: if True, will allow users to upload a video and draw a mask; if False, can only be used to display videos. If not provided, this is inferred based on whether the component is used as an input or output.
+            visible: If False, component will be hidden. If "hidden", component will be visually hidden and not take up space in the layout but still exist in the DOM.
+            elem_id: An optional string that is assigned as the id of this component in the HTML DOM. Can be used for targeting CSS styles.
+            elem_classes: An optional list of strings that are assigned as the classes of this component in the HTML DOM. Can be used for targeting CSS styles.
+            render: If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
+            key: in a gr.render, Components with the same key across re-renders are treated as the same component, not a new component. Properties set in 'preserved_by_key' are not reset across a re-render.
+            preserved_by_key: A list of parameters from this component's constructor. Inside a gr.render() function, if a component is re-rendered with the same key, these (and only these) parameters will be preserved in the UI (if they have been changed by the user or an event listener) instead of re-rendered based on the values provided during constructor.
+            brush_color: default color of the mask brush, in any valid CSS color string.
+            brush_size: default brush size in pixels.
+        """
+        self.sources = sources or ["upload"]
+        self.height = height
+        self.brush_color = brush_color
+        self.brush_size = brush_size
+
+        super().__init__(
+            label=label,
+            every=every,
+            inputs=inputs,
+            show_label=show_label,
+            container=container,
+            scale=scale,
+            min_width=min_width,
+            interactive=interactive,
+            visible=visible,
+            elem_id=elem_id,
+            elem_classes=elem_classes,
+            render=render,
+            key=key,
+            preserved_by_key=preserved_by_key,
+            value=value,
+        )
+
+    def preprocess(self, payload: VideoEditorData | None) -> dict | None:
+        """
+        Parameters:
+            payload: a VideoEditorData object with the uploaded video and optional drawn mask.
+        Returns:
+            A dict with keys "video" (str path to the uploaded video) and "mask" (numpy array of the drawn mask in RGBA, or None).
+        """
+        if payload is None:
+            return None
+
+        mask_arr = None
+        if payload.mask:
+            try:
+                mask_img = PIL.Image.open(payload.mask.path).convert("RGBA")
+            except (PIL.UnidentifiedImageError, OSError) as e:
+                raise Error(f"Could not read mask image: {e}") from e
+            mask_arr = np.array(mask_img)
+
+        return {"video": payload.video.path, "mask": mask_arr}
+
+    def postprocess(self, value: dict | str | Path | None) -> VideoEditorData | None:
+        """
+        Parameters:
+            value: either a path/URL to a video, or a dict with keys "video" and "mask".
+                The mask can be a numpy array, PIL Image, or file path.
+        Returns:
+            A VideoEditorData object suitable for the frontend.
+        """
+        if value is None:
+            return None
+
+        if isinstance(value, (str, Path)):
+            return VideoEditorData(video=FileData(path=str(value)))
+
+        video_path = value.get("video")
+        if not video_path:
+            return None
+
+        video_fd = FileData(path=str(video_path))
+        mask_fd: FileData | None = None
+
+        mask = value.get("mask")
+        if mask is not None:
+            if isinstance(mask, (str, Path)):
+                mask_fd = FileData(path=str(mask))
+            else:
+                mask_path = image_utils.save_image(
+                    mask, self.GRADIO_CACHE, format="png"
+                )
+                mask_fd = FileData(path=mask_path)
+
+        return VideoEditorData(video=video_fd, mask=mask_fd)
+
+    def example_payload(self) -> Any:
+        return {
+            "video": handle_file(
+                "https://github.com/gradio-app/gradio/raw/main/gradio/media_assets/videos/world.mp4"
+            ),
+            "mask": None,
+        }
+
+    def example_value(self) -> Any:
+        return {
+            "video": "https://github.com/gradio-app/gradio/raw/main/gradio/media_assets/videos/world.mp4",
+            "mask": None,
+        }

--- a/js/core/package.json
+++ b/js/core/package.json
@@ -61,7 +61,8 @@
 		"@gradio/uploadbutton": "workspace:^",
 		"@gradio/utils": "workspace:^",
 		"@gradio/vibeeditor": "workspace:^",
-		"@gradio/video": "workspace:^"
+		"@gradio/video": "workspace:^",
+		"@gradio/videoeditor": "workspace:^"
 	},
 	"msw": {
 		"workerDirectory": "public"

--- a/js/videoeditor/Example.svelte
+++ b/js/videoeditor/Example.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import type { VideoEditorData } from "./types";
+
+	interface Props {
+		type: "gallery" | "table";
+		selected?: boolean;
+		value?: VideoEditorData | null;
+	}
+
+	let { type, selected = false, value = null }: Props = $props();
+
+	let video: HTMLVideoElement | undefined = $state();
+
+	async function init(): Promise<void> {
+		if (!video) return;
+		video.muted = true;
+		video.playsInline = true;
+		video.controls = false;
+		video.setAttribute("muted", "");
+		try {
+			await video.play();
+			video.pause();
+		} catch {}
+	}
+</script>
+
+{#if value?.video?.url}
+	<div
+		class="container"
+		class:table={type === "table"}
+		class:gallery={type === "gallery"}
+		class:selected
+	>
+		<!-- svelte-ignore a11y_media_has_caption -->
+		<video
+			muted
+			playsinline
+			bind:this={video}
+			onloadeddata={init}
+			onmouseover={() => video?.play()}
+			onmouseout={() => video?.pause()}
+			onfocus={() => video?.play()}
+			onblur={() => video?.pause()}
+			src={value.video.url}
+		></video>
+	</div>
+{/if}
+
+<style>
+	.container :global(video) {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+	.container.selected { border-color: var(--border-color-accent); }
+	.container.table {
+		margin: 0 auto;
+		border: 2px solid var(--border-color-primary);
+		border-radius: var(--radius-lg);
+		overflow: hidden;
+		width: var(--size-20);
+		height: var(--size-20);
+		object-fit: cover;
+	}
+	.container.gallery {
+		border: 2px solid var(--border-color-primary);
+		height: var(--size-20);
+		max-height: var(--size-20);
+		object-fit: cover;
+	}
+</style>

--- a/js/videoeditor/Index.svelte
+++ b/js/videoeditor/Index.svelte
@@ -40,19 +40,19 @@
 
 	const gradio = new VideoEditorGradio(props);
 
-	let video_src = $state<string | null>(gradio.props.value?.video?.url ?? null);
+	let video_src = $derived<string | null>(
+		gradio.props.value?.video?.url ?? null
+	);
 	let editor: VideoEditor;
 	let uploading = $state(false);
 
 	function handle_upload(file_data: FileData): void {
-		video_src = file_data.url ?? null;
 		gradio.props.value = { video: file_data } as VideoEditorData;
 		gradio.dispatch("upload");
 		gradio.dispatch("change");
 	}
 
 	function handle_remove(): void {
-		video_src = null;
 		gradio.props.value = null;
 		gradio.dispatch("clear");
 		gradio.dispatch("change");

--- a/js/videoeditor/Index.svelte
+++ b/js/videoeditor/Index.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+	import { Block, IconButton, UploadText } from "@gradio/atoms";
+	import { Clear } from "@gradio/icons";
+	import { StatusTracker } from "@gradio/statustracker";
+	import { Gradio } from "@gradio/utils";
+	import { Upload } from "@gradio/upload";
+	import { type Client, type FileData, prepare_files } from "@gradio/client";
+	import VideoEditor from "./shared/VideoEditor.svelte";
+	import type {
+		VideoEditorData,
+		VideoEditorProps,
+		VideoEditorEvents
+	} from "./types";
+
+	const props = $props();
+
+	class VideoEditorGradio extends Gradio<VideoEditorEvents, VideoEditorProps> {
+		async get_data() {
+			const data = (await super.get_data()) as any;
+			if (!data?.value) return data;
+
+			const mask = await upload_mask(this.shared.client, this.shared.root);
+			if (!mask) return data;
+
+			return { ...data, value: { ...data.value, mask } };
+		}
+	}
+
+	async function upload_mask(
+		client: Client,
+		root: string
+	): Promise<FileData | null> {
+		const blob = await editor?.get_mask_blob();
+		if (!blob) return null;
+		const file = new File([blob], "mask.png", { type: "image/png" });
+		const prepared = await prepare_files([file]);
+		const uploaded = await client.upload(prepared, root);
+		return uploaded?.[0] ?? null;
+	}
+
+	const gradio = new VideoEditorGradio(props);
+
+	let video_src = $state<string | null>(gradio.props.value?.video?.url ?? null);
+	let editor: VideoEditor;
+	let uploading = $state(false);
+
+	function handle_upload(file_data: FileData): void {
+		video_src = file_data.url ?? null;
+		gradio.props.value = { video: file_data } as VideoEditorData;
+		gradio.dispatch("upload");
+		gradio.dispatch("change");
+	}
+
+	function handle_remove(): void {
+		video_src = null;
+		gradio.props.value = null;
+		gradio.dispatch("clear");
+		gradio.dispatch("change");
+	}
+</script>
+
+<Block
+	variant="panel"
+	border_mode="base"
+	padding={false}
+	elem_id={gradio.shared.elem_id}
+	elem_classes={gradio.shared.elem_classes}
+	visible={gradio.shared.visible}
+	container={gradio.shared.container}
+	scale={gradio.shared.scale}
+	min_width={gradio.shared.min_width}
+	height={gradio.props.height}
+>
+	<StatusTracker
+		autoscroll={gradio.shared.autoscroll}
+		i18n={gradio.i18n}
+		{...gradio.shared.loading_status}
+		on_clear_status={() =>
+			gradio.dispatch("clear_status", gradio.shared.loading_status)}
+	/>
+
+	{#if !video_src}
+		{#if gradio.shared.interactive}
+			<Upload
+				filetype="video/*"
+				root={gradio.shared.root}
+				upload={(...args) => gradio.shared.client.upload(...args)}
+				stream_handler={(...args) => gradio.shared.client.stream(...args)}
+				bind:uploading
+				onload={(data) => handle_upload(data as FileData)}
+			>
+				<UploadText i18n={gradio.i18n} type="video" />
+			</Upload>
+		{:else}
+			<div class="empty">No video</div>
+		{/if}
+	{:else}
+		<div class="editor-wrap">
+			{#if gradio.shared.interactive}
+				<div class="remove-wrap">
+					<IconButton
+						Icon={Clear}
+						label="Remove video"
+						onclick={handle_remove}
+					/>
+				</div>
+			{/if}
+			<VideoEditor
+				bind:this={editor}
+				src={video_src}
+				brush_color={gradio.props.brush_color}
+				brush_size={gradio.props.brush_size}
+				interactive={gradio.shared.interactive}
+			/>
+		</div>
+	{/if}
+</Block>
+
+<style>
+	.empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: var(--size-40);
+		color: var(--body-text-color-subdued);
+	}
+	.editor-wrap {
+		position: relative;
+	}
+	.remove-wrap {
+		position: absolute;
+		top: var(--size-2);
+		right: var(--size-2);
+		z-index: var(--layer-top);
+	}
+</style>

--- a/js/videoeditor/VideoEditor.test.ts
+++ b/js/videoeditor/VideoEditor.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect, afterEach } from "vitest";
+import {
+	render,
+	cleanup,
+	mock_client,
+	TEST_MP4
+} from "@self/tootils/render";
+import Index from "./Index.svelte";
+
+const default_props = {
+	interactive: true,
+	label: "VideoEditor",
+	show_label: true,
+	value: null,
+	root: "http://localhost:7860",
+	client: mock_client(),
+	brush_color: "rgba(255, 0, 0, 0.5)",
+	brush_size: 20
+};
+
+describe("VideoEditor", () => {
+	afterEach(() => cleanup());
+
+	test("renders the upload area when there is no value", async () => {
+		const { container } = await render(Index, default_props);
+		const file_input = container.querySelector("input[type='file']");
+		expect(file_input).not.toBeNull();
+		expect(file_input?.getAttribute("accept")).toContain("video");
+	});
+
+	test("renders 'No video' when not interactive and no value", async () => {
+		const { getByText } = await render(Index, {
+			...default_props,
+			interactive: false
+		});
+		expect(getByText("No video")).toBeInTheDocument();
+	});
+
+	test("renders the video player when a video value is provided", async () => {
+		const { container } = await render(Index, {
+			...default_props,
+			value: { video: TEST_MP4, mask: null }
+		});
+		const video = container.querySelector("video");
+		expect(video?.getAttribute("src")).toBe(TEST_MP4.url);
+	});
+});
+
+describe("Props: interactive", () => {
+	afterEach(() => cleanup());
+
+	test("interactive=true shows draw and clear controls", async () => {
+		const { getByLabelText } = await render(Index, {
+			...default_props,
+			value: { video: TEST_MP4, mask: null }
+		});
+		expect(getByLabelText(/draw/i)).toBeInTheDocument();
+		expect(getByLabelText(/clear mask/i)).toBeInTheDocument();
+	});
+
+	test("interactive=false hides the controls", async () => {
+		const { queryByLabelText } = await render(Index, {
+			...default_props,
+			interactive: false,
+			value: { video: TEST_MP4, mask: null }
+		});
+		expect(queryByLabelText(/draw mask/i)).toBeNull();
+		expect(queryByLabelText(/clear mask/i)).toBeNull();
+	});
+});
+
+describe("get_data", () => {
+	afterEach(() => cleanup());
+
+	test("returns the video and no mask when nothing has been drawn", async () => {
+		const { get_data } = await render(Index, {
+			...default_props,
+			value: { video: TEST_MP4, mask: null }
+		});
+		const data = await get_data();
+		expect(data.value).toMatchObject({
+			video: expect.objectContaining({ url: TEST_MP4.url })
+		});
+		expect(data.value?.mask ?? null).toBeNull();
+	});
+});

--- a/js/videoeditor/package.json
+++ b/js/videoeditor/package.json
@@ -1,0 +1,43 @@
+{
+	"name": "@gradio/videoeditor",
+	"version": "0.1.0",
+	"description": "Gradio UI packages",
+	"type": "module",
+	"author": "",
+	"license": "ISC",
+	"private": false,
+	"dependencies": {
+		"@gradio/atoms": "workspace:^",
+		"@gradio/client": "workspace:^",
+		"@gradio/icons": "workspace:^",
+		"@gradio/statustracker": "workspace:^",
+		"@gradio/upload": "workspace:^",
+		"@gradio/utils": "workspace:^"
+	},
+	"devDependencies": {
+		"@gradio/preview": "workspace:^"
+	},
+	"main_changeset": true,
+	"main": "./Index.svelte",
+	"exports": {
+		".": {
+			"gradio": "./Index.svelte",
+			"svelte": "./dist/Index.svelte",
+			"types": "./dist/Index.svelte.d.ts"
+		},
+		"./example": {
+			"gradio": "./Example.svelte",
+			"svelte": "./dist/Example.svelte",
+			"types": "./dist/Example.svelte.d.ts"
+		},
+		"./package.json": "./package.json"
+	},
+	"peerDependencies": {
+		"svelte": "^5.48.0"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/gradio-app/gradio.git",
+		"directory": "js/videoeditor"
+	}
+}

--- a/js/videoeditor/shared/MaskCanvas.svelte
+++ b/js/videoeditor/shared/MaskCanvas.svelte
@@ -1,0 +1,244 @@
+<script lang="ts">
+	import { IconButton } from "@gradio/atoms";
+	import { Brush, Erase, Trash, Undo, Redo } from "@gradio/icons";
+
+	interface Props {
+		width?: number;
+		height?: number;
+		brush_color?: string;
+		brush_size?: number;
+		active?: boolean;
+	}
+
+	let {
+		width = 0,
+		height = 0,
+		brush_color = "rgba(255, 0, 0, 0.5)",
+		brush_size = $bindable(20),
+		active = false
+	}: Props = $props();
+
+	const MAX_HISTORY = 20;
+
+	let canvas: HTMLCanvasElement;
+	let ctx: CanvasRenderingContext2D | null = null;
+	let drawing = false;
+	let tool: "brush" | "eraser" = $state("brush");
+	let last_x = 0;
+	let last_y = 0;
+	let undo_stack: ImageData[] = $state([]);
+	let redo_stack: ImageData[] = $state([]);
+
+	$effect(() => {
+		ctx = canvas.getContext("2d");
+	});
+
+	function snapshot(): ImageData | null {
+		if (!ctx || canvas.width === 0 || canvas.height === 0) return null;
+		return ctx.getImageData(0, 0, canvas.width, canvas.height);
+	}
+
+	function push_undo(): void {
+		const snap = snapshot();
+		if (!snap) return;
+		undo_stack.push(snap);
+		if (undo_stack.length > MAX_HISTORY) undo_stack.shift();
+		redo_stack = [];
+	}
+
+	function restore(img: ImageData): void {
+		if (!ctx) return;
+		ctx.globalCompositeOperation = "source-over";
+		ctx.clearRect(0, 0, canvas.width, canvas.height);
+		ctx.putImageData(img, 0, 0);
+	}
+
+	function get_pos(e: MouseEvent | TouchEvent): { x: number; y: number } {
+		const rect = canvas.getBoundingClientRect();
+		const scaleX = canvas.width / rect.width;
+		const scaleY = canvas.height / rect.height;
+		const client = e instanceof TouchEvent ? e.touches[0] : e;
+		return {
+			x: (client.clientX - rect.left) * scaleX,
+			y: (client.clientY - rect.top) * scaleY
+		};
+	}
+
+	function configure_stroke(): void {
+		if (!ctx) return;
+		ctx.globalCompositeOperation =
+			tool === "eraser" ? "destination-out" : "source-over";
+		ctx.strokeStyle = tool === "eraser" ? "rgba(0,0,0,1)" : brush_color;
+		ctx.fillStyle = tool === "eraser" ? "rgba(0,0,0,1)" : brush_color;
+		ctx.lineWidth = brush_size;
+		ctx.lineCap = "round";
+		ctx.lineJoin = "round";
+	}
+
+	function start(e: MouseEvent | TouchEvent): void {
+		if (!active || !ctx) return;
+		e.preventDefault();
+		push_undo();
+		drawing = true;
+		const { x, y } = get_pos(e);
+		last_x = x;
+		last_y = y;
+		configure_stroke();
+		ctx.beginPath();
+		ctx.arc(x, y, brush_size / 2, 0, Math.PI * 2);
+		ctx.fill();
+	}
+
+	function move(e: MouseEvent | TouchEvent): void {
+		if (!drawing || !ctx) return;
+		e.preventDefault();
+		const { x, y } = get_pos(e);
+		configure_stroke();
+		ctx.beginPath();
+		ctx.moveTo(last_x, last_y);
+		ctx.lineTo(x, y);
+		ctx.stroke();
+		last_x = x;
+		last_y = y;
+	}
+
+	function stop(): void {
+		drawing = false;
+	}
+
+	export function clear(): void {
+		if (!ctx) return;
+		push_undo();
+		ctx.globalCompositeOperation = "source-over";
+		ctx.clearRect(0, 0, canvas.width, canvas.height);
+	}
+
+	export function undo(): void {
+		const prev = undo_stack.pop();
+		if (!prev) return;
+		const current = snapshot();
+		if (current) redo_stack.push(current);
+		restore(prev);
+	}
+
+	export function redo(): void {
+		const next = redo_stack.pop();
+		if (!next) return;
+		const current = snapshot();
+		if (current) undo_stack.push(current);
+		restore(next);
+	}
+
+	export function get_blob(): Promise<Blob | null> {
+		return new Promise((resolve) => {
+			canvas.toBlob((blob) => resolve(blob), "image/png");
+		});
+	}
+
+	export function is_empty(): boolean {
+		if (!ctx || canvas.width === 0 || canvas.height === 0) return true;
+		const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+		for (let i = 3; i < data.length; i += 4) {
+			if (data[i] > 0) return false;
+		}
+		return true;
+	}
+</script>
+
+<div class="mask-wrapper" class:active>
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<canvas
+		bind:this={canvas}
+		{width}
+		{height}
+		class="mask-canvas"
+		style="cursor: {active ? (tool === 'eraser' ? 'cell' : 'crosshair') : 'default'}"
+		onmousedown={start}
+		onmousemove={move}
+		onmouseup={stop}
+		onmouseleave={stop}
+		ontouchstart={start}
+		ontouchmove={move}
+		ontouchend={stop}
+	></canvas>
+
+	{#if active}
+		<div class="toolbar">
+			<IconButton
+				Icon={Brush}
+				label="Brush"
+				highlight={tool === "brush"}
+				onclick={() => (tool = "brush")}
+			/>
+			<IconButton
+				Icon={Erase}
+				label="Eraser"
+				highlight={tool === "eraser"}
+				onclick={() => (tool = "eraser")}
+			/>
+			<input
+				type="range"
+				min="4"
+				max="80"
+				bind:value={brush_size}
+				aria-label="Brush size"
+			/>
+			<IconButton
+				Icon={Undo}
+				label="Undo"
+				disabled={undo_stack.length === 0}
+				onclick={undo}
+			/>
+			<IconButton
+				Icon={Redo}
+				label="Redo"
+				disabled={redo_stack.length === 0}
+				onclick={redo}
+			/>
+			<IconButton Icon={Trash} label="Clear" onclick={clear} />
+		</div>
+	{/if}
+</div>
+
+<style>
+	.mask-wrapper {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		pointer-events: none;
+	}
+	.mask-wrapper.active {
+		pointer-events: all;
+	}
+	.mask-canvas {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		pointer-events: none;
+	}
+	.mask-wrapper.active .mask-canvas {
+		pointer-events: auto;
+	}
+	.toolbar {
+		position: absolute;
+		bottom: var(--size-4);
+		left: 50%;
+		transform: translateX(-50%);
+		display: flex;
+		align-items: center;
+		gap: var(--size-1);
+		background: var(--block-background-fill);
+		border: 1px solid var(--border-color-primary);
+		border-radius: var(--radius-md);
+		padding: var(--size-1) var(--size-2);
+		box-shadow: var(--shadow-drop);
+		z-index: var(--layer-top);
+	}
+	input[type="range"] {
+		width: var(--size-20);
+	}
+</style>

--- a/js/videoeditor/shared/MaskCanvas.test.ts
+++ b/js/videoeditor/shared/MaskCanvas.test.ts
@@ -1,0 +1,163 @@
+import { describe, test, expect, afterEach } from "vitest";
+import { tick, mount, unmount } from "svelte";
+import MaskCanvas from "./MaskCanvas.svelte";
+
+const mounted: { component: any; target: HTMLElement }[] = [];
+
+function render_mask(props: {
+	width?: number;
+	height?: number;
+	active?: boolean;
+	brush_color?: string;
+	brush_size?: number;
+}): {
+	component: any;
+	canvas: HTMLCanvasElement;
+	target: HTMLElement;
+} {
+	const target = document.body.appendChild(document.createElement("div"));
+	const component = mount(MaskCanvas, {
+		target,
+		props: {
+			width: 100,
+			height: 100,
+			active: true,
+			brush_color: "rgba(255, 0, 0, 0.5)",
+			brush_size: 20,
+			...props
+		}
+	}) as any;
+	mounted.push({ component, target });
+	const canvas = target.querySelector("canvas") as HTMLCanvasElement;
+	return { component, canvas, target };
+}
+
+afterEach(() => {
+	while (mounted.length) {
+		const { component, target } = mounted.pop()!;
+		unmount(component);
+		target.remove();
+	}
+});
+
+describe("MaskCanvas", () => {
+	test("renders a canvas with the given dimensions", async () => {
+		const { canvas } = render_mask({ width: 200, height: 150 });
+		await tick();
+		expect(canvas).toBeTruthy();
+		expect(canvas.width).toBe(200);
+		expect(canvas.height).toBe(150);
+	});
+
+	test("shows the toolbar only when active=true", async () => {
+		const { target } = render_mask({ active: true });
+		await tick();
+		expect(target.querySelector(".toolbar")).not.toBeNull();
+	});
+
+	test("hides the toolbar when active=false", async () => {
+		const { target } = render_mask({ active: false });
+		await tick();
+		expect(target.querySelector(".toolbar")).toBeNull();
+	});
+});
+
+describe("is_empty / clear", () => {
+	test("is_empty() returns true on a fresh canvas", async () => {
+		const { component } = render_mask({});
+		await tick();
+		expect(component.is_empty()).toBe(true);
+	});
+
+	test("is_empty() returns false after manually painting on the canvas", async () => {
+		const { component, canvas } = render_mask({});
+		await tick();
+		const ctx = canvas.getContext("2d")!;
+		ctx.fillStyle = "rgba(255, 0, 0, 1)";
+		ctx.fillRect(10, 10, 30, 30);
+		expect(component.is_empty()).toBe(false);
+	});
+
+	test("clear() empties a painted canvas", async () => {
+		const { component, canvas } = render_mask({});
+		await tick();
+		const ctx = canvas.getContext("2d")!;
+		ctx.fillStyle = "rgba(0, 0, 255, 1)";
+		ctx.fillRect(0, 0, 50, 50);
+		expect(component.is_empty()).toBe(false);
+		component.clear();
+		expect(component.is_empty()).toBe(true);
+	});
+});
+
+describe("get_blob", () => {
+	test("get_blob() returns a PNG Blob from the canvas", async () => {
+		const { component, canvas } = render_mask({});
+		await tick();
+		const ctx = canvas.getContext("2d")!;
+		ctx.fillStyle = "rgba(255, 0, 0, 1)";
+		ctx.fillRect(0, 0, 10, 10);
+		const blob = await component.get_blob();
+		expect(blob).toBeInstanceOf(Blob);
+		expect(blob.type).toBe("image/png");
+	});
+});
+
+describe("undo / redo", () => {
+	test("undo() and redo() are exposed and don't throw on empty stacks", async () => {
+		const { component } = render_mask({});
+		await tick();
+		expect(() => component.undo()).not.toThrow();
+		expect(() => component.redo()).not.toThrow();
+	});
+
+	function draw_dot(canvas: HTMLCanvasElement): void {
+		const rect = canvas.getBoundingClientRect();
+		canvas.dispatchEvent(
+			new MouseEvent("mousedown", {
+				bubbles: true,
+				clientX: rect.left + 20,
+				clientY: rect.top + 20
+			})
+		);
+		canvas.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+	}
+
+	test("undo() reverts a draw stroke", async () => {
+		const { component, canvas } = render_mask({});
+		await tick();
+		draw_dot(canvas);
+		await tick();
+
+		expect(component.is_empty()).toBe(false);
+		component.undo();
+		expect(component.is_empty()).toBe(true);
+	});
+
+	test("redo() reapplies an undone stroke", async () => {
+		const { component, canvas } = render_mask({});
+		await tick();
+		draw_dot(canvas);
+		await tick();
+
+		component.undo();
+		expect(component.is_empty()).toBe(true);
+		component.redo();
+		expect(component.is_empty()).toBe(false);
+	});
+
+	test("clear() is undoable", async () => {
+		const { component, canvas } = render_mask({});
+		await tick();
+		const ctx = canvas.getContext("2d")!;
+		ctx.fillStyle = "rgba(255, 0, 0, 1)";
+		ctx.fillRect(0, 0, 30, 30);
+		expect(component.is_empty()).toBe(false);
+
+		component.clear();
+		expect(component.is_empty()).toBe(true);
+
+		component.undo();
+		expect(component.is_empty()).toBe(false);
+	});
+});

--- a/js/videoeditor/shared/VideoEditor.svelte
+++ b/js/videoeditor/shared/VideoEditor.svelte
@@ -119,8 +119,6 @@
 	.video-player {
 		width: 100%;
 		display: block;
-		max-height: 480px;
-		object-fit: contain;
 		background: var(--block-background-fill);
 	}
 	.controls-bar {

--- a/js/videoeditor/shared/VideoEditor.svelte
+++ b/js/videoeditor/shared/VideoEditor.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+	import { IconButton } from "@gradio/atoms";
+	import { Brush, Clear } from "@gradio/icons";
+	import MaskCanvas from "./MaskCanvas.svelte";
+
+	interface Props {
+		src?: string | null;
+		brush_color?: string;
+		brush_size?: number;
+		interactive?: boolean;
+		onerror?: (message: string) => void;
+	}
+
+	let {
+		src = null,
+		brush_color = "rgba(255, 0, 0, 0.5)",
+		brush_size = 20,
+		interactive = true,
+		onerror
+	}: Props = $props();
+
+	let mask_canvas: MaskCanvas;
+	let drawing_mode = $state(false);
+	let video_el: HTMLVideoElement;
+	let canvas_width = $state(0);
+	let canvas_height = $state(0);
+	let error_message = $state<string | null>(null);
+
+	function update_canvas_size(): void {
+		error_message = null;
+		if (video_el.videoWidth && video_el.videoHeight) {
+			canvas_width = video_el.videoWidth;
+			canvas_height = video_el.videoHeight;
+		}
+	}
+
+	function get_supported_formats(): string[] {
+		const candidates = [
+			{ label: "MP4", mime: "video/mp4" },
+			{ label: "WebM", mime: "video/webm" },
+			{ label: "OGG", mime: "video/ogg" }
+		];
+		return candidates
+			.filter(({ mime }) => video_el.canPlayType(mime) !== "")
+			.map(({ label }) => label);
+	}
+
+	function handle_video_error(): void {
+		const supported = get_supported_formats();
+		error_message = supported.length
+			? `This video cannot be played in the browser. Supported formats: ${supported.join(", ")}.`
+			: "This video cannot be played in the browser.";
+		onerror?.(error_message);
+	}
+
+	export async function get_mask_blob(): Promise<Blob | null> {
+		if (!mask_canvas || mask_canvas.is_empty()) return null;
+		return await mask_canvas.get_blob();
+	}
+
+	export function clear_mask(): void {
+		mask_canvas?.clear();
+		drawing_mode = false;
+	}
+</script>
+
+<div class="video-editor-wrap">
+	{#if src}
+		<div class="player-wrap">
+			<!-- svelte-ignore a11y_media_has_caption -->
+			<video
+				bind:this={video_el}
+				{src}
+				controls
+				onloadedmetadata={update_canvas_size}
+				onerror={handle_video_error}
+				class="video-player"
+			></video>
+			{#if error_message}
+				<div class="load-error" role="alert">{error_message}</div>
+			{:else if interactive}
+				<MaskCanvas
+					bind:this={mask_canvas}
+					width={canvas_width}
+					height={canvas_height}
+					{brush_color}
+					{brush_size}
+					active={drawing_mode}
+				/>
+			{/if}
+		</div>
+
+		{#if interactive}
+			<div class="controls-bar">
+				<IconButton
+					Icon={Brush}
+					label={drawing_mode ? "Drawing" : "Draw mask"}
+					highlight={drawing_mode}
+					onclick={() => (drawing_mode = !drawing_mode)}
+				/>
+				<IconButton Icon={Clear} label="Clear mask" onclick={clear_mask} />
+			</div>
+		{/if}
+	{:else}
+		<div class="empty">Upload a video to start</div>
+	{/if}
+</div>
+
+<style>
+	.video-editor-wrap {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+	}
+	.player-wrap {
+		position: relative;
+		width: 100%;
+	}
+	.video-player {
+		width: 100%;
+		display: block;
+		max-height: 480px;
+		object-fit: contain;
+		background: var(--block-background-fill);
+	}
+	.controls-bar {
+		display: flex;
+		gap: var(--size-1);
+		padding: var(--size-2);
+		background: var(--background-fill-secondary);
+		border-top: 1px solid var(--border-color-primary);
+	}
+	.empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: var(--size-40);
+		color: var(--body-text-color-subdued);
+	}
+	.load-error {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: var(--size-4);
+		background: var(--error-background-fill);
+		color: var(--error-text-color);
+		text-align: center;
+	}
+</style>

--- a/js/videoeditor/types.ts
+++ b/js/videoeditor/types.ts
@@ -1,0 +1,21 @@
+import type { FileData } from "@gradio/client";
+import type { LoadingStatus } from "@gradio/statustracker";
+
+export interface VideoEditorData {
+	video: FileData;
+	mask?: FileData | null;
+}
+
+export interface VideoEditorProps {
+	value: VideoEditorData | null;
+	brush_color: string;
+	brush_size: number;
+	height: number | string | undefined;
+}
+
+export interface VideoEditorEvents {
+	change: never;
+	upload: never;
+	clear: never;
+	clear_status: LoadingStatus;
+}

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
 		"@gradio/uploadbutton": "workspace:^",
 		"@gradio/vibeeditor": "workspace:^",
 		"@gradio/video": "workspace:^",
+		"@gradio/videoeditor": "workspace:^",
 		"@storybook/addon-a11y": "^10.1.11",
 		"@storybook/addon-docs": "^10.1.11",
 		"@storybook/addon-svelte-csf": "^5.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,9 @@ importers:
       '@gradio/video':
         specifier: workspace:^
         version: link:js/video
+      '@gradio/videoeditor':
+        specifier: workspace:^
+        version: link:js/videoeditor
       '@storybook/addon-a11y':
         specifier: ^10.1.11
         version: 10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
@@ -1186,6 +1189,9 @@ importers:
       '@gradio/video':
         specifier: workspace:^
         version: link:../video
+      '@gradio/videoeditor':
+        specifier: workspace:^
+        version: link:../videoeditor
 
   js/dataframe:
     dependencies:
@@ -2523,9 +2529,6 @@ importers:
       '@gradio/utils':
         specifier: workspace:^
         version: link:../utils
-      '@gradio/video':
-        specifier: workspace:^
-        version: link:../video
       svelte:
         specifier: ^5.48.0
         version: 5.48.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2503,6 +2503,37 @@ importers:
         specifier: workspace:^
         version: link:../preview
 
+  js/videoeditor:
+    dependencies:
+      '@gradio/atoms':
+        specifier: workspace:^
+        version: link:../atoms
+      '@gradio/client':
+        specifier: workspace:^
+        version: link:../../client/js
+      '@gradio/icons':
+        specifier: workspace:^
+        version: link:../icons
+      '@gradio/statustracker':
+        specifier: workspace:^
+        version: link:../statustracker
+      '@gradio/upload':
+        specifier: workspace:^
+        version: link:../upload
+      '@gradio/utils':
+        specifier: workspace:^
+        version: link:../utils
+      '@gradio/video':
+        specifier: workspace:^
+        version: link:../video
+      svelte:
+        specifier: ^5.48.0
+        version: 5.48.0
+    devDependencies:
+      '@gradio/preview':
+        specifier: workspace:^
+        version: link:../preview
+
 packages:
 
   '@acemir/cssom@0.9.31':

--- a/test/components/test_video_editor.py
+++ b/test/components/test_video_editor.py
@@ -1,0 +1,150 @@
+from pathlib import Path
+
+import numpy as np
+import PIL.Image
+import pytest
+
+from gradio.components.video_editor import VideoEditor, VideoEditorData
+from gradio.data_classes import FileData
+from gradio.exceptions import Error
+
+
+VIDEO_PATH = "test/test_files/playable_but_bad_container.mp4"
+MASK_PNG = "test/test_files/bus.png"
+
+
+class TestVideoEditor:
+    def test_data_model_video_required(self):
+        data = VideoEditorData(video=FileData(path="video.mp4"))
+        assert data.video.path == "video.mp4"
+        assert data.mask is None
+
+    def test_data_model_with_mask(self):
+        data = VideoEditorData(
+            video=FileData(path="video.mp4"),
+            mask=FileData(path="mask.png"),
+        )
+        assert data.mask is not None
+        assert data.mask.path == "mask.png"
+
+    def test_default_init(self):
+        comp = VideoEditor()
+        assert comp.brush_color == "rgba(255, 0, 0, 0.5)"
+        assert comp.brush_size == 20
+        assert comp.height is None
+        assert comp.sources == ["upload"]
+
+    def test_custom_brush(self):
+        comp = VideoEditor(brush_color="rgba(0,255,0,0.8)", brush_size=40)
+        assert comp.brush_color == "rgba(0,255,0,0.8)"
+        assert comp.brush_size == 40
+
+    def test_events(self):
+        comp = VideoEditor()
+        event_names = [e.event_name for e in comp.EVENTS]
+        assert event_names == ["change", "upload", "clear"]
+
+    def test_get_config(self):
+        comp = VideoEditor(brush_color="rgba(0,0,255,1)", brush_size=15, height=480)
+        config = comp.get_config()
+        assert config["brush_color"] == "rgba(0,0,255,1)"
+        assert config["brush_size"] == 15
+        assert config["height"] == 480
+        assert config["name"] == "videoeditor"
+
+    def test_preprocess_none(self):
+        assert VideoEditor().preprocess(None) is None
+
+    def test_preprocess_video_only(self):
+        result = VideoEditor().preprocess(
+            VideoEditorData(video=FileData(path=VIDEO_PATH))
+        )
+        assert result == {"video": VIDEO_PATH, "mask": None}
+
+    def test_preprocess_video_with_mask(self):
+        payload = VideoEditorData(
+            video=FileData(path=VIDEO_PATH),
+            mask=FileData(path=MASK_PNG),
+        )
+        result = VideoEditor().preprocess(payload)
+        assert result["video"] == VIDEO_PATH
+        assert isinstance(result["mask"], np.ndarray)
+        assert result["mask"].shape[2] == 4  # RGBA
+
+    def test_preprocess_invalid_mask_file_raises_error(self, tmp_path):
+        bad_mask = tmp_path / "not_an_image.png"
+        bad_mask.write_bytes(b"this is not a PNG")
+        payload = VideoEditorData(
+            video=FileData(path=VIDEO_PATH),
+            mask=FileData(path=str(bad_mask)),
+        )
+        with pytest.raises(Error, match="Could not read mask image"):
+            VideoEditor().preprocess(payload)
+
+    def test_preprocess_missing_mask_file_raises_error(self):
+        payload = VideoEditorData(
+            video=FileData(path=VIDEO_PATH),
+            mask=FileData(path="/nonexistent/path/mask.png"),
+        )
+        with pytest.raises(Error, match="Could not read mask image"):
+            VideoEditor().preprocess(payload)
+
+    def test_postprocess_none(self):
+        assert VideoEditor().postprocess(None) is None
+
+    def test_postprocess_string_path(self):
+        result = VideoEditor().postprocess(VIDEO_PATH)
+        assert isinstance(result, VideoEditorData)
+        assert result.video.path == VIDEO_PATH
+        assert result.mask is None
+
+    def test_postprocess_path_object(self):
+        result = VideoEditor().postprocess(Path(VIDEO_PATH))
+        assert result.video.path == VIDEO_PATH
+
+    def test_postprocess_dict_video_only(self):
+        result = VideoEditor().postprocess({"video": VIDEO_PATH})
+        assert result.video.path == VIDEO_PATH
+        assert result.mask is None
+
+    def test_postprocess_dict_missing_video(self):
+        assert VideoEditor().postprocess({"video": None}) is None
+
+    def test_postprocess_numpy_mask(self):
+        mask = np.zeros((100, 100, 4), dtype=np.uint8)
+        mask[40:60, 40:60] = [255, 0, 0, 180]
+        result = VideoEditor().postprocess({"video": VIDEO_PATH, "mask": mask})
+        assert result.mask is not None
+        assert result.mask.path.endswith(".png")
+
+    def test_postprocess_pil_mask(self):
+        img = PIL.Image.fromarray(np.zeros((50, 50, 4), dtype=np.uint8), "RGBA")
+        result = VideoEditor().postprocess({"video": VIDEO_PATH, "mask": img})
+        assert result.mask.path.endswith(".png")
+
+    def test_postprocess_path_mask_is_reused(self):
+        result = VideoEditor().postprocess(
+            {"video": VIDEO_PATH, "mask": MASK_PNG}
+        )
+        assert result.mask.path == MASK_PNG
+
+    def test_roundtrip(self):
+        comp = VideoEditor()
+        mask = np.zeros((100, 200, 4), dtype=np.uint8)
+        mask[20:80, 50:150] = [255, 0, 0, 255]
+        post = comp.postprocess({"video": VIDEO_PATH, "mask": mask})
+        pre = comp.preprocess(post)
+        assert pre["video"] == VIDEO_PATH
+        assert isinstance(pre["mask"], np.ndarray)
+        assert pre["mask"].shape[2] == 4
+
+    def test_example_payload(self):
+        payload = VideoEditor().example_payload()
+        assert isinstance(payload["video"], dict)
+        assert payload["video"].get("meta", {}).get("_type") == "gradio.FileData"
+        assert payload["mask"] is None
+
+    def test_example_value(self):
+        value = VideoEditor().example_value()
+        assert isinstance(value["video"], str)
+        assert value["mask"] is None


### PR DESCRIPTION
## Description

Adds a new `gr.VideoEditor` component for drawing masks on a video frame,
as requested in #8404. Mirrors `gr.ImageEditor` but for video input.

The user uploads a video and draws a mask on top of the displayed frame
using brush, eraser, undo/redo and clear tools. The backend receives the
video path and the drawn mask as a PNG (numpy RGBA array).

Closes: #8404 

## AI Disclosure

- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Closes: #8404 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive component with standard file upload and image mask handling; no changes to auth, security, or core request routing.
> 
> **Overview**
> Introduces **`gr.VideoEditor`**, a new input component for uploading a video and drawing a frame mask (brush, eraser, undo/redo, clear), modeled after image masking but for video.
> 
> The Python side adds `VideoEditor` / `VideoEditorData` with **`change`**, **`upload`**, and **`clear`** events; **`preprocess`** returns `{"video": path, "mask": RGBA numpy or None}` and **`postprocess`** accepts paths or dicts with numpy/PIL/path masks. The new **`@gradio/videoeditor`** UI uploads video, overlays a canvas on the current frame, and on submit uploads a PNG mask via an extended **`get_data`**. Wiring includes public exports, **`@gradio/core`** dependency, a **`video_editor_mask`** demo, and Python/JS tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 529148e445229a8bf5fd361c2c3edeca46441206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->