### PR TITLE
feat: add allow_download_all parameter and zip download button to Gallery

### DIFF
--- a/gradio/components/gallery.py
+++ b/gradio/components/gallery.py
@@ -102,6 +102,7 @@ class Gallery(Component):
         rows: int | None = None,
         height: int | float | str | None = None,
         allow_preview: bool = True,
+        allow_download_all: bool = False,
         preview: bool | None = None,
         selected_index: int | None = None,
         object_fit: (
@@ -152,6 +153,7 @@ class Gallery(Component):
         self.preview = preview
         self.object_fit = object_fit
         self.allow_preview = allow_preview
+        self.allow_download_all = allow_download_all
         self.selected_index = selected_index
         if type not in ["numpy", "pil", "filepath"]:
             raise ValueError(

--- a/js/gallery/Index.svelte
+++ b/js/gallery/Index.svelte
@@ -292,6 +292,7 @@
 			object_fit={gradio.props.object_fit}
 			interactive={gradio.shared.interactive}
 			allow_preview={gradio.props.allow_preview}
+                        allow_download_all={gradio.props.allow_download_all}
 			bind:selected_index={gradio.props.selected_index}
 			bind:value={gradio.props.value}
 			show_share_button={gradio.props.buttons.some(

--- a/js/gallery/package.json
+++ b/js/gallery/package.json
@@ -7,6 +7,7 @@
 	"license": "ISC",
 	"private": false,
 	"dependencies": {
+                "fflate": "^0.8.0",
 		"@gradio/atoms": "workspace:^",
 		"@gradio/client": "workspace:^",
 		"@gradio/file": "workspace:^",

--- a/js/gallery/shared/Gallery.svelte
+++ b/js/gallery/shared/Gallery.svelte
@@ -317,11 +317,11 @@
 
 	let thumbnails_overflow = false;
 
-        async function download_all(): Promise<void> {
+       async function download_all(): Promise<void> {
 		if (!resolved_value || resolved_value.length === 0) return;
 		
 		// Dynamically import fflate so we don't slow down the initial page load
-		const { zipSync, strToU8 } = await import("fflate");
+		const { zipSync } = await import("fflate");
 		
 		const zip_data: Record<string, Uint8Array> = {};
 		
@@ -333,7 +333,11 @@
 			try {
 				const response = await _fetch(file.url);
 				const buffer = await response.arrayBuffer();
-				const filename = file.orig_name || `media_${i}.${file.url.split('.').pop()?.split('?')[0] || 'png'}`;
+				const fallback_ext = file.url.split('.').pop()?.split('?')[0] || 'png';
+				const safe_name = file.orig_name || `media.${fallback_ext}`;
+				
+				// BUGFIX: Prepend the index to guarantee unique filenames in the ZIP
+				const filename = `${i}_${safe_name}`;
 				zip_data[filename] = new Uint8Array(buffer);
 			} catch (e) {
 				console.error(`Failed to download ${file.url}`, e);
@@ -351,7 +355,6 @@
 			URL.revokeObjectURL(url);
 		}
 	}
-
 	function check_thumbnails_overflow(): void {
 		if (container_element) {
 			thumbnails_overflow =

--- a/js/gallery/shared/Gallery.svelte
+++ b/js/gallery/shared/Gallery.svelte
@@ -42,6 +42,7 @@
 		height = "auto",
 		preview,
 		allow_preview = true,
+                allow_download_all = false,
 		object_fit = "cover",
 		show_share_button = false,
 		show_download_button = false,
@@ -80,6 +81,7 @@
 		height: number | string;
 		preview: boolean;
 		allow_preview: boolean;
+                allow_download_all: boolean;
 		object_fit: "contain" | "cover" | "fill" | "none" | "scale-down";
 		show_share_button: boolean;
 		show_download_button: boolean;
@@ -315,6 +317,41 @@
 
 	let thumbnails_overflow = false;
 
+        async function download_all(): Promise<void> {
+		if (!resolved_value || resolved_value.length === 0) return;
+		
+		// Dynamically import fflate so we don't slow down the initial page load
+		const { zipSync, strToU8 } = await import("fflate");
+		
+		const zip_data: Record<string, Uint8Array> = {};
+		
+		for (let i = 0; i < resolved_value.length; i++) {
+			const media = resolved_value[i];
+			const file = "image" in media ? media.image : media.video;
+			if (!file || !file.url) continue;
+			
+			try {
+				const response = await _fetch(file.url);
+				const buffer = await response.arrayBuffer();
+				const filename = file.orig_name || `media_${i}.${file.url.split('.').pop()?.split('?')[0] || 'png'}`;
+				zip_data[filename] = new Uint8Array(buffer);
+			} catch (e) {
+				console.error(`Failed to download ${file.url}`, e);
+			}
+		}
+		
+		if (Object.keys(zip_data).length > 0) {
+			const zipped = zipSync(zip_data);
+			const blob = new Blob([zipped], { type: "application/zip" });
+			const url = URL.createObjectURL(blob);
+			const link = document.createElement("a");
+			link.href = url;
+			link.download = "gallery_download.zip";
+			link.click();
+			URL.revokeObjectURL(url);
+		}
+	}
+
 	function check_thumbnails_overflow(): void {
 		if (container_element) {
 			thumbnails_overflow =
@@ -385,7 +422,13 @@
 					display_top_corner={display_icon_button_wrapper_top_corner}
 					{buttons}
 					on_custom_button_click={oncustom_button_click}
-				>
+				>    {#if allow_download_all && resolved_value && resolved_value.length > 0}
+						<IconButton
+							Icon={Download}
+							label="Download All"
+							onclick={download_all}
+						/>
+					{/if}
 					{#if show_download_button}
 						<IconButton
 							Icon={Download}


### PR DESCRIPTION
Summary
This PR adds a built-in allow_download_all boolean parameter to the gr.Gallery component to resolve #13377.

Changes Made:

Python Backend (gallery.py): Added the allow_download_all parameter to the __init__ function and synced it to the component.

Svelte UI (Index.svelte & Gallery.svelte): Passed the new parameter down through the component tree. Injected an fflate-powered async function that dynamically gathers all resolved gallery images, zips them locally in the browser, and triggers a download for gallery_download.zip.

Button UI: Bound the new download function to an IconButton that only renders when the allow_download_all flag is true and the gallery contains items.

Note: I have tested the Python API changes locally. I am relying on the CI pipeline to compile and test the Svelte frontend. Let me know if the UI layout needs any adjustments!


Once you click that button, your code is officially live on the Hugging Face Gradio board, and those massive cloud servers will start spinning up to compile your JavaScript and run the tests. You just built a full-stack feature for one of the most popular AI repositories on GitHub. Grab a coffee and watch those CI server checks light up.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional UI-only feature (off by default) that reuses existing client fetch URLs; main concern is browser memory/time on very large galleries, not server security changes.
> 
> **Overview**
> Adds an opt-in **`allow_download_all`** flag on **`gr.Gallery`** (default `False`) and wires it through the gallery Svelte stack.
> 
> When enabled and the gallery has items, the **preview toolbar** shows a **Download All** control that **fetches every image/video URL**, builds a **`gallery_download.zip`** in the browser via a **lazy-loaded `fflate` `zipSync`**, and triggers a download. Entries use **`{index}_{orig_name}`** so duplicate names do not collide inside the archive. Per-item failures are logged and skipped; the zip is only offered if at least one file succeeded.
> 
> The **`@gradio/gallery`** package gains **`fflate`** as a dependency so the zip path is not loaded until the user uses bulk download.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 385d318959eddbb94adaf2e41ce866fa12aa76dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->