### PR TITLE
Image editor test

### DIFF
--- a/js/spa/test/image_editor_layers.spec.ts
+++ b/js/spa/test/image_editor_layers.spec.ts
@@ -10,6 +10,10 @@ test.fixme("ImageEditor layers are properly set", async ({ page }) => {
 test("Clicking on examples should properly run the function", async ({
 	page
 }) => {
-	await page.locator(".gallery > .gallery-item").first().click();
+	const examples = page.locator(".gallery > .gallery-item");
+	await expect(examples).toHaveCount(2);
+	const local_example = examples.nth(1);
+	await expect(local_example).toBeVisible();
+	await local_example.click();
 	await expect(page.getByLabel("Example Ran")).toHaveValue("1");
 });


### PR DESCRIPTION
## Description

Fixes failing image editor test. The test now clicks the local second example instead of the first remote URL example, and waits for the gallery examples to be present/visible before clicking.

Closes: #(issue)

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to Playwright selectors and waits; no production code paths affected.
> 
> **Overview**
> Stabilizes the **ImageEditor** Playwright example-click test in `image_editor_layers.spec.ts` by targeting the **second** gallery item (local example) instead of the first (remote URL), and by asserting the gallery has two items and the chosen item is visible before clicking.
> 
> The flow still expects **Example Ran** to become `1` after the click; only the selector and readiness checks changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df9a17847851cea456990a1f579993dc7843ccf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->