### PR TITLE
Clarify that the share link's 1 week expiration is best-effort (#13398)

### DIFF
--- a/.changeset/quick-share-best-effort.md
+++ b/.changeset/quick-share-best-effort.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Clarify that the share link's 1 week expiration is best-effort (#13398)

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -3018,7 +3018,7 @@ Received inputs:
                 print(f"* Running on public URL: {self.share_url}")
                 if not (quiet):
                     print(
-                        "\nThis share link expires in 1 week. For free permanent hosting and GPU upgrades, run `gradio deploy` from the terminal in the working directory to deploy to Hugging Face Spaces (https://huggingface.co/spaces)"
+                        "\nThis share link is set to expire in 1 week, but this is best-effort and not guaranteed; the link may become unavailable sooner. For free permanent hosting and GPU upgrades, run `gradio deploy` from the terminal in the working directory to deploy to Hugging Face Spaces (https://huggingface.co/spaces)"
                     )
             except Exception as e:
                 if self.analytics_enabled:


### PR DESCRIPTION
## Description

Closes #13398.

The launch message printed when `share=True` stated that the share link "expires in 1 week", which reads like a hard guarantee. As reported in #13398, share links can become unavailable sooner (for example during outages), so the 1-week mark is best-effort rather than guaranteed. This PR rewords the message to set the right expectation:

> This share link is set to expire in 1 week, but this is best-effort and not guaranteed; the link may become unavailable sooner. For free permanent hosting and GPU upgrades, run `gradio deploy` ...

No tests reference this string, so only the message in `gradio/blocks.py` and a changeset were changed.

## AI Disclosure

- [x] I used AI to: find this issue, reword the share link message in `gradio/blocks.py`, and add the changeset. I reviewed the change myself.
- [ ] I did not use AI
