### PR TITLE
Ssr node port

### DIFF
--- a/.changeset/ssr-defer-node-listen.md
+++ b/.changeset/ssr-defer-node-listen.md
@@ -1,0 +1,11 @@
+---
+"gradio": patch
+---
+
+fix:Defer Node front proxy startup until Python is ready in SSR mode
+
+The Node front proxy (introduced in #13366) opened the user-facing port
+before the Python backend was listening. External orchestrators such as
+HF Spaces probe the port to detect readiness and routed traffic into a
+window where every request returned a 502. Node is now started after
+Python (and any static workers) are up.

--- a/.changeset/ssr-defer-node-listen.md
+++ b/.changeset/ssr-defer-node-listen.md
@@ -3,9 +3,3 @@
 ---
 
 fix:Defer Node front proxy startup until Python is ready in SSR mode
-
-The Node front proxy (introduced in #13366) opened the user-facing port
-before the Python backend was listening. External orchestrators such as
-HF Spaces probe the port to detect readiness and routed traffic into a
-window where every request returned a 502. Node is now started after
-Python (and any static workers) are up.

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2755,6 +2755,12 @@ Received inputs:
 
         self._node_is_proxy = False
         static_worker_ports: list[int] = []
+        # Stashed kwargs for the deferred production Node proxy start.
+        # When set, the user-facing Node front proxy is started after
+        # Python (and any static workers) are listening — see the
+        # `if _pending_node_proxy_kwargs is not None:` block further
+        # down for the rationale.
+        _pending_node_proxy_kwargs: dict | None = None
 
         if self.ssr_mode:
             self.node_path = os.environ.get("GRADIO_NODE_PATH", get_node_path())
@@ -2771,10 +2777,14 @@ Received inputs:
                         debug=debug,
                     )
                 )
-            else:
-                # Production: Node is the front proxy on the user-facing port.
-                # Python moves to an internal port after Node.
-                # Workers get ports after Python.
+            elif self.node_path:
+                # Production: Node will be the front proxy on the user-facing
+                # port and Python will be on an internal port behind it.
+                # We DEFER actually starting Node until after Python (and any
+                # static workers) are listening — otherwise the user-facing
+                # port opens before the proxy's targets exist, and any
+                # traffic that arrives during the startup window receives a
+                # 502 from the proxy (observed on HF Spaces after #13366).
                 from gradio.http_server import INITIAL_PORT_VALUE, TRY_NUM_PORTS
 
                 user_port = server_port or int(
@@ -2784,39 +2794,41 @@ Received inputs:
                     "GRADIO_SERVER_NAME", "127.0.0.1"
                 )
 
-                # Find a free port for Python starting after the user-facing port.
-                # We need to know Python's port before starting Node so Node
-                # can proxy to it.
+                # Reserve a free internal port for Python; Node will proxy
+                # non-static traffic here once it starts.
                 python_internal_port = _find_free_port(
                     python_host, start=user_port + 1, try_count=TRY_NUM_PORTS
                 )
 
-                # Pre-compute static worker ports
                 if resolved_num_workers is not None and resolved_num_workers >= 1:
                     worker_start = python_internal_port + 1
                     static_worker_ports = [
                         worker_start + i for i in range(resolved_num_workers)
                     ]
 
-                self.node_server_name, self.node_process, self.node_port = (
-                    start_node_server(
-                        server_name=node_server_name or python_host,
-                        server_port=node_port or user_port,
-                        node_path=self.node_path,
-                        python_port=python_internal_port,
-                        python_host=python_host,
-                        static_worker_ports=static_worker_ports,
-                        debug=debug,
-                    )
-                )
-                # Only use the proxy architecture if Node actually started
-                if self.node_process is not None and self.node_port is not None:
-                    server_port = python_internal_port
-                    self._node_is_proxy = True
-                else:
-                    # Node failed to start — fall back to Python as the
-                    # front server on the original user port.
-                    static_worker_ports = []
+                # Commit Python to the internal port now (so it can bind
+                # without contending with the user-facing port) and stash
+                # the Node start kwargs for later. We also commit to proxy
+                # mode here; if Node ultimately fails to start, Python is
+                # left listening on the internal port — a degraded but
+                # working state we surface via a warning below.
+                server_port = python_internal_port
+                _pending_node_proxy_kwargs = {
+                    "server_name": node_server_name or python_host,
+                    "server_port": node_port or user_port,
+                    "node_path": self.node_path,
+                    "python_port": python_internal_port,
+                    "python_host": python_host,
+                    "static_worker_ports": static_worker_ports,
+                    "debug": debug,
+                }
+                self.node_server_name = self.node_port = self.node_process = None
+            else:
+                # SSR was requested but Node isn't available; fall through to
+                # the Python-only path (matches the original behaviour when
+                # start_node_server returned None).
+                static_worker_ports = []
+                self.node_server_name = self.node_port = self.node_process = None
         else:
             self.node_server_name = self.node_port = self.node_process = None
 
@@ -2877,31 +2889,11 @@ Received inputs:
             if self.mcp_server_obj:
                 self.mcp_server_obj._local_url = self.local_url
 
-            # When Node is the front proxy, the user-facing URL is the Node port
-            if self._node_is_proxy and self.node_port is not None:
-                url_host = (
-                    "localhost" if self.server_name == "0.0.0.0" else self.server_name
-                )
-                self.local_url = f"http://{url_host}:{self.node_port}/"
-                self.local_api_url = f"{self.local_url.rstrip('/')}{API_PREFIX}/"
-
             self.protocol = (
                 "https"
                 if self.local_url.startswith("https") or self.is_colab
                 else "http"
             )
-            if not self.is_colab and not quiet:
-                if self._node_is_proxy and self.node_port is not None:
-                    print(
-                        f"* Running on local URL:  {self.protocol}://{self.server_name}:{self.node_port}, with SSR ⚡ (Node proxy -> Python :{self.server_port})"
-                    )
-                elif self.ssr_mode:
-                    print(
-                        f"* Running on local URL:  {self.protocol}://{self.server_name}:{self.server_port}, with SSR ⚡ (dev mode)"
-                    )
-                else:
-                    s = "* Running on local URL:  {}://{}:{}"
-                    print(s.format(self.protocol, self.server_name, self.server_port))
 
             self._queue.set_server_app(self.server_app)
 
@@ -2944,6 +2936,47 @@ Received inputs:
                     print(
                         f"* Static file workers: {resolved_num_workers} processes on ports {self._static_worker_pool.ports}"
                     )
+
+            # Now that Python (and any static workers) are listening,
+            # start the Node front proxy. Opening the user-facing port
+            # here — rather than before Python is up — closes the race
+            # window in which the proxy port was reachable but every
+            # request resolved to a 502 from an unreachable upstream.
+            if _pending_node_proxy_kwargs is not None:
+                self.node_server_name, self.node_process, self.node_port = (
+                    start_node_server(**_pending_node_proxy_kwargs)
+                )
+                if self.node_process is not None and self.node_port is not None:
+                    self._node_is_proxy = True
+                    url_host = (
+                        "localhost"
+                        if self.server_name == "0.0.0.0"
+                        else self.server_name
+                    )
+                    self.local_url = f"http://{url_host}:{self.node_port}/"
+                    self.local_api_url = f"{self.local_url.rstrip('/')}{API_PREFIX}/"
+                    if self.mcp_server_obj:
+                        self.mcp_server_obj._local_url = self.local_url
+                elif not quiet:
+                    warnings.warn(
+                        "Failed to start Node front proxy for SSR; Gradio is "
+                        f"reachable directly on the internal Python port "
+                        f":{self.server_port}. Check the Node installation "
+                        "or set GRADIO_NODE_PATH."
+                    )
+
+            if not self.is_colab and not quiet:
+                if self._node_is_proxy and self.node_port is not None:
+                    print(
+                        f"* Running on local URL:  {self.protocol}://{self.server_name}:{self.node_port}, with SSR ⚡ (Node proxy -> Python :{self.server_port})"
+                    )
+                elif self.ssr_mode:
+                    print(
+                        f"* Running on local URL:  {self.protocol}://{self.server_name}:{self.server_port}, with SSR ⚡ (dev mode)"
+                    )
+                else:
+                    s = "* Running on local URL:  {}://{}:{}"
+                    print(s.format(self.protocol, self.server_name, self.server_port))
 
             resp = httpx.get(
                 f"{self.local_api_url}startup-events",

--- a/test/test_node_proxy.py
+++ b/test/test_node_proxy.py
@@ -1,5 +1,6 @@
 """Tests for the Node-as-proxy architecture and static worker routing."""
 
+import shutil
 from pathlib import Path
 
 import httpx
@@ -190,3 +191,161 @@ class TestStaticWorkerPool:
                 assert Path(resp.json()[0]).exists()
         finally:
             pool.shutdown()
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node not installed")
+class TestNodeProxyStartupOrdering:
+    """Regression coverage for a race where the Node front proxy began
+    accepting connections on the user-facing port before the Python
+    backend was ready, causing 502 errors on hosts like HF Spaces that
+    route traffic as soon as the port opens."""
+
+    def _cleanup(self, demo):
+        node_process = getattr(demo, "node_process", None)
+        if node_process is not None:
+            node_process.terminate()
+            try:
+                node_process.wait(timeout=5)
+            except Exception:
+                node_process.kill()
+        try:
+            demo.close()
+        except Exception:
+            pass
+
+    def test_node_starts_after_python_is_listening(self, monkeypatch):
+        """When Node is the front proxy, ``start_node_server`` must be
+        invoked only after ``http_server.start_server`` returns (i.e.,
+        after Python's uvicorn instance is listening)."""
+        import gradio as gr
+        import gradio.blocks as blocks_mod
+        from gradio import http_server
+
+        events: list[str] = []
+        original_start_server = http_server.start_server
+        original_start_node = blocks_mod.start_node_server
+
+        def patched_start_server(*args, **kwargs):
+            events.append("python_start")
+            result = original_start_server(*args, **kwargs)
+            events.append("python_ready")
+            return result
+
+        def patched_start_node(*args, **kwargs):
+            events.append("node_start")
+            result = original_start_node(*args, **kwargs)
+            events.append("node_returned")
+            return result
+
+        monkeypatch.setattr(http_server, "start_server", patched_start_server)
+        monkeypatch.setattr(blocks_mod, "start_node_server", patched_start_node)
+
+        demo = gr.Interface(lambda x: x, "text", "text")
+        try:
+            demo.launch(
+                ssr_mode=True,
+                server_port=18860,
+                prevent_thread_lock=True,
+                quiet=True,
+            )
+            if not getattr(demo, "_node_is_proxy", False):
+                pytest.skip("Node proxy mode did not engage in this environment")
+
+            assert "python_ready" in events, (
+                f"http_server.start_server never ran. Events: {events}"
+            )
+            assert "node_start" in events, (
+                f"start_node_server never ran. Events: {events}"
+            )
+            python_ready_idx = events.index("python_ready")
+            node_start_idx = events.index("node_start")
+            assert python_ready_idx < node_start_idx, (
+                "Node front proxy was started before the Python backend "
+                "was listening. The Node port opens immediately when the "
+                "process binds, so clients hitting the port during this "
+                "window receive 502 errors from the proxy. "
+                f"Observed event order: {events}"
+            )
+        finally:
+            self._cleanup(demo)
+
+    def test_node_port_does_not_serve_502_during_python_startup(self, monkeypatch):
+        """Probe the user-facing Node port DURING the Python startup
+        window (achieved by injecting a delay into start_server). If the
+        proxy port becomes reachable before Python is up, the proxy
+        returns 502 for any request that arrives in that window — which
+        is exactly what HF Spaces saw."""
+        import socket
+        import threading
+        import time
+
+        import gradio as gr
+        from gradio import http_server
+
+        node_port = 18864
+        delay = 2.0
+        py_started = threading.Event()
+        original_start_server = http_server.start_server
+
+        def slow_start_server(*args, **kwargs):
+            time.sleep(delay)
+            result = original_start_server(*args, **kwargs)
+            py_started.set()
+            return result
+
+        monkeypatch.setattr(http_server, "start_server", slow_start_server)
+
+        race_observations: dict[str, object] = {}
+
+        def probe():
+            """Probe the Node port repeatedly until Python is ready.
+            Record the first 502 we see (the bug symptom)."""
+            stop_at = time.time() + delay + 5
+            while time.time() < stop_at and not py_started.is_set():
+                try:
+                    with socket.create_connection(
+                        ("127.0.0.1", node_port), timeout=0.1
+                    ):
+                        try:
+                            resp = httpx.get(
+                                f"http://127.0.0.1:{node_port}/config",
+                                timeout=0.5,
+                            )
+                            if (
+                                resp.status_code == 502
+                                and "first_502_at" not in race_observations
+                            ):
+                                race_observations["first_502_at"] = time.time()
+                                race_observations["python_ready_yet"] = (
+                                    py_started.is_set()
+                                )
+                                return
+                        except httpx.HTTPError:
+                            pass
+                except OSError:
+                    pass
+                time.sleep(0.02)
+
+        probe_thread = threading.Thread(target=probe, daemon=True)
+
+        demo = gr.Interface(lambda x: x, "text", "text")
+        try:
+            probe_thread.start()
+            demo.launch(
+                ssr_mode=True,
+                server_port=node_port,
+                prevent_thread_lock=True,
+                quiet=True,
+            )
+            if not getattr(demo, "_node_is_proxy", False):
+                pytest.skip("Node proxy mode did not engage in this environment")
+            probe_thread.join(timeout=delay + 5)
+
+            assert "first_502_at" not in race_observations, (
+                "Node proxy returned 502 to a client probe BEFORE Python "
+                "finished starting — the user-facing port was opened too "
+                "early. This is the race condition that produces 502s on "
+                "HF Spaces."
+            )
+        finally:
+            self._cleanup(demo)


### PR DESCRIPTION
## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reorders production SSR launch sequencing and user-facing URLs; behavior change is localized to SSR proxy mode but affects how failures and early requests are handled at startup.
> 
> **Overview**
> In **production SSR**, Gradio no longer starts the **Node front proxy** before the Python app is listening. `launch()` now reserves the internal Python port and stashes `start_node_server` kwargs, binds **uvicorn** (and any **static workers**) first, then opens the user-facing Node port so early traffic does not hit **502** upstream errors (e.g. on HF Spaces).
> 
> **Local URL** printing and **`local_url` / `local_api_url`** updates for proxy mode were moved to after Node actually starts; a **warning** is emitted if the proxy fails while Python remains on the internal port. **Node-missing** SSR falls through to Python-only behavior explicitly.
> 
> **Tests** (`TestNodeProxyStartupOrdering`) assert Node starts only after `http_server.start_server` completes and that probing during a delayed Python startup does not see **502** on the proxy port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa283cfc9ce4a52212bb47414128a19b0b93d47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->