### PR TITLE
fix: clarify share link availability is best-effort

### DIFF
--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -3051,7 +3051,7 @@ Received inputs:
                 print(f"* Running on public URL: {self.share_url}")
                 if not (quiet):
                     print(
-                        "\nThis share link's availability is best-effort and may expire earlier than 1 week. For free permanent hosting and GPU upgrades, run `gradio deploy` from the terminal in the working directory to deploy to Hugging Face Spaces (https://huggingface.co/spaces)"
+                        "\nThis share link is temporary and will last for up to 1 week (best effort). For free permanent hosting and GPU upgrades, run `gradio deploy` from the terminal in the working directory to deploy to Hugging Face Spaces (https://huggingface.co/spaces)"
                     )
             except Exception as e:
                 if self.analytics_enabled:

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -3051,7 +3051,7 @@ Received inputs:
                 print(f"* Running on public URL: {self.share_url}")
                 if not (quiet):
                     print(
-                        "\nThis share link expires in 1 week. For free permanent hosting and GPU upgrades, run `gradio deploy` from the terminal in the working directory to deploy to Hugging Face Spaces (https://huggingface.co/spaces)"
+                        "\nThis share link's availability is best-effort and may expire earlier than 1 week. For free permanent hosting and GPU upgrades, run `gradio deploy` from the terminal in the working directory to deploy to Hugging Face Spaces (https://huggingface.co/spaces)"
                     )
             except Exception as e:
                 if self.analytics_enabled:


### PR DESCRIPTION
## Description

The share link message currently states 'This share link expires in 1 week', but users have reported that links often expire much sooner (within hours). This creates a discrepancy between documented behavior and actual experience.

## Fix

Updated the share link message to indicate that availability is best-effort and may expire earlier than 1 week.

**Before:**
```
This share link expires in 1 week.
```

**After:**
```
This share link's availability is best-effort and may expire earlier than 1 week.
```

## Testing

- Syntax validation:  ✅

## Related Issue

Fixes #13398

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing string change only in the share-link success path; no tunnel, auth, or API behavior changes.
> 
> **Overview**
> Updates the console message printed after a successful `share=True` tunnel in `Blocks.launch()` so it no longer implies a fixed one-week lifetime.
> 
> The new copy states the public URL is **temporary**, may last **up to one week**, and is **best effort**—aligning user-facing text with reports that share links can stop working much sooner. The existing pointer to `gradio deploy` / Hugging Face Spaces for permanent hosting is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73affa4e536dfde864146510ad41ac04d4b4fbe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->