### PR TITLE
security: fix path traversal in FileExplorer.preprocess

### DIFF
--- a/gradio/components/file_explorer.py
+++ b/gradio/components/file_explorer.py
@@ -149,10 +149,10 @@ class FileExplorer(Component):
             elif len(payload.root) == 0:
                 return None
             else:
-                return os.path.normpath(os.path.join(self.root_dir, *payload.root[0]))
+                return self._safe_join(payload.root[0])
         files = []
         for file in payload.root:
-            file_ = os.path.normpath(os.path.join(self.root_dir, *file))
+            file_ = self._safe_join(file)
             files.append(file_)
         return files
 

--- a/test/components/test_file_explorer.py
+++ b/test/components/test_file_explorer.py
@@ -70,3 +70,17 @@ class TestFileExplorer:
 
         with pytest.raises(InvalidPathError):
             file_explorer.ls(["../file.txt"])
+
+    def test_file_explorer_preprocess_prevents_path_traversal_single(self, tmpdir):
+        file_explorer = gr.FileExplorer(file_count="single", glob="*.txt", root_dir=Path(tmpdir))
+
+        input_data = FileExplorerData(root=[["..", "..", "secret.txt"]])
+        with pytest.raises(InvalidPathError):
+            file_explorer.preprocess(input_data)
+
+    def test_file_explorer_preprocess_prevents_path_traversal_multiple(self, tmpdir):
+        file_explorer = gr.FileExplorer(file_count="multiple", glob="*.txt", root_dir=Path(tmpdir))
+
+        input_data = FileExplorerData(root=[["foo", "..", "..", "secret.txt"]])
+        with pytest.raises(InvalidPathError):
+            file_explorer.preprocess(input_data)


### PR DESCRIPTION
## Summary

Fixes a path traversal vulnerability in the FileExplorer component's preprocess() method where user-provided path components were joined directly against oot_dir without the same path-escape validation used by the ls() server method.

## Impact

The preprocess() method in FileExplorer used os.path.normpath(os.path.join(self.root_dir, *file)) to resolve selected file paths. Because this did not enforce the root-directory boundary check that _safe_join() / safe_join() provides, a crafted payload could resolve to files outside the configured oot_dir.

This is fixed by routing preprocess() through the existing _safe_join() helper, which raises InvalidPathError when path traversal is detected.

## Changes

- gradio/components/file_explorer.py: Replaced unsafe os.path.join + os.path.normpath in preprocess() with self._safe_join()
- 	est/components/test_file_explorer.py: Added tests verifying path traversal is blocked in both single and multiple file_count modes

## Checklist

- [x] I have searched for existing issues and PRs
- [x] Added tests that verify the fix
- [x] Security fix — minimal change, no API breakage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted security hardening reusing existing safe_join logic; behavior change only rejects invalid paths that should never have been allowed.
> 
> **Overview**
> **FileExplorer** selection handling no longer resolves user paths with bare `os.path.join` / `normpath` under `root_dir`. **`preprocess()`** now uses the same **`_safe_join()`** path as **`ls()`**, so crafted `..` segments raise **`InvalidPathError`** instead of escaping the configured root.
> 
> Tests cover **`file_count="single"`** and **`multiple"`** with traversal-style **`FileExplorerData`** payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11ed89abe676d5fb5747e3c857c3dc5830cb2cb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->