### PR TITLE
ci: disable changeset approval requirement on Changeset Results check

### DIFF
--- a/.github/workflows/generate-changeset.yml
+++ b/.github/workflows/generate-changeset.yml
@@ -84,7 +84,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: "Changeset Results"
           pr: ${{ needs.get-pr.outputs.pr_number }}
-          result: ${{ needs.version.outputs.approved == 'true' && 'success' || 'failure' }}
+          # Temporarily disabled: the changeset approval requirement was more hassle than
+          # it was worth (the check failed whenever a maintainer hadn't ticked the approval
+          # checkbox). Force the check to pass for now. To re-enable, restore the line below.
+          # result: ${{ needs.version.outputs.approved == 'true' && 'success' || 'failure' }}
+          result: success
           type: all
   comment-changes-skipped:
     uses: "./.github/workflows/comment-queue.yml"


### PR DESCRIPTION
## Description

The **Changeset Results** check frequently fails simply because a maintainer hasn't ticked the changeset approval checkbox, producing this comment on PRs:

> ‼️ Changeset not approved. Ensure the version bump is appropriate for all packages before approving.

In practice this has been more hassle than value. This PR forces the **Changeset Results** check to always pass for now, so it no longer blocks PRs on a missing checkbox click.

## What changed

In `.github/workflows/generate-changeset.yml`, the `update-status` job no longer derives its result from `needs.version.outputs.approved`. The original line is kept (commented out) directly above the new one so it's trivial to restore:

```yaml
# result: ${{ needs.version.outputs.approved == 'true' && 'success' || 'failure' }}
result: success
```

The change is intentionally commented-out rather than deleted, since we may want the approval gate back later.

## Note on the comment text

The "‼️ Changeset not approved…" message itself is posted by the external action [`gradio-app/github/actions/generate-changeset`](https://github.com/gradio-app/github), not from this repo, so it can't be removed here. With this change the check passes regardless, so the message is no longer a blocker — but if we want to suppress the comment too, that needs a follow-up change in `gradio-app/github`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that stops a GitHub status from failing PRs; no application or security logic is modified.
> 
> **Overview**
> The **Changeset Results** commit status in `generate-changeset.yml` no longer fails when a maintainer has not approved the changeset checkbox. The `update-status` job now always reports `result: success` instead of deriving success/failure from `needs.version.outputs.approved`.
> 
> The previous conditional is left commented in place with a short note so the approval gate can be turned back on later. Changeset generation and PR comments are unchanged; only the blocking check behavior is relaxed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 120e1f7bc89f5b61d199af8410422049bd235836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->