### PR TITLE
feat(dataframe): add case-insensitive column filter support

### DIFF
--- a/gradio/components/dataframe.py
+++ b/gradio/components/dataframe.py
@@ -110,6 +110,7 @@ class Dataframe(Component):
         show_search: Literal["none", "search", "filter"] = "none",
         pinned_columns: int | None = None,
         static_columns: list[int] | None = None,
+        filter_case_sensitive: bool = False,
     ):
         """
         Parameters:
@@ -147,6 +148,7 @@ class Dataframe(Component):
             show_search: Show a search input in the toolbar. If "search", a search input is shown. If "filter", a search input and filter buttons are shown. If "none", no search input is shown.
             pinned_columns: If provided, will pin the specified number of columns from the left.
             static_columns: List of column indices (int) that should not be editable. Only applies when interactive=True. When specified, col_count is automatically set to "fixed" and columns cannot be inserted or deleted.
+            filter_case_sensitive: If False (default), string column filters match case-insensitively. If True, filters are case-sensitive. Users can toggle via the checkbox in the filter dropdown.
         """
         if isinstance(row_count, tuple):
             warnings.warn(
@@ -242,6 +244,7 @@ class Dataframe(Component):
         self.max_chars = max_chars
         self.show_search = show_search
         self.pinned_columns = pinned_columns
+        self.filter_case_sensitive = filter_case_sensitive
 
         super().__init__(
             label=label,

--- a/js/dataframe/Index.svelte
+++ b/js/dataframe/Index.svelte
@@ -116,6 +116,7 @@
 		show_search={gradio.props.show_search}
 		pinned_columns={gradio.props.pinned_columns}
 		static_columns={gradio.props.static_columns ?? []}
+		filter_case_sensitive={gradio.props.filter_case_sensitive ?? false}
 		{fullscreen}
 		onfullscreen={() => {
 			fullscreen = !fullscreen;

--- a/js/dataframe/shared/CellMenu.svelte
+++ b/js/dataframe/shared/CellMenu.svelte
@@ -26,6 +26,7 @@
 		on_filter = () => {},
 		on_clear_filter = () => {},
 		filter_active = null,
+		filter_case_sensitive = false,
 		editable = true,
 		i18n
 	}: {
@@ -49,10 +50,12 @@
 		on_filter?: (
 			datatype: FilterDatatype,
 			selected_filter: string,
-			value: string
+			value: string,
+			case_sensitive: boolean
 		) => void;
 		on_clear_filter?: () => void;
 		filter_active?: boolean | null;
+		filter_case_sensitive?: boolean;
 		editable?: boolean;
 		i18n: I18nFormatter;
 	} = $props();
@@ -92,7 +95,7 @@
 
 	function toggle_filter_menu(): void {
 		if (filter_active) {
-			on_filter("string", "", "");
+			on_filter("string", "", "", filter_case_sensitive);
 			return;
 		}
 
@@ -213,7 +216,7 @@
 </div>
 
 {#if active_filter_menu}
-	<FilterMenu {on_filter} />
+	<FilterMenu {on_filter} {filter_case_sensitive} />
 {/if}
 
 <style>

--- a/js/dataframe/shared/FilterMenu.svelte
+++ b/js/dataframe/shared/FilterMenu.svelte
@@ -4,13 +4,16 @@
 	import type { FilterDatatype } from "./types";
 
 	let {
-		on_filter = () => {}
+		on_filter = () => {},
+		filter_case_sensitive = false
 	}: {
 		on_filter?: (
 			datatype: FilterDatatype,
 			selected_filter: string,
-			value: string
+			value: string,
+			case_sensitive: boolean
 		) => void;
+		filter_case_sensitive?: boolean;
 	} = $props();
 
 	let menu_element: HTMLDivElement;
@@ -18,6 +21,7 @@
 	let current_filter = $state("Contains");
 	let filter_dropdown_open = $state(false);
 	let filter_input_value = $state("");
+	let case_sensitive = $state(filter_case_sensitive);
 
 	const filter_options = {
 		string: [
@@ -115,9 +119,20 @@
 			/>
 		</div>
 
+		{#if datatype === "string"}
+			<label class="case-sensitive-label">
+				<input
+					type="checkbox"
+					bind:checked={case_sensitive}
+					onclick={(e) => e.stopPropagation()}
+				/>
+				Case sensitive
+			</label>
+		{/if}
+
 		<button
 			class="check-button"
-			onclick={() => on_filter(datatype, current_filter, filter_input_value)}
+			onclick={() => on_filter(datatype, current_filter, filter_input_value, case_sensitive)}
 		>
 			<Check />
 		</button>
@@ -234,6 +249,41 @@
 		width: var(--size-4);
 		height: var(--size-4);
 		margin-left: auto;
+	}
+
+	.case-sensitive-label {
+		display: flex;
+		align-items: center;
+		gap: var(--size-2);
+		font-size: var(--text-sm);
+		color: var(--body-text-color);
+		cursor: pointer;
+		user-select: none;
+	}
+
+	.case-sensitive-label input[type="checkbox"] {
+		cursor: pointer;
+		box-shadow: var(--checkbox-shadow);
+		border: 1px solid var(--checkbox-border-color);
+		border-radius: var(--checkbox-border-radius);
+		background-color: var(--checkbox-background-color);
+	}
+
+	.case-sensitive-label input[type="checkbox"]:checked {
+		background-image: var(--checkbox-check);
+		background-color: var(--checkbox-background-color-selected);
+		border-color: var(--checkbox-border-color-focus);
+	}
+
+	.case-sensitive-label input[type="checkbox"]:hover {
+		border-color: var(--checkbox-border-color-hover);
+		background-color: var(--checkbox-background-color-hover);
+	}
+
+	.case-sensitive-label input[type="checkbox"]:checked:hover {
+		background-image: var(--checkbox-check);
+		background-color: var(--checkbox-background-color-selected);
+		border-color: var(--checkbox-border-color-focus);
 	}
 
 	.filter-menu .check-button {

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -68,6 +68,7 @@
 		fullscreen = false,
 		display_value = null,
 		styling = null,
+		filter_case_sensitive = false,
 		onchange,
 		oninput,
 		onselect,
@@ -109,6 +110,7 @@
 		onedit?: (detail: EditData) => void;
 		onsearch?: (detail: string | null) => void;
 		onfullscreen?: () => void;
+		filter_case_sensitive?: boolean;
 	} = $props();
 
 	type GradioRow = Record<string, CellValue> & { _index: number };
@@ -530,7 +532,8 @@
 		col: number,
 		dtype: FilterDatatype,
 		filter: string,
-		fvalue: string
+		fvalue: string,
+		case_sensitive: boolean = filter_case_sensitive
 	): void {
 		const col_id = `col_${col}`;
 		const existing = column_filters.findIndex((f) => f.id === col_id);
@@ -539,7 +542,7 @@
 		} else {
 			column_filters = [
 				...column_filters,
-				{ id: col_id, value: { dtype, filter, value: fvalue } }
+				{ id: col_id, value: { dtype, filter, value: fvalue, case_sensitive } }
 			];
 		}
 	}
@@ -1213,11 +1216,12 @@
 			? get_sort_info(active_header_menu.col).priority
 			: null}
 		on_filter={active_header_menu
-			? (dtype, filter, fvalue) => {
-					handle_filter(active_header_menu!.col, dtype, filter, fvalue);
+			? (dtype, filter, fvalue, case_sensitive) => {
+					handle_filter(active_header_menu!.col, dtype, filter, fvalue, case_sensitive);
 					active_header_menu = null;
 				}
 			: undefined}
+		{filter_case_sensitive}
 		on_clear_filter={active_header_menu
 			? () => {
 					clear_filter();

--- a/js/dataframe/shared/utils/filter.ts
+++ b/js/dataframe/shared/utils/filter.ts
@@ -7,7 +7,7 @@ export function gradio_filter_fn(
 	columnId: string,
 	filterValue: any
 ): boolean {
-	const { dtype, filter, value: fval } = filterValue;
+	const { dtype, filter, value: fval, case_sensitive = false } = filterValue;
 	const cell_value = String(row.getValue(columnId) ?? "");
 	const compare_val = fval ?? "";
 
@@ -41,21 +41,22 @@ export function gradio_filter_fn(
 		}
 	}
 
-	const lower = cell_value.toLowerCase();
-	const target_lower = compare_val.toLowerCase();
+	const normalise = (s: string): string => (case_sensitive ? s : s.toLowerCase());
+	const cv = normalise(cell_value);
+	const query = normalise(compare_val);
 	switch (filter) {
 		case "Contains":
-			return lower.includes(target_lower);
+			return cv.includes(query);
 		case "Does not contain":
-			return !lower.includes(target_lower);
+			return !cv.includes(query);
 		case "Starts with":
-			return lower.startsWith(target_lower);
+			return cv.startsWith(query);
 		case "Ends with":
-			return lower.endsWith(target_lower);
+			return cv.endsWith(query);
 		case "Is":
-			return lower === target_lower;
+			return cv === query;
 		case "Is not":
-			return lower !== target_lower;
+			return cv !== query;
 		case "Is empty":
 			return cell_value.trim() === "";
 		case "Is not empty":

--- a/js/dataframe/test/filter_utils.test.ts
+++ b/js/dataframe/test/filter_utils.test.ts
@@ -1,0 +1,192 @@
+import { describe, test, expect } from "vitest";
+import { gradio_filter_fn } from "../shared/utils/filter";
+
+function make_row(value: string | number): { getValue: (id: string) => string | number } {
+	return { getValue: (_id: string) => value };
+}
+
+function fv(
+	filter: string,
+	value: string,
+	case_sensitive: boolean,
+	dtype: "string" | "number" = "string"
+): { dtype: string; filter: string; value: string; case_sensitive: boolean } {
+	return { dtype, filter, value, case_sensitive };
+}
+
+describe("gradio_filter_fn – case sensitivity", () => {
+	// ── Contains ─────────────────────────────────────────────────────────────
+
+	describe("Contains", () => {
+		test("case-sensitive: exact-case matches, others don't", () => {
+			const fval = fv("Contains", "London", true);
+			expect(gradio_filter_fn(make_row("London"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("london"), "c", fval)).toBe(false);
+			expect(gradio_filter_fn(make_row("LONDON"), "c", fval)).toBe(false);
+			expect(gradio_filter_fn(make_row("Paris"), "c", fval)).toBe(false);
+		});
+
+		test("case-insensitive: all case variants match", () => {
+			const fval = fv("Contains", "london", false);
+			expect(gradio_filter_fn(make_row("London"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("london"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("LONDON"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("Paris"), "c", fval)).toBe(false);
+		});
+	});
+
+	// ── Does not contain ─────────────────────────────────────────────────────
+
+	describe("Does not contain", () => {
+		test("case-sensitive: only exact-case excluded", () => {
+			const fval = fv("Does not contain", "London", true);
+			expect(gradio_filter_fn(make_row("London"), "c", fval)).toBe(false);
+			expect(gradio_filter_fn(make_row("london"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("LONDON"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("Paris"), "c", fval)).toBe(true);
+		});
+
+		test("case-insensitive: all case variants excluded", () => {
+			const fval = fv("Does not contain", "london", false);
+			expect(gradio_filter_fn(make_row("London"), "c", fval)).toBe(false);
+			expect(gradio_filter_fn(make_row("london"), "c", fval)).toBe(false);
+			expect(gradio_filter_fn(make_row("LONDON"), "c", fval)).toBe(false);
+			expect(gradio_filter_fn(make_row("Paris"), "c", fval)).toBe(true);
+		});
+	});
+
+	// ── Starts with ──────────────────────────────────────────────────────────
+
+	describe("Starts with", () => {
+		test("case-sensitive: only exact-case prefix matches", () => {
+			const fval = fv("Starts with", "Lo", true);
+			expect(gradio_filter_fn(make_row("London"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("london"), "c", fval)).toBe(false);
+			expect(gradio_filter_fn(make_row("LONDON"), "c", fval)).toBe(false);
+		});
+
+		test("case-insensitive: any casing matches", () => {
+			const fval = fv("Starts with", "lo", false);
+			expect(gradio_filter_fn(make_row("London"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("london"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("LONDON"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("Paris"), "c", fval)).toBe(false);
+		});
+	});
+
+	// ── Ends with ────────────────────────────────────────────────────────────
+
+	describe("Ends with", () => {
+		test("case-sensitive: only exact-case suffix matches", () => {
+			const fval = fv("Ends with", "don", true);
+			expect(gradio_filter_fn(make_row("London"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("london"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("LONDON"), "c", fval)).toBe(false);
+		});
+
+		test("case-insensitive: all case variants match", () => {
+			const fval = fv("Ends with", "don", false);
+			expect(gradio_filter_fn(make_row("London"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("london"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("LONDON"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("Paris"), "c", fval)).toBe(false);
+		});
+	});
+
+	// ── Is ───────────────────────────────────────────────────────────────────
+
+	describe("Is", () => {
+		test("case-sensitive: exact match only", () => {
+			const fval = fv("Is", "London", true);
+			expect(gradio_filter_fn(make_row("London"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("london"), "c", fval)).toBe(false);
+			expect(gradio_filter_fn(make_row("LONDON"), "c", fval)).toBe(false);
+		});
+
+		test("case-insensitive: all variants match", () => {
+			const fval = fv("Is", "london", false);
+			expect(gradio_filter_fn(make_row("London"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("london"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("LONDON"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("Paris"), "c", fval)).toBe(false);
+		});
+	});
+
+	// ── Is not ───────────────────────────────────────────────────────────────
+
+	describe("Is not", () => {
+		test("case-sensitive: everything except exact match passes", () => {
+			const fval = fv("Is not", "London", true);
+			expect(gradio_filter_fn(make_row("London"), "c", fval)).toBe(false);
+			expect(gradio_filter_fn(make_row("london"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("LONDON"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("Paris"), "c", fval)).toBe(true);
+		});
+
+		test("case-insensitive: all case variants excluded", () => {
+			const fval = fv("Is not", "london", false);
+			expect(gradio_filter_fn(make_row("London"), "c", fval)).toBe(false);
+			expect(gradio_filter_fn(make_row("london"), "c", fval)).toBe(false);
+			expect(gradio_filter_fn(make_row("LONDON"), "c", fval)).toBe(false);
+			expect(gradio_filter_fn(make_row("Paris"), "c", fval)).toBe(true);
+		});
+	});
+
+	// ── Is empty / Is not empty ───────────────────────────────────────────────
+
+	describe("Is empty / Is not empty", () => {
+		test("Is empty – unaffected by case_sensitive flag", () => {
+			expect(gradio_filter_fn(make_row(""), "c", fv("Is empty", "", true))).toBe(true);
+			expect(gradio_filter_fn(make_row(""), "c", fv("Is empty", "", false))).toBe(true);
+			expect(gradio_filter_fn(make_row("London"), "c", fv("Is empty", "", true))).toBe(false);
+		});
+
+		test("Is not empty – unaffected by case_sensitive flag", () => {
+			expect(gradio_filter_fn(make_row("London"), "c", fv("Is not empty", "", true))).toBe(true);
+			expect(gradio_filter_fn(make_row("London"), "c", fv("Is not empty", "", false))).toBe(true);
+			expect(gradio_filter_fn(make_row(""), "c", fv("Is not empty", "", true))).toBe(false);
+		});
+	});
+
+	// ── Numeric filters ───────────────────────────────────────────────────────
+
+	describe("Numeric filters", () => {
+		test.each([
+			["=", "20", 20, true],
+			["=", "20", 10, false],
+			["≠", "20", 10, true],
+			["≠", "20", 20, false],
+			[">", "15", 20, true],
+			[">", "15", 10, false],
+			["<", "25", 10, true],
+			["<", "25", 30, false],
+			["≥", "20", 20, true],
+			["≥", "20", 19, false],
+			["≤", "20", 20, true],
+			["≤", "20", 21, false]
+		] as [string, string, number, boolean][])(
+			"filter '%s' value '%s' for cell %d → %s",
+			(filter, value, cell, expected) => {
+				expect(
+					gradio_filter_fn(make_row(cell), "c", fv(filter, value, true, "number"))
+				).toBe(expected);
+			}
+		);
+	});
+
+	// ── Edge cases ────────────────────────────────────────────────────────────
+
+	describe("edge cases", () => {
+		test("unknown filter returns true (pass-through)", () => {
+			expect(
+				gradio_filter_fn(make_row("anything"), "c", fv("Unknown", "x", true))
+			).toBe(true);
+		});
+
+		test("case_sensitive defaults to false when omitted", () => {
+			const fval = { dtype: "string", filter: "Is", value: "London" };
+			expect(gradio_filter_fn(make_row("London"), "c", fval)).toBe(true);
+			expect(gradio_filter_fn(make_row("london"), "c", fval)).toBe(true);
+		});
+	});
+});

--- a/test/components/test_dataframe.py
+++ b/test/components/test_dataframe.py
@@ -67,6 +67,7 @@ class TestDataframe:
             "column_widths": [],
             "buttons": None,
             "max_chars": None,
+            "filter_case_sensitive": False,
         }
         dataframe_input = gr.Dataframe()
         output = dataframe_input.preprocess(DataframeData(**x_data))  # type: ignore
@@ -121,6 +122,7 @@ class TestDataframe:
             "column_widths": [],
             "buttons": None,
             "max_chars": None,
+            "filter_case_sensitive": False,
         }
 
         dataframe_input = gr.Dataframe(column_widths=["100px", 200, "50%"])
@@ -532,3 +534,36 @@ class TestDataframe:
 
         dataframe = gr.Dataframe(value=np.array([[1, 2], [3, 4]]), datatype="auto")
         assert dataframe.datatype == ["number", "number"]
+
+
+class TestDataframeFilterCaseSensitive:
+    """Tests for the filter_case_sensitive parameter."""
+
+    def test_default_is_case_insensitive(self):
+        """filter_case_sensitive defaults to False (preserves original behaviour)."""
+        df = gr.Dataframe()
+        assert df.filter_case_sensitive is False
+
+    def test_config_includes_filter_case_sensitive(self):
+        """get_config() exposes filter_case_sensitive so the frontend receives it."""
+        df_true = gr.Dataframe(filter_case_sensitive=True)
+        assert df_true.get_config()["filter_case_sensitive"] is True
+
+        df_false = gr.Dataframe(filter_case_sensitive=False)
+        assert df_false.get_config()["filter_case_sensitive"] is False
+
+    def test_filter_case_sensitive_false_stored(self):
+        """Setting filter_case_sensitive=False is stored on the component."""
+        df = gr.Dataframe(filter_case_sensitive=False)
+        assert df.filter_case_sensitive is False
+
+    def test_filter_case_sensitive_combined_with_show_search(self):
+        """filter_case_sensitive works regardless of show_search value."""
+        for mode in ("none", "search", "filter"):
+            df = gr.Dataframe(
+                show_search=mode,  # type: ignore[arg-type]
+                filter_case_sensitive=False,
+            )
+            cfg = df.get_config()
+            assert cfg["show_search"] == mode
+            assert cfg["filter_case_sensitive"] is False


### PR DESCRIPTION
Add filter_case_sensitive parameter to gr.Dataframe that controls whether column filters match case-sensitively (default: false).

A "Case sensitive" checkbox is rendered inside the filter dropdown, allowing users to toggle the behaviour at runtime without reloading.

Closes #11566

## AI Disclosure

- [x] I used AI to debug and create tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only filtering behavior with a backward-compatible default; no auth, persistence, or server-side data handling changes.
> 
> **Overview**
> Adds **`filter_case_sensitive`** on `gr.Dataframe` (default **`False`**) so string column filters are case-insensitive unless configured otherwise; the value is sent to the UI via component config.
> 
> The dataframe filter UI gains a **Case sensitive** checkbox for string filters. Each applied filter stores a `case_sensitive` flag, and **`gradio_filter_fn`** compares strings with optional lowercasing (numeric filters unchanged). Coverage includes Vitest tests for filter behavior and Python tests for the new parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd4e86119290d8c89fb41bc4b899a2c93605a951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->