### PR TITLE
fix: open-redirect bypass in oauth._redirect_to_target (GHSA-vwgg-rgg9-xx9q)

### DIFF
--- a/.changeset/fix-oauth-redirect-leading-slash.md
+++ b/.changeset/fix-oauth-redirect-leading-slash.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix open-redirect bypass in `gradio.oauth._redirect_to_target` where 4+ leading slashes (or backslashes) in `_target_url` produced a scheme-relative redirect to an external host, restoring CVE-2026-28415

--- a/gradio/oauth.py
+++ b/gradio/oauth.py
@@ -222,7 +222,12 @@ def _redirect_to_target(
     target = request.query_params.get("_target_url", default_target)
     # Prevent open redirect by stripping scheme/host and only using the path.
     parsed = urllib.parse.urlparse(target)
-    safe_target = parsed.path or "/"
+    # Collapse any leading slashes/backslashes so the result is always a
+    # single-slash local path. urlparse leaves 4+ leading slashes in `.path`
+    # (e.g. "////evil.com" -> "//evil.com"), which browsers resolve as a
+    # scheme-relative URL to an external host — restoring the CVE-2026-28415
+    # open redirect (GHSA-vwgg-rgg9-xx9q).
+    safe_target = "/" + (parsed.path or "").lstrip("/\\")
     if parsed.query:
         safe_target += "?" + parsed.query
     if parsed.fragment:

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -2361,6 +2361,30 @@ class TestOAuthSecurity:
         response = _redirect_to_target(request)
         assert response.headers["location"] == "/"
 
+    def test_redirect_to_target_blocks_multi_slash_bypass(self):
+        """Regression for GHSA-vwgg-rgg9-xx9q: urlparse keeps 4+ leading
+        slashes in `.path`, so `////evil.com` must not be echoed as the
+        scheme-relative `//evil.com` (which browsers resolve to an external
+        host), bypassing the CVE-2026-28415 fix. Backslashes are treated the
+        same way by browsers and must also be collapsed."""
+        from gradio.oauth import _redirect_to_target
+
+        scope = {"type": "http", "method": "GET", "headers": []}
+
+        # Each hostile target must resolve to a same-origin path: a single
+        # leading slash, never "//host" or "/\host".
+        hostile_to_expected = {
+            b"_target_url=////evil.com/foo": "/evil.com/foo",
+            b"_target_url=//////evil.com/foo": "/evil.com/foo",
+            b"_target_url=/%5Cevil.com": "/evil.com",  # /\evil.com
+        }
+        for query_string, expected in hostile_to_expected.items():
+            scope["query_string"] = query_string
+            location = _redirect_to_target(Request(scope)).headers["location"]
+            assert location == expected
+            assert location.startswith("/")
+            assert not location.startswith(("//", "/\\"))
+
     def test_mocked_oauth_does_not_leak_real_token(self):
         """_get_mocked_oauth_info should return a dummy token, not the real HF token."""
         from unittest.mock import patch


### PR DESCRIPTION
Fixes the open-redirect bypass reported in [GHSA-vwgg-rgg9-xx9q](https://github.com/gradio-app/gradio/security/advisories/GHSA-vwgg-rgg9-xx9q) (CWE-601) — a one-character bypass that fully restores **CVE-2026-28415**.

The CVE-2026-28415 fix stripped scheme/host from the attacker-controlled `_target_url` via `urllib.parse.urlparse(target).path`. But `urlparse` only moves the host into `.netloc` for *exactly two* leading slashes; with **4+ leading slashes** the whole string stays in `.path`:

```
urlparse("////evil.com/foo").path == "//evil.com/foo"
```

`_redirect_to_target` echoed that as `Location: //evil.com/foo`, which every browser resolves as a scheme-relative URL → `https://evil.com/foo`. Reachable on `/logout` and `/login/callback` for any app with `gr.LoginButton` OAuth.

Added pytest to prevent regression