### PR TITLE
Support point cloud data format in Model3D component

### DIFF
--- a/gradio/components/model3d.py
+++ b/gradio/components/model3d.py
@@ -25,6 +25,11 @@ class Model3D(Component):
     """
     Creates a component allows users to upload or view 3D Model files (.obj, .glb, .stl, .gltf, .splat, or .ply).
 
+    Supports both mesh files (with faces) and point cloud files (vertices without faces).
+    For .obj files, point cloud data (vertices without "f" lines) is rendered as a point cloud.
+    For .ply files, both 3D Gaussian Splatting format and simple point cloud format
+    (x, y, z with optional r, g, b) are supported.
+
     Guides: how-to-use-3D-model-component
     """
 
@@ -67,7 +72,7 @@ class Model3D(Component):
         """
         Parameters:
             value: path to (.obj, .glb, .stl, .gltf, .splat, or .ply) file to show in model3D viewer. If a function is provided, the function will be called each time the app loads to set the initial value of this component.
-            display_mode: the display mode of the 3D model in the scene. Can be "solid" (which renders the model as a solid object), "point_cloud", or "wireframe". For .splat, or .ply files, this parameter is ignored, as those files can only be rendered as solid objects.
+            display_mode: the display mode of the 3D model in the scene. Can be "solid" (which renders the model as a solid object), "point_cloud", or "wireframe". For .splat files, this parameter is ignored, as those files can only be rendered as solid objects.
             clear_color: background color of scene, should be a tuple of 4 floats between 0 and 1 representing RGBA values.
             camera_position: initial camera position of scene, provided as a tuple of `(alpha, beta, radius)`. Each value is optional. If provided, `alpha` and `beta` should be in degrees reflecting the angular position along the longitudinal and latitudinal axes, respectively. Radius corresponds to the distance from the center of the object to the camera.
             zoom_speed: the speed of zooming in and out of the scene when the cursor wheel is rotated or when screen is pinched on a mobile device. Should be a positive float, increase this value to make zooming faster, decrease to make it slower. Affects the wheelPrecision property of the camera.
@@ -114,7 +119,8 @@ class Model3D(Component):
         )
         self.buttons = set_default_buttons(buttons, None)
         self._value_description = (
-            "a string path to a (.obj, .glb, .stl, .gltf, .splat, or .ply) file."
+            "a filepath or URL to a (.obj, .glb, .stl, .gltf, .splat, or .ply) file. "
+            "Point cloud files (.obj without faces, .ply with only x,y,z,r,g,b) are supported."
         )
 
     def preprocess(self, payload: FileData | None) -> str | None:
@@ -131,7 +137,7 @@ class Model3D(Component):
     def postprocess(self, value: str | Path | None) -> FileData | None:
         """
         Parameters:
-            value: Expects function to return a {str} or {pathlib.Path} filepath of type (.obj, .glb, .stl, or .gltf)
+            value: Expects function to return a {str} or {pathlib.Path} filepath of type (.obj, .glb, .stl, .gltf, or .ply)
         Returns:
             The uploaded file as an instance of `FileData`.
         """

--- a/js/model3D/shared/Canvas3D.svelte
+++ b/js/model3D/shared/Canvas3D.svelte
@@ -4,6 +4,7 @@
 	import type { Viewer, ViewerDetails } from "@babylonjs/viewer";
 
 	let BABYLON_VIEWER: typeof import("@babylonjs/viewer");
+	let BABYLON_CORE: typeof import("@babylonjs/core");
 
 	let {
 		value,
@@ -27,10 +28,12 @@
 	let viewer = $state<Viewer>();
 	let viewerDetails = $state<Readonly<ViewerDetails>>();
 	let mounted = $state(false);
+	let modelLoaded = $state(false);
 
 	onMount(() => {
 		const initViewer = async (): Promise<void> => {
 			BABYLON_VIEWER = await import("@babylonjs/viewer");
+			BABYLON_CORE = await import("@babylonjs/core");
 			BABYLON_VIEWER.CreateViewerForCanvas(canvas, {
 				clearColor: clear_color,
 				useRightHandedSystem: true,
@@ -53,8 +56,8 @@
 	});
 
 	$effect(() => {
-		if (mounted) {
-			load_model(url);
+		if (mounted && !modelLoaded) {
+			loadModel(url);
 		}
 	});
 
@@ -64,30 +67,273 @@
 		viewerDetails.scene.forceWireframe = wireframe;
 	}
 
-	function load_model(url: string | undefined): void {
-		if (viewer) {
-			if (url) {
-				viewer
-					.loadModel(url, {
-						pluginOptions: {
-							obj: {
-								importVertexColors: true
-							}
-						}
-					})
-					.then(() => {
-						if (display_mode === "point_cloud") {
-							setRenderingMode(true, false);
-						} else if (display_mode === "wireframe") {
-							setRenderingMode(false, true);
-						} else {
-							update_camera(camera_position, zoom_speed, pan_speed);
-						}
-					});
-			} else {
-				viewer.resetModel();
+	/**
+	 * Check if loaded meshes have any indices (faces).
+	 * If all meshes have zero indices, it's point cloud data.
+	 */
+	function checkForPointCloudData(): boolean {
+		if (!viewerDetails) return false;
+		const scene = viewerDetails.scene;
+		let hasIndices = false;
+		let totalVertices = 0;
+		for (const mesh of scene.meshes) {
+			if (mesh.getTotalVertices() > 0) {
+				totalVertices += mesh.getTotalVertices();
+				const indices = mesh.getIndices();
+				if (indices && indices.length > 0) {
+					hasIndices = true;
+				}
 			}
 		}
+		return totalVertices > 0 && !hasIndices;
+	}
+
+	/**
+	 * Load a PLY point cloud file by parsing vertex data
+	 * and creating a BabylonJS mesh with positions (no indices).
+	 */
+	async function loadPLYPointCloud(url: string): Promise<void> {
+		if (!viewerDetails || !BABYLON_CORE) return;
+		const scene = viewerDetails.scene;
+
+		try {
+			const response = await fetch(url);
+			const buffer = await response.arrayBuffer();
+			const { positions, colors } = parsePLYPointCloud(buffer);
+
+			if (positions.length === 0) {
+				console.error("No vertex positions found in PLY file");
+				return;
+			}
+
+			const vertexData = new BABYLON_CORE.VertexData();
+			vertexData.positions = positions;
+			if (colors.length > 0) {
+				vertexData.colors = colors;
+			}
+
+			const mesh = new BABYLON_CORE.Mesh("pointcloud", scene);
+			vertexData.applyToMesh(mesh);
+
+			scene.forcePointsCloud = true;
+		} catch (e) {
+			console.error("Failed to load PLY point cloud:", e);
+		}
+	}
+
+	/**
+	 * Parse a PLY file buffer and extract vertex positions and colors.
+	 * Supports both ASCII and binary (little-endian) PLY formats.
+	 */
+	function parsePLYPointCloud(
+		buffer: ArrayBuffer
+	): { positions: number[]; colors: number[] } {
+		const text = new TextDecoder("utf-8").decode(buffer);
+		const headerEnd = text.indexOf("end_header");
+		if (headerEnd === -1) {
+			throw new Error("Invalid PLY file: no end_header found");
+		}
+		const header = text.substring(0, headerEnd);
+
+		const formatMatch = header.match(
+			/format (ascii|binary_little_endian|binary_big_endian) 1\.0/
+		);
+		const isBinary = formatMatch && formatMatch[1] !== "ascii";
+
+		const vertexCountMatch = header.match(/element vertex (\d+)/);
+		if (!vertexCountMatch) {
+			throw new Error("Invalid PLY file: no vertex count");
+		}
+		const vertexCount = parseInt(vertexCountMatch[1], 10);
+
+		const propLines = header
+			.split("\n")
+			.filter((l) => l.trim().startsWith("property "));
+		const properties: {
+			name: string;
+			type: string;
+			size: number;
+			offset: number;
+		}[] = [];
+		const typeSizes: Record<string, number> = {
+			char: 1,
+			uchar: 1,
+			short: 2,
+			ushort: 2,
+			int: 4,
+			uint: 4,
+			float: 4,
+			double: 8
+		};
+
+		let offset = 0;
+		for (const line of propLines) {
+			const parts = line.trim().split(/\s+/);
+			if (parts[1] === "list") continue;
+			const type = parts[1];
+			const name = parts[2];
+			const size = typeSizes[type] || 4;
+			properties.push({ name, type, size, offset });
+			offset += size;
+		}
+
+		const xProp = properties.find((p) => p.name === "x");
+		const yProp = properties.find((p) => p.name === "y");
+		const zProp = properties.find((p) => p.name === "z");
+		const rProp = properties.find(
+			(p) => p.name === "red" || p.name === "r"
+		);
+		const gProp = properties.find(
+			(p) => p.name === "green" || p.name === "g"
+		);
+		const bProp = properties.find(
+			(p) => p.name === "blue" || p.name === "b"
+		);
+
+		if (!xProp || !yProp || !zProp) {
+			throw new Error("PLY file missing x, y, or z properties");
+		}
+
+		const positions: number[] = [];
+		const colors: number[] = [];
+
+		function readValue(
+			view: DataView,
+			byteOffset: number,
+			prop: { type: string; size: number }
+		): number {
+			switch (prop.type) {
+				case "char":
+					return view.getInt8(byteOffset);
+				case "uchar":
+					return view.getUint8(byteOffset);
+				case "short":
+					return view.getInt16(byteOffset, true);
+				case "ushort":
+					return view.getUint16(byteOffset, true);
+				case "int":
+					return view.getInt32(byteOffset, true);
+				case "uint":
+					return view.getUint32(byteOffset, true);
+				case "float":
+					return view.getFloat32(byteOffset, true);
+				case "double":
+					return view.getFloat64(byteOffset, true);
+				default:
+					return view.getFloat32(byteOffset, true);
+			}
+		}
+
+		if (isBinary) {
+			const dataStart =
+				headerEnd + "end_header".length + 1;
+			const stride = offset;
+			const view = new DataView(buffer, dataStart);
+
+			for (let i = 0; i < vertexCount; i++) {
+				const baseOffset = i * stride;
+				const x = readValue(
+					view,
+					baseOffset + xProp.offset,
+					xProp
+				);
+				const y = readValue(
+					view,
+					baseOffset + yProp.offset,
+					yProp
+				);
+				const z = readValue(
+					view,
+					baseOffset + zProp.offset,
+					zProp
+				);
+				positions.push(x, y, z);
+
+				if (rProp && gProp && bProp) {
+					const r =
+						readValue(
+							view,
+							baseOffset + rProp.offset,
+							rProp
+						) / 255;
+					const g =
+						readValue(
+							view,
+							baseOffset + gProp.offset,
+							gProp
+						) / 255;
+					const b =
+						readValue(
+							view,
+							baseOffset + bProp.offset,
+							bProp
+						) / 255;
+					colors.push(r, g, b, 1);
+				}
+			}
+		} else {
+			const data = text
+				.substring(headerEnd + "end_header".length + 1)
+				.trim();
+			const lines = data.split("\n");
+			for (
+				let i = 0;
+				i < Math.min(vertexCount, lines.length);
+				i++
+			) {
+				const vals = lines[i].trim().split(/\s+/);
+				const x = parseFloat(vals[properties.indexOf(xProp)]);
+				const y = parseFloat(vals[properties.indexOf(yProp)]);
+				const z = parseFloat(vals[properties.indexOf(zProp)]);
+				positions.push(x, y, z);
+
+				if (rProp && gProp && bProp) {
+					const rIdx = properties.indexOf(rProp);
+					const gIdx = properties.indexOf(gProp);
+					const bIdx = properties.indexOf(bProp);
+					const r = parseFloat(vals[rIdx]) / 255;
+					const g = parseFloat(vals[gIdx]) / 255;
+					const b = parseFloat(vals[bIdx]) / 255;
+					colors.push(r, g, b, 1);
+				}
+			}
+		}
+
+		return { positions, colors };
+	}
+
+	async function loadModel(url: string | undefined): Promise<void> {
+		if (!viewer || !url) return;
+
+		if (url.endsWith(".ply")) {
+			// .ply point cloud files: load via BabylonJS custom geometry
+			await loadPLYPointCloud(url);
+			modelLoaded = true;
+			update_camera(camera_position, zoom_speed, pan_speed);
+			return;
+		}
+
+		// Standard model files (.obj, .glb, .stl, .gltf): use BabylonJS viewer
+		viewer
+			.loadModel(url, {
+				pluginOptions: {
+					obj: {
+						importVertexColors: true
+					}
+				}
+			})
+			.then(() => {
+				// Auto-detect point cloud data (no faces/indices)
+				const isPC = checkForPointCloudData();
+				if (display_mode === "point_cloud" || isPC) {
+					setRenderingMode(true, false);
+				} else if (display_mode === "wireframe") {
+					setRenderingMode(false, true);
+				} else {
+					update_camera(camera_position, zoom_speed, pan_speed);
+				}
+				modelLoaded = true;
+			});
 	}
 
 	export function update_camera(

--- a/js/model3D/shared/Canvas3DGS.svelte
+++ b/js/model3D/shared/Canvas3DGS.svelte
@@ -6,11 +6,13 @@
 	let {
 		value,
 		zoom_speed,
-		pan_speed
+		pan_speed,
+		onerror
 	}: {
 		value: FileData;
 		zoom_speed: number;
 		pan_speed: number;
+		onerror?: (message: string) => void;
 	} = $props();
 
 	let url = $derived(value.url);
@@ -55,12 +57,17 @@
 				throw new Error("No resolved URL");
 			}
 			loading = true;
-			if (url.endsWith(".ply")) {
-				await SPLAT.PLYLoader.LoadAsync(url, scene, undefined);
-			} else if (url.endsWith(".splat")) {
-				await SPLAT.Loader.LoadAsync(url, scene, undefined);
-			} else {
-				throw new Error("Unsupported file type");
+			try {
+				if (url.endsWith(".ply")) {
+					await SPLAT.PLYLoader.LoadAsync(url, scene, undefined);
+				} else if (url.endsWith(".splat")) {
+					await SPLAT.Loader.LoadAsync(url, scene, undefined);
+				} else {
+					throw new Error("Unsupported file type");
+				}
+			} catch (e) {
+				console.error("Failed to load 3D file with gsplat:", e);
+				onerror?.((e as Error).message);
 			}
 			loading = false;
 		};

--- a/js/model3D/shared/Model3D.svelte
+++ b/js/model3D/shared/Model3D.svelte
@@ -37,6 +37,9 @@
 	let Canvas3DComponent = $state<typeof Canvas3D>();
 	let canvas3d = $state<Canvas3D | undefined>();
 
+	// Guard to prevent re-resolving on internal state changes
+	let render_guard = $state(false);
+
 	async function loadCanvas3D(): Promise<typeof Canvas3D> {
 		const module = await import("./Canvas3D.svelte");
 		return module.default;
@@ -46,20 +49,52 @@
 		return module.default;
 	}
 
+	// Only run initial resolution when value changes
 	$effect(() => {
 		if (value) {
-			use_3dgs = value.path.endsWith(".splat") || value.path.endsWith(".ply");
-			if (use_3dgs) {
+			// Reset guard on new value
+			render_guard = false;
+		}
+	});
+
+	$effect(() => {
+		if (value && !render_guard) {
+			const path = value.path || value.url || "";
+			render_guard = true;
+			if (path.endsWith(".splat")) {
+				use_3dgs = true;
+				Canvas3DGSComponent = undefined;
+				loadCanvas3DGS().then((component) => {
+					Canvas3DGSComponent = component;
+				});
+			} else if (path.endsWith(".ply")) {
+				// Try Canvas3DGS first; simple point clouds fall back via onerror
+				use_3dgs = true;
+				Canvas3DGSComponent = undefined;
 				loadCanvas3DGS().then((component) => {
 					Canvas3DGSComponent = component;
 				});
 			} else {
+				use_3dgs = false;
+				Canvas3DComponent = undefined;
 				loadCanvas3D().then((component) => {
 					Canvas3DComponent = component;
 				});
 			}
 		}
 	});
+
+	// Fallback: when gsplat fails for a .ply file, switch to Canvas3D
+	function handleGsplatError(_message?: string): void {
+		const path = value?.path || value?.url || "";
+		if (path.endsWith(".ply") && use_3dgs) {
+			use_3dgs = false;
+			Canvas3DComponent = undefined;
+			loadCanvas3D().then((component) => {
+				Canvas3DComponent = component;
+			});
+		}
+	}
 
 	function handle_undo(): void {
 		canvas3d?.reset_camera_position();
@@ -86,7 +121,6 @@
 	<div class="model3D" data-testid="model3d">
 		<IconButtonWrapper>
 			{#if !use_3dgs}
-				<!-- Canvas3DGS doesn't implement the undo method (reset_camera_position) -->
 				<IconButton
 					Icon={Undo}
 					label="Undo"
@@ -110,6 +144,7 @@
 				{value}
 				{zoom_speed}
 				{pan_speed}
+				onerror={handleGsplatError}
 			/>
 		{:else}
 			<svelte:component

--- a/js/model3D/shared/Model3DUpload.svelte
+++ b/js/model3D/shared/Model3DUpload.svelte
@@ -58,6 +58,9 @@
 	let canvas3d = $state<Canvas3D | undefined>();
 	let dragging = $state(false);
 
+	// Guard to prevent re-resolving on internal state changes
+	let render_guard = $state(false);
+
 	async function loadCanvas3D(): Promise<typeof Canvas3D> {
 		const module = await import("./Canvas3D.svelte");
 		return module.default;
@@ -69,18 +72,48 @@
 
 	$effect(() => {
 		if (value) {
-			use_3dgs = value.path.endsWith(".splat") || value.path.endsWith(".ply");
-			if (use_3dgs) {
+			render_guard = false;
+		}
+	});
+
+	$effect(() => {
+		if (value && !render_guard) {
+			const path = value.path || value.url || "";
+			render_guard = true;
+			if (path.endsWith(".splat")) {
+				use_3dgs = true;
+				Canvas3DGSComponent = undefined;
+				loadCanvas3DGS().then((component) => {
+					Canvas3DGSComponent = component;
+				});
+			} else if (path.endsWith(".ply")) {
+				// Try Canvas3DGS first; simple point clouds fall back via onerror
+				use_3dgs = true;
+				Canvas3DGSComponent = undefined;
 				loadCanvas3DGS().then((component) => {
 					Canvas3DGSComponent = component;
 				});
 			} else {
+				use_3dgs = false;
+				Canvas3DComponent = undefined;
 				loadCanvas3D().then((component) => {
 					Canvas3DComponent = component;
 				});
 			}
 		}
 	});
+
+	// Fallback: when gsplat fails for a .ply file, switch to Canvas3D
+	function handleGsplatError(_message?: string): void {
+		const path = value?.path || value?.url || "";
+		if (path.endsWith(".ply") && use_3dgs) {
+			use_3dgs = false;
+			Canvas3DComponent = undefined;
+			loadCanvas3D().then((component) => {
+				Canvas3DComponent = component;
+			});
+		}
+	}
 
 	$effect(() => {
 		ondrag?.(dragging);
@@ -142,6 +175,7 @@
 				{value}
 				{zoom_speed}
 				{pan_speed}
+				onerror={handleGsplatError}
 			/>
 		{:else}
 			<svelte:component

--- a/test/components/test_model3d.py
+++ b/test/components/test_model3d.py
@@ -49,3 +49,9 @@ class TestModel3D:
         input_data = "test/test_files/Box.gltf"
         output_data = iface(input_data)
         assert output_data.endswith(".gltf")
+
+    def test_value_description_includes_pointcloud(self):
+        """Value description should mention point cloud support."""
+        model_component = gr.components.Model3D(None, label="Model")
+        desc = model_component._value_description
+        assert "point cloud" in desc.lower()


### PR DESCRIPTION
## Description

This PR adds support for **point cloud data format** in the `gr.Model3D` component, addressing issue #8826.

Previously, Model3D could only render mesh files with faces (e.g., `.obj` files with `f` lines, or `.gltf`/`.glb` with triangle indices). Files containing only vertex/point data without faces would fail to render.

### Changes

#### Backend (`gradio/components/model3d.py`)
- Updated class and parameter docstrings to document point cloud support
- Updated `_value_description` to mention point cloud file compatibility

#### Frontend — BabylonJS renderer (`js/model3D/shared/Canvas3D.svelte`)
- **Auto-detection of point cloud data**: After BabylonJS loads a model via `viewer.loadModel()`, the code checks if all meshes have zero indices (no faces). If so, it automatically enables `forcePointsCloud = true` for rendering. This handles `.obj` files with only vertices and no `f` lines.
- **PLY point cloud loader**: Added `loadPLYPointCloud()` which fetches and parses PLY files (both ASCII and binary little-endian formats) containing `x, y, z` vertex positions with optional `red, green, blue` color properties. Creates a BabylonJS mesh with vertex data but no indices, rendered as a point cloud.
- The custom PLY parser handles common type sizes (`float`, `double`, `uchar`, `int`, etc.)

#### Frontend — GS renderer (`js/model3D/shared/Canvas3DGS.svelte`)
- Added `onerror` callback prop for graceful fallback handling
- Wraps `PLYLoader.LoadAsync()` in try-catch, calling `onerror` when loading fails

#### Frontend — Renderer routing (`js/model3D/shared/Model3D.svelte` & `Model3DUpload.svelte`)
- **Fallback mechanism for `.ply` files**: First tries the GS renderer (for 3D Gaussian Splatting format PLY files). If gsplat fails (non-3DGS point cloud), the `onerror` callback switches the renderer to Canvas3D (BabylonJS), which loads the file as a point cloud.
- Uses a `render_guard` pattern to prevent reactivity loops during fallback switching

#### Tests (`test/components/test_model3d.py`)
- Added test verifying that `_value_description` mentions point cloud support

### How it works

| File Type | Before | After |
|-----------|--------|-------|
| `.obj` with faces | ✅ Works | ✅ Works |
| `.obj` without faces (only `v` lines) | ❌ Nothing shown | ✅ Renders as point cloud |
| `.ply` 3DGS format | ✅ Works | ✅ Works |
| `.ply` point cloud (x,y,z,r,g,b only) | ❌ Fails in gsplat | ✅ Renders as point cloud via BabylonJS |
| `.glb`/`.gltf`/`.stl` | ✅ Works | ✅ Works |

### Related Issue
Closes: #8826

### AI Disclosure
This PR description was drafted with assistance from an AI coding agent.

kumquat

### PR/Author Checklist
- [x] I have linked this PR to an open issue
- [x] I have used the PR template
- [x] I have reviewed my changes
- [x] Backend changes are ruff-formatted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial new client-side parsing and renderer fallback logic for `.ply`/OBJ; regressions could affect existing splat/mesh viewing but scope is limited to the Model3D frontend and docs.
> 
> **Overview**
> **`gr.Model3D`** now documents and advertises support for **point clouds** (vertices without faces), including faceless `.obj` files and simple `.ply` (x,y,z with optional color).
> 
> The **Babylon** viewer (`Canvas3D.svelte`) **auto-detects** mesh data with no face indices and switches to point-cloud rendering, or **`display_mode="point_cloud"`**. For `.ply` URLs it adds a **custom PLY parser** (ASCII and binary little-endian) and builds a mesh with optional vertex colors.
> 
> **`.ply` routing** in `Model3D` / `Model3DUpload` still tries **gsplat** first for 3D Gaussian splats; **`Canvas3DGS`** now reports load failures via **`onerror`**, which **falls back** to Babylon for non-splat PLY. A **`render_guard`** avoids Svelte effect loops when switching renderers.
> 
> Backend changes are mostly **docstrings** and **`_value_description`**; **`postprocess`** docs now include `.ply`. One test asserts the value description mentions point clouds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fef6b6461f70801f39e27be66297ee8c758cda9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->