### PR TITLE
fix: reset audio player timeline and state when source file changes

### DIFF
--- a/js/audio/shared/MinimalAudioPlayer.svelte
+++ b/js/audio/shared/MinimalAudioPlayer.svelte
@@ -22,9 +22,8 @@
 	let waveform_ready = $state(false);
 
 	let resolved_src = $derived(value.url);
-
-	const create_waveform = async (): Promise<void> => {
-		if (!container || !resolved_src || waveform_ready) return;
+const create_waveform = async (): Promise<void> => {
+		if (!container || !resolved_src) return;
 
 		if (waveform) {
 			waveform.destroy();
@@ -71,6 +70,16 @@
 
 		await waveform.load(resolved_src);
 	};
+
+
+	$effect(() => {
+		if (resolved_src) {
+			currentTime = 0;
+			playing = false;
+			waveform_ready = false;
+			create_waveform();
+		}
+	});
 
 	onMount(async () => {
 		await create_waveform();


### PR DESCRIPTION
## Description

This pull request fixes an issue where the `MinimalAudioPlayer` component does not reset its internal timeline and tracking states back to 0:00 when a new audio file source (`value.url`) is dynamically written to or overrides the component. 

To resolve this, an `$effect` block was introduced to explicitly watch for updates to `resolved_src`. When a new source is detected, the audio state (`currentTime`, `playing`, and `waveform_ready`) is cleanly reset before initializing the new `create_waveform()` instance. Additionally, the early return guard rail in `create_waveform` was streamlined to ensure loading isn't blocked when an existing waveform state is present.

Closes: #13273

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to assist in identifying the Svelte 5 state management lifecycle mismatch and drafting the reactive `$effect` block to trigger the audio player clean up.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Svelte/WaveSurfer lifecycle fix in the shared minimal audio UI with no auth or data-path changes.
> 
> **Overview**
> Fixes **`MinimalAudioPlayer`** so swapping **`value.url`** (via `resolved_src`) no longer leaves the old timeline, play state, or waveform stuck on the previous file.
> 
> A Svelte 5 **`$effect`** watches `resolved_src`, resets `currentTime`, `playing`, and `waveform_ready`, then rebuilds the WaveSurfer instance. **`create_waveform`** no longer bails out when `waveform_ready` is already true, so a new source can always tear down the old waveform and load again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a25e177479f75bbb64fbc4c34ec367a1a474e68b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->