### PR TITLE
fix(dropdown): virtualize large option lists

### DIFF
--- a/.changeset/fast-dropdown-options.md
+++ b/.changeset/fast-dropdown-options.md
@@ -1,0 +1,5 @@
+---
+"@gradio/dropdown": patch
+---
+
+fix:Virtualize large dropdown option lists to keep suggestion rendering responsive

--- a/js/dropdown/dropdown.test.ts
+++ b/js/dropdown/dropdown.test.ts
@@ -267,6 +267,67 @@ describe("Single-select: Filtering", () => {
 	});
 });
 
+describe("Single-select: Large choice lists", () => {
+	afterEach(() => cleanup());
+
+	const large_choices = Array.from({ length: 1_000 }, (_, index) => {
+		const label = `Option ${index.toString().padStart(4, "0")}`;
+		return [label, label] as [string, string];
+	});
+
+	test("renders only the visible option window", async () => {
+		const { getByLabelText, getAllByTestId, getByText, queryByText } =
+			await render(Dropdown, {
+				...single_select_props,
+				choices: large_choices,
+				value: null
+			});
+
+		const input = getByLabelText("Dropdown") as HTMLInputElement;
+		await input.focus();
+
+		await waitFor(() => {
+			expect(getAllByTestId("dropdown-option").length).toBeGreaterThan(0);
+		});
+
+		const options = getAllByTestId("dropdown-option");
+		expect(options.length).toBeLessThan(large_choices.length);
+		expect(getByText("Option 0000")).toBeInTheDocument();
+		expect(queryByText("Option 0999")).not.toBeInTheDocument();
+	});
+
+	test("scrolling a virtualized list exposes and selects later options", async () => {
+		const { getByLabelText, getAllByTestId, getByText, get_data } =
+			await render(Dropdown, {
+				...single_select_props,
+				choices: large_choices,
+				value: null
+			});
+
+		const input = getByLabelText("Dropdown") as HTMLInputElement;
+		await input.focus();
+
+		await waitFor(() => {
+			expect(getAllByTestId("dropdown-option").length).toBeGreaterThan(0);
+		});
+
+		const options_list = getAllByTestId("dropdown-option")[0].closest(
+			"[role='listbox']"
+		) as HTMLElement;
+		options_list.scrollTo(0, 999 * 32);
+		await fireEvent.scroll(options_list);
+
+		await waitFor(() => {
+			expect(getByText("Option 0999")).toBeVisible();
+		});
+		await event.click(getByText("Option 0999"));
+
+		const data = await get_data();
+		expect(data.value).toBe("Option 0999");
+		expect(input.value).toBe("Option 0999");
+	});
+});
+
 describe("Single-select: Selection", () => {
 	afterEach(() => cleanup());
 

--- a/js/dropdown/shared/DropdownOptions.svelte
+++ b/js/dropdown/shared/DropdownOptions.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
 	import { fly } from "svelte/transition";
+
+	const VIRTUALIZE_THRESHOLD = 200;
+	const OPTION_HEIGHT = 32;
+	const OVERSCAN = 8;
+
 	let {
 		choices,
 		filtered_indices,
@@ -36,7 +41,30 @@
 	let bottom: string | null = $state(null);
 	let max_height: number = $state(0);
 	let innerHeight = $state(0);
-	let list_scroll_y = 0;
+	let list_scroll_y = $state(0);
+
+	let use_virtual = $derived(filtered_indices.length > VIRTUALIZE_THRESHOLD);
+	let virtual_count = $derived(
+		Math.ceil(Math.max(max_height, OPTION_HEIGHT) / OPTION_HEIGHT) +
+			OVERSCAN * 2
+	);
+	let virtual_start = $derived(
+		use_virtual
+			? Math.max(0, Math.floor(list_scroll_y / OPTION_HEIGHT) - OVERSCAN)
+			: 0
+	);
+	let virtual_end = $derived(
+		use_virtual
+			? Math.min(filtered_indices.length, virtual_start + virtual_count)
+			: filtered_indices.length
+	);
+	let visible_indices = $derived(
+		use_virtual
+			? filtered_indices.slice(virtual_start, virtual_end)
+			: filtered_indices
+	);
+	let virtual_total_height = $derived(filtered_indices.length * OPTION_HEIGHT);
+	let virtual_offset = $derived(virtual_start * OPTION_HEIGHT);
 
 	function calculate_window_distance(): void {
 		const { top: ref_top, bottom: ref_bottom } =
@@ -66,20 +94,58 @@
 		listElement?.scrollTo?.(0, list_scroll_y);
 	}
 
+	function scroll_to_position(position: number): void {
+		list_scroll_y = position;
+		listElement?.scrollTo?.(0, position);
+	}
+
+	function scroll_to_option(index: number): void {
+		const option_position = filtered_indices.indexOf(index);
+		if (option_position === -1) {
+			return;
+		}
+		scroll_to_position(option_position * OPTION_HEIGHT);
+	}
+
+	function scroll_active_option_into_view(): void {
+		if (!use_virtual || active_index === null || !listElement) {
+			return;
+		}
+		const option_position = filtered_indices.indexOf(active_index);
+		if (option_position === -1) {
+			return;
+		}
+		const option_top = option_position * OPTION_HEIGHT;
+		const option_bottom = option_top + OPTION_HEIGHT;
+		const viewport_height = listElement.clientHeight || max_height;
+		if (option_top < list_scroll_y) {
+			scroll_to_position(option_top);
+		} else if (option_bottom > list_scroll_y + viewport_height) {
+			scroll_to_position(option_bottom - viewport_height);
+		}
+	}
+
 	$effect(() => {
 		if (show_options && refElement) {
 			if (remember_scroll) {
 				restore_last_scroll();
 			} else {
 				if (listElement && selected_indices.length > 0) {
-					let elements = listElement.querySelectorAll("li");
-					for (const element of Array.from(elements)) {
-						if (
-							element.getAttribute("data-index") ===
-							selected_indices[0].toString()
-						) {
-							listElement?.scrollTo?.(0, (element as HTMLLIElement).offsetTop);
-							break;
+					if (use_virtual && typeof selected_indices[0] === "number") {
+						scroll_to_option(selected_indices[0]);
+					} else {
+						let elements = listElement.querySelectorAll("li");
+						for (const element of Array.from(elements)) {
+							if (
+								element.getAttribute("data-index") ===
+								selected_indices[0].toString()
+							) {
+								listElement?.scrollTo?.(
+									0,
+									(element as HTMLLIElement).offsetTop
+								);
+								break;
+							}
 						}
 					}
 				}
@@ -100,6 +166,20 @@
 			top = null;
 		}
 	});
+
+	$effect(() => {
+		if (!use_virtual || !listElement) {
+			return;
+		}
+		const max_scroll = Math.max(0, virtual_total_height - max_height);
+		if (list_scroll_y > max_scroll) {
+			scroll_to_position(max_scroll);
+		}
+	});
+
+	$effect(() => {
+		scroll_active_option_into_view();
+	});
 </script>
 
 <svelte:window on:scroll={scroll_listener} bind:innerHeight />
@@ -108,6 +188,7 @@
 {#if show_options && !disabled}
 	<ul
 		class="options"
+		class:virtual={use_virtual}
 		transition:fly={{ duration: 200, y: 5 }}
 		onmousedown={(e) => {
 			e.preventDefault();
@@ -121,14 +202,26 @@
 		bind:this={listElement}
 		role="listbox"
 	>
-		{#each filtered_indices as index}
+		{#if use_virtual}
+			<li
+				class="virtual-spacer"
+				style:height={virtual_total_height + "px"}
+				aria-hidden="true"
+				role="presentation"
+			></li>
+		{/if}
+		{#each visible_indices as index, offset}
 			<li
 				class="item"
+				class:virtual-item={use_virtual}
 				class:selected={selected_indices.includes(index)}
 				class:active={index === active_index}
 				class:bg-gray-100={index === active_index}
 				class:dark:bg-gray-600={index === active_index}
 				style:width={input_width + "px"}
+				style:transform={use_virtual
+					? `translateY(${virtual_offset + offset * OPTION_HEIGHT}px)`
+					: undefined}
 				data-index={index}
 				aria-label={choices[index][0]}
 				data-testid="dropdown-option"
@@ -146,7 +239,7 @@
 
 <style>
 	.options {
-		--window-padding: var(--size-8);
+		--window-padding: var(--size-8, 32px);
 		position: fixed;
 		z-index: var(--layer-top);
 		margin-left: 0;
@@ -163,8 +256,24 @@
 	.item {
 		display: flex;
 		cursor: pointer;
+		box-sizing: border-box;
+		min-height: 32px;
 		padding: var(--size-2);
 		word-break: break-word;
+	}
+
+	.virtual {
+		position: fixed;
+	}
+
+	.virtual-item {
+		position: absolute;
+		top: 0;
+		left: 0;
+	}
+
+	.virtual-spacer {
+		pointer-events: none;
 	}
 
 	.item:hover,


### PR DESCRIPTION
## Description

Virtualizes the dropdown options list once the filtered choices are large, so opening suggestions no longer renders every option at once. This keeps the DOM small for large choice lists while preserving scrolling, keyboard active-option visibility, and selection behavior.

Closes: #13340

I checked for duplicate open PRs referencing #13340 before opening this PR.

AI-agent keyword: kumquat.

## AI Disclosure

- [x] I used AI to implement and self-review this dropdown performance fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets existing issue #13340.

## Testing and Formatting Your Code

- `CI=1 PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' pnpm exec vitest run --config .config/vitest.config.ts js/dropdown/dropdown.test.ts`
- `pnpm exec svelte-check --workspace js/dropdown/shared --no-tsconfig --threshold error`
- `pnpm exec prettier --ignore-path .config/.prettierignore --check --config .config/.prettierrc.json --plugin prettier-plugin-svelte js/dropdown/shared/DropdownOptions.svelte js/dropdown/dropdown.test.ts .changeset/fast-dropdown-options.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only performance change in the dropdown options panel with regression tests; no auth, API, or data-layer changes.
> 
> **Overview**
> When a dropdown has more than **200** filtered choices, `DropdownOptions` now **virtualizes** the suggestion list instead of mounting every `<li>`. Only a viewport-sized slice of options is rendered, with a tall spacer and `translateY` positioning so scrolling still covers the full list.
> 
> Behavior for large lists is preserved: **scroll** updates the visible window, **keyboard** active options are scrolled into view, and **initial selection** scrolls to the selected row (including the virtual path). Small lists are unchanged (no virtualization).
> 
> New Vitest coverage uses **1,000** choices to assert a bounded DOM count, off-screen options absent until scroll, and selection of a far-down option after scrolling. A **changeset** records a patch for `@gradio/dropdown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4da670f8e531a2a5df2bc0a1ff6c546701de0c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->