### PR TITLE
Fix sidebar overlap amount on resize

### DIFF
--- a/js/sidebar/Sidebar.test.ts
+++ b/js/sidebar/Sidebar.test.ts
@@ -1,8 +1,23 @@
-import { test, describe, afterEach, expect } from "vitest";
+import { test, describe, afterEach, expect, vi } from "vitest";
 import { cleanup, render, fireEvent } from "@self/tootils/render";
 
 import Sidebar from "./Index.svelte";
 import SidebarWithChild from "./WithChild.svelte";
+
+function rect(overrides: Partial<DOMRect> = {}): DOMRect {
+	return {
+		x: 0,
+		y: 0,
+		top: 0,
+		right: 0,
+		bottom: 0,
+		left: 0,
+		width: 0,
+		height: 0,
+		toJSON: () => ({}),
+		...overrides
+	} as DOMRect;
+}
 
 // Sidebar requires both `visible` and `open` to be passed explicitly:
 // - Index.svelte uses {#if gradio.shared.visible}, so omitting visible leaves
@@ -91,6 +106,57 @@ describe("Sidebar", () => {
 			elem_id: "sb-str-hidden"
 		});
 		expect(container.querySelector("#sb-str-hidden")).not.toBeNull();
+	});
+});
+
+describe("Parent overlap", () => {
+	afterEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+		document.documentElement.style.removeProperty("--overlap-amount");
+	});
+
+	test("updates the overlap CSS variable when the window resizes", async () => {
+		const wrap = document.createElement("div");
+		wrap.className = "wrap";
+		document.body.appendChild(wrap);
+
+		let sidebar_width = 320;
+		vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+			function () {
+				if (this.classList.contains("wrap")) {
+					return rect({ left: 120, right: 720, width: 600 });
+				}
+
+				if (this.classList.contains("sidebar")) {
+					return rect({ right: sidebar_width, width: sidebar_width });
+				}
+
+				return rect();
+			}
+		);
+
+		await render(
+			Sidebar,
+			{
+				width: 320,
+				visible: true,
+				open: true,
+				position: "left"
+			},
+			{ container: wrap }
+		);
+
+		expect(
+			document.documentElement.style.getPropertyValue("--overlap-amount")
+		).toBe("230px");
+
+		sidebar_width = 180;
+		await fireEvent.resize(window);
+
+		expect(
+			document.documentElement.style.getPropertyValue("--overlap-amount")
+		).toBe("90px");
 	});
 });
 

--- a/js/sidebar/shared/Sidebar.svelte
+++ b/js/sidebar/shared/Sidebar.svelte
@@ -43,15 +43,18 @@
 
 	onMount(() => {
 		sidebar_div.closest(".wrap")?.classList.add("sidebar-parent");
-		check_overlap();
-		window.addEventListener("resize", check_overlap);
 		const update_parent_overlap = (): void => {
 			document.documentElement.style.setProperty(
 				"--overlap-amount",
 				`${overlap_amount}px`
 			);
 		};
-		update_parent_overlap();
+		const handle_resize = (): void => {
+			check_overlap();
+			update_parent_overlap();
+		};
+		handle_resize();
+		window.addEventListener("resize", handle_resize);
 		mounted = true;
 		const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
 		prefersReducedMotion = mediaQuery.matches;
@@ -60,7 +63,7 @@
 		};
 		mediaQuery.addEventListener("change", updateMotionPreference);
 		return () => {
-			window.removeEventListener("resize", check_overlap);
+			window.removeEventListener("resize", handle_resize);
 			mediaQuery.removeEventListener("change", updateMotionPreference);
 		};
 	});


### PR DESCRIPTION
## Description

This updates the sidebar resize handler so the overlap amount is recalculated and written on each resize. It also cleans up the resize listener on unmount and adds a regression test for the CSS variable.

Closes: #12620

## AI Disclosure

- [x] I used AI to help draft the first patch and PR text; I checked the diff and ran the listed checks. kumquat
- [ ] I did not use AI

## PRs Should Target Issues

This targets #12620.

## Testing and Formatting Your Code

- `corepack pnpm exec prettier --ignore-path .config/.prettierignore --check --config .config/.prettierrc.json --plugin prettier-plugin-svelte js/sidebar/shared/Sidebar.svelte js/sidebar/Sidebar.test.ts`
- `git diff --check`
- Not run locally: `CI=1 corepack pnpm dlx tsx node_modules/vitest/vitest.mjs run --config .config/vitest.config.ts js/sidebar/Sidebar.test.ts`, because Playwright Chromium could not start on this host.
