### PR TITLE
ci: harden Playwright browser installs

### DIFF
--- a/.github/workflows/frontend_profiling.yml
+++ b/.github/workflows/frontend_profiling.yml
@@ -76,9 +76,19 @@ jobs:
         if: steps.changes.outputs.should_run == 'true'
         run: pnpm i --frozen-lockfile --ignore-scripts && pnpm css && pnpm build
 
+      - name: Cache Playwright Browsers
+        if: steps.changes.outputs.should_run == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       - name: Install Playwright (base)
         if: steps.changes.outputs.should_run == 'true'
-        run: pnpm exec playwright install chromium
+        timeout-minutes: 15
+        run: pnpm exec playwright install chromium --no-shell
 
       - name: Checkout benchmark spec and demo from PR
         if: steps.changes.outputs.should_run == 'true'
@@ -111,7 +121,8 @@ jobs:
 
       - name: Install Playwright (PR)
         if: steps.changes.outputs.should_run == 'true'
-        run: pnpm exec playwright install chromium
+        timeout-minutes: 15
+        run: pnpm exec playwright install chromium --no-shell
 
       - name: Run benchmark (PR)
         if: steps.changes.outputs.should_run == 'true'

--- a/.github/workflows/storybook-build.yml
+++ b/.github/workflows/storybook-build.yml
@@ -59,7 +59,16 @@ jobs:
         run: |
           . venv/bin/activate
           python scripts/generate_theme.py --outfile js/storybook/theme.css
-      - run: pnpm exec playwright install chromium
+      - name: cache playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: install playwright
+        timeout-minutes: 15
+        run: pnpm exec playwright install chromium --no-shell
       - name: build storybook
         run: |
           . venv/bin/activate

--- a/.github/workflows/test-functional.yml
+++ b/.github/workflows/test-functional.yml
@@ -60,7 +60,16 @@ jobs:
           . venv/bin/activate
           uv pip install -r demo/outbreak_forecast/requirements.txt
           uv pip install -r demo/stream_video_out/requirements.txt
-      - run: pnpm exec playwright install chromium firefox
+      - name: cache playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: install playwright
+        timeout-minutes: 15
+        run: pnpm exec playwright install chromium --no-shell
       - name: build essential packages
         run: pnpm --filter @gradio/utils --filter @gradio/theme package
       - name: run browser tests

--- a/.github/workflows/tests-js.yml
+++ b/.github/workflows/tests-js.yml
@@ -50,8 +50,16 @@ jobs:
         uses: "gradio-app/gradio/.github/actions/install-frontend-deps@main"
         with:
           skip_build: true
+      - name: cache playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
       - name: install playwright
-        run: pnpm exec playwright install
+        timeout-minutes: 15
+        run: pnpm exec playwright install chromium --no-shell
       - name: build client
         run: pnpm --filter @gradio/client build
       - name: format check


### PR DESCRIPTION
## Description

Hardens the Playwright browser install steps that have recently been getting stuck in GitHub Actions.

This PR:
- caches `~/.cache/ms-playwright` for CI jobs that install Playwright browsers
- installs only Chromium in workflows whose CI configs only run Chromium
- passes `--no-shell` to avoid downloading the unused Chromium headless shell
- adds a 15 minute timeout to Playwright install steps so CDN stalls do not keep runners occupied indefinitely

Closes: #13452

## AI Disclosure

- [x] I used AI to investigate the stuck GitHub Actions jobs, inspect the workflow configs, draft these CI changes, and prepare this PR. I self-reviewed the generated changes. kumquat
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets #13452.

## Testing and Formatting Your Code

Ran:
- `pnpm exec prettier --check .github/workflows/tests-js.yml .github/workflows/test-functional.yml .github/workflows/storybook-build.yml .github/workflows/frontend_profiling.yml`
- `git diff --check`
- `PLAYWRIGHT_BROWSERS_PATH=/tmp/gradio-pw-dry-run pnpm exec playwright install chromium --no-shell --dry-run`

Also ran `bash scripts/format_frontend.sh`; the Prettier portion completed with these workflow files unchanged, but the script exited non-zero on existing unrelated Svelte type-check errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes; narrows browser downloads to match existing CI usage and adds cache/timeouts without touching application code.
> 
> **Overview**
> Hardens Playwright browser setup in four CI workflows (`frontend_profiling`, `storybook-build`, `test-functional`, `tests-js`) so installs are faster and less likely to hang.
> 
> Each affected job now **restores `~/.cache/ms-playwright`** from Actions cache (keyed by OS and `pnpm-lock.yaml`), then runs **`playwright install chromium --no-shell`** with a **15-minute timeout** instead of broader installs (e.g. all browsers or chromium+firefox). **Functional** and **JS** jobs align with CI configs that only need Chromium on runners; Firefox was already skipped in CI via `playwright.config.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b50ee2c171a50b707edefbf76b1f1065b98e469b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->