### PR TITLE
ci: shorten Playwright install timeout

### DIFF
--- a/.github/workflows/frontend_profiling.yml
+++ b/.github/workflows/frontend_profiling.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Install Playwright (base)
         if: steps.changes.outputs.should_run == 'true'
-        timeout-minutes: 15
+        timeout-minutes: 3
         run: pnpm exec playwright install chromium --no-shell
 
       - name: Checkout benchmark spec and demo from PR
@@ -121,7 +121,7 @@ jobs:
 
       - name: Install Playwright (PR)
         if: steps.changes.outputs.should_run == 'true'
-        timeout-minutes: 15
+        timeout-minutes: 3
         run: pnpm exec playwright install chromium --no-shell
 
       - name: Run benchmark (PR)

--- a/.github/workflows/storybook-build.yml
+++ b/.github/workflows/storybook-build.yml
@@ -67,7 +67,7 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-
       - name: install playwright
-        timeout-minutes: 15
+        timeout-minutes: 3
         run: pnpm exec playwright install chromium --no-shell
       - name: build storybook
         run: |

--- a/.github/workflows/test-functional.yml
+++ b/.github/workflows/test-functional.yml
@@ -68,7 +68,7 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-
       - name: install playwright
-        timeout-minutes: 15
+        timeout-minutes: 3
         run: pnpm exec playwright install chromium --no-shell
       - name: build essential packages
         run: pnpm --filter @gradio/utils --filter @gradio/theme package

--- a/.github/workflows/tests-js.yml
+++ b/.github/workflows/tests-js.yml
@@ -58,7 +58,7 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-
       - name: install playwright
-        timeout-minutes: 15
+        timeout-minutes: 3
         run: pnpm exec playwright install chromium --no-shell
       - name: build client
         run: pnpm --filter @gradio/client build


### PR DESCRIPTION
## Description

Reduces the Playwright browser install timeout from 15 minutes to 3 minutes in workflows that install CI browsers.

A healthy Chromium-only install should complete quickly, especially with the Playwright browser cache added in #13453. A 3 minute timeout fails stalled CDN/download attempts faster and frees CI runners sooner.

Closes: #13454

## AI Disclosure

- [x] I used AI to prepare this CI timeout change and PR description. I self-reviewed the workflow diff. kumquat
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets #13454.

## Testing and Formatting Your Code

Ran:
- `pnpm exec prettier --check .github/workflows/tests-js.yml .github/workflows/test-functional.yml .github/workflows/storybook-build.yml .github/workflows/frontend_profiling.yml`
- `git diff --check`
