### PR TITLE
docs: upgrade MiniMax demo to M3

### DIFF
--- a/demo/llm_minimax/run.py
+++ b/demo/llm_minimax/run.py
@@ -15,7 +15,7 @@ client = OpenAI(
 
 def predict(message, history):
     history.append({"role": "user", "content": message})
-    stream = client.chat.completions.create(messages=history, model="MiniMax-M2.7", stream=True)
+    stream = client.chat.completions.create(messages=history, model="MiniMax-M3", stream=True)
     chunks = []
     for chunk in stream:
         chunks.append(chunk.choices[0].delta.content or "")


### PR DESCRIPTION
## Description

Bumps the model used in the MiniMax ChatInterface demo (`demo/llm_minimax/run.py`) from `MiniMax-M2.7` to `MiniMax-M3`, the latest generation in the M-series. M3 is MiniMax's current default chat model and is recommended for new examples.

This is a one-line follow-up to #13411 to keep the demo aligned with MiniMax's current default. No code/structure changes; the OpenAI-compatible client, base URL, and streaming pattern stay the same.

## AI Disclosure

- [x] I used AI to draft the model-string change and PR description (one-line model ID bump in `demo/llm_minimax/run.py`); I self-reviewed.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This is a very small fix (single-line model ID update in a demo) so no tracking issue was filed, per the "unless the fix is very small" exception in the template.

## Testing and Formatting Your Code

- `python -m py_compile demo/llm_minimax/run.py` passes.
- The demo's only change is the `model` string passed to `client.chat.completions.create(...)`; runtime behavior is unchanged on the Gradio side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single model string change in a demo script with no auth, data, or production impact.
> 
> **Overview**
> Updates the MiniMax Gradio chat demo so streaming completions use **`MiniMax-M3`** instead of **`MiniMax-M2.7`**. The OpenAI-compatible client, base URL, and streaming loop are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41d55f94aab45b7c60b05fe3073cead74fe78236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->