### PR TITLE
Fix broken SSR mode by deduping Svelte to a single version

### DIFF
--- a/.changeset/fix-ssr-svelte-version-dedup.md
+++ b/.changeset/fix-ssr-svelte-version-dedup.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix SSR mode failing to start (server render crashed with `TypeError: undefined is not a function`) by deduping Svelte to a single version. Multiple Svelte versions (5.47.1 / 5.48.0 / 5.56.0) were resolved into the SSR bundle, mixing the Svelte compiler and `svelte/server` runtime; a `pnpm.overrides` now pins Svelte to one version.

--- a/package.json
+++ b/package.json
@@ -175,5 +175,10 @@
 		"extends": [
 			"plugin:storybook/recommended"
 		]
+	},
+	"pnpm": {
+		"overrides": {
+			"svelte": "5.56.0"
+		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  svelte: 5.56.0
+
 patchedDependencies:
   '@sveltejs/package':
     hash: 4bf60d897bf9a1418645763e4338b3223b9458b10046bd6cde08601581f05183
@@ -33,7 +36,7 @@ importers:
         version: 3.1.0
       '@playwright/experimental-ct-svelte':
         specifier: ^1.56.0
-        version: 1.57.0(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(svelte@5.48.0)(terser@5.46.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+        version: 1.57.0(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(svelte@5.56.0(@typescript-eslint/types@8.53.1))(terser@5.46.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
@@ -45,10 +48,10 @@ importers:
         version: link:js/tootils
       '@sveltejs/package':
         specifier: ^2.5.7
-        version: 2.5.7(patch_hash=4bf60d897bf9a1418645763e4338b3223b9458b10046bd6cde08601581f05183)(svelte@5.48.0)(typescript@5.9.3)
+        version: 2.5.7(patch_hash=4bf60d897bf9a1418645763e4338b3223b9458b10046bd6cde08601581f05183)(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.1
-        version: 6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+        version: 6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
       '@tailwindcss/forms':
         specifier: ^0.5.10
         version: 0.5.11(tailwindcss@4.1.18)
@@ -87,7 +90,7 @@ importers:
         version: 9.39.2(jiti@1.21.7)
       eslint-plugin-svelte:
         specifier: ^3.12.4
-        version: 3.14.0(eslint@9.39.2(jiti@1.21.7))(svelte@5.48.0)
+        version: 3.14.0(eslint@9.39.2(jiti@1.21.7))(svelte@5.56.0(@typescript-eslint/types@8.53.1))
       globals:
         specifier: ^16.4.0
         version: 16.5.0
@@ -144,7 +147,7 @@ importers:
         version: 2.2.0(postcss@8.5.6)(prettier@3.8.0)
       prettier-plugin-svelte:
         specifier: ^3.4.0
-        version: 3.4.1(prettier@3.8.0)(svelte@5.48.0)
+        version: 3.4.1(prettier@3.8.0)(svelte@5.56.0(@typescript-eslint/types@8.53.1))
       sirv:
         specifier: ^3.0.2
         version: 3.0.2
@@ -152,20 +155,20 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
       svelte-check:
         specifier: ^4.3.2
-        version: 4.3.5(picomatch@4.0.3)(svelte@5.48.0)(typescript@5.9.3)
+        version: 4.3.5(picomatch@4.0.3)(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
       svelte-eslint-parser:
         specifier: ^1.3.3
-        version: 1.4.1(svelte@5.48.0)
+        version: 1.4.1(svelte@5.56.0(@typescript-eslint/types@8.53.1))
       svelte-i18n:
         specifier: ^4.0.1
-        version: 4.0.1(svelte@5.48.0)
+        version: 4.0.1(svelte@5.56.0(@typescript-eslint/types@8.53.1))
       svelte-preprocess:
         specifier: ^6.0.3
-        version: 6.0.3(coffeescript@2.7.0)(postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6))(postcss@8.5.6)(pug@3.0.3)(sass@1.97.2)(stylus@0.64.0)(svelte@5.48.0)(typescript@5.9.3)
+        version: 6.0.3(coffeescript@2.7.0)(postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6))(postcss@8.5.6)(pug@3.0.3)(sass@1.97.2)(stylus@0.64.0)(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.1.14
         version: 4.1.18
@@ -177,7 +180,7 @@ importers:
         version: 5.9.3
       typescript-svelte-plugin:
         specifier: ^0.3.50
-        version: 0.3.50(svelte@5.48.0)(typescript@5.9.3)
+        version: 0.3.50(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
       vite:
         specifier: ^7.1.9
         version: 7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
@@ -376,13 +379,13 @@ importers:
         version: 10.1.11(@types/react@19.2.9)(esbuild@0.25.12)(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
       '@storybook/addon-svelte-csf':
         specifier: ^5.0.10
-        version: 5.0.10(@storybook/svelte@10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0))(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+        version: 5.0.10(@storybook/svelte@10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.0(@typescript-eslint/types@8.53.1)))(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
       '@storybook/addon-vitest':
         specifier: ^10.1.11
         version: 10.1.11(@vitest/browser-playwright@4.0.18)(@vitest/browser@3.2.4(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.0.18))(@vitest/runner@4.0.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.0.18)
       '@storybook/svelte-vite':
         specifier: ^10.1.11
-        version: 10.1.11(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(esbuild@0.25.12)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+        version: 10.1.11(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(esbuild@0.25.12)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -403,7 +406,7 @@ importers:
         version: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       vitest-browser-svelte:
         specifier: ^0.1.0
-        version: 0.1.0(@vitest/browser@3.2.4(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.0.18))(svelte@5.48.0)(vitest@4.0.18)
+        version: 0.1.0(@vitest/browser@3.2.4(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.0.18))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vitest@4.0.18)
       wikidata-lang:
         specifier: 5.0.1
         version: 5.0.1
@@ -443,10 +446,10 @@ importers:
         version: link:../spa
       '@sveltejs/adapter-auto':
         specifier: ^6.1.1
-        version: 6.1.1(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))
+        version: 6.1.1(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))
       '@sveltejs/kit':
         specifier: ^2.46.2
-        version: 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0))
+        version: 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))
       iframe-resizer:
         specifier: ^5.5.7
         version: 5.5.7
@@ -543,8 +546,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -571,8 +574,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -639,8 +642,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
 
   js/audio:
     dependencies:
@@ -678,11 +681,11 @@ importers:
         specifier: 1.5.1
         version: 1.5.1
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
       svelte-range-slider-pips:
         specifier: 4.1.0
-        version: 4.1.0(svelte@5.48.0)
+        version: 4.1.0(svelte@5.56.0(@typescript-eslint/types@8.53.1))
       wavesurfer.js:
         specifier: 7.11.0
         version: 7.11.0
@@ -697,8 +700,8 @@ importers:
         specifier: workspace:^
         version: link:../atoms
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
 
   js/browserstate:
     dependencies:
@@ -712,8 +715,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@types/crypto-js':
         specifier: ^4.2.2
@@ -728,11 +731,11 @@ importers:
         specifier: ^0.25.10
         version: 0.25.12
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
       svelte-i18n:
         specifier: ^4.0.1
-        version: 4.0.1(svelte@5.48.0)
+        version: 4.0.1(svelte@5.56.0(@typescript-eslint/types@8.53.1))
 
   js/button:
     dependencies:
@@ -749,8 +752,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -798,8 +801,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/audio':
         specifier: workspace:^
@@ -826,8 +829,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -848,8 +851,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -933,8 +936,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -958,8 +961,8 @@ importers:
         specifier: ^1.4.6
         version: 1.4.6
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
       tinycolor2:
         specifier: ^1.6.0
         version: 1.6.0
@@ -971,8 +974,8 @@ importers:
   js/column:
     dependencies:
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -995,10 +998,10 @@ importers:
         version: link:../build
       '@sveltejs/adapter-auto':
         specifier: ^6.1.1
-        version: 6.1.1(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))
+        version: 6.1.1(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))
       '@sveltejs/kit':
         specifier: ^2.46.2
-        version: 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0))
+        version: 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))
 
   js/core:
     dependencies:
@@ -1006,8 +1009,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/accordion':
         specifier: workspace:^
@@ -1235,8 +1238,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: '>=5.0.0'
-        version: 5.47.1
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1260,8 +1263,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1282,8 +1285,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1310,8 +1313,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1329,8 +1332,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1339,8 +1342,8 @@ importers:
   js/draggable:
     dependencies:
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1367,8 +1370,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1387,10 +1390,10 @@ importers:
         version: link:../utils
       '@zerodevx/svelte-json-view':
         specifier: ^1.0.11
-        version: 1.0.11(svelte@5.48.0)
+        version: 1.0.11(svelte@5.56.0(@typescript-eslint/types@8.53.1))
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1417,8 +1420,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1454,8 +1457,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1473,8 +1476,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1513,8 +1516,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1526,8 +1529,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1551,8 +1554,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1579,8 +1582,8 @@ importers:
         specifier: ^4.7.9
         version: 4.7.9
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1589,8 +1592,8 @@ importers:
   js/icons:
     dependencies:
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
 
   js/image:
     dependencies:
@@ -1622,8 +1625,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1662,8 +1665,8 @@ importers:
         specifier: ^8.14.0
         version: 8.15.0
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
       tinycolor2:
         specifier: ^1.6.0
         version: 1.6.0
@@ -1705,8 +1708,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1727,8 +1730,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1749,8 +1752,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1774,8 +1777,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1814,8 +1817,8 @@ importers:
         specifier: ^1.30.0
         version: 1.30.0
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1860,8 +1863,8 @@ importers:
         specifier: ^1.2.9
         version: 1.2.9
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1897,8 +1900,8 @@ importers:
         specifier: workspace:^
         version: link:../video
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1922,8 +1925,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
       vega:
         specifier: ^6.2.0
         version: 6.2.0
@@ -1953,8 +1956,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1972,8 +1975,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1994,8 +1997,8 @@ importers:
         specifier: ^1.30.0
         version: 1.30.0
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2028,8 +2031,8 @@ importers:
         specifier: ^3.1.1
         version: 3.3.1
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
       vega:
         specifier: ^5.23.0
         version: 5.33.1
@@ -2079,8 +2082,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2089,8 +2092,8 @@ importers:
   js/row:
     dependencies:
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2130,8 +2133,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2152,8 +2155,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2189,8 +2192,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2211,8 +2214,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2230,8 +2233,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2267,8 +2270,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
 
   js/statustracker:
     dependencies:
@@ -2285,8 +2288,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2310,8 +2313,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2323,8 +2326,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2345,8 +2348,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2355,8 +2358,8 @@ importers:
   js/theme:
     dependencies:
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
 
   js/timer:
     dependencies:
@@ -2364,8 +2367,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2374,8 +2377,8 @@ importers:
   js/tooltip:
     dependencies:
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
 
   js/tootils:
     dependencies:
@@ -2386,8 +2389,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
 
   js/upload:
     dependencies:
@@ -2404,8 +2407,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
 
   js/uploadbutton:
     dependencies:
@@ -2422,8 +2425,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2453,8 +2456,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2496,8 +2499,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       svelte:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: 5.56.0
+        version: 5.56.0(@typescript-eslint/types@8.53.1)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -4860,7 +4863,7 @@ packages:
       '@storybook/svelte': ^0.0.0-0 || ^8.2.0 || ^9.0.0 || ^9.1.0-0 || ^10.0.0-0
       '@sveltejs/vite-plugin-svelte': ^4.0.0 || ^5.0.0 || ^6.0.0
       storybook: ^0.0.0-0 || ^8.2.0 || ^9.0.0 || ^9.1.0-0 || ^10.0.0-0
-      svelte: ^5.0.0
+      svelte: 5.56.0
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@storybook/addon-vitest@10.1.11':
@@ -4957,14 +4960,14 @@ packages:
     peerDependencies:
       '@sveltejs/vite-plugin-svelte': ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
       storybook: ^10.1.11
-      svelte: ^5.0.0
+      svelte: 5.56.0
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@storybook/svelte@10.1.11':
     resolution: {integrity: sha512-G2ASV/Q16YkJf/3+4NXX1MdxFTO5qztePwGR12U8yKyyV2NjKtgnCA3jkvSakBLhRbO1nbD8+H13FgQrRfxdbQ==}
     peerDependencies:
       storybook: ^10.1.11
-      svelte: ^5.0.0
+      svelte: 5.56.0
 
   '@storybook/theming@8.6.14':
     resolution: {integrity: sha512-r4y+LsiB37V5hzpQo+BM10PaCsp7YlZ0YcZzQP1OCkPlYXmUAFy2VvDKaFRpD8IeNPKug2u4iFm/laDEbs03dg==}
@@ -5013,7 +5016,7 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
       '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0
-      svelte: ^4.0.0 || ^5.0.0-next.0
+      svelte: 5.56.0
       typescript: ^5.3.3
       vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0
     peerDependenciesMeta:
@@ -5027,14 +5030,14 @@ packages:
     engines: {node: ^16.14 || >=18}
     hasBin: true
     peerDependencies:
-      svelte: ^3.44.0 || ^4.0.0 || ^5.0.0-next.1
+      svelte: 5.56.0
 
   '@sveltejs/vite-plugin-svelte-inspector@4.0.1':
     resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
       '@sveltejs/vite-plugin-svelte': ^5.0.0
-      svelte: ^5.0.0
+      svelte: 5.56.0
       vite: ^6.0.0
 
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2':
@@ -5042,21 +5045,21 @@ packages:
     engines: {node: ^20.19 || ^22.12 || >=24}
     peerDependencies:
       '@sveltejs/vite-plugin-svelte': ^6.0.0-next.0
-      svelte: ^5.0.0
+      svelte: 5.56.0
       vite: ^6.3.0 || ^7.0.0
 
   '@sveltejs/vite-plugin-svelte@5.1.1':
     resolution: {integrity: sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
-      svelte: ^5.0.0
+      svelte: 5.56.0
       vite: ^6.0.0
 
   '@sveltejs/vite-plugin-svelte@6.2.4':
     resolution: {integrity: sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==}
     engines: {node: ^20.19 || ^22.12 || >=24}
     peerDependencies:
-      svelte: ^5.0.0
+      svelte: 5.56.0
       vite: ^6.3.0 || ^7.0.0
 
   '@tailwindcss/forms@0.5.11':
@@ -5461,7 +5464,7 @@ packages:
   '@zerodevx/svelte-json-view@1.0.11':
     resolution: {integrity: sha512-mIjj0H1al/P4FPlbeDoiey93lNEUqBEAe5LIdD5GttZfEYt3awexD2lHwKNfUeY4jHizOJkoWTPN/2iO0GBqpw==}
     peerDependencies:
-      svelte: ^3.57.0 || ^4.0.0 || ^5.0.0
+      svelte: 5.56.0
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -6312,7 +6315,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.1 || ^9.0.0
-      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
+      svelte: 5.56.0
     peerDependenciesMeta:
       svelte:
         optional: true
@@ -6372,9 +6375,6 @@ packages:
 
   esrap@1.4.9:
     resolution: {integrity: sha512-3OMlcd0a03UGuZpPeUC1HxR3nA23l+HEyCiZw3b3FumJIN9KphoGzDJKMXI1S72jVS1dsenDyQC0kJlO1U9E1g==}
-
-  esrap@2.2.2:
-    resolution: {integrity: sha512-zA6497ha+qKvoWIK+WM9NAh5ni17sKZKhbS5B3PoYbBvaYHZWoS33zmFybmyqpn07RLUxSmn+RCls2/XF+d0oQ==}
 
   esrap@2.2.9:
     resolution: {integrity: sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==}
@@ -7132,7 +7132,7 @@ packages:
   mdsvex@0.12.6:
     resolution: {integrity: sha512-pupx2gzWh3hDtm/iDW4WuCpljmyHbHi34r7ktOqpPGvyiM4MyfNgdJ3qMizXdgCErmvYC9Nn/qyjePy+4ss9Wg==}
     peerDependencies:
-      svelte: ^3.56.0 || ^4.0.0 || ^5.0.0-next.120
+      svelte: 5.56.0
 
   media-encoder-host-broker@7.1.0:
     resolution: {integrity: sha512-Emu3f45Wbf6AoRJxfvZ8e5nh8fRVviBfkABgYNvVUsVBgJ7+l137gn324g/JmNVQhhVQ89fjmGT1kHIJ9JG5Nw==}
@@ -7624,7 +7624,7 @@ packages:
     resolution: {integrity: sha512-xL49LCloMoZRvSwa6IEdN2GV6cq2IqpYGstYtMT+5wmml1/dClEoI0MZR78MiVPpu6BdQFfN0/y73yO6+br5Pg==}
     peerDependencies:
       prettier: ^3.0.0
-      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
+      svelte: 5.56.0
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -8057,21 +8057,21 @@ packages:
     resolution: {integrity: sha512-hRHHufbJoArFmDYQKCpCvc0xUuIEfwYksvyLYEQyH+1xb5LD5sM/IthfooCdXZQtOIqXz6xm7NmaqdfwG4kh6w==}
     engines: {node: '>=18'}
     peerDependencies:
-      svelte: ^5.0.0
+      svelte: 5.56.0
 
   svelte-check@4.3.5:
     resolution: {integrity: sha512-e4VWZETyXaKGhpkxOXP+B/d0Fp/zKViZoJmneZWe/05Y2aqSKj3YN2nLfYPJBQ87WEiY4BQCQ9hWGu9mPT1a1Q==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
     peerDependencies:
-      svelte: ^4.0.0 || ^5.0.0-next.0
+      svelte: 5.56.0
       typescript: '>=5.0.0'
 
   svelte-eslint-parser@1.4.1:
     resolution: {integrity: sha512-1eqkfQ93goAhjAXxZiu1SaKI9+0/sxp4JIWQwUpsz7ybehRE5L8dNuz7Iry7K22R47p5/+s9EM+38nHV2OlgXA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0, pnpm: 10.24.0}
     peerDependencies:
-      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
+      svelte: 5.56.0
     peerDependenciesMeta:
       svelte:
         optional: true
@@ -8081,7 +8081,7 @@ packages:
     engines: {node: '>= 16'}
     hasBin: true
     peerDependencies:
-      svelte: ^3 || ^4 || ^5
+      svelte: 5.56.0
 
   svelte-preprocess@6.0.3:
     resolution: {integrity: sha512-PLG2k05qHdhmRG7zR/dyo5qKvakhm8IJ+hD2eFRQmMLHp7X3eJnjeupUtvuRpbNiF31RjVw45W+abDwHEmP5OA==}
@@ -8096,7 +8096,7 @@ packages:
       sass: ^1.26.8
       stylus: '>=0.55'
       sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^4.0.0 || ^5.0.0-next.100 || ^5.0.0
+      svelte: 5.56.0
       typescript: ^5.0.0
     peerDependenciesMeta:
       '@babel/core':
@@ -8123,21 +8123,13 @@ packages:
   svelte-range-slider-pips@4.1.0:
     resolution: {integrity: sha512-2Zw7MngIuPeqdyJ3ueEp7jPSx0hce+Sx8r1eteCeUPxEWlNavKhBtqJyuoAdpvh5csPPFVZJ4TJ4MX9s4G70uw==}
     peerDependencies:
-      svelte: ^4.2.7 || ^5.0.0
+      svelte: 5.56.0
 
   svelte2tsx@0.7.46:
     resolution: {integrity: sha512-S++Vw3w47a8rBuhbz4JK0fcGea8tOoX1boT53Aib8+oUO2EKeOG+geXprJVTDfBlvR+IJdf3jIpR2RGwT6paQA==}
     peerDependencies:
-      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
+      svelte: 5.56.0
       typescript: ^4.9.4 || ^5.0.0
-
-  svelte@5.47.1:
-    resolution: {integrity: sha512-MhSWfWEpG5T57z0Oyfk9D1GhAz/KTZKZZlWtGEsy9zNk2fafpuU7sJQlXNSA8HtvwKxVC9XlDyl5YovXUXjjHA==}
-    engines: {node: '>=18'}
-
-  svelte@5.48.0:
-    resolution: {integrity: sha512-+NUe82VoFP1RQViZI/esojx70eazGF4u0O/9ucqZ4rPcOZD+n5EVp17uYsqwdzjUjZyTpGKunHbDziW6AIAVkQ==}
-    engines: {node: '>=18'}
 
   svelte@5.56.0:
     resolution: {integrity: sha512-kTXr26t1bchFp28ROrb957LtbujpBmBDibmqMGziVpUs7awBi96TGgX6SovrA8BNoEUDVRK2Fb9FkeYlGspoVg==}
@@ -8758,7 +8750,7 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       '@vitest/browser': ^2.1.0 || ^3.0.0-0
-      svelte: '>3.0.0'
+      svelte: 5.56.0
       vitest: ^2.1.0 || ^3.0.0-0
 
   vitest@4.0.18:
@@ -10631,10 +10623,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@playwright/experimental-ct-svelte@1.57.0(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(svelte@5.48.0)(terser@5.46.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
+  '@playwright/experimental-ct-svelte@1.57.0(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(svelte@5.56.0(@typescript-eslint/types@8.53.1))(terser@5.46.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
     dependencies:
       '@playwright/experimental-ct-core': 1.57.0(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -10982,18 +10974,18 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-svelte-csf@5.0.10(@storybook/svelte@10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0))(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
+  '@storybook/addon-svelte-csf@5.0.10(@storybook/svelte@10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.0(@typescript-eslint/types@8.53.1)))(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
     dependencies:
       '@storybook/csf': 0.1.13
-      '@storybook/svelte': 10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      '@storybook/svelte': 10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.0(@typescript-eslint/types@8.53.1))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
       dedent: 1.7.1
       es-toolkit: 1.44.0
       esrap: 1.4.9
       magic-string: 0.30.21
       storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      svelte: 5.48.0
-      svelte-ast-print: 0.4.2(svelte@5.48.0)
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
+      svelte-ast-print: 0.4.2(svelte@5.56.0(@typescript-eslint/types@8.53.1))
       vite: 7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
       zimmerframe: 1.1.4
     transitivePeerDependencies:
@@ -11074,15 +11066,15 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@storybook/svelte-vite@10.1.11(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(esbuild@0.25.12)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
+  '@storybook/svelte-vite@10.1.11(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(esbuild@0.25.12)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
     dependencies:
       '@storybook/builder-vite': 10.1.11(esbuild@0.25.12)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
-      '@storybook/svelte': 10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      '@storybook/svelte': 10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.0(@typescript-eslint/types@8.53.1))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
       magic-string: 0.30.21
       storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      svelte: 5.48.0
-      svelte2tsx: 0.7.46(svelte@5.48.0)(typescript@5.9.3)
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
+      svelte2tsx: 0.7.46(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
       typescript: 5.9.3
       vite: 7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
     transitivePeerDependencies:
@@ -11091,10 +11083,10 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/svelte@10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0)':
+  '@storybook/svelte@10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.0(@typescript-eslint/types@8.53.1))':
     dependencies:
       storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      svelte: 5.48.0
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
       ts-dedent: 2.2.0
       type-fest: 2.19.0
 
@@ -11109,6 +11101,10 @@ snapshots:
   '@sveltejs/acorn-typescript@1.0.8(acorn@8.15.0)':
     dependencies:
       acorn: 8.15.0
+
+  '@sveltejs/adapter-auto@6.1.1(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))':
+    dependencies:
+      '@sveltejs/kit': 2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))
 
   '@sveltejs/adapter-auto@6.1.1(@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))':
     dependencies:
@@ -11161,6 +11157,27 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))
+      '@types/cookie': 0.6.0
+      acorn: 8.15.0
+      cookie: 0.6.0
+      devalue: 5.6.2
+      esm-env: 1.2.2
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      mrmime: 2.0.1
+      sade: 1.8.1
+      set-cookie-parser: 2.7.2
+      sirv: 3.0.2
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
+      vite: 7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@sveltejs/kit@2.50.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -11182,32 +11199,25 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/package@2.5.7(patch_hash=4bf60d897bf9a1418645763e4338b3223b9458b10046bd6cde08601581f05183)(svelte@5.48.0)(typescript@5.9.3)':
+  '@sveltejs/package@2.5.7(patch_hash=4bf60d897bf9a1418645763e4338b3223b9458b10046bd6cde08601581f05183)(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)':
     dependencies:
       chokidar: 5.0.0
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.7.3
-      svelte: 5.48.0
-      svelte2tsx: 0.7.46(svelte@5.48.0)(typescript@5.9.3)
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
+      svelte2tsx: 0.7.46(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
       debug: 4.4.3
-      svelte: 5.48.0
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
       vite: 7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
     transitivePeerDependencies:
       - supports-color
-
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
-      obug: 2.1.1
-      svelte: 5.48.0
-      vite: 7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
 
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
     dependencies:
@@ -11216,6 +11226,13 @@ snapshots:
       svelte: 5.56.0(@typescript-eslint/types@8.53.1)
       vite: 7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
 
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))
+      obug: 2.1.1
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
+      vite: 7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)
+
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0))
@@ -11223,28 +11240,18 @@ snapshots:
       svelte: 5.56.0(@typescript-eslint/types@8.53.1)
       vite: 7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
-      svelte: 5.48.0
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
       vite: 7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
       vitefu: 1.1.3(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
     transitivePeerDependencies:
       - supports-color
-
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.48.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
-      deepmerge: 4.3.1
-      magic-string: 0.30.21
-      obug: 2.1.1
-      svelte: 5.48.0
-      vite: 7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
-      vitefu: 1.1.3(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
 
   '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
     dependencies:
@@ -11255,6 +11262,16 @@ snapshots:
       svelte: 5.56.0(@typescript-eslint/types@8.53.1)
       vite: 7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
       vitefu: 1.1.3(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))
+      deepmerge: 4.3.1
+      magic-string: 0.30.21
+      obug: 2.1.1
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
+      vite: 7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))
 
   '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0))':
     dependencies:
@@ -11781,9 +11798,9 @@ snapshots:
 
   '@xmldom/xmldom@0.8.11': {}
 
-  '@zerodevx/svelte-json-view@1.0.11(svelte@5.48.0)':
+  '@zerodevx/svelte-json-view@1.0.11(svelte@5.56.0(@typescript-eslint/types@8.53.1))':
     dependencies:
-      svelte: 5.48.0
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
 
   abbrev@3.0.1: {}
 
@@ -12728,7 +12745,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-svelte@3.14.0(eslint@9.39.2(jiti@1.21.7))(svelte@5.48.0):
+  eslint-plugin-svelte@3.14.0(eslint@9.39.2(jiti@1.21.7))(svelte@5.56.0(@typescript-eslint/types@8.53.1)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -12740,9 +12757,9 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.6)
       postcss-safe-parser: 7.0.1(postcss@8.5.6)
       semver: 7.7.3
-      svelte-eslint-parser: 1.4.1(svelte@5.48.0)
+      svelte-eslint-parser: 1.4.1(svelte@5.56.0(@typescript-eslint/types@8.53.1))
     optionalDependencies:
-      svelte: 5.48.0
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
     transitivePeerDependencies:
       - ts-node
 
@@ -12831,10 +12848,6 @@ snapshots:
       '@types/estree': 1.0.8
 
   esrap@1.4.9:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-
-  esrap@2.2.2:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -13264,7 +13277,7 @@ snapshots:
 
   is-reference@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   is-regex@1.2.1:
     dependencies:
@@ -13735,7 +13748,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.12:
+    optional: true
 
   natural-compare@1.4.0: {}
 
@@ -14105,6 +14119,7 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+    optional: true
 
   postcss@8.5.6:
     dependencies:
@@ -14122,11 +14137,6 @@ snapshots:
       prettier: 3.8.0
     transitivePeerDependencies:
       - postcss
-
-  prettier-plugin-svelte@3.4.1(prettier@3.8.0)(svelte@5.48.0):
-    dependencies:
-      prettier: 3.8.0
-      svelte: 5.48.0
 
   prettier-plugin-svelte@3.4.1(prettier@3.8.0)(svelte@5.56.0(@typescript-eslint/types@8.53.1)):
     dependencies:
@@ -14640,7 +14650,7 @@ snapshots:
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
       '@webcontainer/env': 1.1.1
-      esbuild: 0.27.7
+      esbuild: 0.25.12
       open: 10.2.0
       oxc-parser: 0.127.0
       oxc-resolver: 11.20.0
@@ -14725,6 +14735,11 @@ snapshots:
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
 
+  sugarss@5.0.1(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+    optional: true
+
   sugarss@5.0.1(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -14738,23 +14753,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-ast-print@0.4.2(svelte@5.48.0):
+  svelte-ast-print@0.4.2(svelte@5.56.0(@typescript-eslint/types@8.53.1)):
     dependencies:
       esrap: 1.2.2
-      svelte: 5.48.0
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
       zimmerframe: 1.1.2
-
-  svelte-check@4.3.5(picomatch@4.0.3)(svelte@5.48.0)(typescript@5.9.3):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      chokidar: 4.0.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picocolors: 1.1.1
-      sade: 1.8.1
-      svelte: 5.48.0
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - picomatch
 
   svelte-check@4.3.5(picomatch@4.0.3)(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3):
     dependencies:
@@ -14768,7 +14771,7 @@ snapshots:
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@1.4.1(svelte@5.48.0):
+  svelte-eslint-parser@1.4.1(svelte@5.56.0(@typescript-eslint/types@8.53.1)):
     dependencies:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -14777,18 +14780,7 @@ snapshots:
       postcss-scss: 4.0.9(postcss@8.5.6)
       postcss-selector-parser: 7.1.1
     optionalDependencies:
-      svelte: 5.48.0
-
-  svelte-i18n@4.0.1(svelte@5.48.0):
-    dependencies:
-      cli-color: 2.0.4
-      deepmerge: 4.3.1
-      esbuild: 0.19.12
-      estree-walker: 2.0.2
-      intl-messageformat: 10.7.18
-      sade: 1.8.1
-      svelte: 5.48.0
-      tiny-glob: 0.2.9
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
 
   svelte-i18n@4.0.1(svelte@5.56.0(@typescript-eslint/types@8.53.1)):
     dependencies:
@@ -14813,9 +14805,9 @@ snapshots:
       stylus: 0.64.0
       typescript: 5.9.3
 
-  svelte-preprocess@6.0.3(coffeescript@2.7.0)(postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6))(postcss@8.5.6)(pug@3.0.3)(sass@1.97.2)(stylus@0.64.0)(svelte@5.48.0)(typescript@5.9.3):
+  svelte-preprocess@6.0.3(coffeescript@2.7.0)(postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6))(postcss@8.5.6)(pug@3.0.3)(sass@1.97.2)(stylus@0.64.0)(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3):
     dependencies:
-      svelte: 5.48.0
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
     optionalDependencies:
       coffeescript: 2.7.0
       postcss: 8.5.6
@@ -14825,52 +14817,16 @@ snapshots:
       stylus: 0.64.0
       typescript: 5.9.3
 
-  svelte-range-slider-pips@4.1.0(svelte@5.48.0):
+  svelte-range-slider-pips@4.1.0(svelte@5.56.0(@typescript-eslint/types@8.53.1)):
     dependencies:
-      svelte: 5.48.0
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
 
-  svelte2tsx@0.7.46(svelte@5.48.0)(typescript@5.9.3):
+  svelte2tsx@0.7.46(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3):
     dependencies:
       dedent-js: 1.0.1
       scule: 1.3.0
-      svelte: 5.48.0
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
       typescript: 5.9.3
-
-  svelte@5.47.1:
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@types/estree': 1.0.8
-      acorn: 8.15.0
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      clsx: 2.1.1
-      devalue: 5.6.2
-      esm-env: 1.2.2
-      esrap: 2.2.2
-      is-reference: 3.0.3
-      locate-character: 3.0.0
-      magic-string: 0.30.21
-      zimmerframe: 1.1.4
-
-  svelte@5.48.0:
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@types/estree': 1.0.8
-      acorn: 8.15.0
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      clsx: 2.1.1
-      devalue: 5.6.2
-      esm-env: 1.2.2
-      esrap: 2.2.2
-      is-reference: 3.0.3
-      locate-character: 3.0.0
-      magic-string: 0.30.21
-      zimmerframe: 1.1.4
 
   svelte@5.56.0(@typescript-eslint/types@8.53.1):
     dependencies:
@@ -15057,10 +15013,10 @@ snapshots:
 
   type@2.7.3: {}
 
-  typescript-svelte-plugin@0.3.50(svelte@5.48.0)(typescript@5.9.3):
+  typescript-svelte-plugin@0.3.50(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-      svelte2tsx: 0.7.46(svelte@5.48.0)(typescript@5.9.3)
+      svelte2tsx: 0.7.46(svelte@5.56.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - svelte
       - typescript
@@ -15745,12 +15701,30 @@ snapshots:
       stylus: 0.64.0
       terser: 5.46.0
 
+  vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.6
+      rollup: 4.61.0
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.10.9
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      lightningcss: 1.31.0
+      sass: 1.97.2
+      stylus: 0.64.0
+      sugarss: 5.0.1(postcss@8.5.15)
+      terser: 5.46.0
+
   vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.6
       rollup: 4.61.0
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -15767,14 +15741,18 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
 
+  vitefu@1.1.3(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)):
+    optionalDependencies:
+      vite: 7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)
+
   vitefu@1.1.3(vite@7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)):
     optionalDependencies:
       vite: 7.3.5(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
 
-  vitest-browser-svelte@0.1.0(@vitest/browser@3.2.4(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.0.18))(svelte@5.48.0)(vitest@4.0.18):
+  vitest-browser-svelte@0.1.0(@vitest/browser@3.2.4(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.0.18))(svelte@5.56.0(@typescript-eslint/types@8.53.1))(vitest@4.0.18):
     dependencies:
       '@vitest/browser': 3.2.4(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.31.0)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.0.18)
-      svelte: 5.48.0
+      svelte: 5.56.0(@typescript-eslint/types@8.53.1)
       vitest: 4.0.18(@types/node@24.10.9)(@vitest/browser-playwright@4.0.18)(happy-dom@19.0.2)(jiti@1.21.7)(jsdom@27.4.0(bufferutil@4.1.0))(lightningcss@1.31.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
 
   vitest@4.0.18(@types/node@24.10.9)(@vitest/browser-playwright@4.0.18)(happy-dom@19.0.2)(jiti@1.21.7)(jsdom@27.4.0(bufferutil@4.1.0))(lightningcss@1.31.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0):


### PR DESCRIPTION
## Description

SSR mode (`ssr_mode=True` / `GRADIO_SSR_MODE=true`) is currently **broken on `main`** — the demo never launches in true SSR mode and the `functional-test-SSR=true` CI job hangs.

### Symptom

The Node SSR server crashes on **every** render and returns HTTP 500:

```
[500] HEAD /
TypeError: undefined is not a function
    at Array.<anonymous> (.../server/chunks/_page.svelte-*.js)
    at Renderer.run (.../server/chunks/index-*.js)   ← svelte/server
```

Because `HEAD /` never returns `<500`, `verify_server_startup()` times out, the Node front-proxy is torn down, and the app either falls back to degraded CSR or (in the test harness) the SSR app never becomes ready, so `functional-test-SSR=true` hangs until cancelled.

### Root cause

**Three Svelte versions** were resolved across the workspace:

```
svelte@5.47.1
svelte@5.48.0
svelte@5.56.0
```

The SSR bundle (`@self/app` via SvelteKit) mixed them, so compiled components and the bundled `svelte/server` runtime came from **different Svelte versions** and the expected runtime helpers didn't line up → `undefined is not a function` during server render.

(This is the same multiple-Svelte-versions problem that also caused the runtime-i18n duplication fixed in #13461.)

### Fix

Pin Svelte to a single version via `pnpm.overrides`:

```json
"pnpm": { "overrides": { "svelte": "5.56.0" } }
```

After the override the lockfile resolves Svelte to one version (no more `5.47.1`/`5.48.0` references).

## Testing

Verified locally (rebuilt `@self/app`, launched a demo with `ssr_mode=True`):

**Before:** node SSR returns `500 TypeError: undefined is not a function` on every request; app falls back to CSR.

**After:**
```
[gradio-proxy] Listening on http://127.0.0.1:7860
* Running on local URL:  http://127.0.0.1:7860, with SSR ⚡ (Node proxy -> Python :7861)
$ curl -I http://127.0.0.1:7860/  ->  HTTP/1.1 200 OK
```

This should also unblock the `functional-test-SSR=true` job.

## Note

Confirmed pre-existing on `main` and reproduced on an unrelated branch as well, so it is independent of #13461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only lockfile change with no application logic edits; main risk is subtle breakage from the Svelte version bump across the workspace.
> 
> **Overview**
> Fixes **SSR mode** startup failures caused by **multiple Svelte versions** (5.47.1 / 5.48.0 / 5.56.0) being bundled together, which led to server render crashes (`TypeError: undefined is not a function`) when compiled components and `svelte/server` did not match.
> 
> Adds **`pnpm.overrides`** in root `package.json` to pin **`svelte` to `5.56.0`**, and refreshes **`pnpm-lock.yaml`** so the monorepo resolves a single Svelte everywhere. Includes a **gradio patch** changeset describing the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 895a59586a3da6b3aeb6c75ee44e656afbec2010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->