### PR TITLE
Track Gradio Server mode as its own kind in analytics

### DIFF
--- a/.changeset/server-mode-analytics.md
+++ b/.changeset/server-mode-analytics.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+feat:Track Gradio Server mode as its own kind in analytics (`mode="server"`)

--- a/gradio/server.py
+++ b/gradio/server.py
@@ -281,7 +281,7 @@ class Server(App):
         from gradio.blocks import Blocks
         from gradio.events import api as gr_api
 
-        with Blocks() as blocks:
+        with Blocks(mode="server") as blocks:
             for fn, api_kwargs in self._deferred_apis:
                 gr_api(fn=fn, **api_kwargs)
 


### PR DESCRIPTION
## Description

Right now, when a `gr.Server` is launched, `Server.launch()` builds a default `Blocks` internally and calls `blocks.launch()`. Because that `Blocks` uses the default `mode="blocks"`, Server-mode apps are recorded in analytics as `mode="blocks"`

By contrast, `Interface`, `TabbedInterface`, and `ChatInterface` each pass a distinct `mode` (`"interface"`, `"tabbed_interface"`, `"chat_interface"`) so their "kind" is tracked in the `gradio-initiated-analytics` and `gradio-launched-telemetry` events.

This PR passes `mode="server"` when constructing the internal `Blocks` in `Server.launch()`, so Server mode is tracked as its own kind. (Note: `Server.launch()` already set `GRADIO_SERVER_MODE_ENABLED=1`, but nothing in the analytics pipeline read that env var, so the signal never made it into the recorded data.)