### PR TITLE
Raise helpful errors when event handler inputs/outputs are mistyped

### DIFF
--- a/.changeset/issue-3522-typecheck-event-handlers.md
+++ b/.changeset/issue-3522-typecheck-event-handlers.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Raise a helpful error identifying which component/argument was mistyped when pre/postprocessing an event handler's inputs/outputs

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -66,7 +66,9 @@ from gradio.events import (
 )
 from gradio.exceptions import (
     ChecksumMismatchError,
+    ComponentProcessingError,
     DuplicateBlockError,
+    Error,
     InvalidApiNameError,
     InvalidComponentError,
     ShareCertificateWriteError,
@@ -1759,6 +1761,57 @@ Received inputs:
     [{received}]"""
             )
 
+    @staticmethod
+    def _format_processing_error(
+        block_fn: BlockFunction,
+        index: int,
+        block: Block,
+        value: Any,
+        is_input: bool,
+        original_error: Exception,
+    ) -> str:
+        name = (
+            f' (named "{block_fn.name}")'
+            if block_fn.name and block_fn.name != "<lambda>"
+            else ""
+        )
+        blocks = block_fn.inputs if is_input else block_fn.outputs
+        components_list = ", ".join(b.get_block_name() for b in blocks)
+
+        value_repr = repr(value)
+        if len(value_repr) > 200:
+            value_repr = value_repr[:200] + "..."
+
+        kind = "input" if is_input else "output"
+        stage = "preprocess" if is_input else "postprocess"
+        verb = "passed to" if is_input else "returned from"
+
+        method = block.preprocess if is_input else block.postprocess
+        expected_type = None
+        try:
+            params = list(inspect.signature(method).parameters.values())
+            if params and params[0].annotation is not inspect.Parameter.empty:
+                annotation = params[0].annotation
+                expected_type = (
+                    annotation
+                    if isinstance(annotation, str)
+                    else getattr(annotation, "__name__", str(annotation))
+                )
+        except (ValueError, TypeError):
+            expected_type = None
+
+        expected_clause = (
+            f"Expected a `{expected_type}`, but the" if expected_type else "The"
+        )
+        return (
+            f"Could not {stage} {kind} component at index {index} "
+            f"(a `{block.get_block_name()}` component) of the event handler{name} "
+            f"with {kind} components: [{components_list}].\n\n"
+            f"{expected_clause} value {verb} the event handler was: {value_repr} "
+            f"(of type `{type(value).__name__}`).\n\n"
+            f"Original error: {type(original_error).__name__}: {original_error}"
+        )
+
     async def preprocess_data(
         self,
         block_fn: BlockFunction,
@@ -1814,9 +1867,23 @@ Received inputs:
                 state._update_value_in_config(block._id, inputs_serialized)
 
                 if block_fn.preprocess:
-                    processed_value = await anyio.to_thread.run_sync(
-                        block.preprocess, inputs_cached, limiter=self.limiter
-                    )
+                    try:
+                        processed_value = await anyio.to_thread.run_sync(
+                            block.preprocess, inputs_cached, limiter=self.limiter
+                        )
+                    except Error:
+                        raise
+                    except Exception as err:
+                        raise ComponentProcessingError(
+                            self._format_processing_error(
+                                block_fn,
+                                i,
+                                block,
+                                value_to_process,
+                                is_input=True,
+                                original_error=err,
+                            )
+                        ) from err
                 else:
                     processed_value = inputs_serialized
 
@@ -1968,9 +2035,23 @@ Received inputs:
                         )
                     if block._id in state:
                         block = state[block._id]
-                    prediction_value = await anyio.to_thread.run_sync(
-                        block.postprocess, prediction_value, limiter=self.limiter
-                    )
+                    try:
+                        prediction_value = await anyio.to_thread.run_sync(
+                            block.postprocess, prediction_value, limiter=self.limiter
+                        )
+                    except Error:
+                        raise
+                    except Exception as err:
+                        raise ComponentProcessingError(
+                            self._format_processing_error(
+                                block_fn,
+                                i,
+                                block,
+                                predictions[i],
+                                is_input=False,
+                                original_error=err,
+                            )
+                        ) from err
                     if isinstance(prediction_value, (GradioModel, GradioRootModel)):
                         prediction_value_serialized = prediction_value.model_dump()
                     else:

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -1786,19 +1786,20 @@ Received inputs:
         stage = "preprocess" if is_input else "postprocess"
         verb = "passed to" if is_input else "returned from"
 
-        method = block.preprocess if is_input else block.postprocess
+        method = getattr(block, "preprocess" if is_input else "postprocess", None)
         expected_type = None
-        try:
-            params = list(inspect.signature(method).parameters.values())
-            if params and params[0].annotation is not inspect.Parameter.empty:
-                annotation = params[0].annotation
-                expected_type = (
-                    annotation
-                    if isinstance(annotation, str)
-                    else getattr(annotation, "__name__", str(annotation))
-                )
-        except (ValueError, TypeError):
-            expected_type = None
+        if method is not None:
+            try:
+                params = list(inspect.signature(method).parameters.values())
+                if params and params[0].annotation is not inspect.Parameter.empty:
+                    annotation = params[0].annotation
+                    expected_type = (
+                        annotation
+                        if isinstance(annotation, str)
+                        else getattr(annotation, "__name__", str(annotation))
+                    )
+            except (ValueError, TypeError):
+                expected_type = None
 
         expected_clause = (
             f"Expected a `{expected_type}`, but the" if expected_type else "The"

--- a/gradio/exceptions.py
+++ b/gradio/exceptions.py
@@ -54,6 +54,14 @@ class GradioVersionIncompatibleError(Exception):
     pass
 
 
+class ComponentProcessingError(ValueError):
+    """Raised when a component fails to pre/postprocess a value passed to or
+    returned from an event handler. Wraps the original exception with information
+    identifying which component/argument was at fault."""
+
+    pass
+
+
 InvalidApiName = InvalidApiNameError  # backwards compatibility
 
 

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -29,7 +29,7 @@ from gradio import blocks, helpers
 from gradio.context import LocalContext
 from gradio.data_classes import GradioModel, GradioRootModel
 from gradio.events import SelectData
-from gradio.exceptions import DuplicateBlockError
+from gradio.exceptions import ComponentProcessingError, DuplicateBlockError
 from gradio.route_utils import API_PREFIX
 from gradio.utils import assert_configs_are_equivalent_besides_ids, cancel_tasks
 
@@ -894,6 +894,49 @@ class TestBlocksPostprocessing:
             ValueError,
         ):
             await demo.postprocess_data(demo.fns[0], predictions=[1, 2], state=None)
+
+    @pytest.mark.asyncio
+    async def test_helpful_error_when_output_is_mistyped(self):
+        def process_images(n, t):
+            return n, t
+
+        with gr.Blocks() as demo:
+            number = gr.Number(precision=0)
+            textbox = gr.Textbox()
+            btn = gr.Button()
+            btn.click(process_images, [number, textbox], [number, textbox])
+
+        with pytest.raises(ComponentProcessingError) as exc_info:
+            await demo.postprocess_data(
+                demo.fns[0], predictions=[{"foo": "bar"}, "a"], state=None
+            )
+        message = str(exc_info.value)
+        assert "index 0" in message
+        assert "number" in message
+        assert "process_images" in message
+        assert "{'foo': 'bar'}" in message
+        assert isinstance(exc_info.value.__cause__, TypeError)
+
+    @pytest.mark.asyncio
+    async def test_helpful_error_when_input_is_mistyped(self):
+        def process_images(n, s):
+            return n, s
+
+        with gr.Blocks() as demo:
+            number = gr.Number()
+            slider = gr.Slider()
+            btn = gr.Button()
+            btn.click(process_images, [number, slider], [number, slider])
+
+        with pytest.raises(ComponentProcessingError) as exc_info:
+            await demo.preprocess_data(
+                demo.fns[0], inputs=[1, {"foo": "bar"}], state=None
+            )
+        message = str(exc_info.value)
+        assert "index 1" in message
+        assert "slider" in message
+        assert "process_images" in message
+        assert isinstance(exc_info.value.__cause__, TypeError)
 
     @pytest.mark.asyncio
     async def test_dataset_is_updated(self):


### PR DESCRIPTION
Fixes #3522. This is an old issue, but I think it's actually even more important now with agents writing most Gradio code. Having clear errors is helpful for LLMs to fix code that they've written incorrectly.

Previously, when an event handler would receive a wrong-typed input, or returns a wrong-typed output, the error is raised deep inside a component's `preprocess`/`postprocess` method and gives no hint about *which* component or argument is at fault. For example:

```
TypeError: float() argument must be a string or a real number, not 'dict'
```

`Blocks.preprocess_data` / `Blocks.postprocess_data` call each component's `preprocess`/`postprocess` directly with no contextual error handling. This PR wraps those two calls so that any exception is re-raised as a new exception, `ComponentProcessingError` that looks like this:

```
gradio.exceptions.ComponentProcessingError: Could not postprocess output component at index 0 (a `number` component) of the event handler (named "process_images") with output components: [number, textbox, checkbox, slider].

Expected a `float | int | None`, but the value returned from the event handler was: {'foo': 'bar'} (of type `dict`).

Original error: TypeError: type dict doesn't define __round__ method
```

Much better for LLMs (and humans!) to reason about.

Test with a demo like this:

```py
import gradio as gr

def process(num):
    return {"foo": "bar"}  # wrong type: a Number output expects a number

demo = gr.Interface(process, gr.Number(precision=0), gr.Number(precision=0))

if __name__ == "__main__":
    demo.launch(server_port=7861)
```