### PR TITLE
Add ImageEditor brush antialias control

### DIFF
--- a/.changeset/flat-masks-draw.md
+++ b/.changeset/flat-masks-draw.md
@@ -1,0 +1,6 @@
+---
+"gradio": patch
+"@gradio/imageeditor": patch
+---
+
+feat:Allow ImageEditor brush strokes to disable antialiasing.

--- a/gradio/components/image_editor.py
+++ b/gradio/components/image_editor.py
@@ -256,6 +256,7 @@ class ImageEditor(Component):
         layers: bool | LayerOptions = True,
         canvas_size: tuple[int, int] = (800, 800),
         fixed_canvas: bool = False,
+        brush_antialias: bool = True,
         webcam_options: WebcamOptions | None = None,
     ):
         """
@@ -289,6 +290,7 @@ class ImageEditor(Component):
             layers: The options for the layer tool in the image editor. Can be a boolean     or an instance of the `gr.LayerOptions` class. If True, will allow users to add layers to the image. If False, the layers option will be hidden. If an instance of `gr.LayerOptions`, it will be used to configure the layer tool. [See `gr.LayerOptions` docs](#layer-options).
             canvas_size: The initial size of the canvas in pixels. The first value is the width and the second value is the height. If `fixed_canvas` is `True`, uploaded images will be rescaled to fit the canvas size while preserving the aspect ratio. Otherwise, the canvas size will change to match the size of an uploaded image.
             fixed_canvas: If True, the canvas size will not change based on the size of the background image and the image will be rescaled to fit (while preserving the aspect ratio) and placed in the center of the canvas.
+            brush_antialias: If True, brush and eraser strokes will be drawn with antialiasing. If False, strokes will be drawn without antialiasing, which is useful for pixel-perfect segmentation masks.
             webcam_options: The options for the webcam tool in the image editor. Can be an instance of the `gr.WebcamOptions` class, or None to use the default settings. [See `gr.WebcamOptions` docs](#webcam-options).
         """
         self._selectable = _selectable
@@ -334,6 +336,7 @@ class ImageEditor(Component):
         )
         self.canvas_size = canvas_size
         self.fixed_canvas = fixed_canvas
+        self.brush_antialias = brush_antialias
         self.placeholder = placeholder
         super().__init__(
             label=label,

--- a/gradio/templates.py
+++ b/gradio/templates.py
@@ -142,6 +142,7 @@ class Sketchpad(components.ImageEditor):
         format: str = "webp",
         canvas_size: tuple[int, int] = (800, 800),
         fixed_canvas: bool = False,
+        brush_antialias: bool = True,
         layers: LayerOptions | bool = True,
     ):
         if not brush:
@@ -178,6 +179,7 @@ class Sketchpad(components.ImageEditor):
             layers=layers,
             canvas_size=canvas_size,
             fixed_canvas=fixed_canvas,
+            brush_antialias=brush_antialias,
         )
 
 
@@ -228,6 +230,7 @@ class Paint(components.ImageEditor):
         layers: LayerOptions | bool = True,
         canvas_size: tuple[int, int] = (800, 800),
         fixed_canvas: bool = False,
+        brush_antialias: bool = True,
         placeholder: str | None = None,
     ):
         super().__init__(
@@ -262,6 +265,7 @@ class Paint(components.ImageEditor):
             canvas_size=canvas_size,
             placeholder=placeholder,
             fixed_canvas=fixed_canvas,
+            brush_antialias=brush_antialias,
         )
 
 
@@ -316,6 +320,7 @@ class ImageMask(components.ImageEditor):
         layers: LayerOptions | bool = False,
         canvas_size: tuple[int, int] = (800, 800),
         fixed_canvas: bool = False,
+        brush_antialias: bool = True,
         webcam_options: WebcamOptions | None = None,
     ):
         if not brush:
@@ -352,6 +357,7 @@ class ImageMask(components.ImageEditor):
             layers=layers,
             canvas_size=canvas_size,
             fixed_canvas=fixed_canvas,
+            brush_antialias=brush_antialias,
         )
 
 

--- a/js/imageeditor/InteractiveImageEditor.svelte
+++ b/js/imageeditor/InteractiveImageEditor.svelte
@@ -51,6 +51,7 @@
 
 	export let canvas_size: [number, number];
 	export let fixed_canvas = false;
+	export let brush_antialias = true;
 	export let realtime: boolean;
 	export let upload: Client["upload"];
 	export let is_dragging: boolean;
@@ -229,6 +230,7 @@
 	brush_options={brush}
 	eraser_options={eraser}
 	{fixed_canvas}
+	{brush_antialias}
 	{border_region}
 	{layer_options}
 	{i18n}

--- a/js/imageeditor/shared/ImageEditor.svelte
+++ b/js/imageeditor/shared/ImageEditor.svelte
@@ -50,6 +50,7 @@
 	export let brush_options: Brush;
 	export let eraser_options: Eraser;
 	export let fixed_canvas = false;
+	export let brush_antialias = true;
 	export let root: string;
 	export let i18n: I18nFormatter;
 	export let upload: Client["upload"];
@@ -319,7 +320,7 @@
 	export let can_undo = false;
 	let can_redo = false;
 	async function init_image_editor(): Promise<void> {
-		brush = new BrushTool();
+		brush = new BrushTool({ antialias: brush_antialias });
 		zoom = new ZoomTool();
 		editor = new ImageEditor({
 			target_element: pixi_target,
@@ -327,6 +328,7 @@
 			height: canvas_size[1],
 			tools: ["image", zoom, new ResizeTool(), brush],
 			fixed_canvas,
+			antialias: brush_antialias,
 			border_region,
 			layer_options,
 			theme_mode

--- a/js/imageeditor/shared/brush/brush-textures.ts
+++ b/js/imageeditor/shared/brush/brush-textures.ts
@@ -4,10 +4,72 @@ import {
 	Sprite,
 	Graphics,
 	Application,
-	Texture
+	Texture,
 } from "pixi.js";
 import { type ImageEditorContext } from "../core/editor";
 import { type Command } from "../core/commands";
+
+function parse_color(color: string): [number, number, number] {
+	if (!color.startsWith("#")) {
+		return [255, 255, 255];
+	}
+
+	const value = parseInt(color.slice(1), 16);
+	return [(value >> 16) & 255, (value >> 8) & 255, value & 255];
+}
+
+function create_hard_stamp_sprite(
+	x: number,
+	y: number,
+	size: number,
+	color: string,
+): Sprite {
+	const min_x = Math.floor(x - size);
+	const max_x = Math.ceil(x + size);
+	const min_y = Math.floor(y - size);
+	const max_y = Math.ceil(y + size);
+	const width = max_x - min_x + 1;
+	const height = max_y - min_y + 1;
+	const canvas = document.createElement("canvas");
+	canvas.width = width;
+	canvas.height = height;
+
+	const context = canvas.getContext("2d");
+	if (!context) {
+		return new Sprite(Texture.EMPTY);
+	}
+
+	const [r, g, b] = parse_color(color);
+	const image_data = context.createImageData(width, height);
+	const size_squared = size * size;
+
+	for (let py = min_y; py <= max_y; py++) {
+		for (let px = min_x; px <= max_x; px++) {
+			const dx = px + 0.5 - x;
+			const dy = py + 0.5 - y;
+			if (dx * dx + dy * dy <= size_squared) {
+				const index = ((py - min_y) * width + (px - min_x)) * 4;
+				image_data.data[index] = r;
+				image_data.data[index + 1] = g;
+				image_data.data[index + 2] = b;
+				image_data.data[index + 3] = 255;
+			}
+		}
+	}
+
+	context.putImageData(image_data, 0, 0);
+
+	const texture = Texture.from(
+		{
+			resource: canvas,
+			scaleMode: "nearest",
+		},
+		true,
+	);
+	const sprite = new Sprite({ texture, roundPixels: true });
+	sprite.position.set(min_x, min_y);
+	return sprite;
+}
 
 /**
  * Represents a single drawing segment with all its parameters
@@ -21,6 +83,7 @@ interface BrushSegment {
 	color: string;
 	opacity: number;
 	mode: "draw" | "erase";
+	antialias: boolean;
 }
 
 /**
@@ -41,7 +104,7 @@ export class BrushCommand implements Command {
 	constructor(
 		context: ImageEditorContext,
 		stroke_data: BrushStroke,
-		original_texture?: Texture
+		original_texture?: Texture,
 	) {
 		this.name = "Draw";
 		this.stroke_data = stroke_data;
@@ -58,7 +121,8 @@ export class BrushCommand implements Command {
 		const texture = RenderTexture.create({
 			width: source.width,
 			height: source.height,
-			resolution: window.devicePixelRatio || 1
+			resolution: window.devicePixelRatio || 1,
+			antialias: this.stroke_data.segments[0]?.antialias ?? true,
 		});
 
 		const sprite = new Sprite(source);
@@ -66,7 +130,7 @@ export class BrushCommand implements Command {
 		container.addChild(sprite);
 
 		this.context.app.renderer.render(container, {
-			renderTexture: texture
+			renderTexture: texture,
 		});
 
 		container.destroy({ children: true });
@@ -79,11 +143,11 @@ export class BrushCommand implements Command {
 	 */
 	private render_stroke_from_data(
 		stroke_data: BrushStroke,
-		target_texture: RenderTexture
+		target_texture: RenderTexture,
 	): void {
 		const draw_segments = stroke_data.segments.filter((s) => s.mode === "draw");
 		const erase_segments = stroke_data.segments.filter(
-			(s) => s.mode === "erase"
+			(s) => s.mode === "erase",
 		);
 
 		if (draw_segments.length > 0) {
@@ -103,10 +167,10 @@ export class BrushCommand implements Command {
 
 				graphics.setFillStyle({
 					color: colorValue,
-					alpha: 1
+					alpha: 1,
 				});
 
-				this.render_segment_to_graphics(graphics, segment);
+				this.render_segment(container, graphics, segment, segment.color);
 			}
 
 			// we need a sprite in order to set the alpha and for that we need a texture
@@ -114,13 +178,14 @@ export class BrushCommand implements Command {
 			const alpha_sprite_texture = RenderTexture.create({
 				width: target_texture.width,
 				height: target_texture.height,
-				resolution: window.devicePixelRatio || 1
+				resolution: window.devicePixelRatio || 1,
+				antialias: draw_segments[0]?.antialias ?? true,
 			});
 
 			const alpha_sprite = new Sprite(alpha_sprite_texture);
 			this.context.app.renderer.render({
 				container: container,
-				target: alpha_sprite_texture
+				target: alpha_sprite_texture,
 			});
 
 			alpha_sprite.alpha = alpha;
@@ -128,7 +193,7 @@ export class BrushCommand implements Command {
 			this.context.app.renderer.render({
 				container: alpha_sprite,
 				target: target_texture,
-				clear: false
+				clear: false,
 			});
 
 			container.destroy({ children: true });
@@ -141,7 +206,8 @@ export class BrushCommand implements Command {
 			const temp_content_texture = RenderTexture.create({
 				width: target_texture.width,
 				height: target_texture.height,
-				resolution: window.devicePixelRatio || 1
+				resolution: window.devicePixelRatio || 1,
+				antialias: erase_segments[0]?.antialias ?? true,
 			});
 
 			const copy_sprite = new Sprite(target_texture);
@@ -151,7 +217,7 @@ export class BrushCommand implements Command {
 			this.context.app.renderer.render({
 				container: copy_container,
 				target: temp_content_texture,
-				clear: true
+				clear: true,
 			});
 
 			// create a graphics object to draw the erase segments
@@ -161,24 +227,30 @@ export class BrushCommand implements Command {
 
 			erase_graphics.setFillStyle({
 				color: 0xffffff,
-				alpha: 1.0
+				alpha: 1.0,
 			});
 
 			for (const segment of erase_segments) {
-				this.render_segment_to_graphics(erase_graphics, segment);
+				this.render_segment(
+					erase_container,
+					erase_graphics,
+					segment,
+					"#ffffff",
+				);
 			}
 
 			// create a separate texture to hold the mask
 			const mask_texture = RenderTexture.create({
 				width: target_texture.width,
 				height: target_texture.height,
-				resolution: window.devicePixelRatio || 1
+				resolution: window.devicePixelRatio || 1,
+				antialias: erase_segments[0]?.antialias ?? true,
 			});
 
 			this.context.app.renderer.render({
 				container: erase_container,
 				target: mask_texture,
-				clear: true
+				clear: true,
 			});
 
 			const content_sprite = new Sprite(temp_content_texture);
@@ -193,7 +265,7 @@ export class BrushCommand implements Command {
 			this.context.app.renderer.render({
 				container: masked_container,
 				target: target_texture,
-				clear: true
+				clear: true,
 			});
 
 			copy_container.destroy({ children: true });
@@ -205,19 +277,29 @@ export class BrushCommand implements Command {
 	}
 
 	/**
-	 * Renders a segment to a graphics object (extracted from renderSegment)
+	 * Renders a segment to a container.
 	 */
-	private render_segment_to_graphics(
+	private render_segment(
+		container: Container,
 		graphics: Graphics,
-		segment: BrushSegment
+		segment: BrushSegment,
+		color: string,
 	): void {
 		const distance = Math.sqrt(
 			Math.pow(segment.to_x - segment.from_x, 2) +
-				Math.pow(segment.to_y - segment.from_y, 2)
+				Math.pow(segment.to_y - segment.from_y, 2),
 		);
 
 		if (distance < 0.1) {
-			graphics.circle(segment.from_x, segment.from_y, segment.size).fill();
+			this.render_stamp(
+				container,
+				graphics,
+				segment.from_x,
+				segment.from_y,
+				segment.size,
+				color,
+				segment.antialias,
+			);
 		} else {
 			const spacing = Math.max(segment.size / 3, 2);
 			const steps = Math.max(Math.ceil(distance / spacing), 2);
@@ -227,9 +309,34 @@ export class BrushCommand implements Command {
 				const x = segment.from_x + (segment.to_x - segment.from_x) * t;
 				const y = segment.from_y + (segment.to_y - segment.from_y) * t;
 
-				graphics.circle(x, y, segment.size).fill();
+				this.render_stamp(
+					container,
+					graphics,
+					x,
+					y,
+					segment.size,
+					color,
+					segment.antialias,
+				);
 			}
 		}
+	}
+
+	private render_stamp(
+		container: Container,
+		graphics: Graphics,
+		x: number,
+		y: number,
+		size: number,
+		color: string,
+		antialias: boolean,
+	): void {
+		if (antialias) {
+			graphics.circle(x, y, size).fill();
+			return;
+		}
+
+		container.addChild(create_hard_stamp_sprite(x, y, size, color));
 	}
 
 	async execute(context: ImageEditorContext): Promise<void> {
@@ -238,14 +345,14 @@ export class BrushCommand implements Command {
 		}
 
 		let layer_textures = this.context.layer_manager.get_layer_textures(
-			this.stroke_data.layer_id
+			this.stroke_data.layer_id,
 		);
 
 		if (!layer_textures) {
 			const all_layers = this.context.layer_manager.get_layers();
 			const top_layer = all_layers[all_layers.length - 1];
 			layer_textures = this.context.layer_manager.get_layer_textures(
-				top_layer.id
+				top_layer.id,
 			);
 		}
 
@@ -255,7 +362,8 @@ export class BrushCommand implements Command {
 		const temp_texture = RenderTexture.create({
 			width: layer_textures.draw.width,
 			height: layer_textures.draw.height,
-			resolution: window.devicePixelRatio || 1
+			resolution: window.devicePixelRatio || 1,
+			antialias: this.stroke_data.segments[0]?.antialias ?? true,
 		});
 
 		// copy current layer content to temp texture
@@ -266,7 +374,7 @@ export class BrushCommand implements Command {
 		this.context.app.renderer.render({
 			container: temp_container,
 			target: temp_texture,
-			clear: true
+			clear: true,
 		});
 
 		temp_container.destroy({ children: true });
@@ -281,7 +389,7 @@ export class BrushCommand implements Command {
 		this.context.app.renderer.render({
 			container: final_container,
 			target: layer_textures.draw,
-			clear: true
+			clear: true,
 		});
 
 		final_container.destroy({ children: true });
@@ -292,7 +400,7 @@ export class BrushCommand implements Command {
 		if (!this.original_texture) return;
 
 		const layer_textures = this.context.layer_manager.get_layer_textures(
-			this.stroke_data.layer_id
+			this.stroke_data.layer_id,
 		);
 		if (!layer_textures) return;
 
@@ -303,7 +411,7 @@ export class BrushCommand implements Command {
 		this.context.app.renderer.render({
 			container: temp_container,
 			target: layer_textures.draw,
-			clear: true
+			clear: true,
 		});
 
 		temp_container.destroy({ children: true });
@@ -325,20 +433,27 @@ export class BrushTextures {
 	private dimensions: { width: number; height: number };
 	private image_editor_context: ImageEditorContext;
 	private app: Application;
+	private antialias: boolean;
 	private is_new_stroke = true;
 
 	private current_opacity = 1.0;
 	private original_layer_texture: Texture | null = null;
 	private active_layer_id: string | null = null;
 	private current_stroke_segments: BrushSegment[] = [];
+	private hard_stamp_sprites: Sprite[] = [];
 
-	constructor(image_editor_context: ImageEditorContext, app: Application) {
+	constructor(
+		image_editor_context: ImageEditorContext,
+		app: Application,
+		antialias = true,
+	) {
 		this.image_editor_context = image_editor_context;
 		this.app = app;
+		this.antialias = antialias;
 
 		this.dimensions = {
 			width: this.image_editor_context.image_container.width,
-			height: this.image_editor_context.image_container.height
+			height: this.image_editor_context.image_container.height,
 		};
 	}
 
@@ -353,19 +468,21 @@ export class BrushTextures {
 
 		this.dimensions = {
 			width: local_bounds.width,
-			height: local_bounds.height
+			height: local_bounds.height,
 		};
 
 		this.stroke_texture = RenderTexture.create({
 			width: this.dimensions.width,
 			height: this.dimensions.height,
-			resolution: window.devicePixelRatio || 1
+			resolution: window.devicePixelRatio || 1,
+			antialias: this.antialias,
 		});
 
 		this.erase_texture = RenderTexture.create({
 			width: this.dimensions.width,
 			height: this.dimensions.height,
-			resolution: window.devicePixelRatio || 1
+			resolution: window.devicePixelRatio || 1,
+			antialias: this.antialias,
 		});
 
 		this.display_container = new Container();
@@ -384,10 +501,10 @@ export class BrushTextures {
 
 		const clear_container = new Container();
 		this.app.renderer.render(clear_container, {
-			renderTexture: this.stroke_texture
+			renderTexture: this.stroke_texture,
 		});
 		this.app.renderer.render(clear_container, {
-			renderTexture: this.erase_texture
+			renderTexture: this.erase_texture,
 		});
 		clear_container.destroy();
 
@@ -413,6 +530,8 @@ export class BrushTextures {
 	 * Cleans up texture resources.
 	 */
 	cleanup_textures(): void {
+		this.clear_hard_stamp_sprites();
+
 		if (this.stroke_texture) {
 			this.stroke_texture.destroy();
 			this.stroke_texture = null;
@@ -441,6 +560,17 @@ export class BrushTextures {
 		this.preview_sprite = null;
 		this.erase_graphics = null;
 		this.active_layer_id = null;
+		this.hard_stamp_sprites = [];
+	}
+
+	private clear_hard_stamp_sprites(): void {
+		for (const sprite of this.hard_stamp_sprites) {
+			if (sprite.parent) {
+				sprite.parent.removeChild(sprite);
+			}
+			sprite.destroy({ texture: true, textureSource: true });
+		}
+		this.hard_stamp_sprites = [];
 	}
 
 	/**
@@ -468,7 +598,8 @@ export class BrushTextures {
 		this.original_layer_texture = RenderTexture.create({
 			width: this.dimensions.width,
 			height: this.dimensions.height,
-			resolution: window.devicePixelRatio || 1
+			resolution: window.devicePixelRatio || 1,
+			antialias: this.antialias,
 		});
 
 		const temp_sprite = new Sprite(layer_textures.draw);
@@ -476,7 +607,7 @@ export class BrushTextures {
 		temp_container.addChild(temp_sprite);
 
 		this.app.renderer.render(temp_container, {
-			renderTexture: this.original_layer_texture
+			renderTexture: this.original_layer_texture,
 		});
 
 		temp_container.destroy({ children: true });
@@ -498,7 +629,7 @@ export class BrushTextures {
 		this.erase_graphics.endFill();
 
 		this.app.renderer.render(this.erase_graphics, {
-			renderTexture: this.erase_texture
+			renderTexture: this.erase_texture,
 		});
 	}
 
@@ -534,21 +665,22 @@ export class BrushTextures {
 
 		const stroke_data: BrushStroke = {
 			segments: [...this.current_stroke_segments],
-			layer_id: this.active_layer_id
+			layer_id: this.active_layer_id,
 		};
 
 		const brush_command = new BrushCommand(
 			this.image_editor_context,
 			stroke_data,
-			this.original_layer_texture
+			this.original_layer_texture,
 		);
 
 		if (this.stroke_graphics) {
 			this.stroke_graphics.clear();
 		}
+		this.clear_hard_stamp_sprites();
 		const clear_container = new Container();
 		this.app.renderer.render(clear_container, {
-			renderTexture: this.stroke_texture
+			renderTexture: this.stroke_texture,
 		});
 		clear_container.destroy();
 
@@ -559,7 +691,7 @@ export class BrushTextures {
 
 		this.image_editor_context.command_manager.execute(
 			brush_command,
-			this.image_editor_context
+			this.image_editor_context,
 		);
 	}
 
@@ -570,7 +702,7 @@ export class BrushTextures {
 		x1: number,
 		y1: number,
 		x2: number,
-		y2: number
+		y2: number,
 	): number {
 		return Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
 	}
@@ -586,7 +718,7 @@ export class BrushTextures {
 		size: number,
 		color: string,
 		opacity: number,
-		mode: "draw" | "erase"
+		mode: "draw" | "erase",
 	): void {
 		if (
 			!this.stroke_graphics ||
@@ -607,11 +739,12 @@ export class BrushTextures {
 
 		if (this.is_new_stroke) {
 			this.stroke_graphics.clear();
+			this.clear_hard_stamp_sprites();
 			this.current_stroke_segments = [];
 
 			const clear_container = new Container();
 			this.app.renderer.render(clear_container, {
-				renderTexture: this.stroke_texture
+				renderTexture: this.stroke_texture,
 			});
 			clear_container.destroy();
 
@@ -626,7 +759,8 @@ export class BrushTextures {
 			size: scaled_size,
 			color,
 			opacity: this.current_opacity,
-			mode
+			mode,
+			antialias: this.antialias,
 		});
 
 		if (mode === "draw") {
@@ -640,19 +774,26 @@ export class BrushTextures {
 			}
 			this.stroke_graphics.setFillStyle({
 				color: colorValue,
-				alpha: 1.0
+				alpha: 1.0,
 			});
 		} else {
 			this.stroke_graphics.setFillStyle({
 				color: 0xffffff,
-				alpha: 1.0
+				alpha: 1.0,
 			});
 		}
 
 		const distance = this.calculate_distance(from_x, from_y, to_x, to_y);
+		const stamp_color = mode === "draw" ? color : "#ffffff";
 
 		if (distance < 0.1) {
-			this.stroke_graphics.circle(from_x, from_y, scaled_size).fill();
+			this.render_stamp_to_graphics(
+				this.stroke_graphics,
+				from_x,
+				from_y,
+				scaled_size,
+				stamp_color,
+			);
 		} else {
 			const spacing = Math.max(scaled_size / 3, 2);
 			const steps = Math.max(Math.ceil(distance / spacing), 2);
@@ -662,14 +803,20 @@ export class BrushTextures {
 				const x = from_x + (to_x - from_x) * t;
 				const y = from_y + (to_y - from_y) * t;
 
-				this.stroke_graphics.circle(x, y, scaled_size).fill();
+				this.render_stamp_to_graphics(
+					this.stroke_graphics,
+					x,
+					y,
+					scaled_size,
+					stamp_color,
+				);
 			}
 		}
 
 		this.stroke_graphics.endFill();
 
 		this.app.renderer.render(this.stroke_container, {
-			renderTexture: this.stroke_texture
+			renderTexture: this.stroke_texture,
 		});
 
 		if (mode === "draw") {
@@ -693,14 +840,15 @@ export class BrushTextures {
 			const preview_texture = RenderTexture.create({
 				width: this.dimensions.width,
 				height: this.dimensions.height,
-				resolution: window.devicePixelRatio || 1
+				resolution: window.devicePixelRatio || 1,
+				antialias: this.antialias,
 			});
 
 			const base_container = new Container();
 			const content_sprite = new Sprite(layer_textures.draw);
 			base_container.addChild(content_sprite);
 			this.app.renderer.render(base_container, {
-				renderTexture: preview_texture
+				renderTexture: preview_texture,
 			});
 			base_container.destroy({ children: true });
 
@@ -717,7 +865,7 @@ export class BrushTextures {
 			preview_container.addChild(overlay);
 
 			this.app.renderer.render(preview_container, {
-				renderTexture: preview_texture
+				renderTexture: preview_texture,
 			});
 
 			this.preview_sprite.texture = preview_texture;
@@ -728,6 +876,23 @@ export class BrushTextures {
 		}
 
 		this.preview_sprite.visible = true;
+	}
+
+	private render_stamp_to_graphics(
+		graphics: Graphics,
+		x: number,
+		y: number,
+		size: number,
+		color: string,
+	): void {
+		if (this.antialias) {
+			graphics.circle(x, y, size).fill();
+			return;
+		}
+
+		const sprite = create_hard_stamp_sprite(x, y, size, color);
+		this.hard_stamp_sprites.push(sprite);
+		this.stroke_container?.addChild(sprite);
 	}
 
 	/**

--- a/js/imageeditor/shared/brush/brush.ts
+++ b/js/imageeditor/shared/brush/brush.ts
@@ -81,6 +81,11 @@ export class BrushTool implements Tool {
 	 */
 	private brush_cursor: BrushCursor | null = null;
 	private brush_textures: BrushTextures | null = null;
+	private antialias: boolean;
+
+	constructor(options: { antialias?: boolean } = {}) {
+		this.antialias = options.antialias ?? true;
+	}
 
 	/**
 	 * Sets up the brush tool with the given context, tool, and subtool.
@@ -123,7 +128,8 @@ export class BrushTool implements Tool {
 
 		this.brush_textures = new BrushTextures(
 			this.image_editor_context,
-			context.app
+			context.app,
+			this.antialias
 		);
 		this.brush_textures.initialize_textures();
 

--- a/js/imageeditor/shared/core/editor.ts
+++ b/js/imageeditor/shared/core/editor.ts
@@ -46,6 +46,7 @@ interface ImageEditorOptions {
 	layer_options?: LayerOptions;
 	pad_bottom?: number;
 	theme_mode?: "dark" | "light";
+	antialias?: boolean;
 }
 
 const core_tool_map = {
@@ -204,10 +205,12 @@ export class ImageEditor {
 	private overlay_graphics!: Graphics;
 	private pad_bottom: number;
 	private theme_mode: "dark" | "light";
+	private antialias: boolean;
 	constructor(options: ImageEditorOptions) {
 		this.pad_bottom = options.pad_bottom || 0;
 		this.dark = options.dark || false;
 		this.theme_mode = options.theme_mode || "dark";
+		this.antialias = options.antialias ?? true;
 		this.target_element = options.target_element;
 		this.width = options.width;
 		this.height = options.height;
@@ -305,7 +308,7 @@ export class ImageEditor {
 			backgroundColor: this.theme_mode === "dark" ? "#27272a" : "#ffffff",
 			resolution: window.devicePixelRatio,
 			autoDensity: true,
-			antialias: true,
+			antialias: this.antialias,
 			powerPreference: "high-performance"
 		});
 
@@ -523,7 +526,8 @@ export class ImageEditor {
 			this.fixed_canvas,
 			this.dark,
 			this.border_region,
-			this.layer_options
+			this.layer_options,
+			this.antialias
 		);
 		this.layers = this.layer_manager.layer_store;
 	}

--- a/js/imageeditor/shared/core/layers.ts
+++ b/js/imageeditor/shared/core/layers.ts
@@ -47,13 +47,15 @@ export class LayerManager {
 	private dark: boolean;
 	private border_region: number;
 	private layer_options: LayerOptions;
+	private antialias: boolean;
 	constructor(
 		image_container: Container,
 		app: Application,
 		fixed_canvas: boolean,
 		dark: boolean,
 		border_region: number,
-		layer_options: LayerOptions
+		layer_options: LayerOptions,
+		antialias = true
 	) {
 		this.image_container = image_container;
 		this.app = app;
@@ -61,6 +63,11 @@ export class LayerManager {
 		this.dark = dark;
 		this.border_region = border_region;
 		this.layer_options = layer_options;
+		this.antialias = antialias;
+	}
+
+	get is_antialiased(): boolean {
+		return this.antialias;
 	}
 
 	toggle_layer_visibility(id: string): void {
@@ -88,7 +95,7 @@ export class LayerManager {
 			width,
 			height,
 			resolution: window.devicePixelRatio,
-			antialias: true,
+			antialias: this.antialias,
 			scaleMode: SCALE_MODES.NEAREST
 		});
 
@@ -252,7 +259,7 @@ export class LayerManager {
 			width,
 			height,
 			resolution: window.devicePixelRatio,
-			antialias: true,
+			antialias: this.antialias,
 			scaleMode: SCALE_MODES.NEAREST
 		});
 
@@ -949,7 +956,8 @@ export class RemoveLayerCommand implements Command {
 			const texture_copy = RenderTexture.create({
 				width: original_texture.width,
 				height: original_texture.height,
-				resolution: window.devicePixelRatio || 1
+				resolution: window.devicePixelRatio || 1,
+				antialias: this.context.layer_manager.is_antialiased
 			});
 
 			const sprite = new Sprite(original_texture);

--- a/js/imageeditor/types.ts
+++ b/js/imageeditor/types.ts
@@ -44,6 +44,7 @@ export interface ImageEditorProps {
 	};
 	canvas_size?: [number, number];
 	fixed_canvas?: boolean;
+	brush_antialias?: boolean;
 	full_history?: CommandNode | null;
 }
 

--- a/test/components/test_image_editor.py
+++ b/test/components/test_image_editor.py
@@ -75,6 +75,7 @@ class TestImageEditor:
             "placeholder": None,
             "buttons": None,
             "fixed_canvas": False,
+            "brush_antialias": True,
         }
 
     def test_brush_false_eraser_false_config(self):


### PR DESCRIPTION
## Description

Adds a `brush_antialias` parameter to `gr.ImageEditor`, defaulting to `True`, so apps that use ImageEditor for segmentation masks can disable antialiasing for brush and eraser strokes.

The flag is passed through the Python component config into the imageeditor frontend. When antialiasing is enabled, the brush keeps the existing PIXI circle rendering. When disabled, brush strokes use pixel-aligned hard stamps so output masks avoid blended edge pixels.

Closes: #3252

## AI Disclosure

- [x] I used AI to implement and self-review this change. kumquat
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Issue exists: #3252

## Testing and Formatting Your Code

- `python3 -m pytest test/components/test_image_editor.py test/test_components.py::test_template_component_configs -q`
- `pnpm --filter @gradio/imageeditor exec svelte-package --input=. --tsconfig=../../tsconfig.json`
- `python3 - <<'PY' ...` confirmed `gr.ImageEditor(brush_antialias=False).get_config()["brush_antialias"]` is `False`
- `python3 scripts/generate_theme.py && pnpm i --frozen-lockfile --ignore-scripts && pnpm build && python3 scripts/download_offline_assets.py`
- `pnpm ts:check` currently fails on pre-existing repository-wide diagnostics unrelated to this change.
- Demo is running locally from untracked `demo_issue_3252.py` at `http://127.0.0.1:7860`.

Demo code, not committed:

```python
from collections import Counter

import gradio as gr
import numpy as np


def output_image(value):
    if value is None:
        return None
    if value.get("composite") is not None:
        return value["composite"]
    layers = value.get("layers") or []
    return layers[0] if layers else None


def pixel_stats(value):
    image = output_image(value)
    if image is None:
        return "Draw on the editor to inspect the output pixels."

    arr = np.asarray(image.convert("RGBA"))
    pixels = arr.reshape(-1, 4)
    counts = Counter(map(tuple, pixels))
    non_white = [pixel for pixel in pixels if tuple(pixel) != (255, 255, 255, 255)]
    non_palette = [
        pixel
        for pixel in non_white
        if tuple(pixel)
        not in {
            (255, 0, 0, 255),
            (0, 255, 0, 255),
            (0, 0, 255, 255),
            (255, 255, 255, 255),
            (0, 0, 0, 0),
        }
    ]

    top_colors = "\n".join(
        f"{color}: {count}" for color, count in counts.most_common(8)
    )
    return (
        f"unique_colors={len(counts)}\n"
        f"non_white_pixels={len(non_white)}\n"
        f"non_palette_edge_pixels={len(non_palette)}\n\n"
        f"top colors:\n{top_colors}"
    )


brush = gr.Brush(
    colors=["#ff0000", "#00ff00", "#0000ff"],
    default_color="#ff0000",
    color_mode="fixed",
    default_size=18,
)

with gr.Blocks() as demo:
    gr.Markdown("# ImageEditor brush antialiasing comparison")
    with gr.Row():
        with gr.Column():
            aliased = gr.ImageEditor(
                label="Antialiasing disabled",
                sources=(),
                brush=brush,
                eraser=False,
                transforms=(),
                canvas_size=(256, 256),
                brush_antialias=False,
                type="pil",
                format="png",
            )
            aliased_output = gr.Image(label="Antialiasing disabled output", format="png")
            aliased_stats = gr.Textbox(label="Disabled pixel stats", lines=8)
        with gr.Column():
            antialiased = gr.ImageEditor(
                label="Antialiasing enabled",
                sources=(),
                brush=brush,
                eraser=False,
                transforms=(),
                canvas_size=(256, 256),
                brush_antialias=True,
                type="pil",
                format="png",
            )
            antialiased_output = gr.Image(
                label="Antialiasing enabled output", format="png"
            )
            antialiased_stats = gr.Textbox(label="Enabled pixel stats", lines=8)

    aliased.change(output_image, aliased, aliased_output)
    aliased.change(pixel_stats, aliased, aliased_stats)
    antialiased.change(output_image, antialiased, antialiased_output)
    antialiased.change(pixel_stats, antialiased, antialiased_stats)


if __name__ == "__main__":
    demo.launch()
```
