### PR TITLE
workflow: convert `runtime.hardware` to str

### DIFF
--- a/.changeset/tall-forks-fix.md
+++ b/.changeset/tall-forks-fix.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:workflow: convert `runtime.hardware` to str

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -676,7 +676,7 @@ def search_spaces(data, token: Optional[OAuthToken] = None) -> str:
             if "zero-gpu" in tags or "zerogpu" in tags:
                 return True
             hw = (s.get("runtime") or {}).get("hardware") or ""
-            return "zero" in hw.lower()
+            return "zero" in str(hw).lower()
 
         def _fallback_search(q: str) -> list:
             if not q:

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -80,6 +80,7 @@ class TestConstruction:
 # ZeroGPU detection
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 class TestHasZeroGpu:
     def test_detects_via_tag(self):
         assert _has_zero_gpu({"tags": ["zero-gpu", "gradio"]}) is True

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -9,7 +9,6 @@ import gradio as gr
 from gradio.oauth import OAuthToken
 from gradio.workflow import (
     Workflow,
-    _has_zero_gpu,
     _local_hf_token,
     _normalize_space_result,
     _resolve_token,
@@ -74,33 +73,6 @@ class TestConstruction:
     def test_workflow_name_derived_from_filename(self, tmp_path):
         wf = Workflow(graph=str(tmp_path / "marketing_image_creator.json"))
         assert wf._workflow_name == "Marketing Image Creator"
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# ZeroGPU detection
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-class TestHasZeroGpu:
-    def test_detects_via_tag(self):
-        assert _has_zero_gpu({"tags": ["zero-gpu", "gradio"]}) is True
-        assert _has_zero_gpu({"tags": ["zerogpu"]}) is True
-
-    def test_detects_via_string_hardware(self):
-        assert _has_zero_gpu({"runtime": {"hardware": "zero-a10g"}}) is True
-
-    def test_detects_via_dict_hardware(self):
-        assert (
-            _has_zero_gpu(
-                {"runtime": {"hardware": {"current": "zero-a10g", "requested": None}}}
-            )
-            is True
-        )
-
-    def test_returns_false_for_non_zero_hardware(self):
-        assert _has_zero_gpu({"runtime": {"hardware": "cpu-basic"}}) is False
-        assert _has_zero_gpu({}) is False
-        assert _has_zero_gpu({"runtime": {"hardware": None}}) is False
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -9,6 +9,7 @@ import gradio as gr
 from gradio.oauth import OAuthToken
 from gradio.workflow import (
     Workflow,
+    _has_zero_gpu,
     _local_hf_token,
     _normalize_space_result,
     _resolve_token,
@@ -73,6 +74,32 @@ class TestConstruction:
     def test_workflow_name_derived_from_filename(self, tmp_path):
         wf = Workflow(graph=str(tmp_path / "marketing_image_creator.json"))
         assert wf._workflow_name == "Marketing Image Creator"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ZeroGPU detection
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestHasZeroGpu:
+    def test_detects_via_tag(self):
+        assert _has_zero_gpu({"tags": ["zero-gpu", "gradio"]}) is True
+        assert _has_zero_gpu({"tags": ["zerogpu"]}) is True
+
+    def test_detects_via_string_hardware(self):
+        assert _has_zero_gpu({"runtime": {"hardware": "zero-a10g"}}) is True
+
+    def test_detects_via_dict_hardware(self):
+        assert (
+            _has_zero_gpu(
+                {"runtime": {"hardware": {"current": "zero-a10g", "requested": None}}}
+            )
+            is True
+        )
+
+    def test_returns_false_for_non_zero_hardware(self):
+        assert _has_zero_gpu({"runtime": {"hardware": "cpu-basic"}}) is False
+        assert _has_zero_gpu({}) is False
+        assert _has_zero_gpu({"runtime": {"hardware": None}}) is False
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

`_has_zero_gpu'`s `hw.lower()` crashed when HF returned `runtime.hardware` as a dict instead of a string. switched to `str(hw).lower()` so both shapes work

Closes: #13477

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [ ] I used AI to... [fill here]
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

