### PR TITLE
Track Workflow telemetry mode and beta status

### DIFF
--- a/.changeset/chilly-symbols-hug.md
+++ b/.changeset/chilly-symbols-hug.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Track Workflow telemetry mode and beta status

--- a/.changeset/chilly-symbols-hug.md
+++ b/.changeset/chilly-symbols-hug.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Track Workflow telemetry mode and beta status

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -9,6 +9,7 @@ import os
 import re
 import tempfile
 import urllib.parse
+import warnings
 from collections.abc import Callable
 from typing import Optional
 
@@ -936,7 +937,12 @@ class Workflow(Blocks):
         self._bound: dict[str, Callable] = bind or {}
         self._edges: list[tuple[str, str]] = edges or []
 
-        super().__init__()
+        warnings.warn(
+            "gr.Workflow is currently in beta. Its API and UX may change in future releases.",
+            UserWarning,
+        )
+
+        super().__init__(mode="workflow")
         self._build()
 
     def _build(self):


### PR DESCRIPTION
## Description

This PR updates `gr.Workflow` so existing initiated and launched telemetry can distinguish Workflow apps from regular Blocks apps by setting the Blocks mode to `workflow`.

It also emits a `UserWarning` when constructing `gr.Workflow` to make clear that Workflow is currently beta and its API/UX may change.

Closes: #13490

## AI Disclosure

- [x] I used AI to draft the code change and PR description. I self-reviewed the changed line set.