### PR TITLE
Close iterator on terminal error in JS client

### DIFF
--- a/.changeset/light-shrimps-brush.md
+++ b/.changeset/light-shrimps-brush.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": patch
+"gradio": patch
+---
+
+fix:Close iterator on terminal error in JS client

--- a/client/js/src/test/submit.test.ts
+++ b/client/js/src/test/submit.test.ts
@@ -112,12 +112,21 @@ describe("submit iterator", () => {
 
 		await new Promise((r) => setTimeout(r, 0));
 
-		// A server-side exception arrives as process_completed with success:false
-		// and an `error` field in the output. This must fire an "error" status and
-		// terminate the iterator rather than hang the consumer.
+		// Stream a partial result first, so the error below genuinely arrives
+		// mid-stream rather than as the very first message.
+		await callback({
+			msg: "process_generating",
+			output: { data: ["partial"] },
+			success: true
+		});
+
+		// A server-side exception then arrives as process_completed with
+		// success:false and an `error` field in the output. This must fire an
+		// "error" status and terminate the iterator rather than hang the
+		// consumer.
 		await callback({
 			msg: "process_completed",
-			output: { error: "boom before any output" },
+			output: { error: "boom mid-stream" },
 			success: false,
 			title: "Error"
 		});
@@ -127,6 +136,9 @@ describe("submit iterator", () => {
 			1000,
 			"submit iterator did not terminate after a server-side error"
 		);
+
+		// The partial result should have been delivered before the error.
+		expect(events.some((e) => e.type === "data")).toBe(true);
 
 		const error_event = events.find(
 			(e) => e.type === "status" && e.stage === "error"

--- a/client/js/src/test/submit.test.ts
+++ b/client/js/src/test/submit.test.ts
@@ -123,12 +123,17 @@ describe("submit iterator", () => {
 		// A server-side exception then arrives as process_completed with
 		// success:false and an `error` field in the output. This must fire an
 		// "error" status and terminate the iterator rather than hang the
-		// consumer.
+		// consumer. handle_message() reads title/visible/duration from
+		// `output`, so mirror a real payload's shape here.
 		await callback({
 			msg: "process_completed",
-			output: { error: "boom mid-stream" },
-			success: false,
-			title: "Error"
+			output: {
+				error: "boom mid-stream",
+				title: "Error",
+				visible: true,
+				duration: 0
+			},
+			success: false
 		});
 
 		await race_with_timeout(

--- a/client/js/src/test/submit.test.ts
+++ b/client/js/src/test/submit.test.ts
@@ -89,4 +89,48 @@ describe("submit iterator", () => {
 		expect(types).toContain("data");
 		expect(types).toContain("status");
 	});
+
+	test("for-await loop terminates when the server raises an error mid-stream", async () => {
+		const app = await Client.connect("hmb/hello_world", {
+			events: ["data", "status"]
+		});
+		app.stream_status.open = true;
+
+		const iterator = app.submit("/predict", ["hi"]);
+		const event_id = await iterator.wait_for_id();
+		expect(event_id).toBeTruthy();
+
+		const callback = app.event_callbacks[event_id as string];
+		expect(callback).toBeDefined();
+
+		const events: { type: string; stage?: string }[] = [];
+		const consumer = (async () => {
+			for await (const event of iterator) {
+				events.push(event as { type: string; stage?: string });
+			}
+		})();
+
+		await new Promise((r) => setTimeout(r, 0));
+
+		// A server-side exception arrives as process_completed with success:false
+		// and an `error` field in the output. This must fire an "error" status and
+		// terminate the iterator rather than hang the consumer.
+		await callback({
+			msg: "process_completed",
+			output: { error: "boom before any output" },
+			success: false,
+			title: "Error"
+		});
+
+		await race_with_timeout(
+			consumer,
+			1000,
+			"submit iterator did not terminate after a server-side error"
+		);
+
+		const error_event = events.find(
+			(e) => e.type === "status" && e.stage === "error"
+		);
+		expect(error_event).toBeDefined();
+	});
 });

--- a/client/js/src/utils/submit.ts
+++ b/client/js/src/utils/submit.ts
@@ -452,6 +452,7 @@ export function submit(
 							time: new Date(),
 							visible: true
 						});
+						close();
 					} else if (status === 422) {
 						fire_event({
 							type: "status",
@@ -481,6 +482,7 @@ export function submit(
 							time: new Date(),
 							visible: true
 						});
+						close();
 					} else {
 						event_id = response.event_id as string;
 						event_id_final = event_id;
@@ -592,6 +594,9 @@ export function submit(
 									}
 									if (event_id! in pending_diff_streams) {
 										delete pending_diff_streams[event_id!];
+									}
+									if (status?.stage === "error") {
+										close();
 									}
 								}
 							} catch (e) {

--- a/client/js/src/utils/submit.ts
+++ b/client/js/src/utils/submit.ts
@@ -595,9 +595,7 @@ export function submit(
 									if (event_id! in pending_diff_streams) {
 										delete pending_diff_streams[event_id!];
 									}
-									if (status?.stage === "error") {
-										close();
-									}
+									close();
 								}
 							} catch (e) {
 								console.error("Unexpected client exception", e);


### PR DESCRIPTION
## Description

The submit() async iterator fired an "error" status on terminal errors (queue full, validation, broken connection, server-side exception mid-stream) but never called close(). The done flag stayed false, so a for-await consumer hung forever waiting on the next event.

Call close() on the error terminals, mirroring the success path. Add a test that a server-side error mid-stream terminates the iterator.

Closes: #13499

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

