### PR TITLE
Treat expired OAuth sessions as logged out users

### DIFF
--- a/.changeset/thin-files-add.md
+++ b/.changeset/thin-files-add.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:Expire OAuth sessions before injecting tokens
+feat:Treat expired OAuth sessions as logged out users

--- a/.changeset/thin-files-add.md
+++ b/.changeset/thin-files-add.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Expire OAuth sessions before injecting tokens

--- a/gradio/components/login_button.py
+++ b/gradio/components/login_button.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import json
-import time
 from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from gradio_client.documentation import document
 
-from gradio import utils
+from gradio import oauth, utils
 from gradio.components import Button, Component
 from gradio.context import get_blocks_context
 from gradio.routes import Request
@@ -104,15 +103,13 @@ class LoginButton(Button):
             request.request, "session", None
         )
 
-        if session is None or "oauth_info" not in session:
+        if session is None:
             # Cookie set but user not logged in
             return LoginButton(self.value, interactive=True)
 
-        oauth_info = session["oauth_info"]
-        expires_at = oauth_info.get("expires_at")
-        if expires_at is not None and expires_at < time.time():
-            # User is logged in but token has expired => logout
-            session.pop("oauth_info", None)
+        oauth_info = oauth._get_valid_oauth_info_from_session(session)
+        if oauth_info is None:
+            # Cookie set but user not logged in
             return LoginButton(self.value, interactive=True)
 
         # User is correctly logged in

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -991,12 +991,12 @@ def special_args(
                     else:
                         raise e
 
+                oauth_info = oauth._get_valid_oauth_info_from_session(session)
+
                 # Inject user profile
                 if type_hint in (Optional[oauth.OAuthProfile], oauth.OAuthProfile):
                     oauth_profile = (
-                        session["oauth_info"]["userinfo"]
-                        if "oauth_info" in session
-                        else None
+                        oauth_info["userinfo"] if oauth_info is not None else None
                     )
                     if oauth_profile is not None:
                         oauth_profile = oauth.OAuthProfile(oauth_profile)
@@ -1008,7 +1008,6 @@ def special_args(
 
                 # Inject user token
                 elif type_hint in (Optional[oauth.OAuthToken], oauth.OAuthToken):
-                    oauth_info = session.get("oauth_info")
                     oauth_token = (
                         oauth.OAuthToken(
                             token=oauth_info["access_token"],

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -991,6 +991,10 @@ def special_args(
                     else:
                         raise e
 
+                # `session` is usually a copy of the underlying session (gr.Request
+                # converts it to an `Obj`), so expiry means "treat as logged out"
+                # here; the session entry itself is only removed on the next
+                # LoginButton page-load check, which operates on the raw session.
                 oauth_info = oauth._get_valid_oauth_info_from_session(session)
 
                 # Inject user profile

--- a/gradio/oauth.py
+++ b/gradio/oauth.py
@@ -235,6 +235,21 @@ def _redirect_to_target(
     return RedirectResponse(safe_target)
 
 
+def _get_valid_oauth_info_from_session(
+    session: typing.MutableMapping[str, typing.Any],
+) -> dict[str, typing.Any] | None:
+    oauth_info = session.get("oauth_info")
+    if oauth_info is None:
+        return None
+
+    expires_at = oauth_info.get("expires_at")
+    if expires_at is not None and expires_at < time.time():
+        session.pop("oauth_info", None)
+        return None
+
+    return oauth_info
+
+
 @dataclass
 class OAuthProfile(typing.Dict):  # inherit from Dict for backward compatibility
     """

--- a/gradio/oauth.py
+++ b/gradio/oauth.py
@@ -179,7 +179,12 @@ def _add_mocked_oauth_routes(app: fastapi.FastAPI) -> None:
     @app.get("/login/callback")
     async def oauth_redirect_callback(request: fastapi.Request) -> RedirectResponse:
         """Endpoint that handles the OAuth callback."""
-        request.session["oauth_info"] = mocked_oauth_info
+        # `mocked_oauth_info` is computed once at startup, so its `expires_at` would
+        # eventually be in the past and every login would be treated as expired.
+        request.session["oauth_info"] = {
+            **mocked_oauth_info,
+            "expires_at": int(time.time()) + 8 * 60 * 60,  # 8 hours
+        }
         return _redirect_to_target(request)
 
     @app.get("/logout")

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -14,7 +14,7 @@ from starlette.testclient import TestClient
 from tqdm import tqdm
 
 import gradio as gr
-from gradio import helpers, routes, utils
+from gradio import helpers, oauth, routes, utils
 from gradio.media import get_audio, get_image
 from gradio.route_utils import API_PREFIX
 
@@ -964,7 +964,6 @@ def test_expired_oauth_token_is_not_injected():
     inputs, *_ = helpers.special_args(foo, inputs=[], request=_oauth_request(session))
 
     assert inputs == [None]
-    assert "oauth_info" not in session
 
 
 def test_expired_required_oauth_profile_raises():
@@ -975,7 +974,6 @@ def test_expired_required_oauth_profile_raises():
 
     with pytest.raises(gr.Error, match="requires a logged in user"):
         helpers.special_args(foo, inputs=[], request=_oauth_request(session))
-    assert "oauth_info" not in session
 
 
 def test_valid_oauth_session_is_injected():
@@ -989,6 +987,16 @@ def test_valid_oauth_session_is_injected():
     assert inputs[0].username == "test-user"
     assert inputs[1].token == "test-token"
     assert "oauth_info" in session
+
+
+def test_get_valid_oauth_info_removes_expired_session_entry():
+    expired = {"oauth_info": _oauth_info(expires_at=time.time() - 60)}
+    assert oauth._get_valid_oauth_info_from_session(expired) is None
+    assert "oauth_info" not in expired
+
+    valid = {"oauth_info": _oauth_info(expires_at=time.time() + 60)}
+    assert oauth._get_valid_oauth_info_from_session(valid) is not None
+    assert "oauth_info" in valid
 
 
 class _OAuthRequest:

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import time
 from pathlib import Path
+from typing import cast
 from unittest.mock import patch
 
 import gradio_client as grc
@@ -13,7 +14,7 @@ from starlette.testclient import TestClient
 from tqdm import tqdm
 
 import gradio as gr
-from gradio import helpers, utils
+from gradio import helpers, routes, utils
 from gradio.media import get_audio, get_image
 from gradio.route_utils import API_PREFIX
 
@@ -952,6 +953,66 @@ def test_request_session_none_without_sessionmiddleware():
         request=Request(scope={"type": "http"}),  # type: ignore
     )
     assert inputs == [5, None]
+
+
+def test_expired_oauth_token_is_not_injected():
+    def foo(token: gr.OAuthToken | None):
+        return token
+
+    session = {"oauth_info": _oauth_info(expires_at=time.time() - 60)}
+
+    inputs, *_ = helpers.special_args(foo, inputs=[], request=_oauth_request(session))
+
+    assert inputs == [None]
+    assert "oauth_info" not in session
+
+
+def test_expired_required_oauth_profile_raises():
+    def foo(profile: gr.OAuthProfile):
+        return profile
+
+    session = {"oauth_info": _oauth_info(expires_at=time.time() - 60)}
+
+    with pytest.raises(gr.Error, match="requires a logged in user"):
+        helpers.special_args(foo, inputs=[], request=_oauth_request(session))
+    assert "oauth_info" not in session
+
+
+def test_valid_oauth_session_is_injected():
+    def foo(profile: gr.OAuthProfile, token: gr.OAuthToken):
+        return profile, token
+
+    session = {"oauth_info": _oauth_info(expires_at=time.time() + 60)}
+
+    inputs, *_ = helpers.special_args(foo, inputs=[], request=_oauth_request(session))
+
+    assert inputs[0].username == "test-user"
+    assert inputs[1].token == "test-token"
+    assert "oauth_info" in session
+
+
+class _OAuthRequest:
+    def __init__(self, session):
+        self.session = session
+
+
+def _oauth_request(session):
+    return cast(routes.Request, _OAuthRequest(session))
+
+
+def _oauth_info(expires_at):
+    return {
+        "access_token": "test-token",
+        "expires_at": expires_at,
+        "scope": "openid profile",
+        "userinfo": {
+            "name": "Test User",
+            "preferred_username": "test-user",
+            "profile": "https://huggingface.co/test-user",
+            "picture": "https://huggingface.co/front/assets/huggingface_logo.svg",
+            "sub": "test-user",
+        },
+    }
 
 
 def test_examples_no_cache_optional_inputs():


### PR DESCRIPTION
#### Description

Expired OAuth session data was only cleared by `gr.LoginButton` when the page load check ran. Backend event handling still read the same expired `oauth_info` from the session and injected it into app functions as `gr.OAuthProfile` / `gr.OAuthToken`.

This adds a shared OAuth session helper used by both `LoginButton` and `helpers.special_args`: expired sessions are treated as logged out everywhere (no profile/token injection), and the stale `oauth_info` entry is removed from the session on the `LoginButton` page-load check (in the event path, `gr.Request` hands handlers a copy of the session, so removal there would not persist). Also stamps a fresh `expires_at` on each mocked local-dev login, since the previously startup-computed value made logins permanently expired after 8 hours of server uptime.

Closes: #6768

#### AI Disclosure

- [x] I used AI to draft and validate the code changes in this PR. I self-reviewed the changed files. The tests demonstrate the change in behavior. I haven't tested the real changes in a Space, but fairly confident that these changes make sense.
