### PR TITLE
Accept permanent redirects (301, 308) in `networking.url_ok`

### DIFF
--- a/.changeset/shiny-llamas-wave.md
+++ b/.changeset/shiny-llamas-wave.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Accept permanent redirects (301, 308) in `networking.url_ok`

--- a/gradio/networking.py
+++ b/gradio/networking.py
@@ -74,8 +74,8 @@ def url_ok(url: str) -> bool:
                 warnings.filterwarnings("ignore")
                 r = httpx.head(url, timeout=3, verify=False)
             if (
-                r.status_code in (200, 401, 302, 303, 307)
-            ):  # 401 or 302 if auth is set; 303 or 307 are alternatives to 302 for temporary redirects
+                r.status_code in (200, 401, 301, 302, 303, 307, 308)
+            ):  # 401 or 302 if auth is set; 303 or 307 are alternatives to 302 for temporary redirects; 301 and 308 are permanent redirects
                 return True
             time.sleep(0.500)
     except (ConnectionError, httpx.ConnectError, httpx.TimeoutException):


### PR DESCRIPTION
## Description

`test/test_networking.py::TestURLs::test_url_ok` started failing because `https://www.gradio.app` now serves a **301** permanent redirect to `https://gradio.app/` (after the recent domain registrar migration). `url_ok` doesn't follow redirects and only accepted `200, 401, 302, 303, 307`, so the 301 was treated as a failure.

This adds `301` and `308` (the permanent counterparts of `302`/`307`) to the accepted status codes. A host that answers with a permanent redirect is up, so this is also the correct behavior for `url_ok`'s other call site (verifying the local server is reachable during `launch()`).