### PR TITLE
Fix state handling for simple call API

### DIFF
--- a/.changeset/plenty-lands-obey.md
+++ b/.changeset/plenty-lands-obey.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix state handling for simple call API

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1315,6 +1315,15 @@ class App(FastAPI):
                 )
             return ORJSONResponse(output)
 
+        def prepare_simple_api_data(body: PredictBody, fn: Any) -> None:
+            if len(body.data) == len(fn.inputs):
+                return
+            non_stateful_inputs = [block for block in fn.inputs if not block.stateful]
+            if len(body.data) != len(non_stateful_inputs):
+                return
+            data = iter(body.data)
+            body.data = [None if block.stateful else next(data) for block in fn.inputs]
+
         @router.post("/call/v2/{api_name}", dependencies=[Depends(login_check)])
         @router.post("/call/v2/{api_name}/", dependencies=[Depends(login_check)])
         async def _(
@@ -1336,6 +1345,7 @@ class App(FastAPI):
             fn = route_utils.get_fn(
                 blocks=app.get_blocks(), api_name=api_name, body=full_body
             )
+            prepare_simple_api_data(full_body, fn)
             full_body.fn_index = fn._id
             return await queue_join_helper(full_body, request, username)
 
@@ -1351,6 +1361,7 @@ class App(FastAPI):
             fn = route_utils.get_fn(
                 blocks=app.get_blocks(), api_name=api_name, body=full_body
             )
+            prepare_simple_api_data(full_body, fn)
             full_body.fn_index = fn._id
             return await queue_join_helper(full_body, request, username)
 
@@ -1458,7 +1469,9 @@ class App(FastAPI):
                     return None
                 return f"event: {event}\ndata: {json.dumps(data)}\n\n"
 
-            return await queue_data_helper(request, event_id, process_msg)
+            event = app.get_blocks()._queue.event_ids_to_events.get(event_id)
+            session_hash = event.session_hash if event else event_id
+            return await queue_data_helper(request, session_hash, process_msg)
 
         @router.get("/queue/data", dependencies=[Depends(login_check)])
         async def queue_data(

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1318,11 +1318,11 @@ class App(FastAPI):
         def prepare_simple_api_data(body: PredictBody, fn: Any) -> None:
             if len(body.data) == len(fn.inputs):
                 return
-            non_stateful_inputs = [block for block in fn.inputs if not block.stateful]
-            if len(body.data) != len(non_stateful_inputs):
+            api_inputs = [block for block in fn.inputs if not block.skip_api]
+            if len(body.data) != len(api_inputs):
                 return
             data = iter(body.data)
-            body.data = [None if block.stateful else next(data) for block in fn.inputs]
+            body.data = [None if block.skip_api else next(data) for block in fn.inputs]
 
         @router.post("/call/v2/{api_name}", dependencies=[Depends(login_check)])
         @router.post("/call/v2/{api_name}/", dependencies=[Depends(login_check)])

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1979,22 +1979,28 @@ def test_bash_api_multiple_inputs_outputs():
 
 
 def test_bash_api_uses_session_hash_for_stateful_calls():
-    def increment(message, count):
+    def increment(message, button_value, count):
         count = (count or 0) + 1
-        return f"{message}:{count}", count
+        return f"{message}:{button_value}:{count}", count
 
     with gr.Blocks() as demo:
         textbox = gr.Textbox()
+        button = gr.Button("Go")
         state = gr.State(0)
         output = gr.Textbox()
-        textbox.submit(increment, [textbox, state], [output, state], api_name="predict")
+        textbox.submit(
+            increment, [textbox, button, state], [output, state], api_name="predict"
+        )
 
     app, _, _ = demo.queue().launch(prevent_thread_lock=True, _frontend=False)
     test_client = TestClient(app)
 
     try:
         with test_client:
-            for message, expected in [("first", "first:1"), ("second", "second:2")]:
+            for message, expected in [
+                ("first", "first:None:1"),
+                ("second", "second:None:2"),
+            ]:
                 submit = test_client.post(
                     f"{API_PREFIX}/call/predict",
                     json={"data": [message], "session_hash": "stateful-session"},

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1978,6 +1978,36 @@ def test_bash_api_multiple_inputs_outputs():
         assert json.dumps([123, "abc"]) in response.text
 
 
+def test_bash_api_uses_session_hash_for_stateful_calls():
+    def increment(message, count):
+        count = (count or 0) + 1
+        return f"{message}:{count}", count
+
+    with gr.Blocks() as demo:
+        textbox = gr.Textbox()
+        state = gr.State(0)
+        output = gr.Textbox()
+        textbox.submit(increment, [textbox, state], [output, state], api_name="predict")
+
+    app, _, _ = demo.queue().launch(prevent_thread_lock=True, _frontend=False)
+    test_client = TestClient(app)
+
+    try:
+        with test_client:
+            for message, expected in [("first", "first:1"), ("second", "second:2")]:
+                submit = test_client.post(
+                    f"{API_PREFIX}/call/predict",
+                    json={"data": [message], "session_hash": "stateful-session"},
+                )
+                event_id = submit.json()["event_id"]
+                response = test_client.get(f"{API_PREFIX}/call/predict/{event_id}")
+                assert response.status_code == 200
+                assert "event: complete\ndata:" in response.text
+                assert json.dumps([expected, None]) in response.text
+    finally:
+        demo.close()
+
+
 def test_attacker_cannot_change_root_in_config(
     attacker_threads=1, victim_threads=10, max_attempts=30
 ):


### PR DESCRIPTION
Fixes `/call/{api_name}` state handling for queued simple API calls by routing SSE reads through the original `session_hash` and padding omitted `State` inputs before queueing. This lets curl/bash-style requests keep server-side state across calls without clients needing to send state values.

Closes: #8452

Root cause: `/call/{api_name}/{event_id}` read queue messages using the event id as if it were the session hash, and the simple call body was passed to processing without placeholders for stateful inputs.

Here's what I did to confirm the fix. First, run this demo on, say, port 7864:

```python
import gradio as gr

def respond(message, history):
    history = history or []
    turn = len(history) // 2 + 1
    history = [*history, {"role": "user", "content": message}]
    history = [*history, {"role": "assistant", "content": f"Echo {turn}: {message}"}]
    return history, history

with gr.Blocks() as demo:
    chatbot = gr.Chatbot()
    textbox = gr.Textbox()
    state = gr.State([])
    textbox.submit(respond, [textbox, state], [chatbot, state], api_name="chat")

if __name__ == "__main__":
    demo.queue().launch(server_port=7864, _frontend=False)
```

Then, make the following curl requests:

```bash
# First request
EVENT_ID=$(curl -sS -X POST http://127.0.0.1:7864/gradio_api/call/chat \
  -H "Content-Type: application/json" \
  -d '{"data": ["Really?"], "session_hash": "randomsequence1234"}' \
  | python3 -c 'import json,sys; print(json.load(sys.stdin)["event_id"])')

curl -N http://127.0.0.1:7864/gradio_api/call/chat/$EVENT_ID

# Second request with the same session_hash
EVENT_ID=$(curl -sS -X POST http://127.0.0.1:7864/gradio_api/call/chat \
  -H "Content-Type: application/json" \
  -d '{"data": ["Again?"], "session_hash": "randomsequence1234"}' \
  | python3 -c 'import json,sys; print(json.load(sys.stdin)["event_id"])')

curl -N http://127.0.0.1:7864/gradio_api/call/chat/$EVENT_ID
```

On this branch, the second response includes the first turn plus `Echo 2: Again?`, showing state persisted for `randomsequence1234`.

For comparison, I ran the exact same demo from current `origin/main` (`df590646a`) on port 7865 and made the same requests against `http://127.0.0.1:7865/gradio_api`:

```bash
# First request against main
EVENT_ID=$(curl -sS -X POST http://127.0.0.1:7865/gradio_api/call/chat \
  -H "Content-Type: application/json" \
  -d '{"data": ["Really?"], "session_hash": "randomsequence1234"}' \
  | python3 -c 'import json,sys; print(json.load(sys.stdin)["event_id"])')

curl --max-time 5 -N http://127.0.0.1:7865/gradio_api/call/chat/$EVENT_ID

# Second request against main with the same session_hash
EVENT_ID=$(curl -sS -X POST http://127.0.0.1:7865/gradio_api/call/chat \
  -H "Content-Type: application/json" \
  -d '{"data": ["Again?"], "session_hash": "randomsequence1234"}' \
  | python3 -c 'import json,sys; print(json.load(sys.stdin)["event_id"])')

curl --max-time 5 -N http://127.0.0.1:7865/gradio_api/call/chat/$EVENT_ID
```

On `origin/main`, both result streams fail before any chat response is returned:

```text
POST Really?: {"event_id":"9abea98814e54ede9eacf19a68053b75"}
GET Really? event=9abea98814e54ede9eacf19a68053b75:
event: error
data: "404: Not Found"

curl: (18) transfer closed with outstanding read data remaining

POST Again?: {"event_id":"4724780f25264591ac451cffd6bd186a"}
GET Again? event=4724780f25264591ac451cffd6bd186a:
event: error
data: "404: Not Found"

curl: (18) transfer closed with outstanding read data remaining
```



## AI Disclosure

- [x] I used AI to draft this PR and test. I manually verifed the fix

