### PR TITLE
Translate i18n `choices` display names in choice-based components

### DIFF
--- a/.changeset/sharp-insects-attack.md
+++ b/.changeset/sharp-insects-attack.md
@@ -1,0 +1,9 @@
+---
+"@gradio/checkboxgroup": minor
+"@gradio/dropdown": minor
+"@gradio/radio": minor
+"@gradio/simpledropdown": minor
+"gradio": minor
+---
+
+feat:Translate i18n `choices` display names in choice-based components

--- a/js/checkboxgroup/Index.svelte
+++ b/js/checkboxgroup/Index.svelte
@@ -134,7 +134,7 @@
 					name={internal_value?.toString()}
 					title={internal_value?.toString()}
 				/>
-				<span class="ml-2">{display_value}</span>
+				<span class="ml-2">{gradio.i18n(display_value)}</span>
 			</label>
 		{/each}
 	</div>

--- a/js/checkboxgroup/checkboxgroup.test.ts
+++ b/js/checkboxgroup/checkboxgroup.test.ts
@@ -1,9 +1,15 @@
-import { test, describe, expect, afterEach } from "vitest";
+import { test, describe, expect, afterEach, beforeAll } from "vitest";
 import { cleanup, render, fireEvent } from "@self/tootils/render";
 import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
 import event from "@testing-library/user-event";
+import { setupi18n } from "../core/src/i18n";
+import { formatter } from "../core/src/gradio_helper";
 
 import CheckboxGroup from "./Index.svelte";
+
+// Build a real i18n marker the way the backend's I18nData does.
+const marker = (key: string): string =>
+	`__i18n__${JSON.stringify({ __type__: "translation_metadata", key })}`;
 
 const default_props = {
 	label: "Options",
@@ -465,5 +471,42 @@ describe("Edge cases", () => {
 
 		const data = await get_data();
 		expect(data.value).toEqual(["internal_val"]);
+	});
+});
+
+describe("CheckboxGroup: i18n choices", () => {
+	beforeAll(async () => {
+		await setupi18n({ en: { bold_label: "Bold", italic_label: "Italic" } });
+	});
+	afterEach(() => cleanup());
+
+	const i18n_choices: [string, string][] = [
+		[marker("bold_label"), "bold"],
+		[marker("italic_label"), "italic"]
+	];
+
+	test("translates choice display values through the i18n formatter", async () => {
+		const { getByLabelText } = await render(CheckboxGroup, {
+			...default_props,
+			i18n: formatter,
+			choices: i18n_choices
+		});
+
+		expect(getByLabelText("Bold")).toBeTruthy();
+		expect(getByLabelText("Italic")).toBeTruthy();
+	});
+
+	test("internal value is unaffected by translation", async () => {
+		const { getByLabelText, get_data } = await render(CheckboxGroup, {
+			...default_props,
+			i18n: formatter,
+			choices: i18n_choices,
+			value: ["bold"]
+		});
+
+		expect(getByLabelText("Bold")).toBeChecked();
+
+		const data = await get_data();
+		expect(data.value).toEqual(["bold"]);
 	});
 });

--- a/js/checkboxgroup/checkboxgroup.test.ts
+++ b/js/checkboxgroup/checkboxgroup.test.ts
@@ -2,7 +2,7 @@ import { test, describe, expect, afterEach, beforeAll } from "vitest";
 import { cleanup, render, fireEvent } from "@self/tootils/render";
 import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
 import event from "@testing-library/user-event";
-import { setupi18n } from "../core/src/i18n";
+import { setupi18n, changeLocale } from "../core/src/i18n";
 import { formatter } from "../core/src/gradio_helper";
 
 import CheckboxGroup from "./Index.svelte";
@@ -477,6 +477,7 @@ describe("Edge cases", () => {
 describe("CheckboxGroup: i18n choices", () => {
 	beforeAll(async () => {
 		await setupi18n(undefined, "en");
+		changeLocale("en");
 	});
 	afterEach(() => cleanup());
 

--- a/js/checkboxgroup/checkboxgroup.test.ts
+++ b/js/checkboxgroup/checkboxgroup.test.ts
@@ -476,7 +476,7 @@ describe("Edge cases", () => {
 
 describe("CheckboxGroup: i18n choices", () => {
 	beforeAll(async () => {
-		await setupi18n();
+		await setupi18n(undefined, "en");
 	});
 	afterEach(() => cleanup());
 

--- a/js/checkboxgroup/checkboxgroup.test.ts
+++ b/js/checkboxgroup/checkboxgroup.test.ts
@@ -476,13 +476,13 @@ describe("Edge cases", () => {
 
 describe("CheckboxGroup: i18n choices", () => {
 	beforeAll(async () => {
-		await setupi18n({ en: { bold_label: "Bold", italic_label: "Italic" } });
+		await setupi18n();
 	});
 	afterEach(() => cleanup());
 
 	const i18n_choices: [string, string][] = [
-		[marker("bold_label"), "bold"],
-		[marker("italic_label"), "italic"]
+		[marker("common.clear"), "bold"],
+		[marker("common.remove"), "italic"]
 	];
 
 	test("translates choice display values through the i18n formatter", async () => {
@@ -492,8 +492,8 @@ describe("CheckboxGroup: i18n choices", () => {
 			choices: i18n_choices
 		});
 
-		expect(getByLabelText("Bold")).toBeTruthy();
-		expect(getByLabelText("Italic")).toBeTruthy();
+		expect(getByLabelText("Clear")).toBeTruthy();
+		expect(getByLabelText("Remove")).toBeTruthy();
 	});
 
 	test("internal value is unaffected by translation", async () => {
@@ -504,7 +504,7 @@ describe("CheckboxGroup: i18n choices", () => {
 			value: ["bold"]
 		});
 
-		expect(getByLabelText("Bold")).toBeChecked();
+		expect(getByLabelText("Clear")).toBeChecked();
 
 		const data = await get_data();
 		expect(data.value).toEqual(["bold"]);

--- a/js/dropdown/Index.svelte
+++ b/js/dropdown/Index.svelte
@@ -15,6 +15,14 @@
 
 	let props = $props();
 	const gradio = new Gradio<DropdownEvents, DropdownProps>(props);
+
+	// Translate the display side only; values stay raw for event payloads.
+	let translated_choices = $derived(
+		gradio.props.choices.map(
+			([display, value]) =>
+				[gradio.i18n(display), value] as [string, string | number]
+		)
+	);
 </script>
 
 <Block
@@ -40,7 +48,7 @@
 			label={gradio.shared.label}
 			info={gradio.props.info}
 			bind:value={gradio.props.value}
-			choices={gradio.props.choices}
+			choices={translated_choices}
 			interactive={gradio.shared.interactive}
 			show_label={gradio.shared.show_label}
 			container={gradio.shared.container}

--- a/js/dropdown/dropdown.test.ts
+++ b/js/dropdown/dropdown.test.ts
@@ -1,10 +1,16 @@
-import { test, describe, afterEach, expect, vi } from "vitest";
+import { test, describe, afterEach, expect, vi, beforeAll } from "vitest";
 import { cleanup, render, fireEvent, waitFor } from "@self/tootils/render";
 import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
 import event from "@testing-library/user-event";
+import { setupi18n } from "../core/src/i18n";
+import { formatter } from "../core/src/gradio_helper";
 
 import Dropdown from "./Index.svelte";
 import { handle_filter } from "./shared/utils";
+
+// Build a real i18n marker the way the backend's I18nData does.
+const marker = (key: string): string =>
+	`__i18n__${JSON.stringify({ __type__: "translation_metadata", key })}`;
 
 const single_select_props = {
 	label: "Dropdown",
@@ -1599,6 +1605,98 @@ describe("handle_filter", () => {
 
 	test("matches substring anywhere in display name", () => {
 		expect(handle_filter(choices, "an")).toEqual([1]);
+	});
+});
+
+describe("i18n choices", () => {
+	beforeAll(async () => {
+		await setupi18n({ en: { bold_label: "Bold", italic_label: "Italic" } });
+	});
+	afterEach(() => cleanup());
+
+	const i18n_choices: [string, string][] = [
+		[marker("bold_label"), "bold"],
+		[marker("italic_label"), "italic"]
+	];
+
+	test("single-select shows translated display name for the selected value", async () => {
+		const { getByLabelText } = await render(Dropdown, {
+			...single_select_props,
+			i18n: formatter,
+			choices: i18n_choices,
+			value: "bold"
+		});
+
+		const input = getByLabelText("Dropdown") as HTMLInputElement;
+		expect(input.value).toBe("Bold");
+	});
+
+	test("single-select translates option display names", async () => {
+		const { getByLabelText, getAllByTestId } = await render(Dropdown, {
+			...single_select_props,
+			i18n: formatter,
+			choices: i18n_choices,
+			value: "bold"
+		});
+
+		const input = getByLabelText("Dropdown") as HTMLInputElement;
+		await input.focus();
+
+		const options = getAllByTestId("dropdown-option");
+		expect(options[0]).toHaveAttribute("aria-label", "Bold");
+		expect(options[1]).toHaveAttribute("aria-label", "Italic");
+	});
+
+	test("single-select internal value is unaffected by translation", async () => {
+		const { get_data } = await render(Dropdown, {
+			...single_select_props,
+			i18n: formatter,
+			choices: i18n_choices,
+			value: "bold"
+		});
+
+		const data = await get_data();
+		expect(data.value).toBe("bold");
+	});
+
+	test("multiselect renders translated display names in tokens", async () => {
+		const { getByText, queryByText } = await render(Dropdown, {
+			...multiselect_props,
+			i18n: formatter,
+			choices: i18n_choices,
+			value: ["bold", "italic"]
+		});
+
+		expect(getByText("Bold")).toBeTruthy();
+		expect(getByText("Italic")).toBeTruthy();
+		expect(queryByText("__i18n__bold")).toBeNull();
+	});
+
+	test("multiselect translates option display names", async () => {
+		const { container, getAllByTestId } = await render(Dropdown, {
+			...multiselect_props,
+			i18n: formatter,
+			choices: i18n_choices
+		});
+
+		const input = container.querySelector("input") as HTMLInputElement;
+		await input.focus();
+
+		const options = getAllByTestId("dropdown-option");
+		expect(options[0]).toHaveAttribute("aria-label", "Bold");
+		expect(options[1]).toHaveAttribute("aria-label", "Italic");
+	});
+
+	test("multiselect internal value is unaffected by translation", async () => {
+		const { get_data } = await render(Dropdown, {
+			...multiselect_props,
+			i18n: formatter,
+			choices: i18n_choices,
+			value: ["italic"]
+		});
+
+		const data = await get_data();
+		expect(data.value).toEqual(["italic"]);
 	});
 });
 

--- a/js/dropdown/dropdown.test.ts
+++ b/js/dropdown/dropdown.test.ts
@@ -1610,13 +1610,13 @@ describe("handle_filter", () => {
 
 describe("i18n choices", () => {
 	beforeAll(async () => {
-		await setupi18n({ en: { bold_label: "Bold", italic_label: "Italic" } });
+		await setupi18n();
 	});
 	afterEach(() => cleanup());
 
 	const i18n_choices: [string, string][] = [
-		[marker("bold_label"), "bold"],
-		[marker("italic_label"), "italic"]
+		[marker("common.clear"), "bold"],
+		[marker("common.remove"), "italic"]
 	];
 
 	test("single-select shows translated display name for the selected value", async () => {
@@ -1628,7 +1628,7 @@ describe("i18n choices", () => {
 		});
 
 		const input = getByLabelText("Dropdown") as HTMLInputElement;
-		expect(input.value).toBe("Bold");
+		expect(input.value).toBe("Clear");
 	});
 
 	test("single-select translates option display names", async () => {
@@ -1643,8 +1643,8 @@ describe("i18n choices", () => {
 		await input.focus();
 
 		const options = getAllByTestId("dropdown-option");
-		expect(options[0]).toHaveAttribute("aria-label", "Bold");
-		expect(options[1]).toHaveAttribute("aria-label", "Italic");
+		expect(options[0]).toHaveAttribute("aria-label", "Clear");
+		expect(options[1]).toHaveAttribute("aria-label", "Remove");
 	});
 
 	test("single-select internal value is unaffected by translation", async () => {
@@ -1667,9 +1667,9 @@ describe("i18n choices", () => {
 			value: ["bold", "italic"]
 		});
 
-		expect(getByText("Bold")).toBeTruthy();
-		expect(getByText("Italic")).toBeTruthy();
-		expect(queryByText("__i18n__bold")).toBeNull();
+		expect(getByText("Clear")).toBeTruthy();
+		expect(getByText("Remove")).toBeTruthy();
+		expect(queryByText(marker("common.clear"))).toBeNull();
 	});
 
 	test("multiselect translates option display names", async () => {
@@ -1683,8 +1683,8 @@ describe("i18n choices", () => {
 		await input.focus();
 
 		const options = getAllByTestId("dropdown-option");
-		expect(options[0]).toHaveAttribute("aria-label", "Bold");
-		expect(options[1]).toHaveAttribute("aria-label", "Italic");
+		expect(options[0]).toHaveAttribute("aria-label", "Clear");
+		expect(options[1]).toHaveAttribute("aria-label", "Remove");
 	});
 
 	test("multiselect internal value is unaffected by translation", async () => {

--- a/js/dropdown/dropdown.test.ts
+++ b/js/dropdown/dropdown.test.ts
@@ -2,7 +2,7 @@ import { test, describe, afterEach, expect, vi, beforeAll } from "vitest";
 import { cleanup, render, fireEvent, waitFor } from "@self/tootils/render";
 import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
 import event from "@testing-library/user-event";
-import { setupi18n } from "../core/src/i18n";
+import { setupi18n, changeLocale } from "../core/src/i18n";
 import { formatter } from "../core/src/gradio_helper";
 
 import Dropdown from "./Index.svelte";
@@ -1611,6 +1611,7 @@ describe("handle_filter", () => {
 describe("i18n choices", () => {
 	beforeAll(async () => {
 		await setupi18n(undefined, "en");
+		changeLocale("en");
 	});
 	afterEach(() => cleanup());
 

--- a/js/dropdown/dropdown.test.ts
+++ b/js/dropdown/dropdown.test.ts
@@ -1610,7 +1610,7 @@ describe("handle_filter", () => {
 
 describe("i18n choices", () => {
 	beforeAll(async () => {
-		await setupi18n();
+		await setupi18n(undefined, "en");
 	});
 	afterEach(() => cleanup());
 

--- a/js/dropdown/shared/Multiselect.svelte
+++ b/js/dropdown/shared/Multiselect.svelte
@@ -16,8 +16,15 @@
 	let label = $derived(gradio.shared.label || "Multiselect");
 	let buttons = $derived(gradio.props.buttons);
 
+	// Translate the display side only; values stay raw for event payloads.
+	let translated_choices: [string, string | number][] = $derived.by(() => {
+		return gradio.props.choices.map(
+			([display, value]) =>
+				[gradio.i18n(display), value] as [string, string | number]
+		);
+	});
 	let choices_names: string[] = $derived.by(() => {
-		return gradio.props.choices.map((c) => c[0]);
+		return translated_choices.map((c) => c[0]);
 	});
 	let choices_values: (string | number)[] = $derived.by(() => {
 		return gradio.props.choices.map((c) => c[1]);
@@ -29,7 +36,7 @@
 
 	// All of these are indices with respect to the choices array
 	let [filtered_indices, active_index] = $derived.by(() => {
-		const filtered = handle_filter(gradio.props.choices, input_text);
+		const filtered = handle_filter(translated_choices, input_text);
 		return [
 			filtered,
 			filtered.length > 0 && !gradio.props.allow_custom_value
@@ -278,7 +285,7 @@
 		</div>
 		<DropdownOptions
 			{show_options}
-			choices={gradio.props.choices}
+			choices={translated_choices}
 			{filtered_indices}
 			{disabled}
 			{selected_indices}

--- a/js/radio/Index.svelte
+++ b/js/radio/Index.svelte
@@ -58,7 +58,7 @@
 	<div class="wrap">
 		{#each gradio.props.choices as [display_value, internal_value], i (i)}
 			<BaseRadio
-				{display_value}
+				display_value={gradio.i18n(display_value)}
 				{internal_value}
 				bind:selected={gradio.props.value}
 				{disabled}

--- a/js/radio/Radio.test.ts
+++ b/js/radio/Radio.test.ts
@@ -147,7 +147,7 @@ describe("Props: choices", () => {
 
 describe("Props: i18n choices", () => {
 	beforeAll(async () => {
-		await setupi18n();
+		await setupi18n(undefined, "en");
 	});
 
 	const i18n_choices: [string, string][] = [

--- a/js/radio/Radio.test.ts
+++ b/js/radio/Radio.test.ts
@@ -147,12 +147,12 @@ describe("Props: choices", () => {
 
 describe("Props: i18n choices", () => {
 	beforeAll(async () => {
-		await setupi18n({ en: { bold_label: "Bold", italic_label: "Italic" } });
+		await setupi18n();
 	});
 
 	const i18n_choices: [string, string][] = [
-		[marker("bold_label"), "bold"],
-		[marker("italic_label"), "italic"]
+		[marker("common.clear"), "bold"],
+		[marker("common.remove"), "italic"]
 	];
 
 	test("translates choice display values through the i18n formatter", async () => {
@@ -163,8 +163,8 @@ describe("Props: i18n choices", () => {
 			value: "bold"
 		});
 
-		expect(getByText("Bold")).toBeVisible();
-		expect(getByText("Italic")).toBeVisible();
+		expect(getByText("Clear")).toBeVisible();
+		expect(getByText("Remove")).toBeVisible();
 	});
 
 	test("internal value is unaffected by translation", async () => {

--- a/js/radio/Radio.test.ts
+++ b/js/radio/Radio.test.ts
@@ -1,9 +1,15 @@
-import { test, describe, expect, afterEach } from "vitest";
+import { test, describe, expect, afterEach, beforeAll } from "vitest";
 import { cleanup, render, fireEvent, waitFor } from "@self/tootils/render";
 import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
 import event from "@testing-library/user-event";
+import { setupi18n } from "../core/src/i18n";
+import { formatter } from "../core/src/gradio_helper";
 
 import Radio from "./Index.svelte";
+
+// Build a real i18n marker the way the backend's I18nData does.
+const marker = (key: string): string =>
+	`__i18n__${JSON.stringify({ __type__: "translation_metadata", key })}`;
 
 afterEach(cleanup);
 
@@ -136,6 +142,44 @@ describe("Props: choices", () => {
 		});
 
 		expect(queryAllByRole("radio")).toHaveLength(0);
+	});
+});
+
+describe("Props: i18n choices", () => {
+	beforeAll(async () => {
+		await setupi18n({ en: { bold_label: "Bold", italic_label: "Italic" } });
+	});
+
+	const i18n_choices: [string, string][] = [
+		[marker("bold_label"), "bold"],
+		[marker("italic_label"), "italic"]
+	];
+
+	test("translates choice display values through the i18n formatter", async () => {
+		const { getByText } = await render(Radio, {
+			...default_props,
+			i18n: formatter,
+			choices: i18n_choices,
+			value: "bold"
+		});
+
+		expect(getByText("Bold")).toBeVisible();
+		expect(getByText("Italic")).toBeVisible();
+	});
+
+	test("internal value is unaffected by translation", async () => {
+		const { getAllByRole, get_data } = await render(Radio, {
+			...default_props,
+			i18n: formatter,
+			choices: i18n_choices,
+			value: "italic"
+		});
+
+		const radios = getAllByRole("radio") as HTMLInputElement[];
+		expect(radios[1]).toBeChecked();
+
+		const data = await get_data();
+		expect(data.value).toBe("italic");
 	});
 });
 

--- a/js/radio/Radio.test.ts
+++ b/js/radio/Radio.test.ts
@@ -2,7 +2,7 @@ import { test, describe, expect, afterEach, beforeAll } from "vitest";
 import { cleanup, render, fireEvent, waitFor } from "@self/tootils/render";
 import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
 import event from "@testing-library/user-event";
-import { setupi18n } from "../core/src/i18n";
+import { setupi18n, changeLocale } from "../core/src/i18n";
 import { formatter } from "../core/src/gradio_helper";
 
 import Radio from "./Index.svelte";
@@ -148,6 +148,7 @@ describe("Props: choices", () => {
 describe("Props: i18n choices", () => {
 	beforeAll(async () => {
 		await setupi18n(undefined, "en");
+		changeLocale("en");
 	});
 
 	const i18n_choices: [string, string][] = [

--- a/js/simpledropdown/Index.svelte
+++ b/js/simpledropdown/Index.svelte
@@ -13,9 +13,17 @@
 
 	const container = true;
 
+	// Translate the display side only; values stay raw for selection matching.
+	let translated_choices = $derived(
+		gradio.props.choices.map(
+			([display, value]) =>
+				[gradio.i18n(display), value] as [string, string | number]
+		)
+	);
+
 	$effect(() => {
 		if (display_value) {
-			candidate = gradio.props.choices.filter(
+			candidate = translated_choices.filter(
 				(choice) => choice[0] === display_value
 			);
 			gradio.props.value = candidate.length ? candidate[0][1] : "";
@@ -52,7 +60,7 @@
 			>{gradio.shared.label}</BlockTitle
 		>
 		<select disabled={!gradio.shared.interactive} bind:value={display_value}>
-			{#each gradio.props.choices as choice}
+			{#each translated_choices as choice}
 				<option>{choice[0]}</option>
 			{/each}
 		</select>

--- a/js/simpledropdown/simpledropdown.test.ts
+++ b/js/simpledropdown/simpledropdown.test.ts
@@ -1,0 +1,85 @@
+import { test, describe, expect, afterEach, beforeAll } from "vitest";
+import { cleanup, render } from "@self/tootils/render";
+import event from "@testing-library/user-event";
+import { setupi18n } from "../core/src/i18n";
+import { formatter } from "../core/src/gradio_helper";
+
+import SimpleDropdown from "./Index.svelte";
+
+// Build a real i18n marker the way the backend's I18nData does.
+const marker = (key: string): string =>
+	`__i18n__${JSON.stringify({ __type__: "translation_metadata", key })}`;
+
+const default_props = {
+	label: "Simple Dropdown",
+	show_label: true,
+	value: "apple",
+	choices: [
+		["Apple", "apple"],
+		["Banana", "banana"],
+		["Cherry", "cherry"]
+	] as [string, string | number][],
+	interactive: true
+};
+
+describe("SimpleDropdown", () => {
+	afterEach(() => cleanup());
+
+	test("renders all choices as options", async () => {
+		const { container } = await render(SimpleDropdown, default_props);
+
+		const options = container.querySelectorAll("option");
+		const labels = Array.from(options).map((o) => o.textContent?.trim());
+		expect(labels).toEqual(["Apple", "Banana", "Cherry"]);
+	});
+
+	test("selecting an option updates the internal value", async () => {
+		const { container, get_data } = await render(SimpleDropdown, default_props);
+
+		const select = container.querySelector("select") as HTMLSelectElement;
+		await event.selectOptions(select, "Banana");
+
+		const data = await get_data();
+		expect(data.value).toBe("banana");
+	});
+});
+
+describe("SimpleDropdown: i18n choices", () => {
+	beforeAll(async () => {
+		await setupi18n({ en: { bold_label: "Bold", italic_label: "Italic" } });
+	});
+	afterEach(() => cleanup());
+
+	const i18n_choices: [string, string][] = [
+		[marker("bold_label"), "bold"],
+		[marker("italic_label"), "italic"]
+	];
+
+	test("translates option display names through the i18n formatter", async () => {
+		const { container } = await render(SimpleDropdown, {
+			...default_props,
+			i18n: formatter,
+			choices: i18n_choices,
+			value: "bold"
+		});
+
+		const options = container.querySelectorAll("option");
+		const labels = Array.from(options).map((o) => o.textContent?.trim());
+		expect(labels).toEqual(["Bold", "Italic"]);
+	});
+
+	test("selecting a translated option maps back to the internal value", async () => {
+		const { container, get_data } = await render(SimpleDropdown, {
+			...default_props,
+			i18n: formatter,
+			choices: i18n_choices,
+			value: "bold"
+		});
+
+		const select = container.querySelector("select") as HTMLSelectElement;
+		await event.selectOptions(select, "Italic");
+
+		const data = await get_data();
+		expect(data.value).toBe("italic");
+	});
+});

--- a/js/simpledropdown/simpledropdown.test.ts
+++ b/js/simpledropdown/simpledropdown.test.ts
@@ -46,7 +46,7 @@ describe("SimpleDropdown", () => {
 
 describe("SimpleDropdown: i18n choices", () => {
 	beforeAll(async () => {
-		await setupi18n();
+		await setupi18n(undefined, "en");
 	});
 	afterEach(() => cleanup());
 

--- a/js/simpledropdown/simpledropdown.test.ts
+++ b/js/simpledropdown/simpledropdown.test.ts
@@ -1,7 +1,7 @@
 import { test, describe, expect, afterEach, beforeAll } from "vitest";
 import { cleanup, render } from "@self/tootils/render";
 import event from "@testing-library/user-event";
-import { setupi18n } from "../core/src/i18n";
+import { setupi18n, changeLocale } from "../core/src/i18n";
 import { formatter } from "../core/src/gradio_helper";
 
 import SimpleDropdown from "./Index.svelte";
@@ -47,6 +47,7 @@ describe("SimpleDropdown", () => {
 describe("SimpleDropdown: i18n choices", () => {
 	beforeAll(async () => {
 		await setupi18n(undefined, "en");
+		changeLocale("en");
 	});
 	afterEach(() => cleanup());
 

--- a/js/simpledropdown/simpledropdown.test.ts
+++ b/js/simpledropdown/simpledropdown.test.ts
@@ -46,13 +46,13 @@ describe("SimpleDropdown", () => {
 
 describe("SimpleDropdown: i18n choices", () => {
 	beforeAll(async () => {
-		await setupi18n({ en: { bold_label: "Bold", italic_label: "Italic" } });
+		await setupi18n();
 	});
 	afterEach(() => cleanup());
 
 	const i18n_choices: [string, string][] = [
-		[marker("bold_label"), "bold"],
-		[marker("italic_label"), "italic"]
+		[marker("common.clear"), "bold"],
+		[marker("common.remove"), "italic"]
 	];
 
 	test("translates option display names through the i18n formatter", async () => {
@@ -65,7 +65,7 @@ describe("SimpleDropdown: i18n choices", () => {
 
 		const options = container.querySelectorAll("option");
 		const labels = Array.from(options).map((o) => o.textContent?.trim());
-		expect(labels).toEqual(["Bold", "Italic"]);
+		expect(labels).toEqual(["Clear", "Remove"]);
 	});
 
 	test("selecting a translated option maps back to the internal value", async () => {
@@ -77,7 +77,7 @@ describe("SimpleDropdown: i18n choices", () => {
 		});
 
 		const select = container.querySelector("select") as HTMLSelectElement;
-		await event.selectOptions(select, "Italic");
+		await event.selectOptions(select, "Remove");
 
 		const data = await get_data();
 		expect(data.value).toBe("italic");


### PR DESCRIPTION
## Description

`gr.I18n` markers work for the `label` and `info` of choice-based components, but the `choices` display names were never translated. When a choice was supplied as `(i18n("bold"), "bold")`, the option rendered as the raw marker string (`__i18n__{"__type__":"translation_metadata","key":"bold"}`) instead of the translated text.

The i18n machinery only auto-translates a fixed allow-list of scalar props (`label`, `info`, etc.). `choices` is an array of `[display, value]` tuples, so it fell outside that path, and each component rendered the choice display value directly without passing it through the i18n formatter.

This PR routes the display side of each choice through the existing i18n formatter (`gradio.i18n`) at the point each component consumes its choices. Only the display name is translated; the internal value is left untouched, so event payloads and `value` handling are unchanged. Plain string choices are unaffected.

Covers all four choice-based components reported and adjacent:
- `CheckboxGroup`
- `Radio`
- `Dropdown` (single-select and multiselect)
- `SimpleDropdown`

For `Dropdown` and `SimpleDropdown`, the choices are translated once at the top of the data flow so that filtering, the selected-input text, the token labels, and the option list all stay consistent with the translated display names.

Closes: #11611

### Known limitation

This translates choices on initial load, which is what the issue reports. Re-translating choices on a runtime language switch (Settings → Language) is out of scope: `gradio.i18n` is set once per component and is not reactive to locale changes. The existing runtime-switch mechanism only covers scalar `translatable_props`.

The example tables rendered by `gr.Dataset` / `gr.Examples` (the per-component `Example.svelte` files) also display choice names raw, but those components are mounted without an i18n formatter, so translating them would require threading a formatter through the Dataset/Examples chain. That is left as a separate change.

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

