### PR TITLE
Close matplotlib figures after rendering them in `gr.Plot`

### DIFF
--- a/.changeset/great-dogs-carry.md
+++ b/.changeset/great-dogs-carry.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Close matplotlib figures after rendering them in `gr.Plot`

--- a/gradio/components/plot.py
+++ b/gradio/components/plot.py
@@ -143,6 +143,10 @@ class Plot(Component):
         if isinstance(value, ModuleType) or "matplotlib" in value.__module__:
             dtype = "matplotlib"
             out_y = processing_utils.encode_plot_to_base64(value, self.format)
+            if not isinstance(value, ModuleType):
+                import matplotlib.pyplot as plt
+
+                plt.close(value)
         elif "bokeh" in value.__module__:
             dtype = "bokeh"
             from bokeh.embed import json_item  # type: ignore

--- a/gradio/components/plot.py
+++ b/gradio/components/plot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from collections.abc import Sequence
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Literal
@@ -142,13 +143,16 @@ class Plot(Component):
             return value
         if isinstance(value, ModuleType) or "matplotlib" in value.__module__:
             dtype = "matplotlib"
-            out_y = processing_utils.encode_plot_to_base64(value, self.format)
-            from matplotlib.figure import Figure
+            try:
+                out_y = processing_utils.encode_plot_to_base64(value, self.format)
+            finally:
+                # A figure can only be in pyplot's registry if pyplot is
+                # already imported, so don't import it just to close.
+                plt = sys.modules.get("matplotlib.pyplot")
+                from matplotlib.figure import Figure
 
-            if isinstance(value, Figure):
-                import matplotlib.pyplot as plt
-
-                plt.close(value)
+                if plt is not None and isinstance(value, Figure):
+                    plt.close(value)
         elif "bokeh" in value.__module__:
             dtype = "bokeh"
             from bokeh.embed import json_item  # type: ignore

--- a/gradio/components/plot.py
+++ b/gradio/components/plot.py
@@ -143,7 +143,9 @@ class Plot(Component):
         if isinstance(value, ModuleType) or "matplotlib" in value.__module__:
             dtype = "matplotlib"
             out_y = processing_utils.encode_plot_to_base64(value, self.format)
-            if not isinstance(value, ModuleType):
+            from matplotlib.figure import Figure
+
+            if isinstance(value, Figure):
                 import matplotlib.pyplot as plt
 
                 plt.close(value)

--- a/gradio/components/plot.py
+++ b/gradio/components/plot.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from collections.abc import Sequence
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Literal
@@ -146,12 +145,12 @@ class Plot(Component):
             try:
                 out_y = processing_utils.encode_plot_to_base64(value, self.format)
             finally:
-                # A figure can only be in pyplot's registry if pyplot is
-                # already imported, so don't import it just to close.
-                plt = sys.modules.get("matplotlib.pyplot")
-                if plt is not None:
+                try:
+                    import matplotlib.pyplot as plt
                     from matplotlib.figure import Figure
-
+                except ImportError:
+                    pass
+                else:
                     if isinstance(value, Figure):
                         plt.close(value)
         elif "bokeh" in value.__module__:

--- a/gradio/components/plot.py
+++ b/gradio/components/plot.py
@@ -149,10 +149,11 @@ class Plot(Component):
                 # A figure can only be in pyplot's registry if pyplot is
                 # already imported, so don't import it just to close.
                 plt = sys.modules.get("matplotlib.pyplot")
-                from matplotlib.figure import Figure
+                if plt is not None:
+                    from matplotlib.figure import Figure
 
-                if plt is not None and isinstance(value, Figure):
-                    plt.close(value)
+                    if isinstance(value, Figure):
+                        plt.close(value)
         elif "bokeh" in value.__module__:
             dtype = "bokeh"
             from bokeh.embed import json_item  # type: ignore

--- a/gradio/components/plot.py
+++ b/gradio/components/plot.py
@@ -142,17 +142,14 @@ class Plot(Component):
             return value
         if isinstance(value, ModuleType) or "matplotlib" in value.__module__:
             dtype = "matplotlib"
+            out_y = processing_utils.encode_plot_to_base64(value, self.format)
             try:
-                out_y = processing_utils.encode_plot_to_base64(value, self.format)
-            finally:
-                try:
-                    import matplotlib.pyplot as plt
-                    from matplotlib.figure import Figure
-                except ImportError:
-                    pass
-                else:
-                    if isinstance(value, Figure):
-                        plt.close(value)
+                import matplotlib.pyplot as plt
+                from matplotlib.figure import Figure
+            except ImportError:
+                return PlotData(type=dtype, plot=out_y)
+            if isinstance(value, Figure):
+                plt.close(value)
         elif "bokeh" in value.__module__:
             dtype = "bokeh"
             from bokeh.embed import json_item  # type: ignore

--- a/test/components/test_plot.py
+++ b/test/components/test_plot.py
@@ -1,3 +1,4 @@
+import matplotlib.pyplot as plt
 import pytest
 
 import gradio as gr
@@ -63,8 +64,6 @@ class TestPlot:
         postprocess
         """
         with utils.MatplotlibBackendMananger():
-            import matplotlib.pyplot as plt
-
             plt.close("all")
             component = gr.Plot()
             fig = plt.figure()
@@ -77,8 +76,6 @@ class TestPlot:
         postprocess
         """
         with utils.MatplotlibBackendMananger():
-            import matplotlib.pyplot as plt
-
             component = gr.Plot(format="png")
             fig = plt.figure()
             plt.plot([1, 2, 3], [1, 2, 3])

--- a/test/components/test_plot.py
+++ b/test/components/test_plot.py
@@ -78,7 +78,7 @@ class TestPlot:
         with utils.MatplotlibBackendMananger():
             import matplotlib.pyplot as plt
 
-            component = gr.Plot()
+            component = gr.Plot(format="png")
             fig = plt.figure()
             plt.plot([1, 2, 3], [1, 2, 3])
             first = component.postprocess(fig)

--- a/test/components/test_plot.py
+++ b/test/components/test_plot.py
@@ -65,11 +65,12 @@ class TestPlot:
         with utils.MatplotlibBackendMananger():
             import matplotlib.pyplot as plt
 
+            plt.close("all")
             component = gr.Plot()
             fig = plt.figure()
             plt.plot([1, 2, 3], [1, 2, 3])
             component.postprocess(fig)
-            assert not plt.fignum_exists(fig.number)
+            assert not plt.get_fignums()
 
     def test_postprocess_accepts_closed_figure(self):
         """

--- a/test/components/test_plot.py
+++ b/test/components/test_plot.py
@@ -58,6 +58,33 @@ class TestPlot:
         assert isinstance(out["plot"], str)
         assert out["plot"] == chart.to_json()
 
+    def test_postprocess_closes_matplotlib_figure(self):
+        """
+        postprocess
+        """
+        with utils.MatplotlibBackendMananger():
+            import matplotlib.pyplot as plt
+
+            component = gr.Plot()
+            fig = plt.figure()
+            plt.plot([1, 2, 3], [1, 2, 3])
+            component.postprocess(fig)
+            assert not plt.fignum_exists(fig.number)
+
+    def test_postprocess_accepts_closed_figure(self):
+        """
+        postprocess
+        """
+        with utils.MatplotlibBackendMananger():
+            import matplotlib.pyplot as plt
+
+            component = gr.Plot()
+            fig = plt.figure()
+            plt.plot([1, 2, 3], [1, 2, 3])
+            first = component.postprocess(fig)
+            second = component.postprocess(fig)
+            assert first and second and first.plot == second.plot
+
     def test_plot_format_parameter(self):
         """
         postprocess


### PR DESCRIPTION
## Description

Matplotlib figures returned to `gr.Plot` were never closed after being encoded, so every event that updated a plot left another open figure in pyplot's global registry. Long-running apps accumulated figures, leaked memory, and eventually triggered matplotlib's "More than 20 figures have been opened" warning.

`Plot.postprocess` now calls `plt.close(value)` once the figure has been encoded to base64. Only `Figure` instances are closed. The legacy path where a handler returns the `pyplot` module itself is left untouched, since closing the current figure there could break apps that keep drawing on it across calls.

Closing a figure does not prevent it from being rendered again: `savefig` still works on a closed figure, so apps that hold on to a figure (for example in `gr.State`) and return it to `gr.Plot` repeatedly keep working. A test covers this, along with a regression test that the figure registry stays empty after `postprocess`. Figures created directly via `matplotlib.figure.Figure` (not through pyplot) are not in the registry, and closing them is a no-op.

Closes: #11701

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

