### PR TITLE
Fix `gr.SelectData` coordinates when the image in `gr.Image` does not fill its container

### DIFF
--- a/.changeset/fast-cows-hug.md
+++ b/.changeset/fast-cows-hug.md
@@ -1,0 +1,6 @@
+---
+"@gradio/image": patch
+"gradio": patch
+---
+
+fix:Fix `gr.SelectData` coordinates when the image in `gr.Image` does not fill its container

--- a/js/image/Image.test.ts
+++ b/js/image/Image.test.ts
@@ -635,6 +635,52 @@ describe("get_coordinates_of_clicked_image", () => {
 		expect(result).toEqual([100, 200]);
 	});
 
+	test("handles image shown at natural size with empty space on both axes", () => {
+		// `object-fit: scale-down` never upscales: a 100x100 natural image in
+		// a 400x300 box is drawn at natural size, centered at offset (150, 100).
+		// Click at (150, 100) = top-left corner of the drawn image.
+		const evt = make_mock_event(
+			150,
+			100,
+			{
+				naturalWidth: 100,
+				naturalHeight: 100
+			},
+			{
+				left: 0,
+				top: 0,
+				width: 400,
+				height: 300
+			}
+		);
+
+		const result = get_coordinates_of_clicked_image(evt);
+		expect(result).toEqual([0, 0]);
+	});
+
+	test("returns null when click is in the empty space around a natural-size image", () => {
+		// 100x100 natural image in a 1920x1080 box: drawn at natural size,
+		// centered at offset (910, 490). A click at (500, 540) is inside the
+		// box but left of the drawn image, so no image pixel is under it.
+		const evt = make_mock_event(
+			500,
+			540,
+			{
+				naturalWidth: 100,
+				naturalHeight: 100
+			},
+			{
+				left: 0,
+				top: 0,
+				width: 1920,
+				height: 1080
+			}
+		);
+
+		const result = get_coordinates_of_clicked_image(evt);
+		expect(result).toBeNull();
+	});
+
 	test("returns [NaN, NaN] when currentTarget is not an Element", () => {
 		const evt = {
 			currentTarget: {},

--- a/js/image/shared/utils.ts
+++ b/js/image/shared/utils.ts
@@ -9,19 +9,17 @@ export const get_coordinates_of_clicked_image = (
 	}
 
 	const imageRect = image.getBoundingClientRect();
-	const xScale = image.naturalWidth / imageRect.width;
-	const yScale = image.naturalHeight / imageRect.height;
-	if (xScale > yScale) {
-		const displayed_height = image.naturalHeight / xScale;
-		const y_offset = (imageRect.height - displayed_height) / 2;
-		var x = Math.round((evt.clientX - imageRect.left) * xScale);
-		var y = Math.round((evt.clientY - imageRect.top - y_offset) * xScale);
-	} else {
-		const displayed_width = image.naturalWidth / yScale;
-		const x_offset = (imageRect.width - displayed_width) / 2;
-		var x = Math.round((evt.clientX - imageRect.left - x_offset) * yScale);
-		var y = Math.round((evt.clientY - imageRect.top) * yScale);
-	}
+	// The image is rendered with `object-fit: scale-down`: centered, never
+	// scaled above its natural size, so empty space can appear on both axes.
+	const scale = Math.min(
+		imageRect.width / image.naturalWidth,
+		imageRect.height / image.naturalHeight,
+		1
+	);
+	const x_offset = (imageRect.width - image.naturalWidth * scale) / 2;
+	const y_offset = (imageRect.height - image.naturalHeight * scale) / 2;
+	const x = Math.round((evt.clientX - imageRect.left - x_offset) / scale);
+	const y = Math.round((evt.clientY - imageRect.top - y_offset) / scale);
 	if (x < 0 || x >= image.naturalWidth || y < 0 || y >= image.naturalHeight) {
 		return null;
 	}


### PR DESCRIPTION
## Description

When the image shown in `gr.Image` is smaller than its display box, the x/y coordinates reported through `gr.SelectData` are wrong. This is most visible in fullscreen mode: the display box grows to the viewport size while the image stays at its natural size (it is intentionally not upscaled to avoid blurriness), and clicks are reported as if the image had been stretched to fill the screen.

The root cause is a mismatch between the CSS and the coordinate math. The image is rendered with `object-fit: scale-down`, which never enlarges the image beyond its natural size, so a small image is centered with empty space on both axes. But `get_coordinates_of_clicked_image()` assumed `object-fit: contain` behavior, where the image always fills the box along at least one axis and empty space can only appear along one axis. Whenever the box is larger than the image in both dimensions, that assumption breaks and the computed coordinates are scaled and offset incorrectly.

This was previously fixed in #10901 by changing the CSS so the container hugged the image, but that broke scaling when `height=` is set (#10991) and was reverted in #11091. This PR instead leaves the CSS untouched and fixes the math: the displayed image rect is computed with scale-down semantics (`scale = min(box_w / natural_w, box_h / natural_h, 1)`, centered on both axes) and the click position is inverted from that. The two existing code branches (landscape/portrait letterboxing) are special cases of this formula, so behavior is unchanged in the cases that already worked, which the existing unit tests confirm. Clicks landing in the empty space around the image now return no coordinates (no `select` event), matching the existing behavior for clicks outside the image bounds.

Added unit tests for the natural-size-centered case (including a fullscreen-sized box) and for clicks in the surrounding empty space, which fail on `main`.

Closes: #10268

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

