### PR TITLE
Fix fullscreen button not working in ImageSlider, interactive Image, native plots, and AnnotatedImage

### DIFF
--- a/.changeset/pretty-streets-guess.md
+++ b/.changeset/pretty-streets-guess.md
@@ -1,0 +1,9 @@
+---
+"@gradio/annotatedimage": patch
+"@gradio/image": patch
+"@gradio/imageslider": patch
+"@gradio/nativeplot": patch
+"gradio": patch
+---
+
+fix:Fix fullscreen button not working in ImageSlider, interactive Image, native plots, and AnnotatedImage

--- a/js/annotatedimage/AnnotatedImage.test.ts
+++ b/js/annotatedimage/AnnotatedImage.test.ts
@@ -1,5 +1,5 @@
 import { test, describe, afterEach, expect } from "vitest";
-import { cleanup, render, fireEvent } from "@self/tootils/render";
+import { cleanup, render, fireEvent, waitFor } from "@self/tootils/render";
 import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
 
 import AnnotatedImage from "./Index.svelte";
@@ -231,6 +231,24 @@ describe("Props: buttons", () => {
 
 		expect(getByLabelText("Fullscreen")).toBeTruthy();
 		expect(getByLabelText("Fullscreen")).toBeVisible();
+	});
+
+	test("clicking the fullscreen button toggles fullscreen mode", async () => {
+		const { getByLabelText } = await render(AnnotatedImage, {
+			...default_props,
+			value: fake_value,
+			buttons: ["fullscreen"]
+		});
+
+		await fireEvent.click(getByLabelText("Fullscreen"));
+		await waitFor(() => {
+			expect(getByLabelText("Exit fullscreen mode")).toBeVisible();
+		});
+
+		await fireEvent.click(getByLabelText("Exit fullscreen mode"));
+		await waitFor(() => {
+			expect(getByLabelText("Fullscreen")).toBeVisible();
+		});
 	});
 
 	test("empty buttons array shows no fullscreen button", async () => {

--- a/js/annotatedimage/Index.svelte
+++ b/js/annotatedimage/Index.svelte
@@ -74,8 +74,8 @@
 					{#if (gradio.props.buttons || []).some((btn) => typeof btn === "string" && btn === "fullscreen")}
 						<FullscreenButton
 							{fullscreen}
-							on:fullscreen={({ detail }) => {
-								fullscreen = detail;
+							onclick={(value) => {
+								fullscreen = value;
 							}}
 						/>
 					{/if}

--- a/js/image/Image.test.ts
+++ b/js/image/Image.test.ts
@@ -326,6 +326,25 @@ describe("Props: buttons (static mode)", () => {
 		expect(getByLabelText("Fullscreen")).toBeTruthy();
 	});
 
+	test("clicking the fullscreen button toggles fullscreen in interactive mode", async () => {
+		const { getByLabelText } = await render(Image, {
+			...default_props,
+			interactive: true,
+			value: fake_value,
+			buttons: ["fullscreen"]
+		});
+
+		await fireEvent.click(getByLabelText("Fullscreen"));
+		await waitFor(() => {
+			expect(getByLabelText("Exit fullscreen mode")).toBeVisible();
+		});
+
+		await fireEvent.click(getByLabelText("Exit fullscreen mode"));
+		await waitFor(() => {
+			expect(getByLabelText("Fullscreen")).toBeVisible();
+		});
+	});
+
 	test("empty buttons array shows no action buttons", async () => {
 		const { queryByLabelText } = await render(Image, {
 			...default_props,

--- a/js/image/shared/ImageUploader.svelte
+++ b/js/image/shared/ImageUploader.svelte
@@ -121,6 +121,7 @@
 		upload?: never;
 		select: SelectData;
 		end_stream: never;
+		fullscreen: boolean;
 	}>();
 
 	export let dragging = false;
@@ -184,7 +185,13 @@
 	<IconButtonWrapper>
 		{#if value?.url && !active_streaming}
 			{#if show_fullscreen_button}
-				<FullscreenButton {fullscreen} on:fullscreen />
+				<FullscreenButton
+					{fullscreen}
+					onclick={(is_fullscreen) => {
+						fullscreen = is_fullscreen;
+						dispatch("fullscreen", is_fullscreen);
+					}}
+				/>
 			{/if}
 			<IconButton
 				Icon={Clear}

--- a/js/imageslider/ImageSlider.test.ts
+++ b/js/imageslider/ImageSlider.test.ts
@@ -345,6 +345,23 @@ describe("Props: buttons", () => {
 		expect(getByLabelText("Fullscreen")).toBeVisible();
 	});
 
+	test("clicking the fullscreen button toggles fullscreen mode", async () => {
+		const { getByLabelText } = await render(ImageSlider, {
+			...preview_props,
+			buttons: ["fullscreen"]
+		});
+
+		await fireEvent.click(getByLabelText("Fullscreen"));
+		await waitFor(() => {
+			expect(getByLabelText("Exit fullscreen mode")).toBeVisible();
+		});
+
+		await fireEvent.click(getByLabelText("Exit fullscreen mode"));
+		await waitFor(() => {
+			expect(getByLabelText("Fullscreen")).toBeVisible();
+		});
+	});
+
 	test("interactive: true with both images shows Remove Image button", async () => {
 		const { getByLabelText } = await render(ImageSlider, {
 			...default_props,

--- a/js/imageslider/shared/SliderPreview.svelte
+++ b/js/imageslider/shared/SliderPreview.svelte
@@ -34,7 +34,10 @@
 	export let el_width = 0;
 	export let max_height: number;
 	export let interactive = true;
-	const dispatch = createEventDispatcher<{ clear: void }>();
+	const dispatch = createEventDispatcher<{
+		clear: void;
+		fullscreen: boolean;
+	}>();
 
 	let img: HTMLImageElement;
 	let slider_wrap: HTMLDivElement;
@@ -144,7 +147,13 @@
 				onclick={() => zoomable_image?.reset_zoom()}
 			/>
 			{#if show_fullscreen_button}
-				<FullscreenButton {fullscreen} on:fullscreen />
+				<FullscreenButton
+					{fullscreen}
+					onclick={(is_fullscreen) => {
+						fullscreen = is_fullscreen;
+						dispatch("fullscreen", is_fullscreen);
+					}}
+				/>
 			{/if}
 
 			{#if show_download_button}

--- a/js/nativeplot/Index.svelte
+++ b/js/nativeplot/Index.svelte
@@ -378,6 +378,7 @@
 		if (!vegaEmbed) {
 			vegaEmbed = (await import("vega-embed")).default;
 		}
+		if (!chart_element) return;
 		vegaEmbed(chart_element, spec, { actions: false }).then(function (result) {
 			view = result.view;
 			resizeObserver!.observe(chart_element!);
@@ -823,8 +824,8 @@
 			{#if gradio.props.buttons?.some((btn) => typeof btn === "string" && btn === "fullscreen")}
 				<FullscreenButton
 					{fullscreen}
-					on:fullscreen={({ detail }) => {
-						fullscreen = detail;
+					onclick={(value) => {
+						fullscreen = value;
 					}}
 				/>
 			{/if}

--- a/js/nativeplot/NativePlot.test.ts
+++ b/js/nativeplot/NativePlot.test.ts
@@ -1,5 +1,5 @@
 import { test, describe, afterEach, expect } from "vitest";
-import { cleanup, render, waitFor } from "@self/tootils/render";
+import { cleanup, render, fireEvent, waitFor } from "@self/tootils/render";
 import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
 
 import NativePlot from "./Index.svelte";
@@ -95,5 +95,29 @@ describe("Props: colors_in_legend", () => {
 
 		expect(container).toHaveTextContent("alpha");
 		expect(container).not.toHaveTextContent("beta");
+	});
+});
+
+describe("Props: buttons", () => {
+	afterEach(() => cleanup());
+
+	test("clicking the fullscreen button toggles fullscreen mode", async () => {
+		const { container, getByLabelText } = await render(NativePlot, {
+			...default_props,
+			buttons: ["fullscreen"]
+		});
+
+		await waitForChart(container);
+
+		await fireEvent.click(getByLabelText("Fullscreen"));
+		await waitFor(() => {
+			expect(getByLabelText("Exit fullscreen mode")).toBeVisible();
+		});
+
+		await fireEvent.click(getByLabelText("Exit fullscreen mode"));
+		await waitFor(() => {
+			expect(getByLabelText("Fullscreen")).toBeVisible();
+		});
+		await waitForChart(container);
 	});
 });


### PR DESCRIPTION
## Description

The fullscreen button does nothing when clicked in four components: `gr.ImageSlider`, interactive `gr.Image`, native plots (`gr.LinePlot`, `gr.ScatterPlot`, `gr.BarPlot`), and `gr.AnnotatedImage`. The browser console shows `Uncaught TypeError: e.onclick is not a function`.

The shared `FullscreenButton` atom changed its API in the Svelte 5 migration (#12779): it used to dispatch a `fullscreen` event, and now requires an `onclick: (fullscreen: boolean) => void` prop. Four call sites were never updated and still used the old `on:fullscreen` wiring, so `onclick` was undefined and clicking threw. The static `gr.Image` and Gallery instances of this bug were fixed earlier in #13004 and #12865; this PR updates the remaining call sites the same way:

- `js/imageslider/shared/SliderPreview.svelte` and `js/image/shared/ImageUploader.svelte`: wire `onclick` to update the local `fullscreen` state and dispatch a component-level `fullscreen` event, which their parent `Index.svelte` files already listen for (same pattern as the ImagePreview fix in #13004).
- `js/nativeplot/Index.svelte` and `js/annotatedimage/Index.svelte`: replace the inline `on:fullscreen` handler with an `onclick` handler (same pattern as `js/plot/Index.svelte`).

In nativeplot, the now-working fullscreen toggle re-renders the chart and exposed a small race in `load_chart`: the function can resume from `await import("vega-embed")` after the component has unmounted, calling `vegaEmbed` with a null element and producing an unhandled promise rejection. Added a null check after the await.

Each component gets a unit test that clicks the fullscreen button and asserts the mode toggles on and off. All four tests fail on `main` with the `onclick is not a function` error and pass with this fix.

Note: the 2026 comments on #10268 reporting that the fullscreen button "does nothing" on `gr.Image` are the interactive-Image instance of this bug and are fixed here as well (the coordinate issue that #10268 is actually about is being addressed separately).

Closes: #13442

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

