### PR TITLE
Re-translate i18n choices display names when the language is switched at runtime

### DIFF
--- a/.changeset/nice-dogs-hide.md
+++ b/.changeset/nice-dogs-hide.md
@@ -1,0 +1,10 @@
+---
+"@gradio/checkboxgroup": minor
+"@gradio/dropdown": minor
+"@gradio/radio": minor
+"@gradio/simpledropdown": minor
+"@gradio/utils": minor
+"gradio": minor
+---
+
+feat:Re-translate i18n choices display names when the language is switched at runtime

--- a/demo/i18n/run.py
+++ b/demo/i18n/run.py
@@ -2,10 +2,10 @@ import gradio as gr
 
 # create an i18n instance with translations for different languages
 i18n = gr.I18n(
-    en={"greeting": "Hello, welcome to my app!", "name_label": "Your Name", "submit_button": "Greet", "john_doe": "John English", "result_label": "Result"},
-    es={"greeting": "¡Hola, bienvenido a mi aplicación!", "name_label": "Tu Nombre", "submit_button": "Saludar", "john_doe": "John Spanish", "result_label": "Resultado"},
-    fr={"greeting": "Bonjour, bienvenue dans mon application!", "name_label": "Votre Nom", "submit_button": "Saluer", "john_doe": "John French", "result_label": "Résultat"},
-    de={"greeting": "Hallo, willkommen in meiner App!", "name_label": "Dein Name", "submit_button": "Grüßen", "john_doe": "John German", "result_label": "Ergebnis"},
+    en={"greeting": "Hello, welcome to my app!", "name_label": "Your Name", "submit_button": "Greet", "john_doe": "John English", "result_label": "Result", "format_label": "Format", "choice_bold": "Bold", "choice_italic": "Italic"},
+    es={"greeting": "¡Hola, bienvenido a mi aplicación!", "name_label": "Tu Nombre", "submit_button": "Saludar", "john_doe": "John Spanish", "result_label": "Resultado", "format_label": "Formato", "choice_bold": "Negrita", "choice_italic": "Cursiva"},
+    fr={"greeting": "Bonjour, bienvenue dans mon application!", "name_label": "Votre Nom", "submit_button": "Saluer", "john_doe": "John French", "result_label": "Résultat", "format_label": "Format", "choice_bold": "Gras", "choice_italic": "Italique"},
+    de={"greeting": "Hallo, willkommen in meiner App!", "name_label": "Dein Name", "submit_button": "Grüßen", "john_doe": "John German", "result_label": "Ergebnis", "format_label": "Format", "choice_bold": "Fett", "choice_italic": "Kursiv"},
 )
 
 def add_hello_world(name):
@@ -27,7 +27,17 @@ with gr.Blocks() as demo:
     with gr.Row():
         reset_btn = gr.Button("Reset Name")
 
+    with gr.Row():
+        # choices use (display, value) tuples: only the display side is translated
+        format_radio = gr.Radio(
+            choices=[(i18n("choice_bold"), "bold"), (i18n("choice_italic"), "italic")],
+            value="bold",
+            label=i18n("format_label"),
+        )
+        selected_format = gr.Textbox(label="Selected Format")
+
     greet_btn.click(fn=add_hello_world, inputs=name_input, outputs=output_text)
+    format_radio.change(fn=lambda f: f, inputs=format_radio, outputs=selected_format)
     reset_btn.click(fn=lambda: i18n("john_doe"), inputs=None, outputs=name_input)
 
     gr.Markdown("""

--- a/js/checkboxgroup/Index.svelte
+++ b/js/checkboxgroup/Index.svelte
@@ -134,7 +134,7 @@
 					name={internal_value?.toString()}
 					title={internal_value?.toString()}
 				/>
-				<span class="ml-2">{gradio.i18n(display_value)}</span>
+				<span class="ml-2">{gradio.live_i18n(display_value)}</span>
 			</label>
 		{/each}
 	</div>

--- a/js/checkboxgroup/checkboxgroup.test.ts
+++ b/js/checkboxgroup/checkboxgroup.test.ts
@@ -1,9 +1,9 @@
 import { test, describe, expect, afterEach, beforeAll } from "vitest";
-import { cleanup, render, fireEvent } from "@self/tootils/render";
+import { cleanup, render, fireEvent, waitFor } from "@self/tootils/render";
 import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
 import event from "@testing-library/user-event";
 import { setupi18n, changeLocale } from "../core/src/i18n";
-import { formatter } from "../core/src/gradio_helper";
+import { formatter, reactive_formatter } from "../core/src/gradio_helper";
 
 import CheckboxGroup from "./Index.svelte";
 
@@ -506,6 +506,42 @@ describe("CheckboxGroup: i18n choices", () => {
 		});
 
 		expect(getByLabelText("Clear")).toBeChecked();
+
+		const data = await get_data();
+		expect(data.value).toEqual(["bold"]);
+	});
+});
+
+describe("CheckboxGroup: runtime locale switching", () => {
+	beforeAll(async () => {
+		await setupi18n(undefined, "en");
+		changeLocale("en");
+	});
+	afterEach(() => {
+		changeLocale("en");
+		cleanup();
+	});
+
+	test("re-translates choice display values when the locale changes", async () => {
+		const { getByLabelText, get_data } = await render(CheckboxGroup, {
+			...default_props,
+			i18n: formatter,
+			i18n_store: reactive_formatter,
+			choices: [
+				[marker("common.clear"), "bold"],
+				[marker("common.remove"), "italic"]
+			],
+			value: ["bold"]
+		});
+
+		expect(getByLabelText("Clear")).toBeChecked();
+
+		changeLocale("es");
+
+		await waitFor(() => {
+			expect(getByLabelText("Limpiar")).toBeChecked();
+			expect(getByLabelText("Eliminar")).not.toBeChecked();
+		});
 
 		const data = await get_data();
 		expect(data.value).toEqual(["bold"]);

--- a/js/core/src/i18n.test.ts
+++ b/js/core/src/i18n.test.ts
@@ -64,7 +64,8 @@ const mock_translations: Record<string, string> = {
 
 vi.mock("svelte/store", () => ({
 	get: vi.fn(() => (key: string) => mock_translations[key] ?? key),
-	derived: vi.fn()
+	derived: vi.fn(),
+	fromStore: vi.fn()
 }));
 
 import { locale, init, addMessages } from "svelte-i18n";

--- a/js/dropdown/Index.svelte
+++ b/js/dropdown/Index.svelte
@@ -20,7 +20,7 @@
 	let translated_choices = $derived(
 		gradio.props.choices.map(
 			([display, value]) =>
-				[gradio.i18n(display), value] as [string, string | number]
+				[gradio.live_i18n(display), value] as [string, string | number]
 		)
 	);
 </script>

--- a/js/dropdown/dropdown.test.ts
+++ b/js/dropdown/dropdown.test.ts
@@ -3,7 +3,7 @@ import { cleanup, render, fireEvent, waitFor } from "@self/tootils/render";
 import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
 import event from "@testing-library/user-event";
 import { setupi18n, changeLocale } from "../core/src/i18n";
-import { formatter } from "../core/src/gradio_helper";
+import { formatter, reactive_formatter } from "../core/src/gradio_helper";
 
 import Dropdown from "./Index.svelte";
 import { handle_filter } from "./shared/utils";
@@ -1698,6 +1698,75 @@ describe("i18n choices", () => {
 
 		const data = await get_data();
 		expect(data.value).toEqual(["italic"]);
+	});
+});
+
+describe("runtime locale switching", () => {
+	beforeAll(async () => {
+		await setupi18n(undefined, "en");
+		changeLocale("en");
+	});
+	afterEach(() => {
+		changeLocale("en");
+		cleanup();
+	});
+
+	const i18n_choices: [string, string][] = [
+		[marker("common.clear"), "bold"],
+		[marker("common.remove"), "italic"]
+	];
+
+	test("single-select re-translates the selected display name and options", async () => {
+		const { getByLabelText, getAllByTestId, get_data } = await render(
+			Dropdown,
+			{
+				...single_select_props,
+				i18n: formatter,
+				i18n_store: reactive_formatter,
+				choices: i18n_choices,
+				value: "bold"
+			}
+		);
+
+		const input = getByLabelText("Dropdown") as HTMLInputElement;
+		expect(input.value).toBe("Clear");
+
+		changeLocale("es");
+
+		await waitFor(() => {
+			expect(input.value).toBe("Limpiar");
+		});
+
+		await input.focus();
+		const options = getAllByTestId("dropdown-option");
+		expect(options[0]).toHaveAttribute("aria-label", "Limpiar");
+		expect(options[1]).toHaveAttribute("aria-label", "Eliminar");
+
+		const data = await get_data();
+		expect(data.value).toBe("bold");
+	});
+
+	test("multiselect re-translates selected tokens when the locale changes", async () => {
+		const { getByText, get_data } = await render(Dropdown, {
+			...multiselect_props,
+			i18n: formatter,
+			i18n_store: reactive_formatter,
+			choices: i18n_choices,
+			value: ["bold", "italic"]
+		});
+
+		expect(getByText("Clear")).toBeVisible();
+		expect(getByText("Remove")).toBeVisible();
+
+		changeLocale("es");
+
+		await waitFor(() => {
+			expect(getByText("Limpiar")).toBeVisible();
+			expect(getByText("Eliminar")).toBeVisible();
+		});
+
+		const data = await get_data();
+		expect(data.value).toEqual(["bold", "italic"]);
 	});
 });
 

--- a/js/dropdown/shared/Multiselect.svelte
+++ b/js/dropdown/shared/Multiselect.svelte
@@ -20,7 +20,7 @@
 	let translated_choices: [string, string | number][] = $derived.by(() => {
 		return gradio.props.choices.map(
 			([display, value]) =>
-				[gradio.i18n(display), value] as [string, string | number]
+				[gradio.live_i18n(display), value] as [string, string | number]
 		);
 	});
 	let choices_names: string[] = $derived.by(() => {

--- a/js/radio/Index.svelte
+++ b/js/radio/Index.svelte
@@ -58,7 +58,7 @@
 	<div class="wrap">
 		{#each gradio.props.choices as [display_value, internal_value], i (i)}
 			<BaseRadio
-				display_value={gradio.i18n(display_value)}
+				display_value={gradio.live_i18n(display_value)}
 				{internal_value}
 				bind:selected={gradio.props.value}
 				{disabled}

--- a/js/radio/Radio.test.ts
+++ b/js/radio/Radio.test.ts
@@ -3,7 +3,7 @@ import { cleanup, render, fireEvent, waitFor } from "@self/tootils/render";
 import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
 import event from "@testing-library/user-event";
 import { setupi18n, changeLocale } from "../core/src/i18n";
-import { formatter } from "../core/src/gradio_helper";
+import { formatter, reactive_formatter } from "../core/src/gradio_helper";
 
 import Radio from "./Index.svelte";
 
@@ -181,6 +181,42 @@ describe("Props: i18n choices", () => {
 
 		const data = await get_data();
 		expect(data.value).toBe("italic");
+	});
+});
+
+describe("Radio: runtime locale switching", () => {
+	beforeAll(async () => {
+		await setupi18n(undefined, "en");
+		changeLocale("en");
+	});
+	afterEach(() => {
+		changeLocale("en");
+		cleanup();
+	});
+
+	test("re-translates choice display values when the locale changes", async () => {
+		const { getByText, get_data } = await render(Radio, {
+			...default_props,
+			i18n: formatter,
+			i18n_store: reactive_formatter,
+			choices: [
+				[marker("common.clear"), "bold"],
+				[marker("common.remove"), "italic"]
+			],
+			value: "bold"
+		});
+
+		expect(getByText("Clear")).toBeVisible();
+
+		changeLocale("es");
+
+		await waitFor(() => {
+			expect(getByText("Limpiar")).toBeVisible();
+			expect(getByText("Eliminar")).toBeVisible();
+		});
+
+		const data = await get_data();
+		expect(data.value).toBe("bold");
 	});
 });
 

--- a/js/simpledropdown/Index.svelte
+++ b/js/simpledropdown/Index.svelte
@@ -27,8 +27,10 @@
 				(choice) => choice[0] === display_value
 			);
 			if (candidate.length) {
-				gradio.props.value = candidate[0][1];
-				gradio.dispatch("input");
+				if (gradio.props.value !== candidate[0][1]) {
+					gradio.props.value = candidate[0][1];
+					gradio.dispatch("input");
+				}
 			} else {
 				const current = translated_choices.find(
 					(choice) => choice[1] === gradio.props.value

--- a/js/simpledropdown/Index.svelte
+++ b/js/simpledropdown/Index.svelte
@@ -17,7 +17,7 @@
 	let translated_choices = $derived(
 		gradio.props.choices.map(
 			([display, value]) =>
-				[gradio.i18n(display), value] as [string, string | number]
+				[gradio.live_i18n(display), value] as [string, string | number]
 		)
 	);
 
@@ -26,8 +26,23 @@
 			candidate = translated_choices.filter(
 				(choice) => choice[0] === display_value
 			);
-			gradio.props.value = candidate.length ? candidate[0][1] : "";
-			gradio.dispatch("input");
+			if (candidate.length) {
+				gradio.props.value = candidate[0][1];
+				gradio.dispatch("input");
+			} else {
+				const current = translated_choices.find(
+					(choice) => choice[1] === gradio.props.value
+				);
+				if (current) {
+					// The display strings changed under us (e.g. a runtime locale
+					// switch): refresh the displayed string from the still-valid
+					// internal value instead of clearing the selection.
+					display_value = current[0];
+				} else {
+					gradio.props.value = "";
+					gradio.dispatch("input");
+				}
+			}
 		}
 		if (old_value != gradio.props.value) {
 			old_value = gradio.props.value;

--- a/js/simpledropdown/simpledropdown.test.ts
+++ b/js/simpledropdown/simpledropdown.test.ts
@@ -1,8 +1,8 @@
 import { test, describe, expect, afterEach, beforeAll } from "vitest";
-import { cleanup, render } from "@self/tootils/render";
+import { cleanup, render, waitFor } from "@self/tootils/render";
 import event from "@testing-library/user-event";
 import { setupi18n, changeLocale } from "../core/src/i18n";
-import { formatter } from "../core/src/gradio_helper";
+import { formatter, reactive_formatter } from "../core/src/gradio_helper";
 
 import SimpleDropdown from "./Index.svelte";
 
@@ -82,5 +82,46 @@ describe("SimpleDropdown: i18n choices", () => {
 
 		const data = await get_data();
 		expect(data.value).toBe("italic");
+	});
+});
+
+describe("SimpleDropdown: runtime locale switching", () => {
+	beforeAll(async () => {
+		await setupi18n(undefined, "en");
+		changeLocale("en");
+	});
+	afterEach(() => {
+		changeLocale("en");
+		cleanup();
+	});
+
+	test("re-translates options and keeps the selection when the locale changes", async () => {
+		const { getByRole, getAllByRole, get_data } = await render(SimpleDropdown, {
+			...default_props,
+			i18n: formatter,
+			i18n_store: reactive_formatter,
+			choices: [
+				[marker("common.clear"), "bold"],
+				[marker("common.remove"), "italic"]
+			],
+			value: ""
+		});
+
+		const select = getByRole("combobox") as HTMLSelectElement;
+		await event.selectOptions(select, "Clear");
+
+		let data = await get_data();
+		expect(data.value).toBe("bold");
+
+		changeLocale("es");
+
+		await waitFor(() => {
+			const labels = getAllByRole("option").map((o) => o.textContent?.trim());
+			expect(labels).toEqual(["Limpiar", "Eliminar"]);
+			expect(select).toHaveValue("Limpiar");
+		});
+
+		data = await get_data();
+		expect(data.value).toBe("bold");
 	});
 });

--- a/js/spa/test/i18n.spec.ts
+++ b/js/spa/test/i18n.spec.ts
@@ -64,6 +64,27 @@ test("changing language via settings updates UI and persists selection", async (
 	await expect(languageInputGerman).toHaveValue("Deutsch");
 });
 
+test("choice display names re-translate when the language is switched at runtime", async ({
+	page
+}) => {
+	await expect(page.getByRole("radio", { name: "Bold" })).toBeChecked();
+	await expect(page.getByRole("radio", { name: "Italic" })).toBeVisible();
+
+	await page.locator("footer").getByText("Settings").click();
+	await expect(page.getByRole("dialog", { name: "Settings" })).toBeVisible();
+
+	const languageInput = page.locator('input[aria-label="Language"]');
+	await languageInput.click();
+	await languageInput.clear();
+	await languageInput.pressSequentially("Esp");
+	await page.keyboard.press("ArrowDown");
+	await page.keyboard.press("Enter");
+	await page.locator(".backdrop").click();
+
+	await expect(page.getByRole("radio", { name: "Negrita" })).toBeChecked();
+	await expect(page.getByRole("radio", { name: "Cursiva" })).toBeVisible();
+});
+
 test.describe("i18n with Spanish locale", () => {
 	test.use({ locale: "es" });
 

--- a/js/utils/src/utils.svelte.ts
+++ b/js/utils/src/utils.svelte.ts
@@ -512,13 +512,11 @@ export class Gradio<T extends object = {}, U extends object = {}> {
 
 	// Reactive variant of `i18n`. Reading it inside a derived or template
 	// subscribes to the live locale store (via Svelte's createSubscriber), so
-	// the caller re-runs when the locale changes at runtime. Falls back to the
-	// construction-time formatter when no store was injected (e.g. unit tests).
+	// the caller re-runs when the locale changes at runtime. The store is only
+	// the reactivity trigger; translation always goes through `this.i18n` so a
+	// custom formatter passed via props keeps taking effect.
 	live_i18n = (value: string): string => {
-		const live_formatter = this._i18n_from_store?.current;
-		if (typeof live_formatter === "function") {
-			return (live_formatter as I18nFormatter)(value);
-		}
+		void this._i18n_from_store?.current;
 		return this.i18n(value);
 	};
 

--- a/js/utils/src/utils.svelte.ts
+++ b/js/utils/src/utils.svelte.ts
@@ -3,6 +3,7 @@ import type { Client } from "@gradio/client";
 import type { ComponentType, SvelteComponent } from "svelte";
 import { tick, untrack } from "svelte";
 import type { Component } from "svelte";
+import { fromStore } from "svelte/store";
 import type { Readable } from "svelte/store";
 
 export const I18N_MARKER = "__i18n__";
@@ -365,6 +366,7 @@ export class Gradio<T extends object = {}, U extends object = {}> {
 	// workspace resolving to a single Svelte version (pinned to 5.48.0, since
 	// 5.56 regressed lazy-rendering); this injection remains as defense-in-depth.
 	i18n_store: Readable<unknown> | undefined;
+	_i18n_from_store: { readonly current: unknown } | undefined;
 	translatable_props: Record<string, string> = {};
 	dispatcher!: Function;
 	last_update: ReturnType<typeof tick> | null = null;
@@ -404,6 +406,9 @@ export class Gradio<T extends object = {}, U extends object = {}> {
 		this.i18n = this.props.i18n ?? ((v: string) => v);
 		// @ts-ignore - read the raw store reference before it's wrapped in $state
 		this.i18n_store = _props.props.i18n_store;
+		this._i18n_from_store = this.i18n_store
+			? fromStore(this.i18n_store)
+			: undefined;
 
 		for (const key of TRANSLATABLE_PROPS) {
 			// @ts-ignore
@@ -504,6 +509,18 @@ export class Gradio<T extends object = {}, U extends object = {}> {
 		}
 		return translated;
 	}
+
+	// Reactive variant of `i18n`. Reading it inside a derived or template
+	// subscribes to the live locale store (via Svelte's createSubscriber), so
+	// the caller re-runs when the locale changes at runtime. Falls back to the
+	// construction-time formatter when no store was injected (e.g. unit tests).
+	live_i18n = (value: string): string => {
+		const live_formatter = this._i18n_from_store?.current;
+		if (typeof live_formatter === "function") {
+			return (live_formatter as I18nFormatter)(value);
+		}
+		return this.i18n(value);
+	};
 
 	dispatch<E extends keyof T>(event_name: E, data?: T[E]): void {
 		this.dispatcher(this.shared.id, event_name, data);


### PR DESCRIPTION
## Description

Since #13516, `gr.I18n` markers in the `choices` of choice-based components (Radio, CheckboxGroup, Dropdown, SimpleDropdown) are translated on initial load. However, switching the language at runtime (Settings -> Language) only updated scalar props such as `label` and `info`, leaving the choice display names in the previous locale.

This PR makes choice display names follow runtime language switches:

- Adds `Gradio.live_i18n()` in `@gradio/utils`. It wraps the injected `i18n_store` with Svelte's `fromStore()`, so reading it inside a derived or a template subscribes that caller to locale changes. When no store is injected (for example the unit test render helper), it falls back to the construction-time `gradio.i18n`.
- Switches the choice render sites in CheckboxGroup, Radio, Dropdown (single and multiselect) and SimpleDropdown from `gradio.i18n(...)` to `gradio.live_i18n(...)`. Other inline `gradio.i18n(...)` call sites (fallback labels, tooltips) are intentionally left as is to keep the diff scoped to choices; they can be migrated in a follow-up if useful.
- Fixes SimpleDropdown clearing its value when the display strings change underneath it (which is exactly what happens on a locale switch): the display-to-value reverse lookup now re-derives the displayed string from the still-valid internal value before falling back to clearing the selection.

Design note: a shared `$state` counter bumped from the `i18n_store` subscription in the `Gradio` class was tried first and caused an infinite reactive loop in the real app. The `fromStore()` approach keeps the subscription local to each caller, with no shared mutable state. It also deliberately avoids funneling the store value through an intermediate `$derived`: deriveds short-circuit on reference equality and the emitted formatter reference never changes, so propagation would stop there.

Tests:

- Runtime-switch unit tests in all four component suites. They inject both `i18n: formatter` and `i18n_store: reactive_formatter` (the real app always injects the store, the previous tests never did), switch the locale from English to Spanish mid-test, assert the display names re-translate, and assert the internal values are unchanged.
- An e2e test in `js/spa/test/i18n.spec.ts` that switches the language to Spanish via the Settings panel and asserts the choice display names re-translate while the selection stays checked. The `demo/i18n` app gains a Radio with i18n choices to back it (no new testcase file). Verified locally that this test fails without the fix and passes with it.

Closes: #13531

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

