### PR TITLE
Use OAuth fallback for workflow text generation

### DIFF
--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -1446,15 +1446,17 @@
 			callModelWithToken,
 			fetchDatasetWithToken,
 			callFnWithToken,
-			(modelId, prompt, provider, signal, onChunk) =>
-				stream_text_generation({
-					modelId,
-					prompt,
-					provider,
-					hfToken: auth.token || undefined,
-					signal: signal ?? undefined,
-					onChunk
-				})
+			auth.token
+				? (modelId, prompt, provider, signal, onChunk) =>
+						stream_text_generation({
+							modelId,
+							prompt,
+							provider,
+							hfToken: auth.token,
+							signal: signal ?? undefined,
+							onChunk
+						})
+				: undefined
 		);
 
 		running = false;

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -215,6 +215,15 @@ class TestResolveToken:
         )
         assert _resolve_token([], 3, _make_oauth("oauth-tok")) == "oauth-tok"
 
+    def test_empty_manual_slot_falls_back_to_oauth(self, monkeypatch):
+        monkeypatch.setattr(
+            workflow_module, "_get_locally_saved_hf_token", lambda: None
+        )
+        assert (
+            _resolve_token(["m", "tag", "[]", ""], 3, _make_oauth("oauth-tok"))
+            == "oauth-tok"
+        )
+
     def test_local_token_requires_write_access(self, monkeypatch):
         # A share-link visitor (no write token) must never see the host's
         # locally saved HF token.
@@ -224,6 +233,10 @@ class TestResolveToken:
             lambda: "local-tok",
         )
         assert _resolve_token([], 3, None, _write_request()) == "local-tok"
+        assert (
+            _resolve_token(["m", "tag", "[]", ""], 3, None, _write_request())
+            == "local-tok"
+        )
         assert _resolve_token([], 3, None, _make_request()) is None
         assert _resolve_token([], 3, None, None) is None
 


### PR DESCRIPTION
## Description

Fixes workflow text-generation calls so they only use browser-side streaming when the frontend has an HF token. If no frontend token is available, the workflow executor now falls back to the backend `call_model` path, where Gradio can inject the logged-in user's OAuth token and use their inference provider credits.

Also adds regression coverage that an empty manual token slot does not block OAuth or local write-token fallback on the backend.

Closes: #13536

## AI Disclosure

- [x] I used AI to investigate the workflow OAuth/provider-token path, draft the code changes, and write this PR description. I self-reviewed the changed lines and ran the tests below.
- [ ] I did not use AI

## Testing and Formatting Your Code

- `pytest -q test/test_workflow.py -k ResolveToken`
- `pnpm exec vitest run --config .config/vitest.config.ts js/workflowcanvas/workflow/workflow-executor.test.ts`
- `bash scripts/format_backend.sh`
- `bash scripts/format_frontend.sh`
