### PR TITLE
Fix gr.Plot collapsing to zero height for autosize Plotly figures

### DIFF
--- a/.changeset/dull-worlds-deny.md
+++ b/.changeset/dull-worlds-deny.md
@@ -1,0 +1,6 @@
+---
+"@gradio/plot": patch
+"gradio": patch
+---
+
+fix:Fix gr.Plot collapsing to zero height for autosize Plotly figures

--- a/js/plot/Plot.test.ts
+++ b/js/plot/Plot.test.ts
@@ -10,6 +10,15 @@ const matplotlib_value = {
 	chart: "bar"
 };
 
+// layout has no height on purpose: this is the autosize path.
+const plotly_autosize_value = {
+	type: "plotly",
+	plot: JSON.stringify({
+		data: [{ type: "scatter", x: [1, 2, 3], y: [4, 5, 6] }],
+		layout: {}
+	})
+};
+
 const default_props = {
 	value: null as null | Record<string, any>,
 	label: "Plot",
@@ -272,6 +281,24 @@ describe("get_data / set_data", () => {
 
 		const data = await get_data();
 		expect(data.value).toEqual(matplotlib_value);
+	});
+});
+
+describe("Plotly", () => {
+	afterEach(() => cleanup());
+
+	// Regression: this collapsed to zero height after the Svelte 5 migration.
+	test("an autosize figure renders with a non-zero height", async () => {
+		const { getByTestId } = await render(Plot, {
+			...default_props,
+			value: plotly_autosize_value
+		});
+
+		await waitFor(() => {
+			const plot = getByTestId("plotly");
+			expect(plot.querySelector(".main-svg")).toBeTruthy();
+			expect(plot.offsetHeight).toBeGreaterThan(0);
+		});
 	});
 });
 

--- a/js/plot/shared/plot_types/PlotlyPlot.svelte
+++ b/js/plot/shared/plot_types/PlotlyPlot.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	//@ts-nocheck
 	import Plotly from "plotly.js-dist-min";
+	import { untrack } from "svelte";
 
 	let {
 		value,
@@ -32,7 +33,9 @@
 	$effect(() => {
 		if (!plot_div || !plot) return;
 
-		load_plotly_css();
+		// load_plotly_css writes loaded_plotly_css; untrack it so this effect
+		// doesn't re-run and collapse an autosize plot to zero height.
+		untrack(() => load_plotly_css());
 
 		let plotObj = JSON.parse(plot);
 


### PR DESCRIPTION
## Description

A `gr.Plot` showing a Plotly figure with no explicit `layout.height` (i.e. relying on autosize) rendered at zero height in 6.18.0, leaving the plot area blank. A fixed `height` avoided it. This was a regression from #13510 ("Migrate Plot to Svelte 5").

The migration moved the draw logic in `js/plot/shared/plot_types/PlotlyPlot.svelte` from `afterUpdate` to a `$effect`. That effect calls `load_plotly_css()`, which both reads (`if (!loaded_plotly_css)`) and writes (`loaded_plotly_css = true`) the `$bindable` `loaded_plotly_css` state. Writing a tracked dependency from inside the effect re-invalidates it, so the effect runs twice. The first `Plotly.react` establishes the autosize default height (450px); the second re-applies the responsive layout and collapses the container back to zero height. Svelte 4's `afterUpdate` was never dependency-tracked, so it did not self-retrigger.

The fix wraps the one-time CSS load in `untrack(...)` so `loaded_plotly_css` is no longer a dependency of the effect. The effect then runs once per `plot`/`show_label` change, and the bindable write still propagates to the parent for cross-instance CSS deduplication. This is the same `untrack` idiom that `AltairPlot.svelte` already uses (around its `old_spec`/`spec_width` writes) and that was introduced in the same migration PR.

Closes: #13539

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

