### PR TITLE
Fix long unbroken text overflowing in the Markdown component

### DIFF
--- a/.changeset/warm-wolves-flash.md
+++ b/.changeset/warm-wolves-flash.md
@@ -1,0 +1,7 @@
+---
+"@gradio/markdown-code": patch
+"@gradio/theme": patch
+"gradio": patch
+---
+
+fix:Fix long unbroken text overflowing in the Markdown component

--- a/js/markdown-code/MarkdownCode.svelte
+++ b/js/markdown-code/MarkdownCode.svelte
@@ -192,6 +192,13 @@
 </span>
 
 <style>
+	span {
+		/* `anywhere`, not `break-word`: it also lowers min-content width, so
+		   markdown in a table/flex container shrinks to fit instead of forcing
+		   the container to overflow. */
+		overflow-wrap: anywhere;
+	}
+
 	span :global(div[class*="code_wrap"]) {
 		position: relative;
 	}

--- a/js/theme/src/typography.css
+++ b/js/theme/src/typography.css
@@ -53,10 +53,10 @@
 /* lists
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 .prose ul {
-	list-style: circle inside;
+	list-style: circle outside;
 }
 .prose ol {
-	list-style: decimal inside;
+	list-style: decimal outside;
 }
 
 .prose ul > p,
@@ -66,7 +66,9 @@
 .prose ol,
 .prose ul {
 	margin-top: 0;
-	padding-left: 0;
+	/* `outside` markers need this gutter; `inside` pushes the marker onto its
+	   own line when a long unbreakable item wraps. */
+	padding-inline-start: 1.5em;
 }
 .prose ul ul,
 .prose ul ol,


### PR DESCRIPTION
## Description

Long unbreakable strings (a long URL, an underscore-joined token) did not wrap in markdown: they overflowed the container horizontally, and in list items the bullet/number marker was pushed onto its own line. This is the remaining part of #7844.

- `js/markdown-code/MarkdownCode.svelte`: add `overflow-wrap: anywhere` to the markdown span so the text wraps. `anywhere` (not `break-word`) also lowers min-content width, so markdown wraps inside table cells and flex items rather than forcing them to overflow. Code blocks keep `word-wrap: normal` and still scroll.
- `js/theme/src/typography.css`: switch `.prose` lists from `inside` to `outside` markers (with a padding gutter) so the marker stays beside the first line when a long item wraps.

Both edits are on the shared markdown path, so the fix applies to the Markdown component, Chatbot messages, and Dataframe markdown cells. Note it changes list rendering everywhere `.prose` is used: markers now sit in a gutter with a standard hanging indent.

Closes: #7844

## Screenshots

| Before | After |
| --- | --- |
| <img width="1243" height="744" alt="CleanShot 2026-06-16 at 15 53 09" src="https://github.com/user-attachments/assets/62447b6a-7660-4725-8001-3538bb99b444" /> | <img width="1241" height="833" alt="CleanShot 2026-06-16 at 15 53 56" src="https://github.com/user-attachments/assets/31378424-c45c-4eb3-a09b-54f0505c89df" /> |

App used for the screenshots:

```python
import gradio as gr

LONG = "long_text_" * 25

md = f"""# Heading: {LONG}

- {LONG}
- a normal short item

A long URL: https://example.com/{"very_long_path/" * 15}end
"""

with gr.Blocks() as demo:
    with gr.Group():
        gr.Markdown(md)
    gr.Chatbot(value=[{"role": "assistant", "content": md}], height=500)

demo.launch()
```

## Testing

Verified in Storybook and by running Gradio apps: the Markdown component (lists, long URL), Chatbot messages, and Dataframe markdown cells, plus markdown in narrow and uneven `Column`s to check the min-content effect. In each case the text wraps within its container, list markers align with their text, nothing overflows horizontally, and no column collapsed. Markdown tables (already handled by #9260) and Dataframe cells are unchanged.

## AI Disclosure

- [x] I used AI to investigate the root cause, write the fix, and verify it. I reviewed all changes myself.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

