### PR TITLE
Make dropdowns accessible to screen readers (combobox ARIA pattern)

### DIFF
--- a/.changeset/empty-teams-smash.md
+++ b/.changeset/empty-teams-smash.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dropdown": patch
+"gradio": patch
+---
+
+fix:Make dropdowns accessible to screen readers (combobox ARIA pattern)

--- a/js/dropdown/dropdown.test.ts
+++ b/js/dropdown/dropdown.test.ts
@@ -758,11 +758,11 @@ describe("Single-select: get_data / set_data", () => {
 describe("Single-select: Accessibility", () => {
 	afterEach(() => cleanup());
 
-	test("input exposes the listbox role", async () => {
+	test("input exposes the combobox role", async () => {
 		const { getByLabelText } = await render(Dropdown, single_select_props);
 
 		const input = getByLabelText("Dropdown") as HTMLInputElement;
-		expect(input).toHaveAttribute("role", "listbox");
+		expect(input).toHaveAttribute("role", "combobox");
 	});
 
 	test("aria-controls points at the options listbox", async () => {
@@ -780,6 +780,25 @@ describe("Single-select: Accessibility", () => {
 		const listbox = document.getElementById(controls as string);
 		expect(listbox).toBeTruthy();
 		expect(listbox).toHaveAttribute("role", "listbox");
+	});
+
+	test("aria-activedescendant tracks the active option while navigating", async () => {
+		const { getByLabelText } = await render(Dropdown, {
+			...single_select_props,
+			value: null
+		});
+
+		const input = getByLabelText("Dropdown") as HTMLInputElement;
+		await input.focus();
+		expect(input).not.toHaveAttribute("aria-activedescendant");
+
+		await event.keyboard("{ArrowDown}");
+		const active_id = input.getAttribute("aria-activedescendant");
+		expect(active_id).toBeTruthy();
+
+		const active_option = document.getElementById(active_id as string);
+		expect(active_option).toHaveAttribute("role", "option");
+		expect(active_option).toHaveAttribute("aria-label", "apple");
 	});
 });
 
@@ -942,6 +961,28 @@ describe("Multiselect: Rendering", () => {
 		expect(tokens).toHaveLength(2);
 		const removeButtons = container.querySelectorAll(".token-remove");
 		expect(removeButtons).toHaveLength(0);
+	});
+});
+
+describe("Multiselect: Accessibility", () => {
+	afterEach(() => cleanup());
+
+	test("input is a combobox wired to the options listbox", async () => {
+		const { container } = await render(Dropdown, multiselect_props);
+
+		const input = container.querySelector("input") as HTMLInputElement;
+		expect(input).toHaveAttribute("role", "combobox");
+
+		await input.focus();
+
+		const controls = input.getAttribute("aria-controls");
+		const listbox = document.getElementById(controls as string);
+		expect(listbox).toHaveAttribute("role", "listbox");
+
+		const active_id = input.getAttribute("aria-activedescendant");
+		const active_option = document.getElementById(active_id as string);
+		expect(active_option).toHaveAttribute("role", "option");
+		expect(active_option).toHaveAttribute("aria-label", "apple");
 	});
 });
 

--- a/js/dropdown/shared/Dropdown.svelte
+++ b/js/dropdown/shared/Dropdown.svelte
@@ -233,9 +233,13 @@
 		<div class="wrap-inner" class:show_options>
 			<div class="secondary-wrap">
 				<input
-					role="listbox"
+					role="combobox"
 					aria-controls={listbox_id}
 					aria-expanded={show_options}
+					aria-activedescendant={show_options && active_index !== null
+						? `${listbox_id}-option-${active_index}`
+						: undefined}
+					aria-autocomplete={filterable ? "list" : "none"}
 					aria-label={label}
 					class="border-none"
 					class:subdued={!choices_names.includes(input_text) &&

--- a/js/dropdown/shared/Multiselect.svelte
+++ b/js/dropdown/shared/Multiselect.svelte
@@ -14,6 +14,9 @@
 	let filter_input: HTMLElement;
 	let input_text = $state("");
 	let label = $derived(gradio.shared.label || "Multiselect");
+
+	const uid = $props.id();
+	const listbox_id = `${uid}-options`;
 	let buttons = $derived(gradio.props.buttons);
 
 	// Translate the display side only; values stay raw for event payloads.
@@ -242,6 +245,14 @@
 			{/each}
 			<div class="secondary-wrap">
 				<input
+					role="combobox"
+					aria-controls={listbox_id}
+					aria-expanded={show_options}
+					aria-activedescendant={show_options && active_index !== null
+						? `${listbox_id}-option-${active_index}`
+						: undefined}
+					aria-autocomplete={gradio.props.filterable ? "list" : "none"}
+					aria-label={label}
 					class="border-none"
 					class:subdued={(!choices_names.includes(input_text) &&
 						!gradio.props.allow_custom_value) ||
@@ -290,6 +301,7 @@
 			{disabled}
 			{selected_indices}
 			{active_index}
+			{listbox_id}
 			remember_scroll={true}
 			onchange={handle_option_selected}
 		/>

--- a/js/spa/test/change_vs_input.spec.ts
+++ b/js/spa/test/change_vs_input.spec.ts
@@ -96,15 +96,18 @@ test("Radio change and input events work correctly", async ({ page }) => {
 });
 
 test("Dropdown change and input events work correctly", async ({ page }) => {
-	await page.getByRole("listbox", { name: "DD Input" }).click();
+	await page.getByRole("combobox", { name: "DD Input" }).click();
 	await page.getByRole("option", { name: "b" }).click();
 
 	await expect(page.getByLabel("Change counter")).toHaveValue("1");
 
 	await expect(
-		page.getByRole("listbox", { name: "Dropdown Input Event", exact: true })
+		page.getByRole("combobox", { name: "Dropdown Input Event", exact: true })
 	).toHaveValue("b");
 	await expect(
-		page.getByRole("listbox", { name: "Dropdown Change Event x2", exact: true })
+		page.getByRole("combobox", {
+			name: "Dropdown Change Event x2",
+			exact: true
+		})
 	).toHaveValue("b");
 });

--- a/js/spa/test/dropdown_custom_value.spec.ts
+++ b/js/spa/test/dropdown_custom_value.spec.ts
@@ -4,7 +4,7 @@ test.describe("Dropdown with allow_custom_value=True", () => {
 	test("selecting an option updates the textbox with the value, not the name", async ({
 		page
 	}) => {
-		const dropdown = page.getByRole("listbox", { name: "Dropdown" });
+		const dropdown = page.getByRole("combobox", { name: "Dropdown" });
 		const output = page.getByLabel("Output");
 
 		await dropdown.click();
@@ -16,7 +16,7 @@ test.describe("Dropdown with allow_custom_value=True", () => {
 	test("blurring dropdown after selecting an option does not change the value", async ({
 		page
 	}) => {
-		const dropdown = page.getByRole("listbox", { name: "Dropdown" });
+		const dropdown = page.getByRole("combobox", { name: "Dropdown" });
 		const output = page.getByLabel("Output");
 
 		await dropdown.click();
@@ -33,7 +33,7 @@ test.describe("Dropdown with allow_custom_value=True", () => {
 	test("typing a custom value and pressing Enter updates the textbox", async ({
 		page
 	}) => {
-		const dropdown = page.getByRole("listbox", { name: "Dropdown" });
+		const dropdown = page.getByRole("combobox", { name: "Dropdown" });
 		const output = page.getByLabel("Output");
 
 		// Focus the dropdown and type a custom value
@@ -48,7 +48,7 @@ test.describe("Dropdown with allow_custom_value=True", () => {
 	test("typing a custom value and blurring updates the textbox", async ({
 		page
 	}) => {
-		const dropdown = page.getByRole("listbox", { name: "Dropdown" });
+		const dropdown = page.getByRole("combobox", { name: "Dropdown" });
 		const output = page.getByLabel("Output");
 
 		await dropdown.click();
@@ -61,7 +61,7 @@ test.describe("Dropdown with allow_custom_value=True", () => {
 	test("selecting an option after typing a custom value works correctly", async ({
 		page
 	}) => {
-		const dropdown = page.getByRole("listbox", { name: "Dropdown" });
+		const dropdown = page.getByRole("combobox", { name: "Dropdown" });
 		const output = page.getByLabel("Output");
 
 		await dropdown.click();


### PR DESCRIPTION
## Description

Gradio dropdowns are currently unusable with screen readers such as NVDA and JAWS. The text `<input>` is given `role="listbox"`, which is the wrong ARIA role: a listbox is a container of options, not a text field. Screen readers receive contradictory signals (an element that announces as a list but behaves as an editable text field), so users cannot tell what the control is. On top of that, the input has no `aria-activedescendant`, so when the user arrows through the popup the screen reader only re-reads the input's current value and never announces the option names. The net effect is that blind users cannot select anything from any Gradio dropdown, which blocks a large number of Gradio apps.

This switches the dropdown to the standard WAI-ARIA combobox pattern:

- The input now uses `role="combobox"` instead of `role="listbox"`.
- `aria-activedescendant` points at the id of the currently highlighted option while the list is open, so the screen reader announces each option as the user navigates with the arrow keys (DOM focus stays in the input, as the pattern requires).
- `aria-autocomplete` is set (`list` when the dropdown is filterable, `none` otherwise) to describe the filtering behavior.

The popup itself was already correct (`<ul role="listbox">` with `<li role="option" aria-selected>`), so no markup changes were needed there. The existing `aria-controls` / `aria-expanded` wiring is kept.

The same fix is applied to the multiselect variant, which previously had no combobox semantics on its input at all (no role, no `aria-controls`/`aria-expanded`, no `aria-activedescendant`). It now also passes a `listbox_id` to the shared options list so the options have stable ids to reference.

This addresses two issues that describe the same underlying problem: #10532 (single-select `gr.Dropdown`) and #12855 (Gradio's listboxes/comboboxes not usable with a screen reader, which also covers the multiselect case noted by a maintainer there). Fixing both the single-select and multiselect inputs closes both.

Closes: #10532
Closes: #12855

## Testing

- The added unit tests in `js/dropdown/dropdown.test.ts` fail on the unpatched code and pass with the fix, so they pin the regression rather than just asserting the current state.
- Manually verified with VoiceOver on macOS (Safari): the dropdown is now announced as a combobox and each option is read out as you arrow through the list.

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

