### PR TITLE
workflow: validate model before invoking inference client

### DIFF
--- a/.changeset/thirty-nights-kneel.md
+++ b/.changeset/thirty-nights-kneel.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:workflow: validate model before invoking inference client

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -568,6 +568,14 @@ def call_model(
     try:
         from huggingface_hub import InferenceClient
 
+        if not re.fullmatch(r"[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+", model_id or ""):
+            return json.dumps(
+                {
+                    "error": "Invalid model ID",
+                    "error_type": "not_found",
+                    "suggestion": "Model ID must be in owner/repo format",
+                }
+            )
         pipeline_tag = data[1] if len(data) > 1 else None
         args_json = data[2] if len(data) > 2 else "[]"
         hf_token = _resolve_token(data, 3, token, request)

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -15,6 +15,8 @@ from gradio.workflow import (
     _request_has_write_token,
     _resolve_token,
     _workflow_from_bind,
+    call_model,
+    call_space,
     get_oauth_available,
     get_token,
     has_write_access,
@@ -392,3 +394,58 @@ class TestWorkflowFromBind:
         result = json.loads(_workflow_from_bind({"noargs": noargs}))
         node = result["nodes"][0]
         assert node["inputs"] == [{"id": "in_0", "label": "input", "type": "text"}]
+
+
+class TestCallModelValidation:
+    def test_url_shaped_model_id_is_rejected(self):
+        result = json.loads(call_model(["http://169.254.169.254/latest/meta-data/"]))
+        assert result.get("error_type") == "not_found"
+
+    def test_https_url_is_rejected(self):
+        result = json.loads(call_model(["https://attacker.example.com/endpoint"]))
+        assert result.get("error_type") == "not_found"
+
+    def test_empty_model_id_is_rejected(self):
+        result = json.loads(call_model([""]))
+        assert result.get("error_type") == "not_found"
+
+    def test_bare_repo_name_is_rejected(self):
+        result = json.loads(call_model(["gpt2"]))
+        assert result.get("error_type") == "not_found"
+
+    def test_valid_owner_repo_passes_validation(self, monkeypatch):
+        class FakeClient:
+            def __init__(self, **kwargs):
+                pass
+
+            def text_generation(self, *args, **kwargs):
+                return "hello"
+
+        monkeypatch.setattr(
+            "gradio.workflow.InferenceClient", FakeClient, raising=False
+        )
+        import importlib
+        import gradio.workflow as wf
+        orig = wf.call_model.__globals__.get("InferenceClient")
+
+        import sys
+        import types
+        fake_hf = types.ModuleType("huggingface_hub")
+        fake_hf.InferenceClient = FakeClient  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+        result = json.loads(call_model(["owner/model"]))
+        assert "error" not in result
+
+
+class TestCallSpaceValidation:
+    def test_url_shaped_space_id_is_rejected(self):
+        result = json.loads(call_space(["http://169.254.169.254/"]))
+        assert result.get("error_type") == "not_found"
+
+    def test_valid_owner_repo_format_accepted_by_regex(self):
+        import re
+        pattern = r"[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+"
+        assert re.fullmatch(pattern, "owner/repo")
+        assert re.fullmatch(pattern, "my-org/my-space")
+        assert re.fullmatch(pattern, "http://host/path") is None

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -424,12 +424,13 @@ class TestCallModelValidation:
         monkeypatch.setattr(
             "gradio.workflow.InferenceClient", FakeClient, raising=False
         )
-        import importlib
         import gradio.workflow as wf
-        orig = wf.call_model.__globals__.get("InferenceClient")
+
+        wf.call_model.__globals__.get("InferenceClient")
 
         import sys
         import types
+
         fake_hf = types.ModuleType("huggingface_hub")
         fake_hf.InferenceClient = FakeClient  # type: ignore[attr-defined]
         monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
@@ -445,6 +446,7 @@ class TestCallSpaceValidation:
 
     def test_valid_owner_repo_format_accepted_by_regex(self):
         import re
+
         pattern = r"[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+"
         assert re.fullmatch(pattern, "owner/repo")
         assert re.fullmatch(pattern, "my-org/my-space")


### PR DESCRIPTION
## Description

fixes a vulnerability identified by @hackchang. currently we allow unauthenticated SSRF from any exposed gr.Workflow deployment without auth configured via the call_model function. we should reject URL shaped values and require an owner/repo model before invoking the InferenceClient func

thank you @hackchang for identifying this and letting us know!