### PR TITLE
Fix Column staying hidden after a multi-yield visibility update

### DIFF
--- a/.changeset/tiny-bushes-occur.md
+++ b/.changeset/tiny-bushes-occur.md
@@ -1,0 +1,6 @@
+---
+"@gradio/core": patch
+"gradio": patch
+---
+
+fix:Fix Column staying hidden after a multi-yield visibility update

--- a/demo/visibility_test/run.py
+++ b/demo/visibility_test/run.py
@@ -28,6 +28,18 @@ def increment_counter(counter):
     return counter + 1
 
 
+def reveal_hidden_column():
+    """Generator that toggles two columns over multiple yields (issue #13494):
+    the column that starts hidden must end up visible."""
+    yield gr.update(visible=False), gr.update(visible=False)
+    yield gr.update(visible=False), gr.update(visible=True)
+
+
+def hide_revealed_column():
+    yield gr.update(visible=True), gr.update(visible=True)
+    yield gr.update(visible=True), gr.update(visible=False)
+
+
 with gr.Blocks() as demo:
     gr.Markdown("# Visibility Test Demo")
     gr.Markdown(
@@ -79,6 +91,20 @@ with gr.Blocks() as demo:
         lambda x: f"Counter Result: {x}", inputs=counter, outputs=counter_result
     )
     increment_btn.click(increment_counter, inputs=counter, outputs=counter)
+
+    # Regression coverage for #13494: a multi-yield generator that updates two
+    # columns at once (one hidden, one revealed) must leave the revealed column
+    # visible. The reveal/hide buttons sit outside both columns so they persist.
+    with gr.Row():
+        reveal_btn = gr.Button("Reveal Hidden Column", elem_id="yield-reveal")
+        hide_btn = gr.Button("Hide Revealed Column", elem_id="yield-hide")
+    with gr.Column(elem_id="yield-col-x") as yield_col_x:
+        gr.Markdown("Column X")
+    with gr.Column(visible=False, elem_id="yield-col-y") as yield_col_y:
+        gr.Textbox(label="Revealed", elem_id="yield-target")
+
+    reveal_btn.click(reveal_hidden_column, outputs=[yield_col_x, yield_col_y])
+    hide_btn.click(hide_revealed_column, outputs=[yield_col_x, yield_col_y])
 
 
 if __name__ == "__main__":

--- a/js/core/src/init.svelte.ts
+++ b/js/core/src/init.svelte.ts
@@ -482,10 +482,20 @@ export class AppTree {
 			// cause a stale "pending" update to be applied after the correct
 			// "complete" status has already been received, trapping the component
 			// in an infinite loading state.
-			const { loading_status: _ls, ...rest_new_state } = new_state;
+			// Exclude visible as well: it is the source of truth for mounting and
+			// is kept current in place on the node above (and synced into the
+			// component from node props on mount), so it never needs to be replayed
+			// via _set_data. Storing it would let a stale pending visible (captured
+			// on an earlier yield) be applied after the component has already
+			// mounted with the correct visibility, hiding it again (#13494).
+			const {
+				loading_status: _ls,
+				visible: _vis,
+				...rest_new_state
+			} = new_state;
 			// Only store a pending update if there is something other than
-			// loading_status to apply. Otherwise we'd cache an empty object,
-			// which still triggers a no-op deferred _set() on mount (extra
+			// loading_status/visible to apply. Otherwise we'd cache an empty
+			// object, which still triggers a no-op deferred _set() on mount (extra
 			// microtask churn for components hidden while loading status changed).
 			if (Object.keys(rest_new_state).length > 0) {
 				const existing = this.#pending_updates.get(id) || {};

--- a/js/spa/test/visibility_test.spec.ts
+++ b/js/spa/test/visibility_test.spec.ts
@@ -52,6 +52,28 @@ test.describe("Visibility States", () => {
 		await expect(counter_output).toHaveValue("Counter Result: 2");
 	});
 
+	test("column revealed by a multi-yield generator stays visible", async ({
+		page
+	}) => {
+		const target = page.locator("#yield-target");
+
+		// starts hidden (visible=false removes it from the DOM)
+		await expect(target).toHaveCount(0);
+
+		// a generator that yields visible=false then visible=true for this
+		// column (while another column is hidden in the same event) must leave
+		// it visible (#13494)
+		await page.locator("#yield-reveal").click();
+		await expect(target).toBeVisible();
+
+		// round trip: hide it again, then reveal once more
+		await page.locator("#yield-hide").click();
+		await expect(target).not.toBeVisible();
+
+		await page.locator("#yield-reveal").click();
+		await expect(target).toBeVisible();
+	});
+
 	test("hidden textbox maintains its value", async ({ page }) => {
 		const textbox = page.locator("#test-textbox textarea");
 		const button = page.locator("#test-button");


### PR DESCRIPTION
## Description

A `gr.Column` that starts with `visible=False` could stay hidden even after an event handler updated it to `visible=True`, when the handler was a generator that yielded visibility updates more than once and another component's visibility changed in the same event.

Minimal reproduction (from #13494):

```python
import gradio as gr

def next_():
    yield gr.update(visible=False), gr.update(visible=False)
    yield gr.update(visible=False), gr.update(visible=True)

with gr.Blocks() as demo:
    with gr.Column() as a:
        button = gr.Button("Next")
    with gr.Column(visible=False) as b:
        gr.Markdown("Doesn't appear")
    button.click(next_, outputs=[a, b])

demo.launch()
```

Clicking `Next` should reveal column `b`, but it stayed hidden.

Root cause: a column that starts hidden is not mounted (it is lazily loaded when it becomes visible). While it is unmounted, `update_state` stores its updates in a `pending` map. The first yield stores `pending = {visible: false}`. On the second yield, `load_components` mounts the column and `register_component` runs during the same `await tick()`, reading that now-stale `pending = {visible: false}` and scheduling it to be applied on the next microtask. `update_state` then applies the correct `visible: true` directly, but the deferred stale `visible: false` fires afterwards and overwrites it, so the column ends up hidden.

The fix: stop storing `visible` in the pending map at all (in `update_state`), the same way `loading_status` is already excluded. `visible` is the source of truth for whether a component mounts and is kept current in place on the node, and a mounted component syncs `visible` from the node props on mount, so it never needs to be replayed via a deferred `_set_data`. Storing it only allowed the stale earlier-yield value to overwrite the already-correct mounted state. This is the same class of stale-overwrite that `loading_status` is already protected from in this code path.

Closes: #13494

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI
## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

