### PR TITLE
workflow: auto add node on port click 

### DIFF
--- a/.changeset/swift-rabbits-drum.md
+++ b/.changeset/swift-rabbits-drum.md
@@ -1,0 +1,6 @@
+---
+"@gradio/workflowcanvas": minor
+"gradio": minor
+---
+
+feat:workflow: auto add node on port click 

--- a/js/workflowcanvas/workflow/WorkflowApiPanel.svelte
+++ b/js/workflowcanvas/workflow/WorkflowApiPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from "svelte";
+	import CodeIcon from "./icons/CodeIcon.svelte";
 
 	interface ApiParam {
 		label: string;
@@ -158,7 +159,7 @@
 	<div class="api-panel" onclick={(e) => e.stopPropagation()}>
 		<div class="api-header">
 			<div class="api-title">
-				<span class="api-glyph">&lt;/&gt;</span>
+				<span class="api-glyph"><CodeIcon /></span>
 				<div>
 					<div class="api-title-main">API</div>
 					<div class="api-title-sub">
@@ -246,7 +247,7 @@
 		align-items: center;
 		justify-content: center;
 		z-index: 1000;
-		padding: 24px;
+		padding: var(--size-6);
 	}
 	.api-panel {
 		width: min(720px, 100%);
@@ -255,31 +256,31 @@
 		flex-direction: column;
 		background: #101118;
 		border: 1px solid #2a2b38;
-		border-radius: 12px;
-		box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+		border-radius: var(--radius-xl);
+		box-shadow: 0 var(--size-6) 60px rgba(0, 0, 0, 0.5);
 		overflow: hidden;
 	}
 	.api-header {
 		display: flex;
 		align-items: flex-start;
 		justify-content: space-between;
-		padding: 16px 18px;
+		padding: var(--size-4) 18px;
 		border-bottom: 1px solid #1e1f2a;
 	}
 	.api-title {
 		display: flex;
-		gap: 12px;
+		gap: var(--size-3);
 		align-items: center;
 	}
 	.api-glyph {
-		font-family: "JetBrains Mono", monospace;
-		font-size: 13px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 		color: var(--color-accent, #f97316);
 		background: #1a1b25;
 		border: 1px solid #2a2b38;
-		border-radius: 8px;
-		padding: 8px 9px;
-		line-height: 1;
+		border-radius: var(--radius-lg);
+		padding: var(--size-2) var(--size-2-5);
 	}
 	.api-title-main {
 		font-family: "Manrope", sans-serif;
@@ -289,7 +290,7 @@
 	}
 	.api-title-sub {
 		font-family: "Manrope", sans-serif;
-		font-size: 12px;
+		font-size: var(--size-3);
 		color: #8a8c98;
 		margin-top: 2px;
 	}
@@ -304,23 +305,23 @@
 		font-size: 22px;
 		line-height: 1;
 		cursor: pointer;
-		padding: 0 4px;
+		padding: 0 var(--size-1);
 	}
 	.api-close:hover {
 		color: #e6e7ec;
 	}
 	.api-langs {
 		display: flex;
-		gap: 4px;
-		padding: 10px 18px;
+		gap: var(--size-1);
+		padding: var(--size-2-5) 18px;
 		border-bottom: 1px solid #1e1f2a;
 	}
 	.api-lang {
 		font-family: "Manrope", sans-serif;
-		font-size: 12px;
+		font-size: var(--size-3);
 		font-weight: 500;
-		padding: 4px 12px;
-		border-radius: 999px;
+		padding: var(--size-1) var(--size-3);
+		border-radius: var(--radius-full);
 		border: 1px solid transparent;
 		background: transparent;
 		color: #6b6e78;
@@ -336,31 +337,31 @@
 	}
 	.api-body {
 		overflow-y: auto;
-		padding: 16px 18px;
+		padding: var(--size-4) 18px;
 		display: flex;
 		flex-direction: column;
-		gap: 16px;
+		gap: var(--size-4);
 	}
 	.api-empty {
 		font-family: "Manrope", sans-serif;
 		font-size: 13px;
 		color: #8a8c98;
 		text-align: center;
-		padding: 32px 0;
+		padding: var(--size-8) 0;
 	}
 	.api-error {
 		color: #f87171;
 	}
 	.api-endpoint {
 		border: 1px solid #1e1f2a;
-		border-radius: 10px;
+		border-radius: var(--size-2-5);
 		overflow: hidden;
 	}
 	.api-endpoint-head {
 		display: flex;
 		align-items: center;
-		gap: 10px;
-		padding: 10px 12px;
+		gap: var(--size-2-5);
+		padding: var(--size-2-5) var(--size-3);
 		background: #16171f;
 		border-bottom: 1px solid #1e1f2a;
 	}
@@ -371,8 +372,8 @@
 		letter-spacing: 0.05em;
 		color: #1a1b25;
 		background: var(--color-accent, #f97316);
-		border-radius: 4px;
-		padding: 2px 6px;
+		border-radius: var(--radius-sm);
+		padding: 2px var(--size-1-5);
 	}
 	.api-name {
 		font-family: "JetBrains Mono", monospace;
@@ -384,9 +385,9 @@
 		font-family: "Manrope", sans-serif;
 		font-size: 11px;
 		font-weight: 600;
-		padding: 4px 10px;
+		padding: var(--size-1) var(--size-2-5);
 		border: 1px solid #2a2b38;
-		border-radius: 6px;
+		border-radius: var(--radius-md);
 		background: transparent;
 		color: #a0a2ae;
 		cursor: pointer;
@@ -397,8 +398,8 @@
 	}
 	.api-io {
 		display: flex;
-		gap: 24px;
-		padding: 12px;
+		gap: var(--size-6);
+		padding: var(--size-3);
 		border-bottom: 1px solid #1e1f2a;
 	}
 	.api-io-col {
@@ -412,14 +413,14 @@
 		text-transform: uppercase;
 		letter-spacing: 0.06em;
 		color: #6b6e78;
-		margin-bottom: 6px;
+		margin-bottom: var(--size-1-5);
 	}
 	.api-port {
 		display: flex;
 		justify-content: space-between;
-		gap: 8px;
+		gap: var(--size-2);
 		font-family: "JetBrains Mono", monospace;
-		font-size: 12px;
+		font-size: var(--size-3);
 		padding: 3px 0;
 	}
 	.api-port-name {
@@ -434,10 +435,10 @@
 	}
 	.api-code {
 		margin: 0;
-		padding: 12px 14px;
+		padding: var(--size-3) 14px;
 		background: #0b0c12;
 		font-family: "JetBrains Mono", monospace;
-		font-size: 12px;
+		font-size: var(--size-3);
 		line-height: 1.55;
 		color: #c5c7d0;
 		overflow-x: auto;

--- a/js/workflowcanvas/workflow/WorkflowCanvas.css
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.css
@@ -1,6 +1,7 @@
 .workflow-root {
 	display: flex;
 	flex-direction: column;
+	position: relative;
 	height: 100%;
 	min-height: 600px;
 	background: #0c0d10;

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -757,8 +757,10 @@
 		}
 		if (mode.kind === "connection") {
 			activeConnection = null;
-			const dx = Math.abs(mode.cursorCanvasX - mode.startCanvasX);
-			const dy = Math.abs(mode.cursorCanvasY - mode.startCanvasY);
+			const dx =
+				Math.abs(mode.cursorCanvasX - mode.startCanvasX) * viewport.zoom;
+			const dy =
+				Math.abs(mode.cursorCanvasY - mode.startCanvasY) * viewport.zoom;
 			if (dx < 4 && dy < 4) {
 				const direction = mode.reversed ? "input" : "output";
 				const isConnected = connectedPortsSet().has(

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -11,6 +11,7 @@
 	import CheckIcon from "./icons/CheckIcon.svelte";
 	import LayoutIcon from "./icons/LayoutIcon.svelte";
 	import InfoIcon from "./icons/InfoIcon.svelte";
+	import CodeIcon from "./icons/CodeIcon.svelte";
 
 	import {
 		MODALITIES,
@@ -233,6 +234,8 @@
 				reversed: boolean;
 				cursorCanvasX: number;
 				cursorCanvasY: number;
+				startCanvasX: number;
+				startCanvasY: number;
 		  }
 		| {
 				kind: "marquee";
@@ -249,6 +252,7 @@
 
 	// ─── App state ──────────────────────────────────────────────────────────────
 	let canvasEl: HTMLDivElement;
+	let rootEl: HTMLDivElement;
 	let running = $state(false);
 	let abortController: AbortController | null = null;
 	let nodeStatus: Record<string, NodeStatus> = $state({});
@@ -459,7 +463,24 @@
 			portId: string,
 			type: PortType,
 			isInput: boolean
-		) => startConnection(e, nodeId, portId, type, isInput)
+		) => startConnection(e, nodeId, portId, type, isInput),
+		onpopout: (nodeId: string, portId: string, type: PortType, isInput: boolean) => {
+			if (readOnly) return;
+			const node = legacyView.nodes.find((n) => n.id === nodeId);
+			if (!node) return;
+			const template = getComponentForPortType(type);
+			if (!template) return;
+			if (isInput) {
+				const { x, y } = clampToViewport(node.x - 260, node.y, template.width, template.height);
+				const newId = addNode("reference", template, x, y);
+				addEdge({ from_node_id: newId, from_port_id: "out", to_node_id: nodeId, to_port_id: portId, type });
+				updateNodeData(nodeId, portId, "");
+			} else {
+				const { x, y } = clampToViewport(node.x + node.width + 40, node.y, template.width, template.height);
+				const newId = addNode("reference", template, x, y);
+				addEdge({ from_node_id: nodeId, from_port_id: portId, to_node_id: newId, to_port_id: "in", type });
+			}
+		}
 	});
 	setContext("wf", wfCtx);
 
@@ -493,6 +514,20 @@
 		return {
 			x: (clientX - r.left - viewport.x) / viewport.zoom,
 			y: (clientY - r.top - viewport.y) / viewport.zoom
+		};
+	}
+
+	function clampToViewport(x: number, y: number, w: number, h: number): { x: number; y: number } {
+		if (!canvasEl) return { x, y };
+		const r = canvasEl.getBoundingClientRect();
+		const pad = 20;
+		const minX = (-viewport.x) / viewport.zoom + pad;
+		const maxX = (r.width - viewport.x) / viewport.zoom - w - pad;
+		const minY = (-viewport.y) / viewport.zoom + pad;
+		const maxY = (r.height - viewport.y) / viewport.zoom - h - pad;
+		return {
+			x: Math.max(minX, Math.min(maxX, x)),
+			y: Math.max(minY, Math.min(maxY, y))
 		};
 	}
 
@@ -602,7 +637,9 @@
 			type,
 			reversed: isInput,
 			cursorCanvasX: x,
-			cursorCanvasY: y
+			cursorCanvasY: y,
+			startCanvasX: x,
+			startCanvasY: y
 		};
 		activeConnection = {
 			from_node_id: nodeId,
@@ -688,6 +725,31 @@
 		}
 		if (mode.kind === "connection") {
 			activeConnection = null;
+			const dx = Math.abs(mode.cursorCanvasX - mode.startCanvasX);
+			const dy = Math.abs(mode.cursorCanvasY - mode.startCanvasY);
+			if (dx < 4 && dy < 4) {
+				const direction = mode.reversed ? "input" : "output";
+				const isConnected = connectedPortsSet().has(`${mode.fromNodeId}:${mode.fromPortId}:${direction}`);
+				if (!isConnected) {
+					const srcNode = legacyView.nodes.find((n) => n.id === mode.fromNodeId);
+					const template = getComponentForPortType(mode.type);
+					if (srcNode && template) {
+						if (mode.reversed) {
+							const { x, y } = clampToViewport(srcNode.x - 260, srcNode.y, template.width, template.height);
+							const newId = addNode("reference", template, x, y);
+							addEdge({ from_node_id: newId, from_port_id: "out", to_node_id: mode.fromNodeId, to_port_id: mode.fromPortId, type: mode.type });
+							updateNodeData(mode.fromNodeId, mode.fromPortId, "");
+						} else {
+							const { x, y } = clampToViewport(srcNode.x + srcNode.width + 40, srcNode.y, template.width, template.height);
+							const newId = addNode("reference", template, x, y);
+							addEdge({ from_node_id: mode.fromNodeId, from_port_id: mode.fromPortId, to_node_id: newId, to_port_id: "in", type: mode.type });
+						}
+					}
+					dragMode = null;
+					try { canvasEl?.releasePointerCapture(e.pointerId); } catch {}
+					return;
+				}
+			}
 			const targetEl = document.elementFromPoint(
 				e.clientX,
 				e.clientY
@@ -764,9 +826,15 @@
 					mode.reversed
 				);
 				const hasChoices = !!(srcPort?.choices && srcPort.choices.length > 0);
+				const rootRect = rootEl?.getBoundingClientRect();
+				const menuW = 220, menuH = 360;
+				const rawX = rootRect ? e.clientX - rootRect.left : e.clientX - r.left;
+				const rawY = rootRect ? e.clientY - rootRect.top : e.clientY - r.top;
+				const containerW = rootRect ? rootRect.width : r.width;
+				const containerH = rootRect ? rootRect.height : r.height;
 				const choice: DropChoice = {
-					clientX: e.clientX - r.left,
-					clientY: e.clientY - r.top,
+					clientX: Math.min(rawX, containerW - menuW - 8),
+					clientY: Math.min(rawY, containerH - menuH - 8),
 					modelOptions: hasChoices ? [] : buildModelOptions(mode.type),
 					componentOptions: hasChoices
 						? [{ kind: "component", label: srcPort!.label }]
@@ -1749,27 +1817,22 @@
 
 		let anchorX: number | undefined;
 		let anchorY: number | undefined;
-		if (canvasEl) {
-			const r = canvasEl.getBoundingClientRect();
-			const panelWidth = 940;
-			const panelHeight = 720;
-			const nodeScreenRight =
-				node.x * viewport.zoom + viewport.x + node.width * viewport.zoom;
-			anchorX = nodeScreenRight + 12;
-			if (anchorX + panelWidth > r.width) {
-				anchorX = Math.max(
-					4,
-					node.x * viewport.zoom + viewport.x - panelWidth - 12
-				);
+		if (canvasEl && rootEl) {
+			const rootRect = rootEl.getBoundingClientRect();
+			const canvasRect = canvasEl.getBoundingClientRect();
+			const canvasOffsetX = canvasRect.left - rootRect.left;
+			const canvasOffsetY = canvasRect.top - rootRect.top;
+			const panelWidth = Math.min(940, rootRect.width - 8);
+			const panelHeight = Math.min(720, rootRect.height - 160);
+			const nodeRight = canvasOffsetX + node.x * viewport.zoom + viewport.x + node.width * viewport.zoom;
+			const nodeLeft = canvasOffsetX + node.x * viewport.zoom + viewport.x;
+			const nodeTop = canvasOffsetY + node.y * viewport.zoom + viewport.y;
+			anchorX = nodeRight + 12;
+			if (anchorX + panelWidth > rootRect.width - 4) {
+				anchorX = nodeLeft - panelWidth - 12;
 			}
-			anchorX = Math.max(4, anchorX);
-			anchorY = Math.max(
-				4,
-				Math.min(
-					node.y * viewport.zoom + viewport.y,
-					r.height - panelHeight - 8
-				)
-			);
+			anchorX = Math.max(4, Math.min(anchorX, rootRect.width - panelWidth - 4));
+			anchorY = Math.max(4, Math.min(nodeTop, rootRect.height - panelHeight - 8));
 		}
 
 		activePicker = {
@@ -1992,7 +2055,7 @@
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="workflow-root" onclick={handleGlobalClick}>
+<div class="workflow-root" bind:this={rootEl} onclick={handleGlobalClick}>
 	<div class="toolbar">
 		<div class="toolbar-left">
 			{#if readOnly}
@@ -2029,7 +2092,7 @@
 				onclick={() => (showApiPanel = true)}
 				title="View the API for this workflow"
 			>
-				<span class="api-btn-glyph">&lt;/&gt;</span>
+				<CodeIcon />
 				View API
 			</button>
 			{#if saveIndicator}

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -464,21 +464,48 @@
 			type: PortType,
 			isInput: boolean
 		) => startConnection(e, nodeId, portId, type, isInput),
-		onpopout: (nodeId: string, portId: string, type: PortType, isInput: boolean) => {
+		onpopout: (
+			nodeId: string,
+			portId: string,
+			type: PortType,
+			isInput: boolean
+		) => {
 			if (readOnly) return;
 			const node = legacyView.nodes.find((n) => n.id === nodeId);
 			if (!node) return;
 			const template = getComponentForPortType(type);
 			if (!template) return;
 			if (isInput) {
-				const { x, y } = clampToViewport(node.x - 260, node.y, template.width, template.height);
+				const { x, y } = clampToViewport(
+					node.x - 260,
+					node.y,
+					template.width,
+					template.height
+				);
 				const newId = addNode("reference", template, x, y);
-				addEdge({ from_node_id: newId, from_port_id: "out", to_node_id: nodeId, to_port_id: portId, type });
+				addEdge({
+					from_node_id: newId,
+					from_port_id: "out",
+					to_node_id: nodeId,
+					to_port_id: portId,
+					type
+				});
 				updateNodeData(nodeId, portId, "");
 			} else {
-				const { x, y } = clampToViewport(node.x + node.width + 40, node.y, template.width, template.height);
+				const { x, y } = clampToViewport(
+					node.x + node.width + 40,
+					node.y,
+					template.width,
+					template.height
+				);
 				const newId = addNode("reference", template, x, y);
-				addEdge({ from_node_id: nodeId, from_port_id: portId, to_node_id: newId, to_port_id: "in", type });
+				addEdge({
+					from_node_id: nodeId,
+					from_port_id: portId,
+					to_node_id: newId,
+					to_port_id: "in",
+					type
+				});
 			}
 		}
 	});
@@ -517,13 +544,18 @@
 		};
 	}
 
-	function clampToViewport(x: number, y: number, w: number, h: number): { x: number; y: number } {
+	function clampToViewport(
+		x: number,
+		y: number,
+		w: number,
+		h: number
+	): { x: number; y: number } {
 		if (!canvasEl) return { x, y };
 		const r = canvasEl.getBoundingClientRect();
 		const pad = 20;
-		const minX = (-viewport.x) / viewport.zoom + pad;
+		const minX = -viewport.x / viewport.zoom + pad;
 		const maxX = (r.width - viewport.x) / viewport.zoom - w - pad;
-		const minY = (-viewport.y) / viewport.zoom + pad;
+		const minY = -viewport.y / viewport.zoom + pad;
 		const maxY = (r.height - viewport.y) / viewport.zoom - h - pad;
 		return {
 			x: Math.max(minX, Math.min(maxX, x)),
@@ -729,24 +761,52 @@
 			const dy = Math.abs(mode.cursorCanvasY - mode.startCanvasY);
 			if (dx < 4 && dy < 4) {
 				const direction = mode.reversed ? "input" : "output";
-				const isConnected = connectedPortsSet().has(`${mode.fromNodeId}:${mode.fromPortId}:${direction}`);
+				const isConnected = connectedPortsSet().has(
+					`${mode.fromNodeId}:${mode.fromPortId}:${direction}`
+				);
 				if (!isConnected) {
-					const srcNode = legacyView.nodes.find((n) => n.id === mode.fromNodeId);
+					const srcNode = legacyView.nodes.find(
+						(n) => n.id === mode.fromNodeId
+					);
 					const template = getComponentForPortType(mode.type);
 					if (srcNode && template) {
 						if (mode.reversed) {
-							const { x, y } = clampToViewport(srcNode.x - 260, srcNode.y, template.width, template.height);
+							const { x, y } = clampToViewport(
+								srcNode.x - 260,
+								srcNode.y,
+								template.width,
+								template.height
+							);
 							const newId = addNode("reference", template, x, y);
-							addEdge({ from_node_id: newId, from_port_id: "out", to_node_id: mode.fromNodeId, to_port_id: mode.fromPortId, type: mode.type });
+							addEdge({
+								from_node_id: newId,
+								from_port_id: "out",
+								to_node_id: mode.fromNodeId,
+								to_port_id: mode.fromPortId,
+								type: mode.type
+							});
 							updateNodeData(mode.fromNodeId, mode.fromPortId, "");
 						} else {
-							const { x, y } = clampToViewport(srcNode.x + srcNode.width + 40, srcNode.y, template.width, template.height);
+							const { x, y } = clampToViewport(
+								srcNode.x + srcNode.width + 40,
+								srcNode.y,
+								template.width,
+								template.height
+							);
 							const newId = addNode("reference", template, x, y);
-							addEdge({ from_node_id: mode.fromNodeId, from_port_id: mode.fromPortId, to_node_id: newId, to_port_id: "in", type: mode.type });
+							addEdge({
+								from_node_id: mode.fromNodeId,
+								from_port_id: mode.fromPortId,
+								to_node_id: newId,
+								to_port_id: "in",
+								type: mode.type
+							});
 						}
 					}
 					dragMode = null;
-					try { canvasEl?.releasePointerCapture(e.pointerId); } catch {}
+					try {
+						canvasEl?.releasePointerCapture(e.pointerId);
+					} catch {}
 					return;
 				}
 			}
@@ -827,7 +887,8 @@
 				);
 				const hasChoices = !!(srcPort?.choices && srcPort.choices.length > 0);
 				const rootRect = rootEl?.getBoundingClientRect();
-				const menuW = 220, menuH = 360;
+				const menuW = 220,
+					menuH = 360;
 				const rawX = rootRect ? e.clientX - rootRect.left : e.clientX - r.left;
 				const rawY = rootRect ? e.clientY - rootRect.top : e.clientY - r.top;
 				const containerW = rootRect ? rootRect.width : r.width;
@@ -1824,7 +1885,11 @@
 			const canvasOffsetY = canvasRect.top - rootRect.top;
 			const panelWidth = Math.min(940, rootRect.width - 8);
 			const panelHeight = Math.min(720, rootRect.height - 160);
-			const nodeRight = canvasOffsetX + node.x * viewport.zoom + viewport.x + node.width * viewport.zoom;
+			const nodeRight =
+				canvasOffsetX +
+				node.x * viewport.zoom +
+				viewport.x +
+				node.width * viewport.zoom;
 			const nodeLeft = canvasOffsetX + node.x * viewport.zoom + viewport.x;
 			const nodeTop = canvasOffsetY + node.y * viewport.zoom + viewport.y;
 			anchorX = nodeRight + 12;
@@ -1832,7 +1897,10 @@
 				anchorX = nodeLeft - panelWidth - 12;
 			}
 			anchorX = Math.max(4, Math.min(anchorX, rootRect.width - panelWidth - 4));
-			anchorY = Math.max(4, Math.min(nodeTop, rootRect.height - panelHeight - 8));
+			anchorY = Math.max(
+				4,
+				Math.min(nodeTop, rootRect.height - panelHeight - 8)
+			);
 		}
 
 		activePicker = {

--- a/js/workflowcanvas/workflow/WorkflowNodeSF.svelte
+++ b/js/workflowcanvas/workflow/WorkflowNodeSF.svelte
@@ -551,19 +551,19 @@
 					<div
 						class="port-handle-sf output-handle-sf"
 						class:connected={portConnected}
-						class:popout-hint={!portConnected && pending === null}
+						class:popout-hint={!readOnly && !portConnected && pending === null}
 						data-node-id={node.id}
 						data-port-id={port.id}
 						data-port-type={port.type}
 						data-port-direction="output"
 						style="--port-color: {PORT_COLOR[port.type]}"
-						title={!portConnected && pending === null
+						title={!readOnly && !portConnected && pending === null
 							? "Click to create an output node"
 							: undefined}
 						onpointerdown={(e) =>
 							ctx.onportpointerdown(e, node.id, port.id, port.type, false)}
 						onclick={(e) => {
-							if (!portConnected && pending === null) {
+							if (!readOnly && !portConnected && pending === null) {
 								e.stopPropagation();
 								ctx.onpopout(node.id, port.id, port.type, false);
 							}

--- a/js/workflowcanvas/workflow/WorkflowNodeSF.svelte
+++ b/js/workflowcanvas/workflow/WorkflowNodeSF.svelte
@@ -55,7 +55,12 @@
 			type: PortType,
 			isInput: boolean
 		) => void;
-		onpopout: (nodeId: string, portId: string, type: PortType, isInput: boolean) => void;
+		onpopout: (
+			nodeId: string,
+			portId: string,
+			type: PortType,
+			isInput: boolean
+		) => void;
 	}
 
 	const ctx = getContext<WfCtx>("wf");
@@ -377,7 +382,9 @@
 							data-port-type={port.type}
 							data-port-direction="input"
 							style="--port-color: {PORT_COLOR[port.type]}"
-							title={!portConnected && pending === null ? "Click to create an input node" : undefined}
+							title={!portConnected && pending === null
+								? "Click to create an input node"
+								: undefined}
 							onpointerdown={(e) =>
 								ctx.onportpointerdown(e, node.id, port.id, port.type, true)}
 							onclick={(e) => {
@@ -550,7 +557,9 @@
 						data-port-type={port.type}
 						data-port-direction="output"
 						style="--port-color: {PORT_COLOR[port.type]}"
-						title={!portConnected && pending === null ? "Click to create an output node" : undefined}
+						title={!portConnected && pending === null
+							? "Click to create an output node"
+							: undefined}
 						onpointerdown={(e) =>
 							ctx.onportpointerdown(e, node.id, port.id, port.type, false)}
 						onclick={(e) => {

--- a/js/workflowcanvas/workflow/WorkflowNodeSF.svelte
+++ b/js/workflowcanvas/workflow/WorkflowNodeSF.svelte
@@ -55,6 +55,7 @@
 			type: PortType,
 			isInput: boolean
 		) => void;
+		onpopout: (nodeId: string, portId: string, type: PortType, isInput: boolean) => void;
 	}
 
 	const ctx = getContext<WfCtx>("wf");
@@ -370,13 +371,21 @@
 								!ports_compatible(pending.type, port.type)}
 							class:pulse={pending !== null &&
 								ports_compatible(pending.type, port.type)}
+							class:popout-hint={!portConnected && pending === null}
 							data-node-id={node.id}
 							data-port-id={port.id}
 							data-port-type={port.type}
 							data-port-direction="input"
 							style="--port-color: {PORT_COLOR[port.type]}"
+							title={!portConnected && pending === null ? "Click to create an input node" : undefined}
 							onpointerdown={(e) =>
 								ctx.onportpointerdown(e, node.id, port.id, port.type, true)}
+							onclick={(e) => {
+								if (!portConnected && pending === null) {
+									e.stopPropagation();
+									ctx.onpopout(node.id, port.id, port.type, true);
+								}
+							}}
 						></div>
 						{#if !hasWidget}
 							<span
@@ -535,13 +544,21 @@
 					<div
 						class="port-handle-sf output-handle-sf"
 						class:connected={portConnected}
+						class:popout-hint={!portConnected && pending === null}
 						data-node-id={node.id}
 						data-port-id={port.id}
 						data-port-type={port.type}
 						data-port-direction="output"
 						style="--port-color: {PORT_COLOR[port.type]}"
+						title={!portConnected && pending === null ? "Click to create an output node" : undefined}
 						onpointerdown={(e) =>
 							ctx.onportpointerdown(e, node.id, port.id, port.type, false)}
+						onclick={(e) => {
+							if (!portConnected && pending === null) {
+								e.stopPropagation();
+								ctx.onpopout(node.id, port.id, port.type, false);
+							}
+						}}
 					></div>
 				</div>
 			{/each}
@@ -1039,6 +1056,10 @@
 
 	.inline-input::placeholder {
 		color: #4a4b58;
+	}
+
+	.popout-hint {
+		cursor: cell;
 	}
 
 	.inline-number {

--- a/js/workflowcanvas/workflow/icons/CodeIcon.svelte
+++ b/js/workflowcanvas/workflow/icons/CodeIcon.svelte
@@ -1,5 +1,22 @@
 <svg width="20" height="12" viewBox="0 0 20 12" fill="none" aria-hidden="true">
-	<path d="M5 2L2 6l3 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-	<path d="M12 1L8 11" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
-	<path d="M15 2l3 4-3 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+	<path
+		d="M5 2L2 6l3 4"
+		stroke="currentColor"
+		stroke-width="1.6"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+	<path
+		d="M12 1L8 11"
+		stroke="currentColor"
+		stroke-width="1.6"
+		stroke-linecap="round"
+	/>
+	<path
+		d="M15 2l3 4-3 4"
+		stroke="currentColor"
+		stroke-width="1.6"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
 </svg>

--- a/js/workflowcanvas/workflow/icons/CodeIcon.svelte
+++ b/js/workflowcanvas/workflow/icons/CodeIcon.svelte
@@ -1,0 +1,5 @@
+<svg width="20" height="12" viewBox="0 0 20 12" fill="none" aria-hidden="true">
+	<path d="M5 2L2 6l3 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+	<path d="M12 1L8 11" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+	<path d="M15 2l3 4-3 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
it's not super clear that you drag out from the port to add the relevant node, so this allows you to click on the port to add the relevant node type

also tweaks the api icon a bit, and prevents the context menu from overflowing the viewport

updated node UX:
<img width="1828" height="938" alt="Kapture 2026-06-25 at 18 21 52" src="https://github.com/user-attachments/assets/d814c95b-d7b9-41ce-8082-9aecb31aa9af" />

new icon: 
<img width="107" height="41" alt="image" src="https://github.com/user-attachments/assets/20346ccf-8250-4801-ae98-fe84a12063de" />
