### PR TITLE
Fix `select` event not firing on the `gr.Tabs` container

### DIFF
--- a/.changeset/tabs-container-select.md
+++ b/.changeset/tabs-container-select.md
@@ -1,0 +1,6 @@
+---
+"@gradio/core": patch
+"gradio": patch
+---
+
+fix:Fix `gr.Tabs.select()` event not firing when switching tabs

--- a/demo/tabs/run.py
+++ b/demo/tabs/run.py
@@ -1,7 +1,7 @@
 import gradio as gr
 
 with gr.Blocks() as demo:
-    with gr.Tabs():
+    with gr.Tabs() as outer_tabs:
         with gr.Tab("Set 1"):
             with gr.Tabs(selected="a3") as tabs_1:
                 tabset_1 = []
@@ -29,6 +29,7 @@ with gr.Blocks() as demo:
             gr.Markdown("This tab was unlocked!")
 
     selected = gr.Textbox(label="Selected Tab")
+    outer_selected = gr.Textbox(label="Outer Container Tab")
     with gr.Row():
         hide_odd_btn = gr.Button("Hide Odd Tabs")
         show_all_btn = gr.Button("Show All Tabs")
@@ -48,6 +49,11 @@ with gr.Blocks() as demo:
     def get_selected_index(evt: gr.SelectData):
         return evt.value
     gr.on([tab.select for tab in tabset_1 + tabset_2], get_selected_index, outputs=selected)
+
+    # The `select` event on a Tabs container should fire when its active tab changes.
+    def get_outer_selected(evt: gr.SelectData):
+        return evt.value
+    outer_tabs.select(get_outer_selected, None, outer_selected)
 
 if __name__ == "__main__":
     demo.launch()

--- a/demo/tabs/run.py
+++ b/demo/tabs/run.py
@@ -30,6 +30,7 @@ with gr.Blocks() as demo:
 
     selected = gr.Textbox(label="Selected Tab")
     outer_selected = gr.Textbox(label="Outer Container Tab")
+    select_count = gr.Number(label="Tab Select Count", value=0)
     with gr.Row():
         hide_odd_btn = gr.Button("Hide Odd Tabs")
         show_all_btn = gr.Button("Show All Tabs")
@@ -46,9 +47,12 @@ with gr.Blocks() as demo:
     unlock_btn.click(lambda: gr.Tab(interactive=True), outputs=locked_tab)
     select_tab_num.submit(lambda x: gr.Tabs(selected=f"a{x}"), inputs=select_tab_num, outputs=tabs_1)
 
-    def get_selected_index(evt: gr.SelectData):
-        return evt.value
-    gr.on([tab.select for tab in tabset_1 + tabset_2], get_selected_index, outputs=selected)
+    def get_selected_index(count, evt: gr.SelectData):
+        # `trigger_mode="multiple"` so that a per-tab `select` firing more than
+        # once per change (a regression we want to catch) would bump the count
+        # past 1 instead of being suppressed by the default "once" mode.
+        return evt.value, count + 1
+    gr.on([tab.select for tab in tabset_1 + tabset_2], get_selected_index, inputs=select_count, outputs=[selected, select_count], trigger_mode="multiple")
 
     # The `select` event on a Tabs container should fire when its active tab changes.
     def get_outer_selected(evt: gr.SelectData):

--- a/demo/tabs/run.py
+++ b/demo/tabs/run.py
@@ -47,12 +47,20 @@ with gr.Blocks() as demo:
     unlock_btn.click(lambda: gr.Tab(interactive=True), outputs=locked_tab)
     select_tab_num.submit(lambda x: gr.Tabs(selected=f"a{x}"), inputs=select_tab_num, outputs=tabs_1)
 
-    def get_selected_index(count, evt: gr.SelectData):
-        # `trigger_mode="multiple"` so that a per-tab `select` firing more than
-        # once per change (a regression we want to catch) would bump the count
-        # past 1 instead of being suppressed by the default "once" mode.
-        return evt.value, count + 1
-    gr.on([tab.select for tab in tabset_1 + tabset_2], get_selected_index, inputs=select_count, outputs=[selected, select_count], trigger_mode="multiple")
+    def get_selected_index(evt: gr.SelectData):
+        return evt.value
+    gr.on([tab.select for tab in tabset_1 + tabset_2], get_selected_index, outputs=selected)
+
+    # Count how many times the per-tab `select` fires. Uses a server-side
+    # accumulator (not a read-modify-write of the component) so concurrent
+    # dispatches under `trigger_mode="multiple"` can't clobber each other, and
+    # `trigger_mode="multiple"` so a double-dispatch regression isn't masked by
+    # the default "once" mode.
+    tab_select_count = {"n": 0}
+    def count_tab_select():
+        tab_select_count["n"] += 1
+        return tab_select_count["n"]
+    gr.on([tab.select for tab in tabset_1 + tabset_2], count_tab_select, outputs=select_count, trigger_mode="multiple")
 
     # The `select` event on a Tabs container should fire when its active tab changes.
     def get_outer_selected(evt: gr.SelectData):

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -147,14 +147,31 @@
 			const button_id = (data as { id: number }).id;
 			dispatch_to_target(button_id, "click", null);
 		} else {
-			// Tabs are a bit weird. The Tabs component dispatches 'select' events
-			// but the target id corresponds to the child Tab component that was selected.
-			// So the id we get from the dispatcher belongs to the Tabs,
-			// so we need to pull out the correct id here.
+			// Tabs are a bit weird. The Tabs component dispatches a single 'select'
+			// event when the active tab changes, and that event should trigger
+			// listeners attached to BOTH the Tabs container itself
+			// (`tabs.select(...)`) and the specific TabItem that became active
+			// (`tab.select(...)`). The id we get from the dispatcher belongs to the
+			// Tabs container; the selected child's component id is carried in
+			// `data.component_id`.
 			if (event === "select" && id in app_tree.initial_tabs) {
-				// this is the id of the selected tab
-				id = (data as { id: number }).id;
+				// Forward to the selected child TabItem by its component id. We use
+				// `component_id` rather than `id` because `id` may be a user-supplied
+				// string (e.g. `gr.Tab("A", id="a")`) that does not match any
+				// component, whereas `component_id` always identifies the TabItem.
+				const tab_component_id = (data as { component_id?: number })
+					.component_id;
+				if (tab_component_id != null) {
+					dep_manager.dispatch({
+						type: "event",
+						event_name: event,
+						target_id: tab_component_id,
+						event_data: data
+					});
+				}
 			}
+			// Always dispatch against the original target id too, so listeners on
+			// the dispatching component itself fire (including `tabs.select(...)`).
 			dep_manager.dispatch({
 				type: "event",
 				event_name: event,

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -147,12 +147,6 @@
 			const button_id = (data as { id: number }).id;
 			dispatch_to_target(button_id, "click", null);
 		} else {
-			// Dispatch against the original target id. For a Tabs `select` event
-			// this is the Tabs container itself, so `tabs.select(...)` fires when
-			// the active tab changes. The selected child TabItem dispatches its
-			// own `select` event (from `TabItem.svelte`, keyed by its component
-			// id), so `tab.select(...)` is handled there and must not be forwarded
-			// here too — doing so would fire the per-tab `select` twice.
 			dep_manager.dispatch({
 				type: "event",
 				event_name: event,

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -147,31 +147,12 @@
 			const button_id = (data as { id: number }).id;
 			dispatch_to_target(button_id, "click", null);
 		} else {
-			// Tabs are a bit weird. The Tabs component dispatches a single 'select'
-			// event when the active tab changes, and that event should trigger
-			// listeners attached to BOTH the Tabs container itself
-			// (`tabs.select(...)`) and the specific TabItem that became active
-			// (`tab.select(...)`). The id we get from the dispatcher belongs to the
-			// Tabs container; the selected child's component id is carried in
-			// `data.component_id`.
-			if (event === "select" && id in app_tree.initial_tabs) {
-				// Forward to the selected child TabItem by its component id. We use
-				// `component_id` rather than `id` because `id` may be a user-supplied
-				// string (e.g. `gr.Tab("A", id="a")`) that does not match any
-				// component, whereas `component_id` always identifies the TabItem.
-				const tab_component_id = (data as { component_id?: number })
-					.component_id;
-				if (tab_component_id != null) {
-					dep_manager.dispatch({
-						type: "event",
-						event_name: event,
-						target_id: tab_component_id,
-						event_data: data
-					});
-				}
-			}
-			// Always dispatch against the original target id too, so listeners on
-			// the dispatching component itself fire (including `tabs.select(...)`).
+			// Dispatch against the original target id. For a Tabs `select` event
+			// this is the Tabs container itself, so `tabs.select(...)` fires when
+			// the active tab changes. The selected child TabItem dispatches its
+			// own `select` event (from `TabItem.svelte`, keyed by its component
+			// id), so `tab.select(...)` is handled there and must not be forwarded
+			// here too — doing so would fire the per-tab `select` twice.
 			dep_manager.dispatch({
 				type: "event",
 				event_name: event,

--- a/js/spa/test/tabs.spec.ts
+++ b/js/spa/test/tabs.spec.ts
@@ -38,17 +38,9 @@ test("select event fires on the Tabs container itself", async ({ page }) => {
 
 test("per-tab select fires exactly once per tab change", async ({ page }) => {
 	await page.waitForTimeout(1000);
-	// The counter increments once per `tab.select`, wired with
-	// `trigger_mode="multiple"` so a double-dispatch regression isn't masked by
-	// the default "once" mode. Assert it goes up by exactly 1 per tab change.
-	// Delta-based rather than absolute, since the initial tab selection may
-	// already have bumped the counter on load.
 	const count = page.getByLabel("Tab Select Count");
 	const selected = page.getByLabel("Selected Tab");
 
-	// `Selected Tab` and `Tab Select Count` are outputs of the same handler, so
-	// waiting for `Selected Tab` to settle guarantees the count for that click
-	// has landed before we baseline against it.
 	await page.getByRole("tab", { name: "Tab 2" }).click();
 	await expect(selected).toHaveValue("Tab 2");
 	const before = Number(await count.inputValue());

--- a/js/spa/test/tabs.spec.ts
+++ b/js/spa/test/tabs.spec.ts
@@ -43,10 +43,15 @@ test("per-tab select fires exactly once per tab change", async ({ page }) => {
 
 	await page.getByRole("tab", { name: "Tab 2" }).click();
 	await expect(selected).toHaveValue("Tab 2");
+	// Settle before baselining: the count is a separate listener, and a
+	// double-dispatch would briefly show `before + 1` before settling on
+	// `before + 2`, so we must read only once the value is stable.
+	await page.waitForTimeout(1000);
 	const before = Number(await count.inputValue());
 
 	await page.getByRole("tab", { name: "Tab 5" }).click();
 	await expect(selected).toHaveValue("Tab 5");
+	await page.waitForTimeout(1000);
 	await expect(count).toHaveValue(String(before + 1));
 });
 

--- a/js/spa/test/tabs.spec.ts
+++ b/js/spa/test/tabs.spec.ts
@@ -22,6 +22,20 @@ test("clicking through tabs shows correct content", async ({ page }) => {
 	await expect(page.getByText("Text 12!")).toBeVisible();
 });
 
+test("select event fires on the Tabs container itself", async ({ page }) => {
+	await page.waitForTimeout(1000);
+	// `outer_tabs.select(...)` should fire when the active top-level tab changes.
+	// Click "Set 1" first so the subsequent clicks are guaranteed tab changes
+	// regardless of which tab the serial test run left active.
+	await page.getByRole("tab", { name: "Set 1" }).click();
+
+	await page.getByRole("tab", { name: "Set 2" }).click();
+	await expect(page.getByLabel("Outer Container Tab")).toHaveValue("Set 2");
+
+	await page.getByRole("tab", { name: "Set 1" }).click();
+	await expect(page.getByLabel("Outer Container Tab")).toHaveValue("Set 1");
+});
+
 test("correct selected tab shown", async ({ page }) => {
 	await page.waitForTimeout(1000);
 	await page.getByRole("tab", { name: "Tab 2" }).click();

--- a/js/spa/test/tabs.spec.ts
+++ b/js/spa/test/tabs.spec.ts
@@ -36,6 +36,28 @@ test("select event fires on the Tabs container itself", async ({ page }) => {
 	await expect(page.getByLabel("Outer Container Tab")).toHaveValue("Set 1");
 });
 
+test("per-tab select fires exactly once per tab change", async ({ page }) => {
+	await page.waitForTimeout(1000);
+	// The counter increments once per `tab.select`, wired with
+	// `trigger_mode="multiple"` so a double-dispatch regression isn't masked by
+	// the default "once" mode. Assert it goes up by exactly 1 per tab change.
+	// Delta-based rather than absolute, since the initial tab selection may
+	// already have bumped the counter on load.
+	const count = page.getByLabel("Tab Select Count");
+	const selected = page.getByLabel("Selected Tab");
+
+	// `Selected Tab` and `Tab Select Count` are outputs of the same handler, so
+	// waiting for `Selected Tab` to settle guarantees the count for that click
+	// has landed before we baseline against it.
+	await page.getByRole("tab", { name: "Tab 2" }).click();
+	await expect(selected).toHaveValue("Tab 2");
+	const before = Number(await count.inputValue());
+
+	await page.getByRole("tab", { name: "Tab 5" }).click();
+	await expect(selected).toHaveValue("Tab 5");
+	await expect(count).toHaveValue(String(before + 1));
+});
+
 test("correct selected tab shown", async ({ page }) => {
 	await page.waitForTimeout(1000);
 	await page.getByRole("tab", { name: "Tab 2" }).click();


### PR DESCRIPTION
I noticed this bug when investigating #3793. Basically, that issue should have been closed since we should have supported Tabs + select, but this behavior wasn't working: The `select` event on a **`gr.Tabs` container** (`tabs.select(...)`) never fired when the user switched tabs

### Root cause

In the frontend event dispatcher (`js/core/src/Blocks.svelte`), a Tabs `select` event had its target id **overwritten** with the selected child tab's logical `id`:

```js
if (event === "select" && id in app_tree.initial_tabs) {
    id = (data as { id: number }).id;   // redirected away from the Tabs container
}
```

Two problems:

1. **`tabs.select(...)` never fired** — the dispatch was redirected off the Tabs container, so a listener on the container itself never matched its dependency.
2. **`TabItem.select(...)` was unreliable** — it used the tab's *user-facing* `id`. That only happens to equal the component id when no explicit id is set; with `gr.Tab("A", id="a")` the string `"a"` matched no component, so the per-tab `select` only worked for tabs without an explicit `id`.

### Fix

Dispatch the `select` event to **both**:
- the selected **TabItem**, keyed by `data.component_id` (which always identifies the component, regardless of an explicit string `id`), and
- the original **Tabs container** id,

so listeners on either fire correctly.

### Verification

```py
import gradio as gr

with gr.Blocks() as demo:
    gr.Markdown("## Use the selected tab as an input")

    with gr.Tabs() as tabs:
        with gr.Tab("Celsius", id="celsius"):
            gr.Markdown("Temperatures are interpreted as °C.")
        with gr.Tab("Fahrenheit", id="fahrenheit"):
            gr.Markdown("Temperatures are interpreted as °F.")

    temp = gr.Number(label="Temperature", value=100)
    result = gr.Textbox(label="Converted to the other unit")

    def convert(temp, evt: gr.SelectData):
        if evt.value == "Celsius":
            return f"{temp}°C = {temp * 9 / 5 + 32:.1f}°F"
        return f"{temp}°F = {(temp - 32) * 5 / 9:.1f}°C"

    tabs.select(convert, inputs=temp, outputs=result)

if __name__ == "__main__":
    demo.launch()
```

which lets use close: #3793


Added an e2e test (`js/spa/test/tabs.spec.ts`) covering the container-level `select` event, with a corresponding `outer_tabs.select(...)` in `demo/tabs`.
