### PR TITLE
Fix `this.app.$destroy is not a function` in the `<gradio-app>` web component

### DIFF
--- a/.changeset/web-component-unmount.md
+++ b/.changeset/web-component-unmount.md
@@ -1,0 +1,6 @@
+---
+"@self/spa": patch
+"gradio": patch
+---
+
+fix:Fix `TypeError: this.app.$destroy is not a function` when embedding a Gradio app with the `<gradio-app>` web component

--- a/demo/web_component_embed/run.py
+++ b/demo/web_component_embed/run.py
@@ -1,0 +1,11 @@
+import gradio as gr
+
+with gr.Blocks() as demo:
+    gr.Markdown("# Web component embed target")
+    name = gr.Textbox(label="Name")
+    greet = gr.Button("Greet")
+    out = gr.Textbox(label="Greeting")
+    greet.click(lambda n: f"Hello, {n or 'world'}!", name, out)
+
+if __name__ == "__main__":
+    demo.launch()

--- a/js/spa/src/main.ts
+++ b/js/spa/src/main.ts
@@ -84,7 +84,7 @@ function create_custom_element(): void {
 			this.loading = true;
 
 			if (this.app) {
-				this.app.$destroy();
+				unmount(this.app);
 			}
 
 			if (typeof FONTS !== "string") {

--- a/js/spa/test/web_component_embed.spec.ts
+++ b/js/spa/test/web_component_embed.spec.ts
@@ -4,12 +4,14 @@ import { test, expect } from "@self/tootils";
 // component, and that detaching + re-attaching the element re-mounts cleanly
 // (regression test for the `this.app.$destroy is not a function` bug, #12507).
 
-// The `<gradio-app>` web component is a client-side embedding mechanism; in SSR
-// mode the served HTML doesn't expose the client entry chunk this test relies
-// on, so skip it there (matches the other client-rendering specs).
+// Skipped in SSR mode only because of how this test *discovers* the bundle:
+// it scrapes the app's index HTML for the `assets/index-*.js` entry, but in SSR
+// mode the page is served via SvelteKit (`/_app/...`) and doesn't reference it.
+// Embedding itself works fine against an SSR app (the bundle is still served and
+// the web component renders from `/config`) — this is purely a harness limitation.
 test.skip(
 	process.env?.GRADIO_SSR_MODE?.toLowerCase() === "true",
-	"web component embedding is a client-side rendering path"
+	"test discovers the web-component bundle from the client-rendered index HTML"
 );
 
 test("app embeds and renders via the <gradio-app> web component", async ({

--- a/js/spa/test/web_component_embed.spec.ts
+++ b/js/spa/test/web_component_embed.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "@self/tootils";
+
+// Verifies that a Gradio app can be embedded with the `<gradio-app>` web
+// component, and that detaching + re-attaching the element re-mounts cleanly
+// (regression test for the `this.app.$destroy is not a function` bug, #12507).
+
+test("app embeds and renders via the <gradio-app> web component", async ({
+	page
+}) => {
+	// The fixture has already launched the app and navigated to it.
+	const app_url = new URL(page.url()).origin;
+
+	const page_errors: string[] = [];
+	page.on("pageerror", (e) => page_errors.push(e.message));
+
+	// Build a plain host page that loads the app's web-component bundle and
+	// embeds it (same origin as the launched app).
+	await page.setContent(`
+		<h1>Host page</h1>
+		<div id="slot"></div>
+		<script type="module">
+			const html = await (await fetch("/")).text();
+			const entry = html.match(/assets\\/index-[A-Za-z0-9_-]+\\.js/)[0];
+			await import("/" + entry);
+			await customElements.whenDefined("gradio-app");
+			document.getElementById("slot").innerHTML =
+				'<gradio-app src="${app_url}"></gradio-app>';
+		</script>
+	`);
+
+	const embed = page.locator("gradio-app");
+	await expect(embed.getByRole("button", { name: "Greet" })).toBeVisible({
+		timeout: 20_000
+	});
+
+	// #12507: detaching and re-attaching re-runs connectedCallback with
+	// `this.app` already set. The buggy version threw
+	// `TypeError: this.app.$destroy is not a function`; it must now re-mount.
+	await page.evaluate(() => {
+		const slot = document.getElementById("slot");
+		const el = slot?.querySelector("gradio-app");
+		if (el) {
+			el.remove();
+			slot?.appendChild(el);
+		}
+	});
+
+	await expect(embed.getByRole("button", { name: "Greet" })).toBeVisible({
+		timeout: 20_000
+	});
+	expect(
+		page_errors.filter((e) => /\$destroy is not a function/.test(e))
+	).toHaveLength(0);
+});

--- a/js/spa/test/web_component_embed.spec.ts
+++ b/js/spa/test/web_component_embed.spec.ts
@@ -1,14 +1,10 @@
 import { test, expect } from "@self/tootils";
 
-// Verifies that a Gradio app can be embedded with the `<gradio-app>` web
-// component, and that detaching + re-attaching the element re-mounts cleanly
-// (regression test for the `this.app.$destroy is not a function` bug, #12507).
+// Embeds an app with the `<gradio-app>` web component and re-attaches the
+// element, a regression test for `this.app.$destroy is not a function` (#12507).
 
-// Skipped in SSR mode only because of how this test *discovers* the bundle:
-// it scrapes the app's index HTML for the `assets/index-*.js` entry, but in SSR
-// mode the page is served via SvelteKit (`/_app/...`) and doesn't reference it.
-// Embedding itself works fine against an SSR app (the bundle is still served and
-// the web component renders from `/config`) — this is purely a harness limitation.
+// Skipped in SSR mode: the test discovers the bundle from the index HTML, which
+// SSR (SvelteKit) doesn't expose. Embedding itself works fine against an SSR app.
 test.skip(
 	process.env?.GRADIO_SSR_MODE?.toLowerCase() === "true",
 	"test discovers the web-component bundle from the client-rendered index HTML"
@@ -17,14 +13,11 @@ test.skip(
 test("app embeds and renders via the <gradio-app> web component", async ({
 	page
 }) => {
-	// The fixture has already launched the app and navigated to it.
 	const app_url = new URL(page.url()).origin;
 
 	const page_errors: string[] = [];
 	page.on("pageerror", (e) => page_errors.push(e.message));
 
-	// Build a plain host page that loads the app's web-component bundle and
-	// embeds it (same origin as the launched app).
 	await page.setContent(`
 		<h1>Host page</h1>
 		<div id="slot"></div>
@@ -43,9 +36,7 @@ test("app embeds and renders via the <gradio-app> web component", async ({
 		timeout: 20_000
 	});
 
-	// #12507: detaching and re-attaching re-runs connectedCallback with
-	// `this.app` already set. The buggy version threw
-	// `TypeError: this.app.$destroy is not a function`; it must now re-mount.
+	// #12507: re-attaching re-runs connectedCallback with `this.app` already set.
 	await page.evaluate(() => {
 		const slot = document.getElementById("slot");
 		const el = slot?.querySelector("gradio-app");

--- a/js/spa/test/web_component_embed.spec.ts
+++ b/js/spa/test/web_component_embed.spec.ts
@@ -4,6 +4,14 @@ import { test, expect } from "@self/tootils";
 // component, and that detaching + re-attaching the element re-mounts cleanly
 // (regression test for the `this.app.$destroy is not a function` bug, #12507).
 
+// The `<gradio-app>` web component is a client-side embedding mechanism; in SSR
+// mode the served HTML doesn't expose the client entry chunk this test relies
+// on, so skip it there (matches the other client-rendering specs).
+test.skip(
+	process.env?.GRADIO_SSR_MODE?.toLowerCase() === "true",
+	"web component embedding is a client-side rendering path"
+);
+
 test("app embeds and renders via the <gradio-app> web component", async ({
 	page
 }) => {


### PR DESCRIPTION
I've started workthough the issues related to embedding Gradio apps. This is a small bug fix: embedding a Gradio app with the `<gradio-app>` web component could throw:

```
Uncaught (in promise) TypeError: this.app.$destroy is not a function
```

The custom element's `connectedCallback` (`js/spa/src/main.ts`) still called the **Svelte 4** `this.app.$destroy()` API. After the Svelte 5 migration the app is created with `mount(...)`, which returns an object with no `$destroy()` method — it must be torn down with `unmount()`. So whenever `connectedCallback` ran with `this.app` already set (the element was reconnected — moved in the DOM, or detached and re-attached), it threw and left the embed broken.

`attributeChangedCallback` already uses the correct Svelte 5 `unmount(this.app)`; this just makes `connectedCallback` consistent.

```diff
 			if (this.app) {
-				this.app.$destroy();
+				unmount(this.app);
 			}
```


I added an e2e regression test (`js/spa/test/web_component_embed.spec.ts` + `demo/web_component_embed`) that embeds the app via the web component, detaches/re-attaches it, and asserts no `$destroy` error and that the app re-renders. An e2e regression test might be a bit much for a small bug like this, but I'm planning on expanding this e2e test as I fix the other embedding-related issues.

Closes #12507
