### PR TITLE
Add `allowed_origins` to restrict CORS access

### DIFF
--- a/.changeset/cors-allowed-origins.md
+++ b/.changeset/cors-allowed-origins.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Add `allowed_origins` parameter to `launch()` and `mount_gradio_app()` to restrict which origins may make cross-origin (CORS) requests

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2640,6 +2640,7 @@ Received inputs:
         max_file_size: str | int | None = None,
         enable_monitoring: bool | None = None,
         strict_cors: bool = True,
+        allowed_origins: list[str] | None = None,
         node_server_name: str | None = None,
         node_port: int | None = None,
         ssr_mode: bool | None = None,
@@ -2692,6 +2693,7 @@ Received inputs:
             max_file_size: The maximum file size in bytes that can be uploaded. Can be a string of the form "<value><unit>", where value is any positive integer and unit is one of "b", "kb", "mb", "gb", "tb". If None, no limit is set.
             enable_monitoring: Enables traffic monitoring of the app through the /monitoring endpoint. By default is None, which enables this endpoint. If explicitly True, will also print the monitoring URL to the console. If False, will disable monitoring altogether.
             strict_cors: If True, prevents external domains from making requests to a Gradio server running on localhost. If False, allows requests to localhost that originate from localhost but also, crucially, from "null". This parameter should normally be True to prevent CSRF attacks but may need to be False when embedding a *locally-running Gradio app* using web components.
+            allowed_origins: A list of exact origins (e.g. ["https://example.com"]) that are permitted to make cross-origin (CORS) requests to this app. When set, only these origins are allowed, regardless of the server host — this is the supported way to restrict which sites may embed or call a publicly-hosted Gradio app. When None (default), Gradio only applies its built-in localhost CSRF protection and otherwise reflects the requesting origin.
             ssr_mode: If True, the Gradio app will be rendered using server-side rendering mode, which is typically more performant and provides better SEO, but this requires Node 20+ to be installed on the system. If False, the app will be rendered using client-side rendering mode. If None, will use GRADIO_SSR_MODE environment variable or default to False.
             pwa: If True, the Gradio app will be set up as an installable PWA (Progressive Web App). If set to None (default behavior), then the PWA feature will be enabled if this Gradio app is launched on Spaces, but not otherwise.
             i18n: An I18n instance containing custom translations, which are used to translate strings in our components (e.g. the labels of components or Markdown strings). This feature can only be used to translate static text in the frontend, not values in the backend.
@@ -2928,6 +2930,7 @@ Received inputs:
             auth_dependency=auth_dependency,
             app_kwargs=app_kwargs,
             strict_cors=strict_cors,
+            allowed_origins=allowed_origins,
             mcp_server=mcp_server,
             debug=debug,
         )

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -899,6 +899,7 @@ class CustomCORSMiddleware:
         self,
         app: ASGIApp,
         strict_cors: bool = True,
+        allowed_origins: list[str] | None = None,
     ) -> None:
         self.app = app
         self.all_methods = ("DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT")
@@ -908,6 +909,10 @@ class CustomCORSMiddleware:
             "Access-Control-Allow-Credentials": "true",
         }
         self.simple_headers = {"Access-Control-Allow-Credentials": "true"}
+        # An explicit allow-list of origins (e.g. ["https://example.com"]). When set,
+        # only these origins are reflected in Access-Control-Allow-Origin, regardless
+        # of the server host. When None, the default localhost-protection logic applies.
+        self.allowed_origins = allowed_origins
         # Any of these hosts suggests that the Gradio app is running locally.
         self.localhost_aliases = ["localhost", "127.0.0.1", "0.0.0.0"]
         if not strict_cors or os.getenv("GRADIO_LOCAL_DEV_MODE") is not None:  # type: ignore
@@ -963,6 +968,13 @@ class CustomCORSMiddleware:
 
     def is_valid_origin(self, request_headers: Headers) -> bool:
         origin = request_headers["Origin"]
+
+        # When an explicit allow-list is configured, it takes precedence: only
+        # those exact origins are permitted (this is what lets a non-localhost
+        # server actually restrict which sites may make cross-origin requests).
+        if self.allowed_origins is not None:
+            return origin in self.allowed_origins
+
         host = request_headers["Host"]
         host_name = get_hostname(host)
         origin_name = get_hostname(origin)

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -361,6 +361,7 @@ class App(FastAPI):
         app_kwargs: dict[str, Any] | None = None,
         auth_dependency: Callable[[fastapi.Request], str | None] | None = None,
         strict_cors: bool = True,
+        allowed_origins: list[str] | None = None,
         mcp_server: bool | None = None,
         debug: bool = False,
     ) -> App:
@@ -384,7 +385,11 @@ class App(FastAPI):
 
         app.configure_app(blocks)
 
-        app.add_middleware(CustomCORSMiddleware, strict_cors=strict_cors)  # type: ignore
+        app.add_middleware(
+            CustomCORSMiddleware,  # type: ignore
+            strict_cors=strict_cors,
+            allowed_origins=allowed_origins,
+        )
         app.add_middleware(
             BrotliMiddleware,  # type: ignore
             quality=4,
@@ -2472,6 +2477,8 @@ def mount_gradio_app(
     js: str | Literal[True] | None = None,
     head: str | None = None,
     head_paths: str | Path | Sequence[str | Path] | None = None,
+    strict_cors: bool = True,
+    allowed_origins: list[str] | None = None,
 ) -> fastapi.FastAPI:
     """Mount a gradio.Blocks to an existing FastAPI application.
 
@@ -2503,6 +2510,8 @@ def mount_gradio_app(
         js: Custom js as a code string. The custom js should be in the form of a single js function. This function will automatically be executed when the page loads. For more flexibility, use the head parameter to insert js inside <script> tags.
         head: Custom html code to insert into the head of the demo webpage. This can be used to add custom meta tags, multiple scripts, stylesheets, etc. to the page.
         head_paths: Custom html code as a pathlib.Path to a html file or a list of such paths. This html files will be read, concatenated, and included in the head of the demo webpage. If the `head` parameter is also set, the html from `head` will be included first.
+        strict_cors: If True, prevents external domains from making requests to a Gradio server running on localhost. If False, also allows requests from "null" origin (needed when embedding a locally-running app as a web component). Should normally be True to prevent CSRF attacks.
+        allowed_origins: A list of exact origins (e.g. ["https://example.com"]) permitted to make cross-origin (CORS) requests to the mounted app. When set, only these origins are allowed, regardless of the server host. When None (default), Gradio only applies its built-in localhost CSRF protection and otherwise reflects the requesting origin.
     Example:
         from fastapi import FastAPI
         import gradio as gr
@@ -2589,6 +2598,8 @@ def mount_gradio_app(
         blocks,
         app_kwargs=app_kwargs,
         auth_dependency=auth_dependency,
+        strict_cors=strict_cors,
+        allowed_origins=allowed_origins,
         mcp_server=mcp_server,
     )
     old_lifespan = app.router.lifespan_context

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -750,6 +750,31 @@ class TestRoutes:
 
         io.close()
 
+    def test_allowed_origins_cors_restrictions(self):
+        io = gr.Interface(lambda s: s.name, gr.File(), gr.File())
+        app, _, _ = io.launch(
+            prevent_thread_lock=True, allowed_origins=["https://example.com"]
+        )
+        client = TestClient(app)
+
+        # A non-localhost host would normally reflect any origin; with
+        # allowed_origins set, only the listed origin is permitted.
+        disallowed = client.get(
+            f"{API_PREFIX}/config",
+            headers={"host": "myapp.example.com", "origin": "https://evil.com"},
+        )
+        assert "access-control-allow-origin" not in disallowed.headers
+
+        allowed = client.get(
+            f"{API_PREFIX}/config",
+            headers={"host": "myapp.example.com", "origin": "https://example.com"},
+        )
+        assert (
+            allowed.headers["access-control-allow-origin"] == "https://example.com"
+        )
+
+        io.close()
+
     def test_delete_cache(self, connect, gradio_temp_dir, capsys):
         def check_num_files_exist(blocks: Blocks):
             num_files = 0


### PR DESCRIPTION
## Description

Gradio's built-in `CustomCORSMiddleware` only ever enforced a **localhost CSRF guard**. On any non-localhost host (a deployed app, a LAN host, an `hf.space`) it reflected *whatever* `Origin` the request sent back into `Access-Control-Allow-Origin` — and there was **no supported way to restrict which origins may make cross-origin requests** (#10276). Adding your own `CORSMiddleware` after `mount_gradio_app` doesn't help, because Gradio's middleware still writes the reflected header. `mount_gradio_app` also never forwarded `strict_cors` at all.

## Change

Add an `allowed_origins: list[str] | None = None` parameter to:
- `Blocks.launch()`
- `gradio.mount_gradio_app()` (which now also forwards `strict_cors`)
- `App.create_app()` → `CustomCORSMiddleware`

When set, only those exact origins are reflected in `Access-Control-Allow-Origin`, regardless of the server host. When unset (default), behavior is unchanged (localhost CSRF protection + origin reflection).

```python
demo.launch(allowed_origins=["https://example.com"])
```

## Verification

New test `test_allowed_origins_cors_restrictions` + existing CORS tests pass. Manual curl against a non-localhost `Host`:

| request | before | after (`allowed_origins=["https://example.com"]`) |
|---|---|---|
| `Origin: https://evil.com` | `ACAO: https://evil.com` (reflected) | no `ACAO` header (blocked) |
| `Origin: https://example.com` | reflected | `ACAO: https://example.com` |

Scoped to #10276. The related #5117 (CSP / `X-Frame-Options` to disable *framing*) is a distinct mechanism — its frontend "respect CSP" half is gated on Spaces emitting the header — and is left as a follow-up that can build on this.

Closes #10276

🤖 Generated with [Claude Code](https://claude.com/claude-code)