### PR TITLE
Fix embedded apps growing infinitely tall on Spaces

### DIFF
--- a/.changeset/embed-height-growth.md
+++ b/.changeset/embed-height-growth.md
@@ -1,0 +1,6 @@
+---
+"@gradio/core": patch
+"gradio": patch
+---
+
+fix:Fix embedded Gradio apps growing infinitely tall on HF Spaces when using `vh`/`%` heights or `fill_height`

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -401,12 +401,42 @@
 		return container.children[container.children.length - 1] as HTMLElement;
 	}
 
+	let last_reported_height = 0;
+	let consecutive_grows = 0;
+
 	function handle_resize(): void {
-		if ("parentIFrame" in window) {
-			const box = root_container.children[0].getBoundingClientRect();
-			if (!box) return;
-			window.parentIFrame?.size(box.bottom + footer_height + 32);
+		if (!("parentIFrame" in window)) return;
+		const box = root_container.children[0].getBoundingClientRect();
+		if (!box) return;
+		const next = box.bottom + footer_height + 32;
+		const viewport = window.innerHeight;
+
+		// Ignore sub-pixel echoes from our own resize.
+		if (Math.abs(next - last_reported_height) < 2) {
+			consecutive_grows = 0;
+			return;
 		}
+
+		if (next > last_reported_height) {
+			// Content sized in viewport-relative units (`vh`/`%`) or stretched by
+			// `fill_height` grows to fill whatever height the iframe is given, so its
+			// measured bottom just tracks the viewport. Requesting a larger size in
+			// that case feeds back into an unbounded growth loop (#12089, #12992).
+			// (a) If the content merely fills the viewport (no real overflow), don't grow.
+			if (next > viewport && box.bottom <= viewport + 2) return;
+			// (b) Circuit breaker: if we keep growing tick after tick, the content is
+			// tracking the iframe we just grew (a feedback loop), not genuinely taller
+			// content. Stop growing so the height stays bounded. Legitimate content
+			// (late-loading images, revealed blocks) settles within a few grows.
+			consecutive_grows += 1;
+			if (consecutive_grows > 4) return;
+		} else {
+			// Shrinking to fit shorter content is always safe and breaks any loop.
+			consecutive_grows = 0;
+		}
+
+		last_reported_height = next;
+		window.parentIFrame?.size(next);
 	}
 
 	function screen_recording(): void {

--- a/js/model3D/Model3D.test.ts
+++ b/js/model3D/Model3D.test.ts
@@ -34,8 +34,6 @@ function suppress_3d_library_errors(e: PromiseRejectionEvent): void {
 		msg.includes("Viewer is disposed") ||
 		msg.includes("Invalid URL") ||
 		msg.includes("Unsupported property type") ||
-		// BabylonJS render loop touching `scene.postProcessManager` after the
-		// scene has been disposed on cleanup.
 		msg.includes("postProcessManager")
 	) {
 		e.preventDefault();

--- a/js/model3D/Model3D.test.ts
+++ b/js/model3D/Model3D.test.ts
@@ -33,7 +33,10 @@ function suppress_3d_library_errors(e: PromiseRejectionEvent): void {
 		msg.includes("addEventListener") ||
 		msg.includes("Viewer is disposed") ||
 		msg.includes("Invalid URL") ||
-		msg.includes("Unsupported property type")
+		msg.includes("Unsupported property type") ||
+		// BabylonJS render loop touching `scene.postProcessManager` after the
+		// scene has been disposed on cleanup.
+		msg.includes("postProcessManager")
 	) {
 		e.preventDefault();
 	}

--- a/scripts/download_offline_assets.py
+++ b/scripts/download_offline_assets.py
@@ -141,18 +141,14 @@ def download_iframe_resizer() -> None:
     dest_dir = STATIC / "js"
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest = dest_dir / "iframeResizer.contentWindow.min.js"
-    node_modules = (
-        ROOT
-        / "node_modules"
-        / "@iframe-resizer"
-        / "child"
-        / "umd"
-        / "iframeResizer.contentWindow.min.js"
-    )
-    if node_modules.exists():
-        shutil.copy2(node_modules, dest)
-        print(f"  iframe-resizer: {dest.relative_to(ROOT)}")
-        return
+    # Pin the iframe-resizer *child* to v4.3.1. It has to match the iframe-resizer
+    # *parent* that HF Spaces runs to embed apps: a v5 child speaks a different
+    # postMessage protocol that the v4 parent can't handshake with, so
+    # `window.parentIFrame` never appears in the embedded app and the height
+    # reporting in Blocks.svelte silently never runs (the app won't size to its
+    # content on Spaces). v4.3.1 is also MIT-licensed, whereas v5 is GPL-3.0.
+    # `@iframe-resizer/child` in node_modules is v5 (a devDependency of the spaces
+    # test harness), so fetch the pinned v4.3.1 build rather than copying it.
     url = (
         "https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/"
         "iframeResizer.contentWindow.min.js"


### PR DESCRIPTION
We've had many reports of embedded Gradio apps growing **infinitely tall** on HF Spaces, including these two:
- **#12089** — a component height set with `vh`/`%` units grows without bound (regressed between v5.34 and v5.49).
- **#12992** — `fill_height` apps grow without bound when launched with `footer_links=[]` (since 6.9.0).

## Root cause and fix

When embedded on Spaces, the app reports its own height via `parentIFrame.size()` from a `ResizeObserver` on the root container (`js/core/src/Blocks.svelte`). Content sized in `vh`/`%`, or stretched by `fill_height`, grows to fill whatever height the iframe is given — so its measured bottom just **tracks the viewport**. The unconditional `+ 32` padding then makes every report larger than the last, so each report grows the iframe → grows the content → triggers another report: an unbounded feedback loop. The closing `ResizeObserver` was added in #11919 (v5.49); `fill_height` being restored in #12956 (6.9.0) supplied a second elastic-content trigger; and `footer_links=[]` removed the footer slack that had been masking it.

> For `fill_height` (#12992) the divergence is **start-height dependent**: at a small iframe height the content doesn't fully fill, leaving a stabilizing gap, so it only runs away once the iframe is tall enough to be fully filled — which is exactly the case on a real Space, and why it doesn't reproduce when you run the app directly.

**1. `handle_resize` (`js/core/src/Blocks.svelte`)** now:
1. **skips growth when content merely fills the viewport** (no genuine overflow),
2. **ignores sub-pixel echoes** from our own resize, and
3. trips a **circuit breaker** after several consecutive grows (a self-induced loop), so the reported height stays bounded.

## Verification

This Space demonstrates the issue: https://huggingface.co/spaces/abidlabs/embed-height-bug-12089
Same Space but with this wheel no longer has the issue: https://huggingface.co/spaces/abidlabs/embed-height-bug-12089-fixed

Closes #12089
Closes #12992
