### PR TITLE
ci: speed up functional tests + frontend profiling

### DIFF
--- a/.config/playwright.config.js
+++ b/.config/playwright.config.js
@@ -18,7 +18,16 @@ const base = defineConfig({
 	timeout: 30_000,
 	testMatch: /.*\.spec\.ts/,
 	testDir: "..",
-	workers: process.env.CUSTOM_TEST ? 1 : process.env.CI ? 4 : undefined,
+	// Reload tests must stay serial (CUSTOM_TEST=1) — several rewrite a shared
+	// `run.py` in the same cwd, so parallel workers would clobber each other.
+	// For the regular browser suite on CI, allow PW_BROWSER_WORKERS to raise the
+	// count above the historical default of 4 (the runner has 16 cores and the
+	// tests are largely wait-bound, so they parallelize well).
+	workers: process.env.CUSTOM_TEST
+		? 1
+		: process.env.CI
+			? Number(process.env.PW_BROWSER_WORKERS) || 4
+			: undefined,
 	retries: 3,
 	fullyParallel: false
 });

--- a/.github/actions/install-all-deps/action.yml
+++ b/.github/actions/install-all-deps/action.yml
@@ -8,6 +8,9 @@ inputs:
   skip_gradio_install:
     description: "Skip installing gradio/client and building frontend (use when installing from pre-built wheels)"
     default: "false"
+  skip_docs_gen:
+    description: "Skip generating website docs (CSS-var docs + website JSON). Not needed for functional/browser tests; saves ~80s."
+    default: "false"
   test:
     description: "Test"
     default: "false"
@@ -125,13 +128,13 @@ runs:
         skip_build: ${{ inputs.skip_build }}
     - name: generate css vars docs
       shell: bash
-      if: inputs.skip_gradio_install != 'true' && inputs.os == 'ubuntu-latest'
+      if: inputs.skip_gradio_install != 'true' && inputs.skip_docs_gen != 'true' && inputs.os == 'ubuntu-latest'
       run: |
         . ${{ env.VENV_ACTIVATE }}
         [ -f scripts/generate_css_vars_docs.py ] && python scripts/generate_css_vars_docs.py || true
     - name: generate json
       shell: bash
-      if: inputs.skip_gradio_install != 'true' && inputs.os == 'ubuntu-latest'
+      if: inputs.skip_gradio_install != 'true' && inputs.skip_docs_gen != 'true' && inputs.os == 'ubuntu-latest'
       run: |
         . ${{ env.VENV_ACTIVATE }}
         uv pip install boto3 markdown requests && python js/_website/generate_jsons/generate.py

--- a/.github/workflows/frontend_profiling.yml
+++ b/.github/workflows/frontend_profiling.yml
@@ -60,62 +60,30 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      - name: Checkout latest release
-        if: steps.changes.outputs.should_run == 'true'
-        run: git checkout ${{ steps.latest_tag.outputs.tag }}
-
-      - name: Create venv and install Python deps (base)
+      # Install the benchmark "base" (latest release) straight from PyPI instead
+      # of checking out the tag and rebuilding it — the published wheel already
+      # ships the built frontend (gradio/templates), so this drops the ~4min base
+      # `pnpm build` on every run. We stay on the PR checkout the whole job: the
+      # benchmark spec + demo are the PR's versions for both runs, and the demo is
+      # launched as `python <runner>.py` (the runner/demo dir is on sys.path, not
+      # the cwd), so `import gradio` resolves to the installed package — the wheel
+      # here, the editable PR build later. Base and PR use separate venvs so the
+      # PR's editable install can't shadow the base wheel.
+      - name: Install base gradio from the published release (base)
         if: steps.changes.outputs.should_run == 'true'
         run: |
           export PATH="$HOME/.cargo/bin:$PATH"
-          uv venv --allow-existing venv --python=3.10
-          . venv/bin/activate
-          uv pip install -e client/python
-          uv pip install -e ".[oauth,mcp]"
+          uv venv --python=3.10 venv_base
+          . venv_base/bin/activate
+          TAG="${{ steps.latest_tag.outputs.tag }}"
+          uv pip install "gradio==${TAG#gradio@}"
 
-      # The benchmark "base" is the latest release tag — identical across every
-      # PR until the next release — yet it was rebuilt from scratch on every run
-      # (~4min). Cache the built frontend keyed on the tag and skip `pnpm build`
-      # on subsequent runs. We use restore + explicit save (rather than plain
-      # actions/cache) because the PR build later overwrites gradio/templates;
-      # auto-save at post-job would cache PR output under the base-tag key.
-      - name: Restore base frontend build (keyed on release tag)
+      - name: Install frontend test deps (base)
         if: steps.changes.outputs.should_run == 'true'
-        id: base_build_cache
-        uses: actions/cache/restore@v4
-        with:
-          path: gradio/templates
-          key: frontend-profiling-base-${{ runner.os }}-${{ steps.latest_tag.outputs.tag }}
-
-      - name: Install frontend deps (base)
-        if: steps.changes.outputs.should_run == 'true'
+        # node_modules is only needed to run the Playwright benchmark (no build).
         run: |
           pnpm i --frozen-lockfile --ignore-scripts
           pnpm add -Dw --ignore-scripts playwright@$PLAYWRIGHT_VERSION @playwright/test@$PLAYWRIGHT_VERSION
-          pnpm css
-
-      - name: Build frontend (base)
-        if: steps.changes.outputs.should_run == 'true' && steps.base_build_cache.outputs.cache-hit != 'true'
-        run: pnpm build
-
-      - name: Save base frontend build (keyed on release tag)
-        # Save right after the base build, before the PR build overwrites
-        # gradio/templates. Only on a miss (cache/save no-ops if key exists).
-        if: steps.changes.outputs.should_run == 'true' && steps.base_build_cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: gradio/templates
-          key: frontend-profiling-base-${{ runner.os }}-${{ steps.latest_tag.outputs.tag }}
-
-      - name: Pin Playwright with browser-extraction fix (base)
-        if: steps.changes.outputs.should_run == 'true'
-        # The latest release (the benchmark base) pins Playwright ^1.56, whose
-        # browser download hangs during extraction on current CI runners
-        # (microsoft/playwright#40724, fixed in 1.60 — the version this repo
-        # already uses everywhere else). Pin the base env to the fixed version so
-        # `playwright install` below succeeds; this also runs the base benchmark
-        # on the same Playwright as the PR side for an apples-to-apples harness.
-        run: pnpm add -w playwright@1.60.0 @playwright/test@1.60.0
 
       - name: Cache Playwright Browsers
         if: steps.changes.outputs.should_run == 'true'
@@ -131,23 +99,13 @@ jobs:
         timeout-minutes: 3
         run: pnpm exec playwright install chromium --only-shell
 
-      - name: Checkout benchmark spec and demo from PR
-        if: steps.changes.outputs.should_run == 'true'
-        run: git checkout ${{ github.event.pull_request.head.sha }} -- js/spa/test/big_complex_demo.spec.ts demo/big_complex_demo
-
       - name: Run benchmark (base)
         if: steps.changes.outputs.should_run == 'true'
         run: |
-          . venv/bin/activate
+          . venv_base/bin/activate
           PERF_RESULTS_FILE=/tmp/bench_base.json pnpm exec playwright test \
             --config .config/playwright.config.js \
             js/spa/test/big_complex_demo.spec.ts
-
-      - name: Checkout PR branch
-        if: steps.changes.outputs.should_run == 'true'
-        run: |
-          git clean -fd
-          git checkout -f ${{ github.event.pull_request.head.sha }}
 
       - name: Install and build PR
         if: steps.changes.outputs.should_run == 'true'

--- a/.github/workflows/frontend_profiling.yml
+++ b/.github/workflows/frontend_profiling.yml
@@ -73,13 +73,39 @@ jobs:
           uv pip install -e client/python
           uv pip install -e ".[oauth,mcp]"
 
-      - name: Install frontend deps and build (base)
+      # The benchmark "base" is the latest release tag — identical across every
+      # PR until the next release — yet it was rebuilt from scratch on every run
+      # (~4min). Cache the built frontend keyed on the tag and skip `pnpm build`
+      # on subsequent runs. We use restore + explicit save (rather than plain
+      # actions/cache) because the PR build later overwrites gradio/templates;
+      # auto-save at post-job would cache PR output under the base-tag key.
+      - name: Restore base frontend build (keyed on release tag)
+        if: steps.changes.outputs.should_run == 'true'
+        id: base_build_cache
+        uses: actions/cache/restore@v4
+        with:
+          path: gradio/templates
+          key: frontend-profiling-base-${{ runner.os }}-${{ steps.latest_tag.outputs.tag }}
+
+      - name: Install frontend deps (base)
         if: steps.changes.outputs.should_run == 'true'
         run: |
           pnpm i --frozen-lockfile --ignore-scripts
           pnpm add -Dw --ignore-scripts playwright@$PLAYWRIGHT_VERSION @playwright/test@$PLAYWRIGHT_VERSION
           pnpm css
-          pnpm build
+
+      - name: Build frontend (base)
+        if: steps.changes.outputs.should_run == 'true' && steps.base_build_cache.outputs.cache-hit != 'true'
+        run: pnpm build
+
+      - name: Save base frontend build (keyed on release tag)
+        # Save right after the base build, before the PR build overwrites
+        # gradio/templates. Only on a miss (cache/save no-ops if key exists).
+        if: steps.changes.outputs.should_run == 'true' && steps.base_build_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: gradio/templates
+          key: frontend-profiling-base-${{ runner.os }}-${{ steps.latest_tag.outputs.tag }}
 
       - name: Pin Playwright with browser-extraction fix (base)
         if: steps.changes.outputs.should_run == 'true'

--- a/.github/workflows/test-functional.yml
+++ b/.github/workflows/test-functional.yml
@@ -84,14 +84,14 @@ jobs:
     if: needs.changes.outputs.should_run == 'true'
     steps:
       - uses: actions/checkout@v4
-      # install-all-deps is referenced locally (not @main) so this PR exercises
-      # its `skip_docs_gen` change. `skip_build: true` skips the frontend build
-      # (we download it from the `build` job instead); `skip_docs_gen: true`
-      # skips website JSON/CSS-var doc generation (~80s, irrelevant to browser
-      # tests). Can be flipped back to @main once merged.
+      # `skip_build: true` skips the frontend build (we download it from the
+      # `build` job instead). `skip_docs_gen: true` skips website JSON/CSS-var
+      # doc generation (~80s, irrelevant to browser tests); it's a new input on
+      # install-all-deps, so it only takes effect once this PR is merged and the
+      # @main action carries it (the current @main ignores the unknown input).
       - name: install dependencies
         id: install_deps
-        uses: "./.github/actions/install-all-deps"
+        uses: "gradio-app/gradio/.github/actions/install-all-deps@main"
         with:
           python_version: "3.10"
           test: true

--- a/.github/workflows/test-functional.yml
+++ b/.github/workflows/test-functional.yml
@@ -62,14 +62,25 @@ jobs:
           retention-days: 1
           include-hidden-files: true
   test:
-    name: "functional-test-SSR=${{ matrix.SSR }}"
+    # Browser legs keep their original check names (functional-test-SSR=true/
+    # false); reload runs as its own leg named functional-reload.
+    name: "${{ matrix.suite == 'reload' && 'functional-reload' || format('functional-test-SSR={0}', matrix.ssr) }}"
     permissions:
       contents: read
     runs-on: ubuntu-20.04-16core
     needs: [changes, build]
     strategy:
+      fail-fast: false
       matrix:
-        ssr: [true, false]
+        # Reload tests get their own leg instead of running after the browser
+        # suite inside each SSR leg: the ~99s serial reload run is taken off the
+        # browser legs' critical path. Reload doesn't depend on SSR mode (the
+        # reload step never set GRADIO_SSR_MODE), so it runs once here rather
+        # than redundantly in both legs.
+        include:
+          - { suite: browser, ssr: true }
+          - { suite: browser, ssr: false }
+          - { suite: reload }
     if: needs.changes.outputs.should_run == 'true'
     steps:
       - uses: actions/checkout@v4
@@ -115,6 +126,7 @@ jobs:
       - name: build essential packages
         run: pnpm --filter @gradio/utils --filter @gradio/theme package
       - name: run browser tests
+        if: matrix.suite == 'browser'
         env:
           GRADIO_SSR_MODE: ${{ matrix.ssr }}
           # 16-core runner + largely wait-bound tests → parallelize beyond the
@@ -125,19 +137,20 @@ jobs:
           pnpm test:browser
       - name: upload screenshots
         uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && matrix.suite == 'browser'
         with:
           name: playwright-screenshots-SSR-${{ matrix.ssr }}
           path: |
             ./test-results
       - name: run reload mode test
+        if: matrix.suite == 'reload'
         run: |
           . venv/bin/activate
           pnpm test:browser:reload
       - name: upload reload mode screenshots
         uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && matrix.suite == 'reload'
         with:
-          name: reload-mode-playwright-screenshots-SSR-${{ matrix.ssr }}
+          name: reload-mode-playwright-screenshots
           path: |
             ./test-results

--- a/.github/workflows/test-functional.yml
+++ b/.github/workflows/test-functional.yml
@@ -37,24 +37,66 @@ jobs:
         with:
           filter: "functional"
           token: ${{ secrets.GITHUB_TOKEN }}
+  build:
+    name: "build-frontend"
+    permissions:
+      contents: read
+    runs-on: ubuntu-20.04-16core
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      # Build the frontend exactly once and share it with both SSR test legs
+      # (below) via an artifact. Previously each leg rebuilt it independently,
+      # paying the ~3min `pnpm build` twice. This action sets up node/pnpm,
+      # installs deps and builds into `gradio/templates/**` (the SPA + the SSR
+      # server bundle) — no Python/venv needed (the build only reads the
+      # checked-in `gradio/package.json` for the version string).
+      - name: build frontend
+        uses: "gradio-app/gradio/.github/actions/install-frontend-deps@main"
+      - name: upload built frontend templates
+        uses: actions/upload-artifact@v4
+        with:
+          name: gradio-templates
+          path: gradio/templates
+          retention-days: 1
+          include-hidden-files: true
   test:
     name: "functional-test-SSR=${{ matrix.SSR }}"
     permissions:
       contents: read
     runs-on: ubuntu-20.04-16core
-    needs: changes
+    needs: [changes, build]
     strategy:
       matrix:
         ssr: [true, false]
     if: needs.changes.outputs.should_run == 'true'
     steps:
       - uses: actions/checkout@v4
+      # install-all-deps is referenced locally (not @main) so this PR exercises
+      # its `skip_docs_gen` change. `skip_build: true` skips the frontend build
+      # (we download it from the `build` job instead); `skip_docs_gen: true`
+      # skips website JSON/CSS-var doc generation (~80s, irrelevant to browser
+      # tests). Can be flipped back to @main once merged.
       - name: install dependencies
         id: install_deps
-        uses: "gradio-app/gradio/.github/actions/install-all-deps@main"
+        uses: "./.github/actions/install-all-deps"
         with:
           python_version: "3.10"
           test: true
+          skip_build: true
+          skip_docs_gen: true
+      - name: download built frontend templates
+        uses: actions/download-artifact@v4
+        with:
+          name: gradio-templates
+          path: gradio/templates
+      - name: verify frontend templates present
+        run: |
+          test -f gradio/templates/frontend/index.html \
+            || { echo "::error::frontend templates missing after artifact download"; ls -laR gradio/templates | head -50; exit 1; }
+          test -d gradio/templates/node/build \
+            || { echo "::error::SSR node build missing after artifact download"; ls -laR gradio/templates | head -50; exit 1; }
       - name: install dependencies for specific tests
         run: |
           . venv/bin/activate
@@ -75,6 +117,9 @@ jobs:
       - name: run browser tests
         env:
           GRADIO_SSR_MODE: ${{ matrix.ssr }}
+          # 16-core runner + largely wait-bound tests → parallelize beyond the
+          # historical default of 4 workers (see .config/playwright.config.js).
+          PW_BROWSER_WORKERS: 8
         run: |
           . venv/bin/activate
           pnpm test:browser


### PR DESCRIPTION
Speeds up the two slowest frontend-related CI workflows.

## 1. `functional` workflow: ~10.5 min/leg → ~3.8 min slowest leg

Before, one leg ([run](https://github.com/gradio-app/gradio/actions/runs/28389062296)): `install 302s` (a ~197s `pnpm build` run independently in **both** SSR legs + ~80s website-doc generation browser tests don't need) + `browser tests 207s` (only 4 workers on a 16-core runner) + `reload 98s` (run **redundantly in both legs** — reload never sets `GRADIO_SSR_MODE`).

- **Build the frontend once** in a shared `build` job; both SSR legs download `gradio/templates/**` as an artifact instead of each rebuilding it. The build needs only the checked-out repo + node (no Python).
- **Skip website-doc generation** in the test legs via a new `skip_docs_gen` input on the shared `install-all-deps` action (default `"false"`, so the 6 other callers are unchanged) — install dropped from **302s → 48s**.
- **8 browser workers** (was 4) via a scoped `PW_BROWSER_WORKERS` env (default stays 4, so storybook/snapshot runs are unaffected).
- **Reload tests get their own leg** (`functional-reload`) instead of running after the browser suite in both SSR legs. Browser legs keep their exact check names (`functional-test-SSR=true/false`).

Result with all four changes active ([run](https://github.com/gradio-app/gradio/actions/runs/28391599838), all ✅): `build 0.5m`, `SSR=true 3.8m`, `SSR=false 3.2m`, `reload 2.5m`.

> Note: `skip_docs_gen` is a new input on the `@main` `install-all-deps` action, so it only takes effect **after this PR merges** (the current `@main` action ignores the unknown input). Until then the test legs still run doc-gen (~80s) — the other three changes apply immediately.

## 2. `frontend-profiling` workflow: ~9.9 min → ~5.6 min, every run

The benchmark built the frontend twice (~4 min each, [run](https://github.com/gradio-app/gradio/actions/runs/28391006327)): once for the latest **release tag** ("base") and once for the PR — the benchmarks themselves take ~25s total.

- **Install the base from the published PyPI wheel** instead of checking out the tag and rebuilding it. The release wheel already ships the built frontend, so the base side drops the ~4min `pnpm build` entirely — on every run, no cache. The job stays on the PR checkout (benchmark spec + demo are the PR's for both runs); the demo is launched as `python <runner>.py` (runner/demo dir on `sys.path`, not cwd), so `import gradio` resolves to the installed package — the wheel for base, the editable build for PR. Base and PR use separate venvs so the editable install can't shadow the base wheel.

Result ([run](https://github.com/gradio-app/gradio/actions/runs/28397018596), ✅): base side ~40s (wheel install + deps + benchmark, no build); the remaining 235s is the PR build (the artifact being measured). `base benchmark` and `compare` both pass, confirming the wheel base produces a valid measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
