### PR TITLE
Remove unused external deps (bokeh/plotly/opencv) from e2e test setup

### DIFF
--- a/.github/workflows/test-functional.yml
+++ b/.github/workflows/test-functional.yml
@@ -108,11 +108,6 @@ jobs:
             || { echo "::error::frontend templates missing after artifact download"; ls -laR gradio/templates | head -50; exit 1; }
           test -d gradio/templates/node/build \
             || { echo "::error::SSR node build missing after artifact download"; ls -laR gradio/templates | head -50; exit 1; }
-      - name: install dependencies for specific tests
-        run: |
-          . venv/bin/activate
-          uv pip install -r demo/outbreak_forecast/requirements.txt
-          uv pip install -r demo/stream_video_out/requirements.txt
       - name: cache playwright browsers
         uses: actions/cache@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,8 +277,6 @@ pnpm test
 To install browser test dependencies:
 
 ```
-pip install -r demo/outbreak_forecast/requirements.txt
-pip install -r demo/stream_video_out/requirements.txt
 pnpm exec playwright install chromium firefox
 pnpm exec playwright install-deps chromium firefox
 pnpm --filter @gradio/utils --filter @gradio/theme package

--- a/js/README.md
+++ b/js/README.md
@@ -101,8 +101,6 @@ Currently the following checks are run in CI:
 ### functional test
 
 ```
-pip install -r demo/outbreak_forecast/requirements.txt
-pip install -r demo/stream_video_out/requirements.txt
 pnpm exec playwright install chromium firefox
 pnpm exec playwright install-deps chromium firefox
 pnpm --filter @gradio/utils --filter @gradio/theme package


### PR DESCRIPTION
Follow up from https://github.com/gradio-app/gradio/pull/13568, closes #11310.

I'll merge this in too when green since it's just CI

## Root cause

The `functional` workflow ran an **install dependencies for specific tests** step before the browser tests:

```yaml
uv pip install -r demo/outbreak_forecast/requirements.txt   # numpy, matplotlib, bokeh, plotly, altair
uv pip install -r demo/stream_video_out/requirements.txt    # opencv-python
```

Of those packages, the only ones **not already in `test/requirements.txt`** (installed for all functional CI) are **bokeh, plotly, and opencv-python**. And those three are used *only* by the two demos above — both of whose e2e specs are **entirely skipped**:

- `js/spa/test/outbreak_forecast.spec.ts` — every test is `test.fixme(...)`
- `js/spa/test/stream_video_out.spec.ts` — every test is `test.skip(...)` ("Not supported in CI")

Because the skips are at the declaration level, Playwright never runs their (auto) fixtures, so the demo apps are never launched and the external deps are never imported. The install step was pure overhead — uncached, slow, and an extra failure point on an already-flaky path (exactly as the issue describes).

## Fix

- Remove the `install dependencies for specific tests` step from `.github/workflows/test-functional.yml`.
- Remove the matching `pip install -r demo/.../requirements.txt` lines from the contributor docs (`js/README.md`, `CONTRIBUTING.md`) — which also addresses the stale setup steps noted in #11309.

No change to which tests actually run. Every other e2e demo only needs packages already present in `test/requirements.txt` (numpy, pandas, pillow, matplotlib, altair) — verified by cross-referencing each spec's demo `requirements.txt` against `test/requirements.txt`.

## Verification

The `functional` workflow on this PR runs the full browser e2e suite **without** the removed installs; a green run confirms no running test needed bokeh/plotly/opencv. (No repro demo applies — this is a CI/setup change.)