### PR TITLE
Fix `gr.ImageEditor` high CPU usage when idle

### DIFF
--- a/.changeset/image-editor-idle-cpu.md
+++ b/.changeset/image-editor-idle-cpu.md
@@ -1,0 +1,6 @@
+---
+"@gradio/imageeditor": patch
+"gradio": patch
+---
+
+fix:Fix `gr.ImageEditor` high CPU usage when idle by sleeping the render loop when nothing is changing

--- a/js/imageeditor/shared/core/editor.ts
+++ b/js/imageeditor/shared/core/editor.ts
@@ -74,6 +74,7 @@ export interface ImageEditorContext {
 	resize_canvas: (width: number, height: number) => void;
 	reset: () => void;
 	set_background_image: (image: Sprite) => void;
+	request_render: () => void;
 	pad_bottom: number;
 }
 
@@ -81,6 +82,8 @@ const spring_config = {
 	stiffness: 0.45,
 	damping: 0.8
 };
+
+const RENDER_IDLE_TIMEOUT_MS = 500;
 
 interface EditorStatePublic {
 	position: { x: number; y: number };
@@ -204,6 +207,15 @@ export class ImageEditor {
 	private overlay_graphics!: Graphics;
 	private pad_bottom: number;
 	private theme_mode: "dark" | "light";
+	private render_idle_remaining = RENDER_IDLE_TIMEOUT_MS;
+	private static readonly WAKE_EVENTS: string[] = [
+		"pointerdown",
+		"pointermove",
+		"pointerup",
+		"pointerenter",
+		"wheel"
+	];
+	private wake_render_loop_bound = this.wake_render_loop.bind(this);
 	constructor(options: ImageEditorOptions) {
 		this.pad_bottom = options.pad_bottom || 0;
 		this.dark = options.dark || false;
@@ -278,7 +290,8 @@ export class ImageEditor {
 			execute_command: this.execute_command.bind(this),
 			resize_canvas: this.resize_canvas.bind(this),
 			reset: this.reset.bind(this),
-			set_background_image: this.set_background_image.bind(this)
+			set_background_image: this.set_background_image.bind(this),
+			request_render: this.wake_render_loop.bind(this)
 		};
 	}
 
@@ -337,17 +350,20 @@ export class ImageEditor {
 			this.dimensions_value = dimensions;
 			this.image_container.width = dimensions.width;
 			this.image_container.height = dimensions.height;
+			this.wake_render_loop();
 		});
 
 		this.scale.subscribe((scale) => {
 			this.scale_value = scale;
+			this.wake_render_loop();
 		});
 
 		this.position.subscribe((position) => {
 			this.position_value = position;
+			this.wake_render_loop();
 		});
 
-		this.app.ticker.add(() => {
+		this.app.ticker.add((ticker) => {
 			this.image_container.scale.set(this.scale_value);
 			this.image_container.position.set(
 				this.position_value.x,
@@ -442,9 +458,26 @@ export class ImageEditor {
 			} else {
 				this.overlay_graphics.clear();
 			}
+
+			this.render_idle_remaining -= ticker.deltaMS;
+			if (this.render_idle_remaining <= 0) {
+				ticker.stop();
+			}
 		});
 
+		for (const event_name of ImageEditor.WAKE_EVENTS) {
+			canvas.addEventListener(event_name, this.wake_render_loop_bound);
+		}
+
+		this.wake_render_loop();
 		this.ready_resolve();
+	}
+
+	private wake_render_loop(): void {
+		this.render_idle_remaining = RENDER_IDLE_TIMEOUT_MS;
+		if (this.app?.ticker && !this.app.ticker.started) {
+			this.app.ticker.start();
+		}
 	}
 
 	private setup_containers(): void {
@@ -542,6 +575,7 @@ export class ImageEditor {
 		if (this.outline_container) {
 			this.outline_container.position.set(app_center_x, app_center_y);
 		}
+		this.wake_render_loop();
 	}
 
 	reset(): void {
@@ -557,6 +591,7 @@ export class ImageEditor {
 		if (brush) {
 			this.set_tool("draw");
 		}
+		this.wake_render_loop();
 	}
 
 	async set_image_properties(properties: {
@@ -647,6 +682,7 @@ export class ImageEditor {
 		for (const tool of this.tools.values()) {
 			tool.set_tool(this.current_tool, this.current_subtool);
 		}
+		this.wake_render_loop();
 	}
 
 	set_subtool(subtool: Subtool): void {
@@ -655,6 +691,7 @@ export class ImageEditor {
 		for (const tool of this.tools.values()) {
 			tool.set_tool(this.current_tool, this.current_subtool);
 		}
+		this.wake_render_loop();
 	}
 
 	set_background_image(image: Sprite): void {
@@ -829,6 +866,7 @@ export class ImageEditor {
 	}
 
 	private notify(event: "change" | "input"): void {
+		this.wake_render_loop();
 		for (const callback of this.event_callbacks.get(event) || []) {
 			callback();
 		}
@@ -836,6 +874,13 @@ export class ImageEditor {
 
 	destroy(): void {
 		if (!this.app) return;
+
+		const canvas = this.app.canvas as HTMLCanvasElement | undefined;
+		if (canvas) {
+			for (const event_name of ImageEditor.WAKE_EVENTS) {
+				canvas.removeEventListener(event_name, this.wake_render_loop_bound);
+			}
+		}
 
 		this.app?.destroy();
 	}
@@ -877,9 +922,11 @@ export class ImageEditor {
 			this.width,
 			this.height
 		);
+		this.wake_render_loop();
 	}
 
 	toggle_layer_visibility(id: string): void {
 		this.layer_manager.toggle_layer_visibility(id);
+		this.wake_render_loop();
 	}
 }


### PR DESCRIPTION
## Description

Fixes #7586

`gr.ImageEditor` pinned the CPU (70%+ in the reporter's case) whenever its browser tab was focused, even when the editor was completely idle.

### Root cause

The ImageEditor is built on Pixi.js, whose `Application` ticker auto-renders the stage every animation frame (`autoStart` defaults to `true`). On top of that, the editor adds a per-frame ticker callback that clears and redraws the canvas outline/overlay graphics. Nothing ever gates this, so the editor fully re-rendered at the display's refresh rate (60–120+ fps) forever — even when nothing on screen was changing. This matches the diagnosis from @pngwn on the issue ("the internal ticker that handles frame redraws runs always").

### Fix

Make the render loop idle-aware (`js/imageeditor/shared/core/editor.ts`). The ticker now stops itself after 500 ms of no activity, and is woken again on any signal that can change the scene:

- **Pointer/wheel events over the canvas** — brush drawing, the brush cursor following the pointer, crop-handle dragging, panning.
- **Spring animation frames** — zoom, pan, resize and image-fitting all animate through the `scale`/`position`/`dimensions` springs.
- **Discrete mutations** — `notify` (change/input), tool/subtool switches, layer add/remove/reorder/visibility, canvas resize and reset.

While idle the ticker is fully stopped, so the editor uses no CPU/GPU until the next interaction. The frame that crosses the idle threshold is still rendered (the renderer runs at a lower ticker priority later in the same tick), so the final state is always flushed and there is no stale-canvas flicker.

All existing rendering behaviour during interactions/animations is unchanged — the loop simply sleeps when there is nothing to draw.

### Verification

Built the frontend and ran a Playwright probe that counts frames actually rendered by the editor's ticker (`window.editor.app.ticker`):

```
Idle (2s, no interaction):      0 frames   | ticker.started=false
Interacting (2s, drawing):      221 frames | ticker.started=true
Idle again (2s):                0 frames   | ticker.started=false
```

So the editor renders ~110 fps while you draw and drops to a completely stopped ticker (0 frames) when idle. Before this change the ticker never stopped.

Existing ImageEditor e2e specs pass, confirming drawing, erasing, cropping, change/input events, uploads, clearing and canvas resizing still work:
- `image_editor_events` — 7/7 passed
- `image_editor_canvas_size` — passed

### Minimal repro demo (not committed)

```python
import gradio as gr


def edit_image(im):
    return [im["background"].size, im["background"], im["layers"][0], im["composite"]]


with gr.Blocks() as demo:
    with gr.Tab("ImageEditor"):
        im = gr.ImageEditor(type="pil")
        with gr.Group():
            with gr.Row():
                text_out = gr.Textbox(label="Edited Size")
            with gr.Row():
                im_out_1 = gr.Image(type="pil", label="Background")
                im_out_2 = gr.Image(type="pil", label="Layer 0")
                im_out_3 = gr.Image(type="pil", label="Composite")
        im.change(edit_image, outputs=[text_out, im_out_1, im_out_2, im_out_3], inputs=im)

demo.launch()
```

Open the ImageEditor, leave it idle, and watch the tab's CPU usage: it now drops to ~0 instead of staying pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
