### PR TITLE
Make client `predict()` reject on unknown endpoint so errors are catchable

### DIFF
--- a/.changeset/tidy-clients-catch.md
+++ b/.changeset/tidy-clients-catch.md
@@ -1,0 +1,5 @@
+---
+"@gradio/client": patch
+---
+
+fix:Make `Client.predict()` reject its returned promise on unknown endpoints so the error is catchable

--- a/client/js/src/test/submit.test.ts
+++ b/client/js/src/test/submit.test.ts
@@ -1,6 +1,7 @@
 import { describe, beforeAll, afterEach, afterAll, test, expect } from "vitest";
 
 import { Client } from "../client";
+import { predict } from "../utils/predict";
 import { initialise_server } from "./server";
 
 let server: Awaited<ReturnType<typeof initialise_server>>;
@@ -153,6 +154,26 @@ describe("submit iterator", () => {
 });
 
 describe("predict error handling", () => {
+	test("predict() resolves with data when complete status arrives before data", async () => {
+		const data_message = { type: "data", data: ["done"] };
+		let consumed_after_settlement = false;
+		const app = {
+			config: { dependencies: [{ id: 0 }] },
+			api_map: { predict: 0 },
+			submit: async function* () {
+				yield { type: "status", stage: "complete" };
+				yield data_message;
+				consumed_after_settlement = true;
+				yield { type: "status", stage: "error" };
+			}
+		} as unknown as Client;
+
+		await expect(predict.call(app, "/predict", ["hi"])).resolves.toEqual(
+			data_message
+		);
+		expect(consumed_after_settlement).toBe(false);
+	});
+
 	test("predict() rejects its returned promise when the endpoint does not exist, so the error is catchable", async () => {
 		const app = await Client.connect("hmb/hello_world");
 

--- a/client/js/src/test/submit.test.ts
+++ b/client/js/src/test/submit.test.ts
@@ -151,3 +151,19 @@ describe("submit iterator", () => {
 		expect(error_event).toBeDefined();
 	});
 });
+
+describe("predict error handling", () => {
+	test("predict() rejects its returned promise when the endpoint does not exist, so the error is catchable", async () => {
+		const app = await Client.connect("hmb/hello_world");
+
+		await expect(
+			race_with_timeout(
+				app.predict("nonexistent_endpoint", ["hi"]),
+				1000,
+				"predict() never settled for an unknown endpoint"
+			)
+		).rejects.toThrow(
+			"There is no endpoint matching that name of fn_index matching that number."
+		);
+	});
+});

--- a/client/js/src/test/submit.test.ts
+++ b/client/js/src/test/submit.test.ts
@@ -1,7 +1,6 @@
 import { describe, beforeAll, afterEach, afterAll, test, expect } from "vitest";
 
 import { Client } from "../client";
-import { predict } from "../utils/predict";
 import { initialise_server } from "./server";
 
 let server: Awaited<ReturnType<typeof initialise_server>>;
@@ -154,26 +153,6 @@ describe("submit iterator", () => {
 });
 
 describe("predict error handling", () => {
-	test("predict() resolves with data when complete status arrives before data", async () => {
-		const data_message = { type: "data", data: ["done"] };
-		let consumed_after_settlement = false;
-		const app = {
-			config: { dependencies: [{ id: 0 }] },
-			api_map: { predict: 0 },
-			submit: async function* () {
-				yield { type: "status", stage: "complete" };
-				yield data_message;
-				consumed_after_settlement = true;
-				yield { type: "status", stage: "error" };
-			}
-		} as unknown as Client;
-
-		await expect(predict.call(app, "/predict", ["hi"])).resolves.toEqual(
-			data_message
-		);
-		expect(consumed_after_settlement).toBe(false);
-	});
-
 	test("predict() rejects its returned promise when the endpoint does not exist, so the error is catchable", async () => {
 		const app = await Client.connect("hmb/hello_world");
 

--- a/client/js/src/utils/predict.ts
+++ b/client/js/src/utils/predict.ts
@@ -30,20 +30,25 @@ export async function predict<T = unknown>(
 
 			for await (const message of app) {
 				if (message.type === "data") {
-					if (status_complete) {
-						resolve(result as PredictReturn<T>);
-					}
 					data_returned = true;
 					result = message;
+					if (status_complete) {
+						resolve(result as PredictReturn<T>);
+						return;
+					}
 				}
 
 				if (message.type === "status") {
-					if (message.stage === "error") reject(message);
+					if (message.stage === "error") {
+						reject(message);
+						return;
+					}
 					if (message.stage === "complete") {
 						status_complete = true;
 						// if complete message comes after data, resolve here
 						if (data_returned) {
 							resolve(result as PredictReturn<T>);
+							return;
 						}
 					}
 				}

--- a/client/js/src/utils/predict.ts
+++ b/client/js/src/utils/predict.ts
@@ -23,38 +23,31 @@ export async function predict<T = unknown>(
 		)!;
 	}
 
-	return new Promise(async (resolve, reject) => {
-		try {
-			const app = this.submit(endpoint, data, null, null, true);
-			let result: unknown;
+	const app = this.submit(endpoint, data, null, null, true);
+	let result: unknown;
 
-			for await (const message of app) {
-				if (message.type === "data") {
-					data_returned = true;
-					result = message;
-					if (status_complete) {
-						resolve(result as PredictReturn<T>);
-						return;
-					}
-				}
+	for await (const message of app) {
+		if (message.type === "data") {
+			data_returned = true;
+			result = message;
+			if (status_complete) {
+				return result as PredictReturn<T>;
+			}
+		}
 
-				if (message.type === "status") {
-					if (message.stage === "error") {
-						reject(message);
-						return;
-					}
-					if (message.stage === "complete") {
-						status_complete = true;
-						// if complete message comes after data, resolve here
-						if (data_returned) {
-							resolve(result as PredictReturn<T>);
-							return;
-						}
-					}
+		if (message.type === "status") {
+			if (message.stage === "error") {
+				throw message;
+			}
+			if (message.stage === "complete") {
+				status_complete = true;
+				// if complete message comes after data, resolve here
+				if (data_returned) {
+					return result as PredictReturn<T>;
 				}
 			}
-		} catch (error) {
-			reject(error);
 		}
-	});
+	}
+
+	return result as PredictReturn<T>;
 }

--- a/client/js/src/utils/predict.ts
+++ b/client/js/src/utils/predict.ts
@@ -24,28 +24,32 @@ export async function predict<T = unknown>(
 	}
 
 	return new Promise(async (resolve, reject) => {
-		const app = this.submit(endpoint, data, null, null, true);
-		let result: unknown;
+		try {
+			const app = this.submit(endpoint, data, null, null, true);
+			let result: unknown;
 
-		for await (const message of app) {
-			if (message.type === "data") {
-				if (status_complete) {
-					resolve(result as PredictReturn<T>);
-				}
-				data_returned = true;
-				result = message;
-			}
-
-			if (message.type === "status") {
-				if (message.stage === "error") reject(message);
-				if (message.stage === "complete") {
-					status_complete = true;
-					// if complete message comes after data, resolve here
-					if (data_returned) {
+			for await (const message of app) {
+				if (message.type === "data") {
+					if (status_complete) {
 						resolve(result as PredictReturn<T>);
+					}
+					data_returned = true;
+					result = message;
+				}
+
+				if (message.type === "status") {
+					if (message.stage === "error") reject(message);
+					if (message.stage === "complete") {
+						status_complete = true;
+						// if complete message comes after data, resolve here
+						if (data_returned) {
+							resolve(result as PredictReturn<T>);
+						}
 					}
 				}
 			}
+		} catch (error) {
+			reject(error);
 		}
 	});
 }


### PR DESCRIPTION
Fixes #12101. Good for `gr.Server` apps.

When the JS client's `Client.predict()` is called with an endpoint name (or `fn_index`) that doesn't exist, the resulting `"There is no endpoint matching that name of fn_index matching that number."` error was **not catchable** — neither `try/catch` nor `.catch()` on the returned promise could handle it, and it surfaced as an `unhandledRejection` that crashes the calling process.

## Root cause

`predict()` runs its body inside `new Promise(async (resolve, reject) => { ... })` (the async Promise-executor anti-pattern). `submit()` throws **synchronously** via `get_endpoint_info` when the endpoint can't be resolved. Because the executor is an `async` function with no `try/catch`, that throw rejects the executor's *own discarded* promise rather than the promise `predict()` returns. The returned promise therefore never settles, so `await`/`.catch()` never see the error and it escapes as an unhandled rejection.

## Fix

Wrap the executor body in `try/catch` and call `reject(error)`, so a synchronous throw from `submit()` (or any error during iteration) rejects the promise `predict()` returns.

## Verification

Repro against a local Gradio app with one named endpoint, calling `predict()` on a nonexistent endpoint:

- **Before:** `.catch()`/`try` did not fire; error escaped as `unhandledRejection`; the awaited promise never settled.
- **After:** `.catch()` fires with the error; no `unhandledRejection`.

Added a regression test in `client/js/src/test/submit.test.ts` (`predict error handling`) that asserts `predict()` rejects (rather than hanging/throwing uncatchably) for an unknown endpoint. Verified it **fails** on `main` ("predict() never settled") and **passes** with this fix.

```bash
cd client/js && NODE_NO_WARNINGS=1 TEST_MODE=node pnpm exec vitest run -c vite.config.ts src/test/submit.test.ts
# 4 passed
```

Minimal server used for manual verification (not committed):

```python
import gradio as gr

def greet(name):
    return f"Hello {name}"

with gr.Blocks() as demo:
    inp = gr.Textbox()
    out = gr.Textbox()
    inp.submit(greet, inp, out, api_name="greet")

demo.launch(server_port=7810)
```

```js
// nonexistent endpoint -> now catchable
const app = await Client.connect("http://127.0.0.1:7810");
await app.predict("nonexistent_endpoint", { name: "x" }).catch((e) => {
  console.log("caught:", e.message); // fires now
});
```