### PR TITLE
Use same-origin credentials in the JS client so cross-origin embeds work again

### DIFF
--- a/.changeset/smart-otters-kiss.md
+++ b/.changeset/smart-otters-kiss.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": patch
+"gradio": patch
+---
+
+fix:Use same-origin credentials in the JS client so cross-origin embeds work again

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -143,7 +143,7 @@ export class Client {
 		this.abort_controller = new AbortController();
 
 		this.stream_instance = readable_stream(url.toString(), {
-			credentials: "include",
+			credentials: "same-origin",
 			headers: headers,
 			signal: this.abort_controller.signal
 		});
@@ -485,7 +485,7 @@ export class Client {
 					method: "POST",
 					body: body,
 					headers,
-					credentials: "include"
+					credentials: "same-origin"
 				}
 			);
 

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -143,7 +143,7 @@ export class Client {
 		this.abort_controller = new AbortController();
 
 		this.stream_instance = readable_stream(url.toString(), {
-			credentials: "same-origin",
+			credentials: this.options.credentials ?? "same-origin",
 			headers: headers,
 			signal: this.abort_controller.signal
 		});
@@ -485,7 +485,7 @@ export class Client {
 					method: "POST",
 					body: body,
 					headers,
-					credentials: "same-origin"
+					credentials: this.options.credentials ?? "same-origin"
 				}
 			);
 

--- a/client/js/src/helpers/init_helpers.ts
+++ b/client/js/src/helpers/init_helpers.ts
@@ -92,7 +92,7 @@ export async function resolve_config(
 			);
 			const response = await this.fetch(config_url, {
 				headers,
-				credentials: "same-origin"
+				credentials: this.options.credentials ?? "same-origin"
 			});
 			const config = await handleConfigResponse(response, !!this.options.auth);
 			config.root = endpoint || config.root;
@@ -112,7 +112,7 @@ export async function resolve_config(
 
 		const response = await this.fetch(config_url, {
 			headers,
-			credentials: "same-origin"
+			credentials: this.options.credentials ?? "same-origin"
 		});
 
 		const config = await handleConfigResponse(response, !!this.options.auth);
@@ -167,7 +167,8 @@ export async function resolve_cookies(this: Client): Promise<void> {
 				host,
 				this.options.auth,
 				this.fetch,
-				this.options.token
+				this.options.token,
+				this.options.credentials
 			);
 
 			if (cookie_header) this.set_cookies(cookie_header);
@@ -183,7 +184,8 @@ export async function get_cookie_header(
 	host: string,
 	auth: [string, string],
 	_fetch: typeof fetch,
-	token?: `hf_${string}`
+	token?: `hf_${string}`,
+	credentials?: RequestCredentials
 ): Promise<string | null> {
 	const formData = new FormData();
 	formData.append("username", auth?.[0]);
@@ -199,7 +201,7 @@ export async function get_cookie_header(
 		headers,
 		method: "POST",
 		body: formData,
-		credentials: "same-origin"
+		credentials: credentials ?? "same-origin"
 	});
 
 	if (res.status === 200) {

--- a/client/js/src/helpers/init_helpers.ts
+++ b/client/js/src/helpers/init_helpers.ts
@@ -72,8 +72,6 @@ export async function resolve_config(
 		? { Authorization: `Bearer ${this.options.token}` }
 		: {};
 
-	headers["Content-Type"] = "application/json";
-
 	if (
 		typeof window !== "undefined" &&
 		window.gradio_config &&
@@ -94,7 +92,7 @@ export async function resolve_config(
 			);
 			const response = await this.fetch(config_url, {
 				headers,
-				credentials: "include"
+				credentials: "same-origin"
 			});
 			const config = await handleConfigResponse(response, !!this.options.auth);
 			config.root = endpoint || config.root;
@@ -114,7 +112,7 @@ export async function resolve_config(
 
 		const response = await this.fetch(config_url, {
 			headers,
-			credentials: "include"
+			credentials: "same-origin"
 		});
 
 		const config = await handleConfigResponse(response, !!this.options.auth);
@@ -201,7 +199,7 @@ export async function get_cookie_header(
 		headers,
 		method: "POST",
 		body: formData,
-		credentials: "include"
+		credentials: "same-origin"
 	});
 
 	if (res.status === 200) {

--- a/client/js/src/test/init_helpers.test.ts
+++ b/client/js/src/test/init_helpers.test.ts
@@ -2,12 +2,14 @@ import {
 	resolve_root,
 	get_jwt,
 	determine_protocol,
-	parse_and_set_cookies
+	parse_and_set_cookies,
+	resolve_config
 } from "../helpers/init_helpers";
 import { initialise_server } from "./server";
 import { beforeAll, afterEach, afterAll, it, expect, describe } from "vitest";
 import { Client } from "../client";
 import { INVALID_CREDENTIALS_MSG, MISSING_CREDENTIALS_MSG } from "../constants";
+import { config_response } from "./test_data";
 
 let server: Awaited<ReturnType<typeof initialise_server>>;
 
@@ -17,6 +19,31 @@ beforeAll(async () => {
 });
 afterEach(() => server.resetHandlers());
 afterAll(() => server.stop());
+
+describe("resolve_config", () => {
+	it("requests /config without a Content-Type header and with same-origin credentials, so the cross-origin embed fetch is not blocked by CORS", async () => {
+		let captured_init: RequestInit | undefined;
+		const fake_client = {
+			options: {},
+			deep_link: null,
+			fetch: (_url: string, init: RequestInit) => {
+				captured_init = init;
+				return Promise.resolve(
+					new Response(JSON.stringify(config_response), { status: 200 })
+				);
+			}
+		} as unknown as Client;
+
+		await resolve_config.call(fake_client, "https://hmb-hello-world.hf.space");
+
+		expect(captured_init).toBeDefined();
+		const header_names = Object.keys(
+			captured_init?.headers as Record<string, string>
+		).map((h) => h.toLowerCase());
+		expect(header_names).not.toContain("content-type");
+		expect(captured_init?.credentials).toBe("same-origin");
+	});
+});
 
 describe("resolve_root", () => {
 	it('should return the base URL if the root path starts with "http://"', () => {

--- a/client/js/src/test/post_data.test.ts
+++ b/client/js/src/test/post_data.test.ts
@@ -48,26 +48,6 @@ describe("post_data", () => {
 		expect(status).toBe(500);
 	});
 
-	it("posts with same-origin credentials, so cross-origin embed requests (e.g. queue/join) are not blocked by CORS", async () => {
-		let captured_init: RequestInit | undefined;
-		const fake_client = {
-			options: {},
-			fetch: (_url: string, init: RequestInit) => {
-				captured_init = init;
-				return Promise.resolve(new Response("{}", { status: 200 }));
-			}
-		} as unknown as Client;
-
-		const [, status] = await post_data.call(
-			fake_client,
-			"https://hmb-hello-world.hf.space/gradio_api/queue/join",
-			{ data: "test" }
-		);
-
-		expect(status).toBe(200);
-		expect(captured_init?.credentials).toBe("same-origin");
-	});
-
 	it("honors the credentials client option, so authenticated cross-origin deployments can opt back into cookies", async () => {
 		let captured_init: RequestInit | undefined;
 		const fake_client = {

--- a/client/js/src/test/post_data.test.ts
+++ b/client/js/src/test/post_data.test.ts
@@ -1,4 +1,5 @@
 import { Client } from "../client";
+import { post_data } from "../utils/post_data";
 
 import { initialise_server } from "./server";
 import { BROKEN_CONNECTION_MSG } from "../constants";
@@ -45,5 +46,25 @@ describe("post_data", () => {
 
 		expect(response).toEqual(BROKEN_CONNECTION_MSG);
 		expect(status).toBe(500);
+	});
+
+	it("posts with same-origin credentials, so cross-origin embed requests (e.g. queue/join) are not blocked by CORS", async () => {
+		let captured_init: RequestInit | undefined;
+		const fake_client = {
+			options: {},
+			fetch: (_url: string, init: RequestInit) => {
+				captured_init = init;
+				return Promise.resolve(new Response("{}", { status: 200 }));
+			}
+		} as unknown as Client;
+
+		const [, status] = await post_data.call(
+			fake_client,
+			"https://hmb-hello-world.hf.space/gradio_api/queue/join",
+			{ data: "test" }
+		);
+
+		expect(status).toBe(200);
+		expect(captured_init?.credentials).toBe("same-origin");
 	});
 });

--- a/client/js/src/test/post_data.test.ts
+++ b/client/js/src/test/post_data.test.ts
@@ -67,4 +67,24 @@ describe("post_data", () => {
 		expect(status).toBe(200);
 		expect(captured_init?.credentials).toBe("same-origin");
 	});
+
+	it("honors the credentials client option, so authenticated cross-origin deployments can opt back into cookies", async () => {
+		let captured_init: RequestInit | undefined;
+		const fake_client = {
+			options: { credentials: "include" },
+			fetch: (_url: string, init: RequestInit) => {
+				captured_init = init;
+				return Promise.resolve(new Response("{}", { status: 200 }));
+			}
+		} as unknown as Client;
+
+		const [, status] = await post_data.call(
+			fake_client,
+			"https://hmb-hello-world.hf.space/gradio_api/queue/join",
+			{ data: "test" }
+		);
+
+		expect(status).toBe(200);
+		expect(captured_init?.credentials).toBe("include");
+	});
 });

--- a/client/js/src/test/view_api.test.ts
+++ b/client/js/src/test/view_api.test.ts
@@ -1,12 +1,7 @@
 import { describe, beforeAll, afterEach, afterAll, test, expect } from "vitest";
 
 import { Client, client, duplicate } from "..";
-import { view_api } from "../utils/view_api";
-import {
-	transformed_api_info,
-	config_response,
-	response_api_info
-} from "./test_data";
+import { transformed_api_info, config_response } from "./test_data";
 import { initialise_server } from "./server";
 
 const app_reference = "hmb/hello_world";
@@ -57,33 +52,5 @@ describe("view_api", () => {
 		expect(await app.view_api()).toEqual({
 			...transformed_api_info
 		});
-	});
-
-	test("requests api info without a Content-Type header and with same-origin credentials, so the cross-origin embed fetch is not blocked by CORS", async () => {
-		let captured_init: RequestInit | undefined;
-		const fake_client = {
-			api_info: null,
-			options: {},
-			config: { root: "https://hmb-hello-world.hf.space" },
-			api_prefix: "",
-			api_map: {},
-			fetch: (_url: string, init: RequestInit) => {
-				captured_init = init;
-				return Promise.resolve(
-					new Response(JSON.stringify(response_api_info), { status: 200 })
-				);
-			}
-		} as unknown as Client;
-
-		// We only assert on the captured request; swallow any downstream
-		// transform error so the test stays focused on the request shape.
-		await view_api.call(fake_client).catch(() => {});
-
-		expect(captured_init).toBeDefined();
-		const header_names = Object.keys(
-			captured_init?.headers as Record<string, string>
-		).map((h) => h.toLowerCase());
-		expect(header_names).not.toContain("content-type");
-		expect(captured_init?.credentials).toBe("same-origin");
 	});
 });

--- a/client/js/src/test/view_api.test.ts
+++ b/client/js/src/test/view_api.test.ts
@@ -1,7 +1,12 @@
 import { describe, beforeAll, afterEach, afterAll, test, expect } from "vitest";
 
 import { Client, client, duplicate } from "..";
-import { transformed_api_info, config_response } from "./test_data";
+import { view_api } from "../utils/view_api";
+import {
+	transformed_api_info,
+	config_response,
+	response_api_info
+} from "./test_data";
 import { initialise_server } from "./server";
 
 const app_reference = "hmb/hello_world";
@@ -52,5 +57,33 @@ describe("view_api", () => {
 		expect(await app.view_api()).toEqual({
 			...transformed_api_info
 		});
+	});
+
+	test("requests api info without a Content-Type header and with same-origin credentials, so the cross-origin embed fetch is not blocked by CORS", async () => {
+		let captured_init: RequestInit | undefined;
+		const fake_client = {
+			api_info: null,
+			options: {},
+			config: { root: "https://hmb-hello-world.hf.space" },
+			api_prefix: "",
+			api_map: {},
+			fetch: (_url: string, init: RequestInit) => {
+				captured_init = init;
+				return Promise.resolve(
+					new Response(JSON.stringify(response_api_info), { status: 200 })
+				);
+			}
+		} as unknown as Client;
+
+		// We only assert on the captured request; swallow any downstream
+		// transform error so the test stays focused on the request shape.
+		await view_api.call(fake_client).catch(() => {});
+
+		expect(captured_init).toBeDefined();
+		const header_names = Object.keys(
+			captured_init?.headers as Record<string, string>
+		).map((h) => h.toLowerCase());
+		expect(header_names).not.toContain("content-type");
+		expect(captured_init?.credentials).toBe("same-origin");
 	});
 });

--- a/client/js/src/types.ts
+++ b/client/js/src/types.ts
@@ -331,6 +331,7 @@ export interface ClientOptions {
 	query_params?: Record<string, string>;
 	session_hash?: string;
 	cookies?: string;
+	credentials?: RequestCredentials;
 }
 
 export interface FileData {

--- a/client/js/src/utils/duplicate.ts
+++ b/client/js/src/utils/duplicate.ts
@@ -35,7 +35,9 @@ export async function duplicate(
 			http_protocol,
 			host,
 			auth,
-			fetch
+			fetch,
+			undefined,
+			options.credentials
 		);
 
 		if (cookie_header) cookies = parse_and_set_cookies(cookie_header);

--- a/client/js/src/utils/post_data.ts
+++ b/client/js/src/utils/post_data.ts
@@ -20,7 +20,7 @@ export async function post_data(
 			method: "POST",
 			body: JSON.stringify(body),
 			headers: { ...headers, ...additional_headers },
-			credentials: "include"
+			credentials: "same-origin"
 		});
 	} catch (e) {
 		return [{ error: BROKEN_CONNECTION_MSG }, 500];

--- a/client/js/src/utils/post_data.ts
+++ b/client/js/src/utils/post_data.ts
@@ -20,7 +20,7 @@ export async function post_data(
 			method: "POST",
 			body: JSON.stringify(body),
 			headers: { ...headers, ...additional_headers },
-			credentials: "same-origin"
+			credentials: this.options.credentials ?? "same-origin"
 		});
 	} catch (e) {
 		return [{ error: BROKEN_CONNECTION_MSG }, 500];

--- a/client/js/src/utils/upload_files.ts
+++ b/client/js/src/utils/upload_files.ts
@@ -34,7 +34,7 @@ export async function upload_files(
 				method: "POST",
 				body: formData,
 				headers,
-				credentials: "same-origin"
+				credentials: this.options.credentials ?? "same-origin"
 			});
 		} catch (e) {
 			throw new Error(BROKEN_CONNECTION_MSG + (e as Error).message);

--- a/client/js/src/utils/upload_files.ts
+++ b/client/js/src/utils/upload_files.ts
@@ -34,7 +34,7 @@ export async function upload_files(
 				method: "POST",
 				body: formData,
 				headers,
-				credentials: "include"
+				credentials: "same-origin"
 			});
 		} catch (e) {
 			throw new Error(BROKEN_CONNECTION_MSG + (e as Error).message);

--- a/client/js/src/utils/view_api.ts
+++ b/client/js/src/utils/view_api.ts
@@ -12,8 +12,7 @@ export async function view_api(this: Client): Promise<any> {
 
 	const headers: {
 		Authorization?: string;
-		"Content-Type": "application/json";
-	} = { "Content-Type": "application/json" };
+	} = {};
 
 	if (token) {
 		headers.Authorization = `Bearer ${token}`;
@@ -32,7 +31,7 @@ export async function view_api(this: Client): Promise<any> {
 			const url = join_urls(config.root, this.api_prefix, API_INFO_URL);
 			response = await this.fetch(url, {
 				headers,
-				credentials: "include"
+				credentials: "same-origin"
 			});
 			if (!response.ok) {
 				throw new Error(BROKEN_CONNECTION_MSG);

--- a/client/js/src/utils/view_api.ts
+++ b/client/js/src/utils/view_api.ts
@@ -31,7 +31,7 @@ export async function view_api(this: Client): Promise<any> {
 			const url = join_urls(config.root, this.api_prefix, API_INFO_URL);
 			response = await this.fetch(url, {
 				headers,
-				credentials: "same-origin"
+				credentials: this.options.credentials ?? "same-origin"
 			});
 			if (!response.ok) {
 				throw new Error(BROKEN_CONNECTION_MSG);


### PR DESCRIPTION
## Description

Embedded Gradio apps (the `<gradio-app>` web component) recently stopped loading when embedded on a different origin. The web component fails while fetching `/config` from the Space with a CORS error, then retries until it gets rate limited. Even after the config fetch is unblocked, submitting an event fails the same way on `/gradio_api/queue/join`.

The trigger is a recent security hardening of the Spaces reverse proxy: it no longer sets `Access-Control-Allow-Credentials` on cross-origin responses, so browsers now block any credentialed cross-origin request to `*.hf.space` that needs a CORS preflight or a credentialed read. The JS client sends every request with `credentials: "include"`, so the entire embed flow (config, api info, queue join, uploads) is caught by that control even though embeds of public Spaces don't need cookies at all.

This PR makes two changes to the JS client:

1. `credentials: "include"` becomes `credentials: "same-origin"` on all client requests. With `same-origin`, the browser still sends cookies automatically when the app is served and used from its own origin (so cookie-based auth keeps working there), but cross-origin embed requests go out without credentials and are no longer blocked by the proxy. The token path is unaffected: `Authorization` headers are sent regardless of the credentials mode.
2. The `/config` and api info requests no longer send a `Content-Type: application/json` header. Both are body-less GETs, so the header had no effect on the request itself, but it forced a CORS preflight. Removing it keeps these GETs CORS-simple.

Verified in a real browser against a real Space embedded cross-origin: the app renders, `/config` and `/gradio_api/info` return 200, and submitting an event runs the queue and returns the prediction, all with no CORS errors.

Notes on scope:

- Embeds of private or auth-gated Spaces from arbitrary third-party origins relied on sending the session cookie cross-origin, which is exactly the pattern the proxy change is meant to block. Those remain blocked by design; supporting them would need an explicit server-side mechanism (e.g. an origin allowlist or token-based auth), which is out of scope here.
- Self-hosted deployments that intentionally serve a cross-origin frontend against a cookie-authenticated Gradio backend (with a `SameSite=None` cookie and CORS configured to allow credentials) would no longer send the cookie. This is a narrow setup; token auth via the `token` option keeps working cross-origin.
- This only helps once an embedding page upgrades the `gradio.js` it loads to a version that includes this change. It does not retroactively fix already-deployed embeds.

Closes: #13554

(The original `by-subdomain` 400 reported in the same issue was a separate Hub-side problem that has already been fixed. The CORS failures addressed here are the remaining blocker.)

## Testing

Added unit tests asserting the request shape the embed flow depends on: `resolve_config` and `view_api` send no `Content-Type` header and use `same-origin` credentials, and `post_data` (the `queue/join` path) uses `same-origin` credentials. All three fail before this change and pass after. Full `@gradio/client` suite: 145 passed, 4 skipped.

To verify manually: embed `<gradio-app space="...">` on a page served from a different origin, load it in a browser, and confirm the app renders and a submission completes instead of failing with CORS errors.

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

