### PR TITLE
workflow: update input change handling

### DIFF
--- a/.changeset/fine-clowns-act.md
+++ b/.changeset/fine-clowns-act.md
@@ -1,0 +1,6 @@
+---
+"@gradio/workflowcanvas": minor
+"gradio": minor
+---
+
+feat:workflow: update input change handling

--- a/js/workflowcanvas/workflow/NodeWidget.svelte
+++ b/js/workflowcanvas/workflow/NodeWidget.svelte
@@ -208,7 +208,7 @@
 							? '{"key": "value"}'
 							: "Enter text..."}
 					disabled={isReadonly}
-					oninput={(val) => ondatachange(node.id, widgetPortId, val)}
+					onchange={(val) => { if (val !== getTextValue()) ondatachange(node.id, widgetPortId, val); }}
 				/>
 			</div>
 		</div>

--- a/js/workflowcanvas/workflow/NodeWidget.svelte
+++ b/js/workflowcanvas/workflow/NodeWidget.svelte
@@ -208,7 +208,10 @@
 							? '{"key": "value"}'
 							: "Enter text..."}
 					disabled={isReadonly}
-					onchange={(val) => { if (val !== getTextValue()) ondatachange(node.id, widgetPortId, val); }}
+					onchange={(val) => {
+						if (node.data?.[widgetPortId] !== val)
+							ondatachange(node.id, widgetPortId, val);
+					}}
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
fixes a bug that @AK391 found: pasting into a reference node's field doesn't register. fix is to replace oninput with onchange