### PR TITLE
Fire `state.change()` for streaming (`.stream()`) events

### DIFF
--- a/.changeset/purple-hairs-bow.md
+++ b/.changeset/purple-hairs-bow.md
@@ -1,0 +1,7 @@
+---
+"@gradio/client": patch
+"@gradio/core": patch
+"gradio": patch
+---
+
+fix:Fire `state.change()` for streaming (`.stream()`) events

--- a/client/js/src/helpers/api_info.ts
+++ b/client/js/src/helpers/api_info.ts
@@ -344,6 +344,7 @@ export function handle_message(
 					time_limit: data.time_limit,
 					code: data.code,
 					progress_data: data.progress_data,
+					changed_state_ids: data.output.changed_state_ids,
 					eta: data.eta
 				},
 				data: data.output

--- a/client/js/src/test/api_info.test.ts
+++ b/client/js/src/test/api_info.test.ts
@@ -184,6 +184,34 @@ describe("handle_message", () => {
 		});
 	});
 
+	it("should carry changed_state_ids in the streaming status when msg is 'process_streaming'", () => {
+		const data = {
+			msg: "process_streaming",
+			success: true,
+			code: 200,
+			time_limit: 30,
+			eta: 5,
+			progress_data: { current: 50, total: 100 },
+			output: { data: [1], changed_state_ids: [3] }
+		};
+		const last_status = "pending";
+		const result = handle_message(data, last_status);
+		expect(result).toEqual({
+			type: "streaming",
+			status: {
+				queue: true,
+				message: undefined,
+				stage: "streaming",
+				time_limit: 30,
+				code: 200,
+				progress_data: { current: 50, total: 100 },
+				changed_state_ids: [3],
+				eta: 5
+			},
+			data: { data: [1], changed_state_ids: [3] }
+		});
+	});
+
 	it("should return type 'complete' with success status when msg is 'process_completed' and success is true", () => {
 		const data = {
 			msg: "process_completed",

--- a/js/core/src/dependency.ts
+++ b/js/core/src/dependency.ts
@@ -481,7 +481,10 @@ export class DependencyManager {
 									});
 									this.update_loading_stati_state();
 									break submit_loop;
-								} else if (result.stage === "generating") {
+								} else if (
+									result.stage === "generating" ||
+									result.stage === "streaming"
+								) {
 									this.dispatch_state_change_events(result);
 									// @ts-ignore
 									this.loading_stati.update({


### PR DESCRIPTION
## Description

Updating a `gr.State` from a streaming event (`gr.Audio(streaming=True).stream(fn, inp, state)`) did not trigger the state's `.change()` listener, even though the same update from a regular event (for example `.start_recording(fn, inp, state)`) did.

The backend already computes `changed_state_ids` for streaming calls and sends it in the `process_streaming` message, so the data was reaching the client. The frontend dropped it in two places:

1. `client/js/src/helpers/api_info.ts` normalized the `process_streaming` message into a status object without copying `changed_state_ids` (the `process_generating` and `process_completed` cases already copy it).
2. `js/core/src/dependency.ts` only called `dispatch_state_change_events` for the `complete` and `generating` stages. A streaming chunk arrives with stage `streaming`, which fell through to the branch that skips the dispatch.

This was never a regression. The `state.change` feature (#8446) and its extension to generators (#9299) simply never wired up the separate streaming message path.

The fix carries `changed_state_ids` through the `process_streaming` case and handles the `streaming` stage alongside `generating` in the dispatch loop (their branch bodies are otherwise identical). The change still only fires when the state value actually changes, because the backend gates `changed_state_ids` behind a deep-hash comparison, matching the behavior of regular events.

Closes: #10285

## Testing

Added a unit test in `client/js/src/test/api_info.test.ts` that asserts `handle_message` carries `changed_state_ids` through a `process_streaming` message. It fails before the fix and passes after.

End-to-end verification of a live `.stream()` event needs a real media stream (microphone/webcam), which cannot run in CI (the existing audio-stream Playwright specs are skipped there for the same reason). Verified manually with the reproduction app from the issue: while recording from the microphone, the `state.change` handler now runs.

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

