### PR TITLE
workflow: make `call_space` async

### DIFF
--- a/.changeset/petite-pens-stop.md
+++ b/.changeset/petite-pens-stop.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:workflow: make call_space async to avoid blocking Client()
+feat:workflow: make `call_space` async

--- a/.changeset/petite-pens-stop.md
+++ b/.changeset/petite-pens-stop.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:workflow: make call_space async to avoid blocking Client()

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -508,7 +508,9 @@ async def call_space(
         if cached_entry and (now - cached_entry[0]) < _CLIENT_CACHE_TTL:
             client = cached_entry[1]
         else:
-            client = await asyncio.to_thread(Client, space_id, token=hf_token, httpx_kwargs={"timeout": None})
+            client = await asyncio.to_thread(
+                Client, space_id, token=hf_token, httpx_kwargs={"timeout": None}
+            )
             if len(_CLIENT_CACHE) >= 64:
                 cutoff = now - _CLIENT_CACHE_TTL
                 for k, (t, _) in list(_CLIENT_CACHE.items()):

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -500,10 +500,24 @@ async def call_space(
                     "suggestion": "Space ID must be in owner/repo format",
                 }
             )
-        client = await asyncio.to_thread(Client, space_id, token=hf_token)
+        import time
+
+        cache_key = (space_id, hf_token)
+        now = time.monotonic()
+        cached_entry = _CLIENT_CACHE.get(cache_key)
+        if cached_entry and (now - cached_entry[0]) < _CLIENT_CACHE_TTL:
+            client = cached_entry[1]
+        else:
+            client = await asyncio.to_thread(Client, space_id, token=hf_token, httpx_kwargs={"timeout": None})
+            if len(_CLIENT_CACHE) >= 64:
+                cutoff = now - _CLIENT_CACHE_TTL
+                for k, (t, _) in list(_CLIENT_CACHE.items()):
+                    if t < cutoff:
+                        _CLIENT_CACHE.pop(k, None)
+            _CLIENT_CACHE[cache_key] = (now, client)
         args = json.loads(args_json)
         if not endpoint or endpoint == "/predict":
-            api_info = await asyncio.to_thread(client.view_api, return_format="dict")
+            api_info = client.view_api(return_format="dict")
             named = list(
                 (
                     api_info.get("named_endpoints", {})
@@ -1008,6 +1022,9 @@ def is_curated(data, _token: Optional[OAuthToken] = None) -> str:
 
 _QUICKSEARCH_CACHE: dict[str, tuple[float, str]] = {}
 _QUICKSEARCH_TTL = 30.0
+
+_CLIENT_CACHE: dict[tuple[str, str | None], tuple[float, object]] = {}
+_CLIENT_CACHE_TTL = 300.0
 
 
 def search_quick(

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -15,7 +15,7 @@ import warnings
 import webbrowser
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, Optional, TypedDict
 
 import httpx
 from huggingface_hub import HfApi
@@ -1025,7 +1025,7 @@ def is_curated(data, _token: Optional[OAuthToken] = None) -> str:
 _QUICKSEARCH_CACHE: dict[str, tuple[float, str]] = {}
 _QUICKSEARCH_TTL = 30.0
 
-_CLIENT_CACHE: dict[tuple[str, str | None], tuple[float, object]] = {}
+_CLIENT_CACHE: dict[tuple[str, str | None], tuple[float, Any]] = {}
 _CLIENT_CACHE_TTL = 300.0
 
 

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -480,9 +480,11 @@ def get_oauth_available(_data=None) -> str:
     )
 
 
-def call_space(
+async def call_space(
     data, request: Optional[Request] = None, token: Optional[OAuthToken] = None
 ) -> str:
+    import asyncio
+
     space_id = data[0] if data else ""
     try:
         from gradio_client import Client, handle_file
@@ -498,10 +500,10 @@ def call_space(
                     "suggestion": "Space ID must be in owner/repo format",
                 }
             )
-        client = Client(space_id, token=hf_token)
+        client = await asyncio.to_thread(Client, space_id, token=hf_token)
         args = json.loads(args_json)
         if not endpoint or endpoint == "/predict":
-            api_info = client.view_api(return_format="dict")
+            api_info = await asyncio.to_thread(client.view_api, return_format="dict")
             named = list(
                 (
                     api_info.get("named_endpoints", {})
@@ -521,7 +523,7 @@ def call_space(
                 processed.append(arg)
         while processed and processed[-1] is None:
             processed.pop()
-        result = client.predict(*processed, api_name=endpoint)
+        result = await asyncio.to_thread(client.predict, *processed, api_name=endpoint)
         result = list(result) if isinstance(result, (list, tuple)) else [result]
 
         _tmpdir = os.path.realpath(tempfile.gettempdir())

--- a/gradio/workflow_api.py
+++ b/gradio/workflow_api.py
@@ -15,6 +15,7 @@ mocked in tests.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import inspect
 import json
@@ -498,7 +499,10 @@ class WorkflowExecutor:
         caller = self.callers.get(kind)
         if caller is None:
             raise WorkflowExecutionError(f"No executor available for '{kind}' nodes")
-        result_json = caller(data, self._request, self._token)
+        if inspect.iscoroutinefunction(caller):
+            result_json = asyncio.run(caller(data, self._request, self._token))
+        else:
+            result_json = caller(data, self._request, self._token)
         parsed = json.loads(result_json)
         if isinstance(parsed, dict) and "error" in parsed:
             msg = (

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -470,9 +470,9 @@ class TestCallSpaceAsync:
         fake_client = MagicMock()
         fake_client.predict.return_value = ("hello",)
 
-        FakeClient = MagicMock(return_value=fake_client)
+        fake_client_cls = MagicMock(return_value=fake_client)
         fake_gradio_client = types.ModuleType("gradio_client")
-        fake_gradio_client.Client = FakeClient
+        fake_gradio_client.Client = fake_client_cls
         fake_gradio_client.handle_file = lambda x: x
         monkeypatch.setitem(sys.modules, "gradio_client", fake_gradio_client)
 
@@ -489,5 +489,5 @@ class TestCallSpaceAsync:
         )
 
         assert "error" not in result
-        assert FakeClient in thread_fns
+        assert fake_client_cls in thread_fns
         assert fake_client.predict in thread_fns

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -440,8 +440,9 @@ class TestCallModelValidation:
 
 
 class TestCallSpaceValidation:
-    def test_url_shaped_space_id_is_rejected(self):
-        result = json.loads(call_space(["http://169.254.169.254/"]))
+    @pytest.mark.asyncio
+    async def test_url_shaped_space_id_is_rejected(self):
+        result = json.loads(await call_space(["http://169.254.169.254/"]))
         assert result.get("error_type") == "not_found"
 
     def test_valid_owner_repo_format_accepted_by_regex(self):
@@ -451,3 +452,42 @@ class TestCallSpaceValidation:
         assert re.fullmatch(pattern, "owner/repo")
         assert re.fullmatch(pattern, "my-org/my-space")
         assert re.fullmatch(pattern, "http://host/path") is None
+
+
+class TestCallSpaceAsync:
+    def test_call_space_is_coroutine(self):
+        import asyncio
+
+        assert asyncio.iscoroutinefunction(call_space)
+
+    @pytest.mark.asyncio
+    async def test_client_construction_and_predict_run_in_thread(self, monkeypatch):
+        import asyncio
+        import sys
+        import types
+        from unittest.mock import MagicMock
+
+        fake_client = MagicMock()
+        fake_client.predict.return_value = ("hello",)
+
+        FakeClient = MagicMock(return_value=fake_client)
+        fake_gradio_client = types.ModuleType("gradio_client")
+        fake_gradio_client.Client = FakeClient
+        fake_gradio_client.handle_file = lambda x: x
+        monkeypatch.setitem(sys.modules, "gradio_client", fake_gradio_client)
+
+        thread_fns: list = []
+
+        async def spy_to_thread(fn, *args, **kwargs):
+            thread_fns.append(fn)
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr(asyncio, "to_thread", spy_to_thread)
+
+        result = json.loads(
+            await call_space(["owner/space", "/run/predict", '["hello"]'])
+        )
+
+        assert "error" not in result
+        assert FakeClient in thread_fns
+        assert fake_client.predict in thread_fns

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -472,8 +472,8 @@ class TestCallSpaceAsync:
 
         fake_client_cls = MagicMock(return_value=fake_client)
         fake_gradio_client = types.ModuleType("gradio_client")
-        setattr(fake_gradio_client, "Client", fake_client_cls)
-        setattr(fake_gradio_client, "handle_file", lambda x: x)
+        fake_gradio_client.Client = fake_client_cls
+        fake_gradio_client.handle_file = lambda x: x
         monkeypatch.setitem(sys.modules, "gradio_client", fake_gradio_client)
 
         thread_fns: list = []

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -491,3 +491,4 @@ class TestCallSpaceAsync:
         assert "error" not in result
         assert FakeClient in thread_fns
         assert fake_client.predict in thread_fns
+

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -472,8 +472,8 @@ class TestCallSpaceAsync:
 
         fake_client_cls = MagicMock(return_value=fake_client)
         fake_gradio_client = types.ModuleType("gradio_client")
-        fake_gradio_client.Client = fake_client_cls
-        fake_gradio_client.handle_file = lambda x: x
+        setattr(fake_gradio_client, "Client", fake_client_cls)
+        setattr(fake_gradio_client, "handle_file", lambda x: x)
         monkeypatch.setitem(sys.modules, "gradio_client", fake_gradio_client)
 
         thread_fns: list = []

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -471,9 +471,10 @@ class TestCallSpaceAsync:
         fake_client.predict.return_value = ("hello",)
 
         fake_client_cls = MagicMock(return_value=fake_client)
-        fake_gradio_client = types.ModuleType("gradio_client")
-        fake_gradio_client.Client = fake_client_cls
-        fake_gradio_client.handle_file = lambda x: x
+        fake_gradio_client = types.SimpleNamespace(
+            Client=fake_client_cls,
+            handle_file=lambda x: x,
+        )
         monkeypatch.setitem(sys.modules, "gradio_client", fake_gradio_client)
 
         thread_fns: list = []

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -491,4 +491,3 @@ class TestCallSpaceAsync:
         assert "error" not in result
         assert FakeClient in thread_fns
         assert fake_client.predict in thread_fns
-


### PR DESCRIPTION
## Description

make `call_space` async and offload blocking `Client() `

when running a video generation Space (in my case, Wan2.2-faster-Pro) through gr.Workflow, the space appeared to be down even though it was running fine. The real cause was a 5 sec httpx timeout baked into `gradio_client.Client` by default. the connection was cut before the model finished, and the error was misclassified as the Space being unavailable

the fix is passing `httpx_kwargs={"timeout": None}` when constructing the client, which disables the timeout and lets long running models complete
