### PR TITLE
Fix `JSONDecodeError` when loading cached examples with negative number outputs

### DIFF
--- a/.changeset/breezy-zoos-sell.md
+++ b/.changeset/breezy-zoos-sell.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix `JSONDecodeError` when loading cached examples with negative number outputs

--- a/.changeset/breezy-zoos-sell.md
+++ b/.changeset/breezy-zoos-sell.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Fix `JSONDecodeError` when loading cached examples with negative number outputs
+fix:Fix `JSONDecodeError` when loading cached examples with negative number outputs

--- a/gradio/components/json_component.py
+++ b/gradio/components/json_component.py
@@ -19,7 +19,7 @@ from gradio.data_classes import JsonData
 from gradio.events import Events
 from gradio.exceptions import Error
 from gradio.i18n import I18nData
-from gradio.utils import parse_flagged_json, set_default_buttons
+from gradio.utils import parse_escaped_json, set_default_buttons
 
 if TYPE_CHECKING:
     from gradio.components import Timer
@@ -168,7 +168,7 @@ class JSON(Component):
         return {"foo": "bar"}
 
     def read_from_flag(self, payload: Any):
-        return parse_flagged_json(payload)
+        return parse_escaped_json(payload)
 
     def api_info(self) -> dict[str, Any]:
         return {"type": {}, "description": "any valid json"}

--- a/gradio/components/json_component.py
+++ b/gradio/components/json_component.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import warnings
 from collections.abc import Callable, Sequence
 from typing import (
@@ -20,7 +19,7 @@ from gradio.data_classes import JsonData
 from gradio.events import Events
 from gradio.exceptions import Error
 from gradio.i18n import I18nData
-from gradio.utils import set_default_buttons
+from gradio.utils import parse_flagged_json, set_default_buttons
 
 if TYPE_CHECKING:
     from gradio.components import Timer
@@ -169,7 +168,7 @@ class JSON(Component):
         return {"foo": "bar"}
 
     def read_from_flag(self, payload: Any):
-        return json.loads(payload)
+        return parse_flagged_json(payload)
 
     def api_info(self) -> dict[str, Any]:
         return {"type": {}, "description": "any valid json"}

--- a/gradio/components/number.py
+++ b/gradio/components/number.py
@@ -12,7 +12,7 @@ from gradio.components.button import Button
 from gradio.events import Events
 from gradio.exceptions import Error
 from gradio.i18n import I18nData
-from gradio.utils import parse_flagged_json, set_default_buttons
+from gradio.utils import parse_escaped_json, set_default_buttons
 
 if TYPE_CHECKING:
     from gradio.components import Timer
@@ -174,4 +174,4 @@ class Number(FormComponent):
 
     def read_from_flag(self, payload: str):
         """Numbers are stored as strings in the flagging file, so we need to parse them as json."""
-        return parse_flagged_json(payload)
+        return parse_escaped_json(payload)

--- a/gradio/components/number.py
+++ b/gradio/components/number.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -13,7 +12,7 @@ from gradio.components.button import Button
 from gradio.events import Events
 from gradio.exceptions import Error
 from gradio.i18n import I18nData
-from gradio.utils import set_default_buttons
+from gradio.utils import parse_flagged_json, set_default_buttons
 
 if TYPE_CHECKING:
     from gradio.components import Timer
@@ -175,4 +174,4 @@ class Number(FormComponent):
 
     def read_from_flag(self, payload: str):
         """Numbers are stored as strings in the flagging file, so we need to parse them as json."""
-        return json.loads(payload)
+        return parse_flagged_json(payload)

--- a/gradio/components/slider.py
+++ b/gradio/components/slider.py
@@ -13,7 +13,7 @@ from gradio.components.base import Component, FormComponent
 from gradio.components.number import Number
 from gradio.events import Events
 from gradio.i18n import I18nData
-from gradio.utils import parse_flagged_json
+from gradio.utils import parse_escaped_json
 
 if TYPE_CHECKING:
     from gradio.components import Timer
@@ -159,4 +159,4 @@ class Slider(FormComponent):
 
     def read_from_flag(self, payload: Any):
         """Sliders are stored as strings in the flagging file, so we need to parse them as json."""
-        return parse_flagged_json(payload)
+        return parse_escaped_json(payload)

--- a/gradio/components/slider.py
+++ b/gradio/components/slider.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import math
 import random
 from collections.abc import Callable, Sequence
@@ -14,6 +13,7 @@ from gradio.components.base import Component, FormComponent
 from gradio.components.number import Number
 from gradio.events import Events
 from gradio.i18n import I18nData
+from gradio.utils import parse_flagged_json
 
 if TYPE_CHECKING:
     from gradio.components import Timer
@@ -159,4 +159,4 @@ class Slider(FormComponent):
 
     def read_from_flag(self, payload: Any):
         """Sliders are stored as strings in the flagging file, so we need to parse them as json."""
-        return json.loads(payload)
+        return parse_flagged_json(payload)

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -919,16 +919,23 @@ def sanitize_value_for_csv(value: str | float) -> str | float:
     if not isinstance(value, str):
         value = str(value)
 
-    # Special handling for JSON-like values. A leading "-" is only valid JSON
-    # for a negative number, which is not a formula injection vector, so it is
-    # safe to leave unescaped (see issue #13591).
-    if value.startswith(("{", "[", "-")):
+    # Special handling for JSON-like values
+    if value.startswith(("{", "[")):
         try:
             parsed = json.loads(value)
             # Return normalized, safe JSON
             return json.dumps(parsed)
         except (json.JSONDecodeError, ValueError, TypeError):
             # Not valid JSON → treat as normal string
+            pass
+
+    # A leading "-" is only valid JSON for a negative number, which is not a
+    # formula injection vector, so return it unchanged (see issue #13591)
+    if value.startswith("-"):
+        try:
+            json.loads(value)
+            return value
+        except (json.JSONDecodeError, ValueError, TypeError):
             pass
 
     # Typical CSV injection protection

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -929,15 +929,6 @@ def sanitize_value_for_csv(value: str | float) -> str | float:
             # Not valid JSON → treat as normal string
             pass
 
-    # A leading "-" is only valid JSON for a negative number, which is not a
-    # formula injection vector, so return it unchanged (see issue #13591)
-    if value.startswith("-"):
-        try:
-            json.loads(value)
-            return value
-        except (json.JSONDecodeError, ValueError, TypeError):
-            pass
-
     # Typical CSV injection protection
     unsafe_prefixes = ["=", "+", "-", "@", "\t", "\n"]
     unsafe_sequences = [",=", ",+", ",-", ",@", ",\t", ",\n"]
@@ -969,10 +960,10 @@ def sanitize_list_for_csv(values: list[Any]) -> list[Any]:
 
 def parse_flagged_json(payload: Any) -> Any:
     """
-    Parses a JSON value read back from a flagging or example-cache CSV file.
-    Falls back to stripping the CSV-injection escape character ("'") that older
-    Gradio versions prepended to negative numbers when writing the file, so
-    caches created before the fix for issue #13591 still load.
+    Parses a JSON value read back from a flagging or example-cache CSV file,
+    tolerating the CSV-injection escape character ("'") that
+    sanitize_value_for_csv() prepends to values starting with "-", such as
+    negative numbers (see issue #13591).
     """
     try:
         return json.loads(payload)

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -919,8 +919,10 @@ def sanitize_value_for_csv(value: str | float) -> str | float:
     if not isinstance(value, str):
         value = str(value)
 
-    # Special handling for JSON-like values
-    if value.startswith(("{", "[")):
+    # Special handling for JSON-like values. A leading "-" is only valid JSON
+    # for a negative number, which is not a formula injection vector, so it is
+    # safe to leave unescaped (see issue #13591).
+    if value.startswith(("{", "[", "-")):
         try:
             parsed = json.loads(value)
             # Return normalized, safe JSON

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -958,7 +958,7 @@ def sanitize_list_for_csv(values: list[Any]) -> list[Any]:
     return sanitized_values
 
 
-def parse_flagged_json(payload: Any) -> Any:
+def parse_escaped_json(payload: Any) -> Any:
     """
     Parses a JSON value read back from a flagging or example-cache CSV file,
     tolerating the CSV-injection escape character ("'") that

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -967,6 +967,21 @@ def sanitize_list_for_csv(values: list[Any]) -> list[Any]:
     return sanitized_values
 
 
+def parse_flagged_json(payload: Any) -> Any:
+    """
+    Parses a JSON value read back from a flagging or example-cache CSV file.
+    Falls back to stripping the CSV-injection escape character ("'") that older
+    Gradio versions prepended to negative numbers when writing the file, so
+    caches created before the fix for issue #13591 still load.
+    """
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
+        if isinstance(payload, str) and payload.startswith("'"):
+            return json.loads(payload[1:])
+        raise
+
+
 def append_unique_suffix(name: str, list_of_names: list[str]):
     """Appends a numerical suffix to `name` so that it does not appear in `list_of_names`."""
     set_of_names: set[str] = set(list_of_names)  # for O(1) lookup

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -249,26 +249,6 @@ class TestProcessExamples:
             prediction = io.examples_handler.load_from_cache(0)
         assert prediction[0] == -0.5678
 
-    def test_caching_negative_number_in_stale_escaped_cache(
-        self, patched_cache_folder, connect
-    ):
-        io = gr.Interface(
-            lambda x: -0.5678,
-            "text",
-            gr.Number(),
-            examples=[["hi"]],
-            cache_examples=True,
-        )
-        with connect(io):
-            # Rewrite the cache the way versions before the fix for #13591
-            # wrote it, with the negative number CSV-escaped by a leading "'"
-            cached_file = Path(io.examples_handler.cached_file)
-            cached_file.write_text(
-                cached_file.read_text().replace("-0.5678", "'-0.5678")
-            )
-            prediction = io.examples_handler.load_from_cache(0)
-        assert prediction[0] == -0.5678
-
     def test_example_caching_relaunch(self, patched_cache_folder, connect):
         def combine(a, b):
             return a + " " + b

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -249,6 +249,26 @@ class TestProcessExamples:
             prediction = io.examples_handler.load_from_cache(0)
         assert prediction[0] == -0.5678
 
+    def test_caching_negative_number_in_stale_escaped_cache(
+        self, patched_cache_folder, connect
+    ):
+        io = gr.Interface(
+            lambda x: -0.5678,
+            "text",
+            gr.Number(),
+            examples=[["hi"]],
+            cache_examples=True,
+        )
+        with connect(io):
+            # Rewrite the cache the way versions before the fix for #13591
+            # wrote it, with the negative number CSV-escaped by a leading "'"
+            cached_file = Path(io.examples_handler.cached_file)
+            cached_file.write_text(
+                cached_file.read_text().replace("-0.5678", "'-0.5678")
+            )
+            prediction = io.examples_handler.load_from_cache(0)
+        assert prediction[0] == -0.5678
+
     def test_example_caching_relaunch(self, patched_cache_folder, connect):
         def combine(a, b):
             return a + " " + b

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -237,6 +237,18 @@ class TestProcessExamples:
             prediction = io.examples_handler.load_from_cache(1)
         assert prediction[0] == "Hello Dunya"
 
+    def test_caching_negative_number(self, patched_cache_folder, connect):
+        io = gr.Interface(
+            lambda x: -0.5678,
+            "text",
+            gr.Number(),
+            examples=[["hi"]],
+            cache_examples=True,
+        )
+        with connect(io):
+            prediction = io.examples_handler.load_from_cache(0)
+        assert prediction[0] == -0.5678
+
     def test_example_caching_relaunch(self, patched_cache_folder, connect):
         def combine(a, b):
             return a + " " + b

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -44,6 +44,7 @@ from gradio.utils import (
     is_hosted_notebook,
     is_in_or_equal,
     is_special_typed_parameter,
+    parse_flagged_json,
     safe_aclose_iterator,
     safe_deepcopy,
     sanitize_list_for_csv,
@@ -231,6 +232,13 @@ class TestSanitizeForCSV:
             [["=abc", "def", "gh,+ij"], ["abc", "=def", "+ghij"]]
         ) == [["'=abc", "def", "'gh,+ij"], ["abc", "'=def", "'+ghij"]]
         assert sanitize_list_for_csv([1, ["ab", "=de"]]) == [1, ["ab", "'=de"]]
+
+    def test_parse_flagged_json(self):
+        assert parse_flagged_json("-0.5678") == -0.5678
+        # Escaped values written by versions before the fix for #13591
+        assert parse_flagged_json("'-0.5678") == -0.5678
+        with pytest.raises(json.JSONDecodeError):
+            parse_flagged_json("'not json")
 
 
 class TestValidateURL:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -44,7 +44,7 @@ from gradio.utils import (
     is_hosted_notebook,
     is_in_or_equal,
     is_special_typed_parameter,
-    parse_flagged_json,
+    parse_escaped_json,
     safe_aclose_iterator,
     safe_deepcopy,
     sanitize_list_for_csv,
@@ -229,12 +229,12 @@ class TestSanitizeForCSV:
         ) == [["'=abc", "def", "'gh,+ij"], ["abc", "'=def", "'+ghij"]]
         assert sanitize_list_for_csv([1, ["ab", "=de"]]) == [1, ["ab", "'=de"]]
 
-    def test_parse_flagged_json(self):
-        assert parse_flagged_json("-0.5678") == -0.5678
+    def test_parse_escaped_json(self):
+        assert parse_escaped_json("-0.5678") == -0.5678
         # Negative numbers get CSV-escaped with a leading "'" on write (#13591)
-        assert parse_flagged_json("'-0.5678") == -0.5678
+        assert parse_escaped_json("'-0.5678") == -0.5678
         with pytest.raises(json.JSONDecodeError):
-            parse_flagged_json("'not json")
+            parse_escaped_json("'not json")
 
 
 class TestValidateURL:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -214,12 +214,16 @@ class TestSanitizeForCSV:
         assert sanitize_value_for_csv("=OPEN()") == "'=OPEN()"
         assert sanitize_value_for_csv("=1+2") == "'=1+2"
         assert sanitize_value_for_csv('=1+2";=1+2') == "'=1+2\";=1+2"
+        assert sanitize_value_for_csv("-2+3+cmd|calc") == "'-2+3+cmd|calc"
 
     def test_safe_value(self):
         assert sanitize_value_for_csv(4) == 4
         assert sanitize_value_for_csv(-44.44) == -44.44
         assert sanitize_value_for_csv("1+1=2") == "1+1=2"
         assert sanitize_value_for_csv("1aaa2") == "1aaa2"
+        assert sanitize_value_for_csv("-0.5678") == "-0.5678"
+        assert sanitize_value_for_csv("-42") == "-42"
+        assert sanitize_value_for_csv("-1e-5") == "-1e-05"
 
     def test_list(self):
         assert sanitize_list_for_csv([4, "def=", "=gh+ij"]) == [4, "def=", "'=gh+ij"]

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -215,16 +215,12 @@ class TestSanitizeForCSV:
         assert sanitize_value_for_csv("=OPEN()") == "'=OPEN()"
         assert sanitize_value_for_csv("=1+2") == "'=1+2"
         assert sanitize_value_for_csv('=1+2";=1+2') == "'=1+2\";=1+2"
-        assert sanitize_value_for_csv("-2+3+cmd|calc") == "'-2+3+cmd|calc"
 
     def test_safe_value(self):
         assert sanitize_value_for_csv(4) == 4
         assert sanitize_value_for_csv(-44.44) == -44.44
         assert sanitize_value_for_csv("1+1=2") == "1+1=2"
         assert sanitize_value_for_csv("1aaa2") == "1aaa2"
-        assert sanitize_value_for_csv("-0.5678") == "-0.5678"
-        assert sanitize_value_for_csv("-42") == "-42"
-        assert sanitize_value_for_csv("-1e-5") == "-1e-5"
 
     def test_list(self):
         assert sanitize_list_for_csv([4, "def=", "=gh+ij"]) == [4, "def=", "'=gh+ij"]
@@ -235,7 +231,7 @@ class TestSanitizeForCSV:
 
     def test_parse_flagged_json(self):
         assert parse_flagged_json("-0.5678") == -0.5678
-        # Escaped values written by versions before the fix for #13591
+        # Negative numbers get CSV-escaped with a leading "'" on write (#13591)
         assert parse_flagged_json("'-0.5678") == -0.5678
         with pytest.raises(json.JSONDecodeError):
             parse_flagged_json("'not json")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -223,7 +223,7 @@ class TestSanitizeForCSV:
         assert sanitize_value_for_csv("1aaa2") == "1aaa2"
         assert sanitize_value_for_csv("-0.5678") == "-0.5678"
         assert sanitize_value_for_csv("-42") == "-42"
-        assert sanitize_value_for_csv("-1e-5") == "-1e-05"
+        assert sanitize_value_for_csv("-1e-5") == "-1e-5"
 
     def test_list(self):
         assert sanitize_list_for_csv([4, "def=", "=gh+ij"]) == [4, "def=", "'=gh+ij"]


### PR DESCRIPTION
## Description

When a `gr.Examples` output is a `gr.Number` (or `gr.Slider`, or `gr.JSON` holding a top-level negative number) and the cached value is negative, clicking the example crashes with `json.decoder.JSONDecodeError`.

The cache write path stores the value as the string `json.dumps(-0.5678)` -> `"-0.5678"`, and `sanitize_value_for_csv` escapes it to `'-0.5678` because it starts with the unsafe CSV prefix `-`. On read-back, `Number.read_from_flag` calls `json.loads` on the raw cell and fails on the leading quote.

The fix is read-path only, so `sanitize_value_for_csv` and its CSV-injection protection stay exactly as they are. `read_from_flag` for `Number`, `Slider`, and `JSON` (the three components that json-parse flagged values) now goes through a small helper that retries `json.loads` with the leading `'` stripped when the raw cell fails to parse. These cells only ever contain `json.dumps` output, and `json.dumps` never emits a leading `'`, so the fallback cannot misread a legitimate value.

Since the fix is on the read side, caches written by older versions also load correctly, with no need to regenerate them with `GRADIO_RESET_EXAMPLES_CACHE=True`.

Closes: #13591

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Targets #13591.

## Testing and Formatting Your Code

1. Added `TestProcessExamples::test_caching_negative_number` in `test/test_helpers.py`, which reproduces the issue's exact scenario (an `Interface` with a negative `gr.Number` output and `cache_examples=True`) and fails with `JSONDecodeError` without the fix. Added `TestSanitizeForCSV::test_parse_flagged_json` in `test/test_utils.py` covering the new helper, including that invalid values still raise. `test/test_utils.py`, `test/test_helpers.py`, `test/test_flagging.py`, `test/components/test_number.py`, `test/components/test_slider.py`, and `test/components/test_json.py` pass locally.

2. Ran `ruff check --fix` and `ruff format` on the changed files.
