### PR TITLE
workflow: forward `_token` to bound fn when no request session

### DIFF
--- a/.changeset/deep-keys-rule.md
+++ b/.changeset/deep-keys-rule.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:workflow: forward `_token` to bound fn when no request session
+feat:workflow: forward `_token` to bound fn via `special_args` when no request session

--- a/.changeset/deep-keys-rule.md
+++ b/.changeset/deep-keys-rule.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:workflow: forward _token to bound fn when no request session
+feat:workflow: forward `_token` to bound fn when no request session

--- a/.changeset/deep-keys-rule.md
+++ b/.changeset/deep-keys-rule.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:workflow: forward _token to bound fn when no request session

--- a/.changeset/deep-keys-rule.md
+++ b/.changeset/deep-keys-rule.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:workflow: forward `_token` to bound fn via `special_args` when no request session
+fix:workflow: forward `_token` to bound fn when no request session

--- a/gradio/helpers.py
+++ b/gradio/helpers.py
@@ -941,6 +941,7 @@ def special_args(
     request: routes.Request | None = None,
     event_data: EventData | None = None,
     component_props: dict[int, dict[str, Any]] | None = None,
+    token: oauth.OAuthToken | None = None,
 ) -> tuple[list, int | None, int | None, list[int]]:
     """
     Checks if function has special arguments Request or EventData (via annotation) or Progress (via default value).
@@ -952,6 +953,9 @@ def special_args(
         request: request to load into inputs.
         event_data: event-related data to load into inputs.
         component_props: dictionary mapping input indices to their full component props.
+        token: an OAuthToken to inject into OAuthToken-annotated params when one cannot
+            be derived from the request session (e.g. server-side workflow calls that
+            resolve the token outside of a browser session).
     Returns:
         updated inputs, progress index, event data index, list of input indices that need component props.
     """
@@ -1023,6 +1027,10 @@ def special_args(
                         if oauth_info is not None
                         else None
                     )
+                    # Fall back to a directly-supplied token when the session does
+                    # not yield one (e.g. server-side workflow calls).
+                    if oauth_token is None and token is not None:
+                        oauth_token = token
                     if oauth_token is None and type_hint == oauth.OAuthToken:
                         raise Error(
                             "This action requires a logged in user. Please sign in and retry."

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -1359,17 +1359,7 @@ class Workflow(Blocks):
                 args = json.loads(args_json)
                 if not isinstance(args, list):
                     args = [args]
-                args, *_ = _special_args(fn, args, _request, None)
-                if _token is not None:
-                    hints = get_type_hints(fn)
-                    params = list(inspect.signature(fn).parameters.keys())
-                    for i, p in enumerate(params):
-                        if (
-                            _is_injected_param(hints.get(p))
-                            and i < len(args)
-                            and args[i] is None
-                        ):
-                            args[i] = _token
+                args, *_ = _special_args(fn, args, _request, None, token=_token)
                 result = fn(*args)
                 result = list(result) if isinstance(result, (list, tuple)) else [result]
                 return json.dumps(result)

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -1360,6 +1360,12 @@ class Workflow(Blocks):
                 if not isinstance(args, list):
                     args = [args]
                 args, *_ = _special_args(fn, args, _request, None)
+                if _token is not None:
+                    hints = get_type_hints(fn)
+                    params = list(inspect.signature(fn).parameters.keys())
+                    for i, p in enumerate(params):
+                        if _is_injected_param(hints.get(p)) and i < len(args) and args[i] is None:
+                            args[i] = _token
                 result = fn(*args)
                 result = list(result) if isinstance(result, (list, tuple)) else [result]
                 return json.dumps(result)

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -1364,7 +1364,11 @@ class Workflow(Blocks):
                     hints = get_type_hints(fn)
                     params = list(inspect.signature(fn).parameters.keys())
                     for i, p in enumerate(params):
-                        if _is_injected_param(hints.get(p)) and i < len(args) and args[i] is None:
+                        if (
+                            _is_injected_param(hints.get(p))
+                            and i < len(args)
+                            and args[i] is None
+                        ):
                             args[i] = _token
                 result = fn(*args)
                 result = list(result) if isinstance(result, (list, tuple)) else [result]

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -486,9 +486,7 @@ class TestCallFn:
         direct.token = "direct-token"
         direct.scope = "openid"
         direct.expires_at = 9999999999
-        result = json.loads(
-            call_fn(["fn", '["hello"]'], _request=None, _token=direct)
-        )
+        result = json.loads(call_fn(["fn", '["hello"]'], _request=None, _token=direct))
         assert result == ["direct-token,None"]
 
     def test_unknown_fn_returns_error(self, tmp_path):

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -477,6 +477,20 @@ class TestCallFn:
         assert result == ["hi"]
         assert received["token"].token == "test-tok"
 
+    def test_injects_oauth_token_from_direct_token(self, tmp_path):
+        def fn_with_token(text: str, token: Optional[OAuthToken]) -> str:
+            return token.token if token else "missing"
+
+        call_fn = self._call_fn(tmp_path, {"fn_with_token": fn_with_token})
+        direct = OAuthToken.__new__(OAuthToken)
+        direct.token = "direct-token"
+        direct.scope = "openid"
+        direct.expires_at = 9999999999
+        result = json.loads(
+            call_fn(["fn_with_token", '["hello"]'], _request=None, _token=direct)
+        )
+        assert result == ["direct-token"]
+
     def test_unknown_fn_returns_error(self, tmp_path):
         call_fn = self._call_fn(tmp_path, {"echo": lambda x: x})
         result = json.loads(call_fn(["missing", "[]"]))

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -477,52 +477,19 @@ class TestCallFn:
         assert result == ["hi"]
         assert received["token"].token == "test-tok"
 
-    def test_injects_oauth_token_from_direct_token(self, tmp_path):
-        def fn_with_token(text: str, token: Optional[OAuthToken]) -> str:
-            return token.token if token else "missing"
+    def test_injects_direct_token_without_session(self, tmp_path):
+        def fn(text: str, token: OAuthToken, profile: Optional[OAuthProfile]) -> str:
+            return f"{token.token},{profile}"
 
-        call_fn = self._call_fn(tmp_path, {"fn_with_token": fn_with_token})
+        call_fn = self._call_fn(tmp_path, {"fn": fn})
         direct = OAuthToken.__new__(OAuthToken)
         direct.token = "direct-token"
         direct.scope = "openid"
         direct.expires_at = 9999999999
         result = json.loads(
-            call_fn(["fn_with_token", '["hello"]'], _request=None, _token=direct)
+            call_fn(["fn", '["hello"]'], _request=None, _token=direct)
         )
-        assert result == ["direct-token"]
-
-    def test_direct_token_injected_into_required_token_param(self, tmp_path):
-        # A non-optional OAuthToken param must be satisfied by the directly
-        # supplied token rather than raising "requires a logged in user".
-        def fn_required(text: str, token: OAuthToken) -> str:
-            return token.token
-
-        call_fn = self._call_fn(tmp_path, {"fn_required": fn_required})
-        direct = OAuthToken.__new__(OAuthToken)
-        direct.token = "direct-token"
-        direct.scope = "openid"
-        direct.expires_at = 9999999999
-        result = json.loads(
-            call_fn(["fn_required", '["hello"]'], _request=None, _token=direct)
-        )
-        assert result == ["direct-token"]
-
-    def test_direct_token_does_not_clobber_profile_param(self, tmp_path):
-        # The direct token must only fill OAuthToken params; an OAuthProfile
-        # param that resolves to None (logged out) must stay None, not receive
-        # the OAuthToken object.
-        def fn_with_profile(text: str, profile: Optional[OAuthProfile]) -> str:
-            return type(profile).__name__ if profile is not None else "none"
-
-        call_fn = self._call_fn(tmp_path, {"fn_with_profile": fn_with_profile})
-        direct = OAuthToken.__new__(OAuthToken)
-        direct.token = "direct-token"
-        direct.scope = "openid"
-        direct.expires_at = 9999999999
-        result = json.loads(
-            call_fn(["fn_with_profile", '["hello"]'], _request=None, _token=direct)
-        )
-        assert result == ["none"]
+        assert result == ["direct-token,None"]
 
     def test_unknown_fn_returns_error(self, tmp_path):
         call_fn = self._call_fn(tmp_path, {"echo": lambda x: x})

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -7,7 +7,7 @@ import pytest
 
 import gradio as gr
 import gradio.workflow as workflow_module
-from gradio.oauth import OAuthToken
+from gradio.oauth import OAuthProfile, OAuthToken
 from gradio.route_utils import Request
 from gradio.workflow import (
     WRITE_TOKEN,
@@ -490,6 +490,39 @@ class TestCallFn:
             call_fn(["fn_with_token", '["hello"]'], _request=None, _token=direct)
         )
         assert result == ["direct-token"]
+
+    def test_direct_token_injected_into_required_token_param(self, tmp_path):
+        # A non-optional OAuthToken param must be satisfied by the directly
+        # supplied token rather than raising "requires a logged in user".
+        def fn_required(text: str, token: OAuthToken) -> str:
+            return token.token
+
+        call_fn = self._call_fn(tmp_path, {"fn_required": fn_required})
+        direct = OAuthToken.__new__(OAuthToken)
+        direct.token = "direct-token"
+        direct.scope = "openid"
+        direct.expires_at = 9999999999
+        result = json.loads(
+            call_fn(["fn_required", '["hello"]'], _request=None, _token=direct)
+        )
+        assert result == ["direct-token"]
+
+    def test_direct_token_does_not_clobber_profile_param(self, tmp_path):
+        # The direct token must only fill OAuthToken params; an OAuthProfile
+        # param that resolves to None (logged out) must stay None, not receive
+        # the OAuthToken object.
+        def fn_with_profile(text: str, profile: Optional[OAuthProfile]) -> str:
+            return type(profile).__name__ if profile is not None else "none"
+
+        call_fn = self._call_fn(tmp_path, {"fn_with_profile": fn_with_profile})
+        direct = OAuthToken.__new__(OAuthToken)
+        direct.token = "direct-token"
+        direct.scope = "openid"
+        direct.expires_at = 9999999999
+        result = json.loads(
+            call_fn(["fn_with_profile", '["hello"]'], _request=None, _token=direct)
+        )
+        assert result == ["none"]
 
     def test_unknown_fn_returns_error(self, tmp_path):
         call_fn = self._call_fn(tmp_path, {"echo": lambda x: x})


### PR DESCRIPTION
## Description

`call_fn` accepts `_token` from gradio's injection but passes `None` to `special_args`, so any bound function always gets `None` even when the user is authenticated. this fix fills the token after `special_args` runs

caught by @abidlabs in #13574 (i meant to add this fix to that PR but merged too soon) 