### PR TITLE
Fix outdated `Slider(default=)` and `launch(cache_examples=)` usage in the GAN guide

### DIFF
--- a/guides/11_other-tutorials/create-your-own-friends-with-a-gan.md
+++ b/guides/11_other-tutorials/create-your-own-friends-with-a-gan.md
@@ -105,7 +105,7 @@ import gradio as gr
 gr.Interface(
     predict,
     inputs=[
-        gr.Slider(0, 1000, label='Seed', default=42),
+        gr.Slider(0, 1000, label='Seed', value=42),
     ],
     outputs="image",
 ).launch()
@@ -120,8 +120,8 @@ Generating 4 punks at a time is a good start, but maybe we'd like to control how
 gr.Interface(
     predict,
     inputs=[
-        gr.Slider(0, 1000, label='Seed', default=42),
-        gr.Slider(4, 64, label='Number of Punks', step=1, default=10), # Adding another slider!
+        gr.Slider(0, 1000, label='Seed', value=42),
+        gr.Slider(4, 64, label='Number of Punks', step=1, value=10), # Adding another slider!
     ],
     outputs="image",
 ).launch()
@@ -151,7 +151,8 @@ gr.Interface(
     # ...
     # keep everything as it is, and then add
     examples=[[123, 15], [42, 29], [456, 8], [1337, 35]],
-).launch(cache_examples=True) # cache_examples is optional
+    cache_examples=True, # cache_examples is optional
+).launch()
 ```
 
 The `examples` parameter takes a list of lists, where each item in the sublists is ordered in the same order that we've listed the `inputs`. So in our case, `[seed, num_punks]`. Give it a try!
@@ -206,12 +207,13 @@ def predict(seed, num_punks):
 gr.Interface(
     predict,
     inputs=[
-        gr.Slider(0, 1000, label='Seed', default=42),
-        gr.Slider(4, 64, label='Number of Punks', step=1, default=10),
+        gr.Slider(0, 1000, label='Seed', value=42),
+        gr.Slider(4, 64, label='Number of Punks', step=1, value=10),
     ],
     outputs="image",
     examples=[[123, 15], [42, 29], [456, 8], [1337, 35]],
-).launch(cache_examples=True)
+    cache_examples=True,
+).launch()
 ```
 
 ---


### PR DESCRIPTION
## Description

The "Create your own friends with a GAN" guide still used the Gradio 2.x Slider API, so copy-pasting its code fails on current Gradio with `TypeError: Slider.__init__() got an unexpected keyword argument 'default'`.

The guide originally used `gr.inputs.Slider(..., default=...)`, which was valid at the time. When #1796 replaced the deprecated `gr.inputs.Slider` with `gr.Slider`, the `default=` kwarg was left behind, and plain `gr.Slider` only accepts `value`. This PR renames `default=` to `value=` in the five `gr.Slider(...)` calls.

While fixing that, I noticed the same guide also passes `cache_examples=True` to `.launch()` in two code blocks. `cache_examples` is a `gr.Interface` parameter and `Blocks.launch()` does not accept it, so the full-code example would still raise a `TypeError` after the slider fix. This PR moves `cache_examples=True` into the `gr.Interface(...)` call.

Docs-only change (one guide file). The Chinese translation of this guide has the same stale snippets, but it is not referenced by the website build, so it is left untouched here.

Closes: #13603

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

