### PR TITLE
Fix `gr.Code` not rendering when it has no initial value

### DIFF
--- a/.changeset/itchy-steaks-walk.md
+++ b/.changeset/itchy-steaks-walk.md
@@ -1,0 +1,6 @@
+---
+"@gradio/code": patch
+"gradio": patch
+---
+
+fix:Fix `gr.Code` not rendering when it has no initial value

--- a/js/code/Code.test.ts
+++ b/js/code/Code.test.ts
@@ -429,6 +429,28 @@ describe("Edge cases", () => {
 		expect(getByLabelText("Code input container")).toBeTruthy();
 	});
 
+	// The backend strips `value` from the config when gr.Code has no initial
+	// value, so the frontend sees undefined rather than null (issue #13598).
+	test("missing value with interactive=true renders the editor", async () => {
+		const { value: _, ...props_without_value } = default_props;
+		const { getByLabelText } = await render(Code, props_without_value);
+		expect(getByLabelText("Code input container")).toBeVisible();
+	});
+
+	test("value set from the backend after mounting with no value is displayed", async () => {
+		const { value: _, ...props_without_value } = default_props;
+		const { getByLabelText, get_data, set_data } = await render(
+			Code,
+			props_without_value
+		);
+		await set_data({ value: "default value" });
+		const data = await get_data();
+		expect(data.value).toBe("default value");
+		expect(getByLabelText("Code input container")).toHaveTextContent(
+			"default value"
+		);
+	});
+
 	test("value with leading and trailing whitespace is displayed", async () => {
 		const { get_data } = await render(Code, {
 			...default_props,

--- a/js/code/shared/Code.svelte
+++ b/js/code/shared/Code.svelte
@@ -39,7 +39,7 @@
 
 	let {
 		class_names = "",
-		value = $bindable(""),
+		value = $bindable(),
 		dark_mode,
 		basic = true,
 		language,
@@ -78,7 +78,7 @@
 	});
 
 	$effect(() => {
-		set_doc(value);
+		set_doc(value ?? "");
 	});
 
 	update_lines();


### PR DESCRIPTION
## Description

An interactive `gr.Code` component created without an initial value stopped rendering in 6.19.0. The label and the editor both disappeared, and no error was shown server-side (only a Svelte runtime error in the browser console). This closes the regression reported in the issue.

The cause is a one-line change in #13526. That PR gave the `value` prop of `shared/Code.svelte` a fallback value (`value = $bindable("")`) to satisfy the newly enforced frontend typecheck. When `gr.Code` has no initial value, the backend strips the `value` key from the config entirely, so the frontend receives `undefined`. In Svelte 5, binding an `undefined` parent value to a `$bindable` prop that has a fallback throws `props_invalid_value` during mount, which aborts rendering of the whole component.

The fix removes the fallback again and handles the possibly-`undefined` value where it is used internally (`set_doc(value ?? "")`), so the typecheck the original PR was enforcing still passes.

Closes: #13598

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

