### PR TITLE
Fix spurious separators from empty tokens in `HighlightedText` with `combine_adjacent=True`

### DIFF
--- a/.changeset/great-ears-grab.md
+++ b/.changeset/great-ears-grab.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Fix spurious separators from empty tokens in `HighlightedText` with `combine_adjacent=True`

--- a/gradio/components/highlighted_text.py
+++ b/gradio/components/highlighted_text.py
@@ -187,8 +187,10 @@ class HighlightedText(Component):
             running_text, running_category = None, None
             for text, category in value:
                 if not text:
-                    # Skip fully empty items, these get added in processing
-                    # of dictionaries.
+                    # Drop empty tokens so they neither seed a run nor get a
+                    # spurious separator when merged. These are inserted
+                    # between entities when a dict value is converted above,
+                    # but skipping them for list values is also correct.
                     continue
                 if running_text is None:
                     running_text = text

--- a/gradio/components/highlighted_text.py
+++ b/gradio/components/highlighted_text.py
@@ -186,15 +186,15 @@ class HighlightedText(Component):
             output = []
             running_text, running_category = None, None
             for text, category in value:
+                if not text:
+                    # Skip fully empty items, these get added in processing
+                    # of dictionaries.
+                    continue
                 if running_text is None:
                     running_text = text
                     running_category = category
                 elif category == running_category:
                     running_text += self.adjacent_separator + text
-                elif not text:
-                    # Skip fully empty item, these get added in processing
-                    # of dictionaries.
-                    pass
                 else:
                     output.append((running_text, running_category))
                     running_text = text

--- a/test/components/test_highlighted_text.py
+++ b/test/components/test_highlighted_text.py
@@ -96,7 +96,6 @@ class TestHighlightedText:
         ]
 
     def test_combine_adjacent_empty_tokens(self):
-        # https://github.com/gradio-app/gradio/issues/13602
         component = gr.HighlightedText(combine_adjacent=True, adjacent_separator=" ")
 
         value = [("", None), ("foo", None), ("bar", None)]

--- a/test/components/test_highlighted_text.py
+++ b/test/components/test_highlighted_text.py
@@ -50,9 +50,8 @@ class TestHighlightedText:
             {"entity": "PER", "start": 4, "end": 8},
             {"entity": "LOC", "start": 18, "end": 24},
         ]
-        # After a merge empty entries are stripped except the leading one
+        # After a merge empty entries are stripped
         result_after_merge = [
-            {"token": "", "class_or_confidence": None},
             {"token": "Wolfgang", "class_or_confidence": "PER"},
             {"token": " lives in ", "class_or_confidence": None},
             {"token": "Berlin", "class_or_confidence": "LOC"},
@@ -94,6 +93,30 @@ class TestHighlightedText:
             {"token": "", "class_or_confidence": None},
             {"token": text, "class_or_confidence": "PER"},
             {"token": "", "class_or_confidence": None},
+        ]
+
+    def test_combine_adjacent_empty_tokens(self):
+        # https://github.com/gradio-app/gradio/issues/13602
+        component = gr.HighlightedText(combine_adjacent=True, adjacent_separator=" ")
+
+        value = [("", None), ("foo", None), ("bar", None)]
+        assert (result_ := component.postprocess(value))
+        assert result_.model_dump() == [
+            {"token": "foo bar", "class_or_confidence": None}
+        ]
+
+        value = [("foo", None), ("", None), ("bar", None)]
+        assert (result_ := component.postprocess(value))
+        assert result_.model_dump() == [
+            {"token": "foo bar", "class_or_confidence": None}
+        ]
+
+        text = "Wolfgang lives in Berlin"
+        entities = [{"entity": "PER", "start": 0, "end": 8}]
+        assert (result_ := component.postprocess({"text": text, "entities": entities}))
+        assert result_.model_dump() == [
+            {"token": "Wolfgang", "class_or_confidence": "PER"},
+            {"token": " lives in Berlin", "class_or_confidence": None},
         ]
 
     def test_show_whitespaces(self):


### PR DESCRIPTION
## Description

When `combine_adjacent=True`, empty tokens in the value list slip past the empty-token skip in `HighlightedText.postprocess` because that check is evaluated after the "start a new run" and "merge into the current run" branches. This causes:

- A leading separator when the first token is empty: `[("", None), ("foo", None), ("bar", None)]` with `adjacent_separator=" "` yields `[(" foo bar", None)]` instead of `[("foo bar", None)]`.
- A doubled separator when an empty token sits inside a run of the same category: `[("foo", None), ("", None), ("bar", None)]` yields `[("foo  bar", None)]`.
- A stray empty `("", None)` token in the output when a dict value's first entity starts at index 0.

This PR hoists the empty-token skip to the top of the loop, so empty tokens (which the dict-to-list conversion inserts between entities) never seed a run or receive a separator. The behavior for non-empty tokens is unchanged, and merging same-category entities across empty gaps (added in #2767) still works.

One expectation in the existing test was updated: with `combine_adjacent=True`, the leading empty token is now stripped like the other empty tokens, instead of being kept as an empty `("", None)` entry.

Closes: #13602

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

