### PR TITLE
Fix `gr.State` passing its callable default to event handlers instead of the called value

### DIFF
--- a/.changeset/pink-news-relax.md
+++ b/.changeset/pink-news-relax.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix `gr.State` passing its callable default to event handlers instead of the called value

--- a/gradio/state_holder.py
+++ b/gradio/state_holder.py
@@ -85,9 +85,6 @@ class SessionState:
         if block.stateful:
             if key not in self.state_data:
                 value = getattr(block, "value", None)
-                # A callable default is a factory that provides the initial
-                # value, same as for non-stateful components (see
-                # Component.get_load_fn_and_initial_value).
                 if callable(value):
                     value = value()
                 self.state_data[key] = deepcopy(value)

--- a/gradio/state_holder.py
+++ b/gradio/state_holder.py
@@ -84,7 +84,13 @@ class SessionState:
         block = self.blocks_config.blocks[key]
         if block.stateful:
             if key not in self.state_data:
-                self.state_data[key] = deepcopy(getattr(block, "value", None))
+                value = getattr(block, "value", None)
+                # A callable default is a factory that provides the initial
+                # value, same as for non-stateful components (see
+                # Component.get_load_fn_and_initial_value).
+                if callable(value):
+                    value = value()
+                self.state_data[key] = deepcopy(value)
             return self.state_data[key]
         else:
             return block

--- a/test/components/test_state.py
+++ b/test/components/test_state.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic import BaseModel
 
 import gradio as gr
+from gradio.state_holder import SessionState
 
 
 class TestModel(BaseModel):
@@ -22,6 +23,18 @@ class TestState:
     def test_initial_value_pydantic(self):
         state = gr.State(value=TestModel(name="Freddy"))
         assert isinstance(state.value, TestModel)
+
+    @pytest.mark.asyncio
+    async def test_callable_default_is_called_before_load_event(self):
+        with gr.Blocks() as demo:
+            state = gr.State(value=lambda: {"count": 42})
+            num = gr.Number()
+            btn = gr.Button()
+            btn.click(lambda s: s["count"], state, num)
+
+        session = SessionState(demo)
+        result = await demo.process_api(0, [None], state=session)
+        assert result["data"][0] == 42
 
     @pytest.mark.asyncio
     async def test_in_interface(self):


### PR DESCRIPTION
## Description

When `gr.State` is given a callable as its default value, anything that reads the state before the session's load event has stored a value gets the raw callable instead of the value it returns.

The callable default is documented as a factory ("the function will be called whenever the app loads to set the initial value of the state"), and `Component.__init__` does resolve it, but `State.__init__` restores the raw callable on `self.value` afterwards (this was done in #10036 to keep pydantic `BaseModel` defaults intact). Since `SessionState.__getitem__` falls back to `block.value` for a state that has no session value yet, that raw callable is what early readers see.

On current main this surfaces in two ways. Events invoked through the API or the client libraries receive the function itself, because load events never run for those sessions. And on page load, the callable leaks into the change tracking of the state's own load event (the pre-execution `deep_hash` in `get_state_ids_to_track` hashes the callable), so storing the real initial value registers as a change and fires a spurious `state.change`; with the issue's app, a `@gr.render` that takes the state as an input runs twice on page load. On the 5.x versions the issue was reported against, the render also ran before the load event and received the raw function directly.

This PR resolves the callable in `SessionState.__getitem__` when a session reads a state that has not been set yet, so each session gets a fresh factory value from the first read on. The `State.value` attribute is left untouched, keeping the `BaseModel` behavior from #10036 intact, and the load event attached by `Component.__init__` still refreshes the value on every page load as before.

Added a regression test that runs an event through `process_api` with a real `SessionState` and asserts the handler receives the called value.

Closes: #10658

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

