### PR TITLE
Restore gradio_client release tags

### DIFF
--- a/.changeset/fresh-clients-tag.md
+++ b/.changeset/fresh-clients-tag.md
@@ -1,0 +1,5 @@
+---
+"gradio_client": patch
+---
+
+fix:Restore Git tags for Python `gradio_client` releases

--- a/client/python/gradio_client/package.json
+++ b/client/python/gradio_client/package.json
@@ -3,5 +3,6 @@
 	"version": "2.5.0",
 	"description": "",
 	"python": "true",
-	"main_changeset": true
+	"main_changeset": true,
+	"private": true
 }

--- a/client/python/gradio_client/package.json
+++ b/client/python/gradio_client/package.json
@@ -3,6 +3,5 @@
 	"version": "2.5.0",
 	"description": "",
 	"python": "true",
-	"main_changeset": true,
-	"private": true
+	"main_changeset": true
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build",
 		"ci:version": "changeset version && pnpm i --lockfile-only && node ./.changeset/fix_changelogs.cjs",
-		"ci:publish": "pnpm changeset tag && TAG=gradio_client@$(node -p \"require('./client/python/gradio_client/package.json').version\") && (git rev-parse --verify --quiet \"refs/tags/$TAG\" >/dev/null || git tag \"$TAG\" -m \"$TAG\") && git push origin --tags && pnpm publish --no-git-checks --access public -r --filter=@gradio/*",
+		"ci:publish": "pnpm changeset tag && TAG=gradio_client@$(node -p \"require('./client/python/gradio_client/package.json').version\") && (git rev-parse --verify --quiet \"refs/tags/$TAG\" >/dev/null || git tag -a \"$TAG\" -m \"$TAG\") && git push origin --tags && pnpm publish --no-git-checks --access public -r --filter=@gradio/*",
 		"website": "pnpm --filter @gradio/website build",
 		"package": "pnpm --filter @gradio/* --filter=!@gradio/client --filter=!@gradio/preview exec svelte-package --input=. --tsconfig=../../tsconfig.json",
 		"spaces:dev": "pnpm css && pnpm --filter @gradio/preview build && pnpm --filter @self/spaces-test dev"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build",
 		"ci:version": "changeset version && pnpm i --lockfile-only && node ./.changeset/fix_changelogs.cjs",
-		"ci:publish": "pnpm changeset tag && TAG=gradio_client@$(node -p \"require('./client/python/gradio_client/package.json').version\") && (git rev-parse --verify --quiet \"refs/tags/$TAG\" >/dev/null || git tag \"$TAG\") && git push origin --tags && pnpm publish --no-git-checks --access public -r --filter=@gradio/*",
+		"ci:publish": "pnpm changeset tag && TAG=gradio_client@$(node -p \"require('./client/python/gradio_client/package.json').version\") && (git rev-parse --verify --quiet \"refs/tags/$TAG\" >/dev/null || git tag \"$TAG\" -m \"$TAG\") && git push origin --tags && pnpm publish --no-git-checks --access public -r --filter=@gradio/*",
 		"website": "pnpm --filter @gradio/website build",
 		"package": "pnpm --filter @gradio/* --filter=!@gradio/client --filter=!@gradio/preview exec svelte-package --input=. --tsconfig=../../tsconfig.json",
 		"spaces:dev": "pnpm css && pnpm --filter @gradio/preview build && pnpm --filter @self/spaces-test dev"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build",
 		"ci:version": "changeset version && pnpm i --lockfile-only && node ./.changeset/fix_changelogs.cjs",
-		"ci:publish": "pnpm changeset tag && git push origin --tags && pnpm publish --no-git-checks --access public -r --filter=@gradio/*",
+		"ci:publish": "pnpm changeset tag && TAG=gradio_client@$(node -p \"require('./client/python/gradio_client/package.json').version\") && (git rev-parse --verify --quiet \"refs/tags/$TAG\" >/dev/null || git tag \"$TAG\") && git push origin --tags && pnpm publish --no-git-checks --access public -r --filter=@gradio/*",
 		"website": "pnpm --filter @gradio/website build",
 		"package": "pnpm --filter @gradio/* --filter=!@gradio/client --filter=!@gradio/preview exec svelte-package --input=. --tsconfig=../../tsconfig.json",
 		"spaces:dev": "pnpm css && pnpm --filter @gradio/preview build && pnpm --filter @self/spaces-test dev"


### PR DESCRIPTION
Changesets 2.29 and later no longer tags private packages by default, so the existing `pnpm changeset tag` release step stopped creating `gradio_client@...` tags even though client versions continued to be released to PyPI.

This PR keeps the Python `gradio_client` workspace package private so it cannot be accidentally published to npm. During `ci:publish`, it creates an annotated `gradio_client@<version>` Git tag idempotently alongside the normal Changesets tags, then pushes all tags through the existing release workflow. The npm publish command remains filtered to `@gradio/*`.

I ran the exact steps twice confirmed that the tag was created idempotently here: https://github.com/gradio-app/gradio/tree/gradio_client@2.5.0

<img width="284" height="268" alt="image" src="https://github.com/user-attachments/assets/3b90d62b-391c-4dac-9d63-d562540210c6" />
