### PR TITLE
workflow: ensure we handle trailing null values

### DIFF
--- a/.changeset/three-tigers-fold.md
+++ b/.changeset/three-tigers-fold.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:workflow: ensure we handle null values

--- a/.changeset/three-tigers-fold.md
+++ b/.changeset/three-tigers-fold.md
@@ -3,4 +3,4 @@
 "gradio": minor
 ---
 
-feat:workflow: ensure we handle null values
+feat:workflow: ensure we handle trailing null values

--- a/.changeset/three-tigers-fold.md
+++ b/.changeset/three-tigers-fold.md
@@ -1,4 +1,5 @@
 ---
+"@gradio/workflowcanvas": minor
 "gradio": minor
 ---
 

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -545,7 +545,9 @@ def call_space(
                 processed.append(arg)
         while processed and processed[-1] is _EMPTY:
             processed.pop()
-        result = client.predict(*[None if v is _EMPTY else v for v in processed], api_name=endpoint)
+        result = client.predict(
+            *[None if v is _EMPTY else v for v in processed], api_name=endpoint
+        )
         result = list(result) if isinstance(result, (list, tuple)) else [result]
 
         _tmpdir = os.path.realpath(tempfile.gettempdir())

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -535,18 +535,18 @@ def call_space(
             endpoint = (
                 endpoint if endpoint in named else (named[0] if named else "/predict")
             )
-        _EMPTY = object()
+        _empty = object()
         processed = []
         for arg in args:
             if isinstance(arg, dict) and ("url" in arg or "path" in arg):
                 url = arg.get("url") or arg.get("path", "")
-                processed.append(handle_file(url) if url else _EMPTY)
+                processed.append(handle_file(url) if url else _empty)
             else:
                 processed.append(arg)
-        while processed and processed[-1] is _EMPTY:
+        while processed and processed[-1] is _empty:
             processed.pop()
         result = client.predict(
-            *[None if v is _EMPTY else v for v in processed], api_name=endpoint
+            *[None if v is _empty else v for v in processed], api_name=endpoint
         )
         result = list(result) if isinstance(result, (list, tuple)) else [result]
 

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -535,16 +535,17 @@ def call_space(
             endpoint = (
                 endpoint if endpoint in named else (named[0] if named else "/predict")
             )
+        _EMPTY = object()
         processed = []
         for arg in args:
             if isinstance(arg, dict) and ("url" in arg or "path" in arg):
                 url = arg.get("url") or arg.get("path", "")
-                processed.append(handle_file(url) if url else None)
+                processed.append(handle_file(url) if url else _EMPTY)
             else:
                 processed.append(arg)
-        while processed and processed[-1] is None:
+        while processed and processed[-1] is _EMPTY:
             processed.pop()
-        result = client.predict(*processed, api_name=endpoint)
+        result = client.predict(*[None if v is _EMPTY else v for v in processed], api_name=endpoint)
         result = list(result) if isinstance(result, (list, tuple)) else [result]
 
         _tmpdir = os.path.realpath(tempfile.gettempdir())

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -535,19 +535,16 @@ def call_space(
             endpoint = (
                 endpoint if endpoint in named else (named[0] if named else "/predict")
             )
-        _empty = object()
         processed = []
         for arg in args:
             if isinstance(arg, dict) and ("url" in arg or "path" in arg):
                 url = arg.get("url") or arg.get("path", "")
-                processed.append(handle_file(url) if url else _empty)
+                processed.append(handle_file(url) if url else None)
             else:
                 processed.append(arg)
-        while processed and processed[-1] is _empty:
+        while processed and processed[-1] is None:
             processed.pop()
-        result = client.predict(
-            *[None if v is _empty else v for v in processed], api_name=endpoint
-        )
+        result = client.predict(*processed, api_name=endpoint)
         result = list(result) if isinstance(result, (list, tuple)) else [result]
 
         _tmpdir = os.path.realpath(tempfile.gettempdir())

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -45,6 +45,7 @@
 		WFEdge,
 		NodeStatus,
 		NodeRole,
+		NodeDataValue,
 		Workflow
 	} from "./workflow-types";
 	import { executeWorkflow } from "./workflow-executor";
@@ -483,6 +484,11 @@
 					template.height
 				);
 				const newId = addNode("reference", template, x, y);
+				const port = node.inputs.find((p) => p.id === portId);
+				if (port?.default_value !== undefined) {
+					const outId = template.outputs[0]?.id ?? "out";
+					updateNodeData(newId, outId, port.default_value as NodeDataValue);
+				}
 				addEdge({
 					from_node_id: newId,
 					from_port_id: "out",
@@ -1993,6 +1999,9 @@
 						inStartY + i * (compH + compGap)
 					);
 					const cId = addNode("reference", comp, cx, cy);
+					if (port.default_value !== undefined) {
+						updateNodeData(cId, comp.outputs[0]?.id ?? "out", port.default_value as NodeDataValue);
+					}
 					addEdge({
 						from_node_id: cId,
 						from_port_id: "out",

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -2000,7 +2000,11 @@
 					);
 					const cId = addNode("reference", comp, cx, cy);
 					if (port.default_value !== undefined) {
-						updateNodeData(cId, comp.outputs[0]?.id ?? "out", port.default_value as NodeDataValue);
+						updateNodeData(
+							cId,
+							comp.outputs[0]?.id ?? "out",
+							port.default_value as NodeDataValue
+						);
 					}
 					addEdge({
 						from_node_id: cId,

--- a/js/workflowcanvas/workflow/workflow-store.ts
+++ b/js/workflowcanvas/workflow/workflow-store.ts
@@ -94,7 +94,7 @@ export function sanitize_for_save(wf: Workflow): Workflow {
 }
 
 // ─── Actions ────────────────────────────────────────────────────────────────
-export const PORT_DEFAULTS: Partial<Record<PortType, NodeDataValue>> = {
+const PORT_DEFAULTS: Partial<Record<PortType, NodeDataValue>> = {
 	boolean: false,
 	number: 0,
 	text: ""

--- a/js/workflowcanvas/workflow/workflow-store.ts
+++ b/js/workflowcanvas/workflow/workflow-store.ts
@@ -94,6 +94,11 @@ export function sanitize_for_save(wf: Workflow): Workflow {
 }
 
 // ─── Actions ────────────────────────────────────────────────────────────────
+export const PORT_DEFAULTS: Partial<Record<PortType, NodeDataValue>> = {
+	boolean: false,
+	number: 0,
+	text: ""
+};
 
 function addReference(
 	template: Omit<ReferenceNode, "id" | "role" | "x" | "y" | "data">,
@@ -102,19 +107,11 @@ function addReference(
 ): string {
 	const id = uuid();
 	const data: Record<string, NodeDataValue> = {};
-	for (const port of template.inputs) {
+	for (const port of [...template.inputs, ...template.outputs]) {
 		if (port.default_value !== undefined) {
 			data[port.id] = port.default_value as NodeDataValue;
-		}
-	}
-	const PORT_DEFAULTS: Partial<Record<PortType, NodeDataValue>> = {
-		boolean: false,
-		number: 0,
-		text: ""
-	};
-	for (const port of template.outputs) {
-		if (data[port.id] === undefined && port.type in PORT_DEFAULTS) {
-			data[port.id] = PORT_DEFAULTS[port.type]!;
+		} else if (port.type in PORT_DEFAULTS) {
+			data[port.id] ??= PORT_DEFAULTS[port.type]!;
 		}
 	}
 	const node: ReferenceNode = {

--- a/js/workflowcanvas/workflow/workflow-store.ts
+++ b/js/workflowcanvas/workflow/workflow-store.ts
@@ -107,6 +107,16 @@ function addReference(
 			data[port.id] = port.default_value as NodeDataValue;
 		}
 	}
+	const PORT_DEFAULTS: Partial<Record<PortType, NodeDataValue>> = {
+		boolean: false,
+		number: 0,
+		text: ""
+	};
+	for (const port of template.outputs) {
+		if (data[port.id] === undefined && port.type in PORT_DEFAULTS) {
+			data[port.id] = PORT_DEFAULTS[port.type]!;
+		}
+	}
 	const node: ReferenceNode = {
 		...template,
 		role: "reference",


### PR DESCRIPTION
## Description

When trailing values are null (e.g. an unchecked boolean) they were being stripped from the args list before being sent to the space. The space never received the argument at all, so it fell back to its own default. 

~The fix i've implemented is to use an `_EMPTY` marker. If a text/number/boolean node sends null, it stays in the list and reaches the space unchanged.~ text/number/boolean nodes also now send typed defaults instead of null. Only empty file nodes get marked with `_EMPTY` and stripped from the end. 

slack thread: https://huggingface.slack.com/archives/C03JMRM52C9/p1783659983304819?thread_ts=1783651622.002489&cid=C03JMRM52C9 cc @hysts @AK391 

test space here: https://huggingface.co/spaces/hmb/Z-Image-Turbo