### PR TITLE
Fix chained events after cancellation and in hidden tabs

### DIFF
--- a/.changeset/quiet-chains-continue.md
+++ b/.changeset/quiet-chains-continue.md
@@ -1,0 +1,7 @@
+---
+"@gradio/client": patch
+"@gradio/core": patch
+"gradio": patch
+---
+
+Fix chained events after cancellation and while the browser tab is hidden.

--- a/client/js/src/test/stream.test.ts
+++ b/client/js/src/test/stream.test.ts
@@ -84,32 +84,4 @@ describe("open_stream", () => {
 		} as MessageEvent);
 		expect(app.stream_status.open).toBe(false);
 	});
-
-	it.runIf(typeof document !== "undefined")(
-		"should process stream messages immediately when the page is hidden",
-		async () => {
-			await app.open_stream();
-
-			if (!app.stream_instance?.onmessage) {
-				throw new Error("stream instance is not defined");
-			}
-
-			const callback = vi.fn();
-			const message = {
-				msg: "process_completed",
-				event_id: "hidden-tab-event"
-			};
-			app.event_callbacks[message.event_id] = callback;
-			const visibility_spy = vi
-				.spyOn(document, "visibilityState", "get")
-				.mockReturnValue("hidden");
-
-			app.stream_instance.onmessage({
-				data: JSON.stringify(message)
-			} as MessageEvent);
-
-			expect(callback).toHaveBeenCalledWith(message);
-			visibility_spy.mockRestore();
-		}
-	);
 });

--- a/client/js/src/test/stream.test.ts
+++ b/client/js/src/test/stream.test.ts
@@ -84,4 +84,32 @@ describe("open_stream", () => {
 		} as MessageEvent);
 		expect(app.stream_status.open).toBe(false);
 	});
+
+	it.runIf(typeof document !== "undefined")(
+		"should process stream messages immediately when the page is hidden",
+		async () => {
+			await app.open_stream();
+
+			if (!app.stream_instance?.onmessage) {
+				throw new Error("stream instance is not defined");
+			}
+
+			const callback = vi.fn();
+			const message = {
+				msg: "process_completed",
+				event_id: "hidden-tab-event"
+			};
+			app.event_callbacks[message.event_id] = callback;
+			const visibility_spy = vi
+				.spyOn(document, "visibilityState", "get")
+				.mockReturnValue("hidden");
+
+			app.stream_instance.onmessage({
+				data: JSON.stringify(message)
+			} as MessageEvent);
+
+			expect(callback).toHaveBeenCalledWith(message);
+			visibility_spy.mockRestore();
+		}
+	);
 });

--- a/client/js/src/utils/stream.ts
+++ b/client/js/src/utils/stream.ts
@@ -62,9 +62,15 @@ export async function open_stream(this: Client): Promise<void> {
 			}
 			let fn: (data: any) => void = event_callbacks[event_id];
 
-			if (typeof window !== "undefined" && typeof document !== "undefined") {
-				// fn(_data); // need to do this to put the event on the end of the event loop, so the browser can refresh between callbacks and not freeze in case of quick generations. See
-				setTimeout(fn, 0, _data); // need to do this to put the event on the end of the event loop, so the browser can refresh between callbacks and not freeze in case of quick generations. See https://github.com/gradio-app/gradio/pull/7055
+			if (
+				typeof window !== "undefined" &&
+				typeof document !== "undefined" &&
+				document.visibilityState !== "hidden"
+			) {
+				// Put the event at the end of the event loop so the browser can refresh
+				// between callbacks and not freeze during quick generations. Hidden tabs
+				// throttle timers, so process those messages immediately instead.
+				setTimeout(fn, 0, _data); // See https://github.com/gradio-app/gradio/pull/7055
 			} else {
 				fn(_data);
 			}

--- a/demo/cancel_events/run.py
+++ b/demo/cancel_events/run.py
@@ -28,6 +28,7 @@ with gr.Blocks() as demo:
             run = gr.Button(value="Start Iterating")
             output = gr.Textbox(label="Iterative Output")
             stop = gr.Button(value="Stop Iterating")
+            cancel_followup = gr.Textbox(label="Cancel Follow-up")
         with gr.Column():
             textbox = gr.Textbox(label="Prompt")
             loading_box = gr.Textbox(
@@ -58,7 +59,9 @@ with gr.Blocks() as demo:
             )
 
     click_event = run.click(fake_diffusion, n, output)
-    stop.click(fn=None, inputs=None, outputs=None, cancels=[click_event])
+    stop.click(fn=None, inputs=None, outputs=None, cancels=[click_event]).then(
+        lambda: "Cancel follow-up ran", outputs=cancel_followup
+    )
     pred_event = run_pred.click(
         fn=long_prediction,
         inputs=[textbox],

--- a/js/core/src/dependency.ts
+++ b/js/core/src/dependency.ts
@@ -413,11 +413,19 @@ export class DependencyManager {
 						target_id
 					);
 
-					if (dep_submission.type === "void") {
+					if (dep_submission.type !== "submit") {
+						if (dep_submission.type === "data") {
+							await this.handle_data(dep.outputs, dep_submission.data);
+						}
 						unset_args.forEach((fn) => fn());
-					} else if (dep_submission.type === "data") {
-						await this.handle_data(dep.outputs, dep_submission.data);
-						unset_args.forEach((fn) => fn());
+						[...success, ...all].forEach((dep_id) => {
+							this.dispatch({
+								type: "fn",
+								fn_index: dep_id,
+								event_data: null,
+								target_id: target_id as number | undefined
+							});
+						});
 					} else {
 						let stream_state: "open" | "closed" | "waiting" | null = null;
 

--- a/js/spa/test/cancel_events.spec.ts
+++ b/js/spa/test/cancel_events.spec.ts
@@ -41,6 +41,9 @@ test("when using an iterative function it should be possible to cancel the funct
 	await page.waitForTimeout(200);
 	await stop_button.click();
 	await expect(textbox).not.toHaveValue("9");
+	await expect(page.getByLabel("Cancel Follow-up")).toHaveValue(
+		"Cancel follow-up ran"
+	);
 });
 
 test("when using an iterative function and the user closes the page, the python function should stop running", async ({


### PR DESCRIPTION
Fix two cases where chained `.then()`/`.success()` events could stall. 

- Dispatch success and always triggers after frontend-only dependencies, including the `fn=None` dependency created for cancellation controls.
- Process event-stream messages immediately while the document is hidden, avoiding background-tab timer throttling while retaining the event-loop yield for visible pages.

Note that second issue was flakey, I couldn't fully reproduce them because it depends on browser behavior, but this behavior should be more robust. Also, I confirmed that this PR doesn't cause any regressions related to #7055.

Closes: #10432
Closes: #10538

You can test everything works with this:

```py
import time

import gradio as gr


def stream_numbers():
    for number in range(30):
        time.sleep(0.25)
        yield str(number)


def cancellation_followup():
    return "✅ The cancellation event's .then() ran"


def chain_step(step: int):
    print(f"Step {step} started", flush=True)
    time.sleep(2)
    print(f"Step {step} finished", flush=True)
    return f"✅ Step {step} finished"


def rapid_generator():
    for index in range(1000):
        yield "hello " * index


with gr.Blocks(title="Gradio event regressions") as demo:
    gr.Markdown("# Gradio event regression demo")

    with gr.Tab("Cancellation chain — #10432"):
        gr.Markdown(
            "Click **Start streaming**, then **Stop**. The follow-up field should "
            "confirm that the stop event's `.then()` ran."
        )
        stream_output = gr.Textbox(label="Stream output")
        cancel_output = gr.Textbox(label="Cancellation follow-up")
        with gr.Row():
            start = gr.Button("Start streaming", variant="primary")
            stop = gr.Button("Stop")

        stream_event = start.click(stream_numbers, outputs=stream_output)
        stop.click(fn=None, cancels=[stream_event]).then(
            cancellation_followup, outputs=cancel_output
        )

    with gr.Tab("Hidden-tab chain — #10538"):
        gr.Markdown(
            "Click **Run three steps**, switch to another browser tab, wait about "
            "7 seconds, then return. All three steps should have completed."
        )
        chain_output = gr.Textbox(label="Latest completed step")
        run_chain = gr.Button("Run three steps", variant="primary")

        run_chain.click(lambda: chain_step(1), outputs=chain_output).then(
            lambda: chain_step(2), outputs=chain_output
        ).then(lambda: chain_step(3), outputs=chain_output)

    with gr.Tab("Rapid generator responsiveness — #7055"):
        gr.Markdown(
            "This is the original #7055 stress case. Enter a number and press "
            "**Enter**. The HTML should update through 100 rapid generations "
            "without freezing the page, despite the 5,000-button component tree."
        )
        rapid_output = gr.HTML(elem_id="rapid-generator-output")
        rapid_trigger = gr.Number(label="Press Enter to run")
        rapid_trigger.submit(rapid_generator, inputs=None, outputs=rapid_output)

        for _ in range(5_000):
            gr.Button()


if __name__ == "__main__":
    demo.launch()
```

## AI Disclosure

- [x] I used AI to reproduce both issues, investigate the frontend event paths, draft the implementation and tests, and prepare this PR description. I reviewed all the changes myself and tested everything works as expected.