### PR TITLE
Reset audio playback position when the file is cleared or a new one is uploaded

### DIFF
--- a/.changeset/curvy-worms-happen.md
+++ b/.changeset/curvy-worms-happen.md
@@ -1,0 +1,6 @@
+---
+"@gradio/audio": patch
+"gradio": patch
+---
+
+fix:Reset audio playback position when the file is cleared or a new one is uploaded

--- a/js/audio/audio.test.ts
+++ b/js/audio/audio.test.ts
@@ -412,6 +412,57 @@ describe("Events: upload via file input", () => {
 	});
 });
 
+describe("Props: playback_position", () => {
+	setupi18n();
+	afterEach(() => cleanup());
+
+	test("clicking clear resets playback_position to 0", async () => {
+		const { getByLabelText, set_data, get_data } = await render(Audio, {
+			...default_props,
+			interactive: true,
+			value: fake_value
+		});
+
+		await set_data({ playback_position: 1.5 });
+		await fireEvent.click(getByLabelText("common.clear"));
+
+		expect((await get_data()).playback_position).toBe(0);
+	});
+
+	test("uploading a new file starts playback from the beginning", async () => {
+		const { listen, set_data, get_data } = await render(Audio, {
+			...upload_props,
+			value: fake_value
+		});
+
+		const upload = listen("upload");
+
+		await set_data({ playback_position: 1.5 });
+		await set_data({ value: null });
+		await upload_file(TEST_WAV);
+
+		await waitFor(() => {
+			expect(upload).toHaveBeenCalledTimes(1);
+		});
+		expect((await get_data()).playback_position).toBe(0);
+	});
+
+	test("a backend update can still set playback_position alongside a new value", async () => {
+		const { set_data, get_data } = await render(Audio, {
+			...default_props,
+			interactive: true,
+			value: fake_value
+		});
+
+		await set_data({
+			value: { ...fake_value, url: `${fake_value.url}?v=2` },
+			playback_position: 2
+		});
+
+		expect((await get_data()).playback_position).toBe(2);
+	});
+});
+
 describe("Waveform controls", () => {
 	setupi18n();
 	afterEach(() => cleanup());

--- a/js/audio/interactive/InteractiveAudio.svelte
+++ b/js/audio/interactive/InteractiveAudio.svelte
@@ -262,10 +262,12 @@
 		onclear?.();
 		mode = "";
 		value = null;
+		playback_position = 0;
 	}
 
 	function handle_load(detail: FileData): void {
 		value = detail;
+		playback_position = 0;
 		onchange?.(detail);
 		onupload?.(detail);
 	}

--- a/js/audio/interactive/InteractiveAudio.svelte
+++ b/js/audio/interactive/InteractiveAudio.svelte
@@ -258,11 +258,11 @@
 	}
 
 	function clear(): void {
-		onchange?.(null);
-		onclear?.();
 		mode = "";
 		value = null;
 		playback_position = 0;
+		onchange?.(null);
+		onclear?.();
 	}
 
 	function handle_load(detail: FileData): void {


### PR DESCRIPTION
## Description

Fixes a bug where an interactive `gr.Audio` keeps the previous file's playback position after the user clears it and uploads a new file, so the new file starts playing partway through instead of from 0:00. A repro video is attached to the issue.

Root cause: `playback_position` (added in #12504) is bound two-way to the component props, which outlive the player UI. Clearing an interactive audio sets the value to null and unmounts the player, and uploading a new file mounts a fresh one. The fresh player sees the leftover `playback_position`, can't tell it apart from a position set from the backend, and seeks the new file there. Output components are unaffected because the player stays mounted while the value changes, so no seek is triggered and the new file starts from the beginning.

The fix resets `playback_position` to 0 in `clear()` and `handle_load()` in `InteractiveAudio.svelte`, i.e. at the two user actions that discard the current file. The player's seek logic is untouched, so setting the position from the backend still works, including together with a new value (`gr.Audio(value=..., playback_position=...)`).

#13387 attempted a similar fix earlier. This PR keeps its `clear()` reset, adds the reset on upload, and leaves out the unconditional reset inside `AudioPlayer.svelte`, which would have broken backend updates that set a new value and a playback position at the same time.

Added three unit tests in `js/audio/audio.test.ts`: the first two reproduce the bug (they fail without the fix) and the third guards the combined value + position update.

Closes: #13273

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

