### PR TITLE
workflow: add oauth hint

### DIFF
--- a/.changeset/whole-paths-dream.md
+++ b/.changeset/whole-paths-dream.md
@@ -1,0 +1,6 @@
+---
+"@gradio/workflowcanvas": minor
+"gradio": minor
+---
+
+feat:workflow: add oauth hint

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -138,6 +138,24 @@
 		void auth.init();
 	});
 
+	let oauthHintShown = false;
+	$effect(() => {
+		if (
+			!oauthHintShown &&
+			auth.isHFSpace &&
+			auth.writeAccessKnown &&
+			!auth.canWrite &&
+			!auth.oauthAvailable
+		) {
+			oauthHintShown = true;
+			showToast(
+				"Sign-in has not beed enabled on this Space. The author should add `hf_oauth: true` to the README so users can run workflows on their own inference quota, and authors can edit.",
+				0,
+				"warning"
+			);
+		}
+	});
+
 	$effect(() => {
 		if (!initialValue) return;
 		try {
@@ -2357,8 +2375,14 @@
 							</div>
 						{/if}
 					</div>
-				{:else if auth.isHFSpace && auth.oauthAvailable}
-					<button class="toolbar-login-btn" onclick={auth.signIn}
+				{:else if auth.isHFSpace}
+					<button
+						class="toolbar-login-btn"
+						onclick={auth.signIn}
+						disabled={!auth.oauthAvailable}
+						title={auth.oauthAvailable
+							? undefined
+							: "OAuth is not enabled for this Space. If you're the owner, add `hf_oauth: true` to the Space README and redeploy."}
 						>Sign in with 🤗</button
 					>
 				{:else}
@@ -2992,10 +3016,14 @@
 		border-color: #e2e4ea;
 		color: #6b6e78;
 	}
-	:global(body:not(.dark) .toolbar-login-btn:hover) {
+	:global(body:not(.dark) .toolbar-login-btn:hover:not(:disabled)) {
 		background: #f0f1f5;
 		color: #1a1b25;
 		border-color: #d0d2dc;
+	}
+	:global(.toolbar-login-btn:disabled) {
+		opacity: 0.45;
+		cursor: not-allowed;
 	}
 	:global(body:not(.dark) .toolbar-user-chip) {
 		border-color: #e2e4ea;


### PR DESCRIPTION
## Description

It's not always clear to users that they need to add hf_oauth: true to the README to enable hf sign in on HF spaces. This PR shows a warning on the screen that they should add it to enable users to run the workflow and authors to edit

<img width="1512" height="743" alt="image" src="https://github.com/user-attachments/assets/2bb7da74-120e-4dc2-928e-4fbda68a6458" />

test space https://huggingface.co/spaces/hmb/oauth-workflow?logs=container
