### PR TITLE
Fix Dataframe whole-table keyboard focus

### DIFF
--- a/.changeset/fuzzy-tables-focus.md
+++ b/.changeset/fuzzy-tables-focus.md
@@ -1,0 +1,7 @@
+---
+"@gradio/dataframe": patch
+"@gradio/upload": patch
+"gradio": patch
+---
+
+Prevent Dataframe container elements from adding whole-table stops to keyboard navigation.

--- a/js/dataframe/Dataframe.test.ts
+++ b/js/dataframe/Dataframe.test.ts
@@ -6,6 +6,7 @@ import {
 	waitFor,
 	within
 } from "@self/tootils/render";
+import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
 import { tick } from "svelte";
 
 import Dataframe from "./Index.svelte";
@@ -37,6 +38,15 @@ const default_props = {
 	max_height: 500
 };
 
+run_shared_prop_tests({
+	component: Dataframe,
+	name: "Dataframe",
+	base_props: default_props,
+	// Dataframe renders visible and screen-reader label copies; targeted tests below cover its label behavior.
+	has_label: false,
+	has_validation_error: false
+});
+
 function get_cell(container: HTMLElement, row: number, col: number) {
 	return container.querySelector(
 		`[data-row='${row}'][data-col='${col}']`
@@ -63,6 +73,27 @@ async function wait(ms = 50) {
 
 describe("Dataframe rendering", () => {
 	afterEach(() => cleanup());
+
+	test("tabbing skips dataframe containers and reaches individual cells", async () => {
+		const { getAllByRole, getByRole } = await render(Dataframe, default_props);
+
+		await waitFor(() => {
+			expect(getByRole("button", { name: "Alice" })).toBeVisible();
+		});
+
+		expect(getAllByRole("grid").every((grid) => grid.tabIndex === -1)).toBe(
+			true
+		);
+		expect(
+			getByRole("button", {
+				name: "dataframe.drop_to_upload"
+			})
+		).toHaveAttribute("tabindex", "-1");
+		expect(getByRole("button", { name: "Alice" })).toHaveAttribute(
+			"tabindex",
+			"0"
+		);
+	});
 
 	test("renders provided headers", async () => {
 		const { container } = await render(Dataframe, default_props);

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -947,7 +947,7 @@
 		class:menu-open={active_cell_menu || active_header_menu}
 		onkeydown={handle_keydown}
 		role="grid"
-		tabindex="0"
+		tabindex="-1"
 		style="--df-max-col-width: {viewport_width}px;"
 	>
 		<Upload

--- a/js/upload/src/Upload.svelte
+++ b/js/upload/src/Upload.svelte
@@ -308,7 +308,7 @@
 					? height + "px"
 					: height
 				: "100%"}
-		tabindex={hidden ? -1 : 0}
+		tabindex={hidden || disable_click ? -1 : 0}
 		use:drag={{
 			on_drag_change: (d) => (dragging = d),
 			on_files: (files) => load_files_from_upload(files),


### PR DESCRIPTION
## Description

This removes the Dataframe's whole-table containers from the normal keyboard Tab sequence while preserving programmatic grid focus and individual cell focus. It also prevents the disabled-click upload wrapper used by Dataframe from becoming a separate Tab stop and adds regression coverage for the resulting focus targets.

Closes: #11735

## AI Disclosure

- [x] I used AI to investigate the focus behavior, draft the implementation and test, and prepare this PR description. I reviewed every changed line and ran the verification listed below.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets #11735. I checked open PRs by issue number and focus-related wording before opening this PR and found no overlapping work.

## Testing and Formatting Your Code

- `CI=1 npx vitest run --config .config/vitest.config.ts js/dataframe/Dataframe.test.ts` — 51 passed, 2 todo.
- `pnpm build` — passed.
- `bash scripts/format_frontend.sh` — formatting completed; the repository-wide `svelte-check` step reported 15 errors outside the touched files (existing utility, Prism declaration, and preview/Rollup typing errors).
- Rebuilt and manually verified the local demo: Dataframe grid/upload containers have `tabIndex = -1`, while the individual `Alice` cell remains at `tabIndex = 0`.

The reproduction demo was kept untracked and is not part of this PR:

```python
import gradio as gr


def filter_records(records: list[list[str]], gender: str) -> list[list[str]]:
    return [record for record in records if record[2] == gender]


demo = gr.Interface(
    filter_records,
    [
        gr.Dataframe(
            headers=["name", "age", "gender"],
            datatype=["str", "number", "str"],
            value=[
                ["Alice", 30, "F"],
                ["Bob", 25, "M"],
                ["Casey", 28, "O"],
            ],
            row_count=3,
            column_count=(3, "fixed"),
        ),
        gr.Dropdown(["M", "F", "O"], label="Gender"),
    ],
    "dataframe",
    description="Tab through the controls and inspect which Dataframe element receives focus.",
)

if __name__ == "__main__":
    demo.launch()
```
