### PR TITLE
Fix hidden tab focus and label overflow menu

### DIFF
--- a/.changeset/shy-sites-turn.md
+++ b/.changeset/shy-sites-turn.md
@@ -1,0 +1,6 @@
+---
+"@gradio/tabs": patch
+"gradio": patch
+---
+
+fix:Fix hidden tab focus and label overflow menu

--- a/js/tabs/Tabs.test.ts
+++ b/js/tabs/Tabs.test.ts
@@ -1,6 +1,7 @@
 import { test, describe, afterEach, expect } from "vitest";
-import { cleanup, render, fireEvent } from "@self/tootils/render";
+import { cleanup, render, fireEvent, waitFor } from "@self/tootils/render";
 import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
+import event from "@testing-library/user-event";
 import type { Tab } from "./shared/Tabs.svelte";
 
 import Tabs from "./Index.svelte";
@@ -78,6 +79,36 @@ describe("Tabs", () => {
 			"aria-selected",
 			"false"
 		);
+	});
+});
+
+describe("Accessibility", () => {
+	afterEach(() => cleanup());
+
+	test("keyboard focus skips the hidden tab measurement buttons", async () => {
+		const { getByRole } = await render(Tabs, default_props);
+
+		await event.tab();
+
+		expect(getByRole("tab", { name: "First" })).toHaveFocus();
+	});
+
+	test("the tab overflow button has an accessible name", async () => {
+		const many_tabs = Array.from({ length: 20 }, (_, index) =>
+			make_tab({
+				label: `Long tab label ${index + 1}`,
+				id: `t${index + 1}`,
+				component_id: index + 1
+			})
+		);
+		const { getByRole } = await render(Tabs, {
+			...default_props,
+			initial_tabs: many_tabs
+		});
+
+		await waitFor(() => {
+			expect(getByRole("button", { name: "More tabs" })).toBeVisible();
+		});
 	});
 });
 

--- a/js/tabs/shared/Tabs.svelte
+++ b/js/tabs/shared/Tabs.svelte
@@ -232,7 +232,7 @@
 			<div class="tab-container visually-hidden" aria-hidden="true">
 				{#each tabs as t, i}
 					{#if is_visible_tab(t)}
-						<button bind:this={tab_els[t.id]}>
+						<button tabindex="-1" bind:this={tab_els[t.id]}>
 							{t?.label}
 						</button>
 					{/if}
@@ -274,6 +274,7 @@
 				bind:this={overflow_menu}
 			>
 				<button
+					aria-label="More tabs"
 					onclick={(e) => {
 						e.stopPropagation();
 						overflow_menu_open = !overflow_menu_open;


### PR DESCRIPTION
## Description

Prevent measurement-only tab buttons from entering the sequential keyboard focus order, and give the tab overflow menu button the accessible name "More tabs".

The hidden measurement buttons were ordinary focusable buttons inside an `aria-hidden` container. Adding `tabindex="-1"` preserves their width measurement behavior while removing the invisible keyboard stops. The icon-only overflow control now has an explicit accessible name.

## Before / after Spaces
<!-- gradio-before-after-spaces -->
- [Before fix](https://huggingface.co/spaces/dawood/gradio-13635-before)
- [After fix](https://huggingface.co/spaces/dawood/gradio-13635-after)

Closes: #13635

## AI Disclosure

- [x] I used AI to reproduce the issue, implement the fix, and draft tests and this PR description. I self-reviewed every changed line.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets #13635. I checked for issue ownership and overlapping open PRs immediately before pushing; the issue is unassigned and no overlapping PR exists.

## Testing and Formatting Your Code

- `CI=1 npx vitest run --config .config/vitest.config.ts js/tabs/Tabs.test.ts` — 25 passed
- `bash scripts/build_frontend.sh` — passed
- `bash scripts/format_frontend.sh` — formatting completed; the repository-wide `ts:check` phase reports 15 pre-existing errors outside `js/tabs`
- `git diff --check` — passed

Minimal reproduction:

```python
import gradio as gr


with gr.Blocks() as demo:
    with gr.Tabs():
        with gr.Tab("First"):
            gr.Markdown("first tab content")
        with gr.Tab("Second"):
            gr.Markdown("second tab content")
        with gr.Tab("A Longer Third Tab"):
            gr.Markdown("third")
        with gr.Tab("Fourth Tab Name"):
            gr.Markdown("fourth")
        with gr.Tab("Fifth And Final"):
            gr.Markdown("fifth")

demo.launch()
```

The reproduction file `demo_issue_13635.py` is intentionally untracked and was not committed.
