### PR TITLE
Stop workflows after an upstream function fails

### DIFF
--- a/.changeset/calm-workflows-stop.md
+++ b/.changeset/calm-workflows-stop.md
@@ -1,0 +1,6 @@
+---
+"@gradio/workflowcanvas": patch
+"gradio": patch
+---
+
+fix: stop downstream workflow functions when an upstream node fails

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -214,6 +214,7 @@ def _workflow_from_bind(
                 "id": f"in_{p}",
                 "label": p,
                 "type": _PY_TO_PORT.get(param.annotation, "text"),
+                "required": param.default is inspect.Parameter.empty,
             }
             for p, param in sig.parameters.items()
             if p != "self" and not _is_injected_param(_hints.get(p))
@@ -1407,6 +1408,7 @@ class Workflow(Blocks):
                         "id": f"in_{p}",
                         "label": p,
                         "type": _PY_TO_PORT.get(param.annotation, "text"),
+                        "required": param.default is inspect.Parameter.empty,
                     }
                     for p, param in sig.parameters.items()
                     if p != "self" and not _is_injected_param(_hints.get(p))

--- a/js/workflowcanvas/workflow/workflow-executor.test.ts
+++ b/js/workflowcanvas/workflow/workflow-executor.test.ts
@@ -658,7 +658,7 @@ describe("executeWorkflow — space multi-output mapping", () => {
 });
 
 describe("executeWorkflow — cascading failure messages", () => {
-	test("downstream node's missing-input error names the failed upstream", async () => {
+	test("legacy fn nodes skip execution and name the failed upstream", async () => {
 		const failingFn = "boom";
 		const downstreamFn = "consumer";
 		const callFn = vi.fn().mockImplementation(async (name: string) => {
@@ -693,7 +693,7 @@ describe("executeWorkflow — cascading failure messages", () => {
 			kind: "fn",
 			label: "FLUX",
 			fn: downstreamFn,
-			inputs: [{ id: "in", label: "Prompt", type: "text", required: true }],
+			inputs: [{ id: "in", label: "Prompt", type: "text" }],
 			outputs: [{ id: "out", label: "Image", type: "image" }],
 			data: {},
 			x: 0,
@@ -726,5 +726,6 @@ describe("executeWorkflow — cascading failure messages", () => {
 
 		expect(errors.d).toContain('"Prompt" is missing');
 		expect(errors.d).toContain("moondream2");
+		expect(callFn).toHaveBeenCalledTimes(1);
 	});
 });

--- a/js/workflowcanvas/workflow/workflow-executor.ts
+++ b/js/workflowcanvas/workflow/workflow-executor.ts
@@ -242,16 +242,22 @@ export async function executeWorkflow(
 	}
 
 	function missing_input_message(node: WFNode, port: Port): string {
+		const upstream = failed_upstream(node, port);
+		if (upstream) {
+			return `"${port.label}" is missing — upstream node "${upstream.label}" failed`;
+		}
+		return `"${port.label}" is missing — an upstream node may have failed`;
+	}
+
+	function failed_upstream(node: WFNode, port: Port): WFNode | undefined {
 		const edge = edges.find(
 			(e) => e.to_node_id === node.id && e.to_port_id === port.id
 		);
 		if (edge) {
 			const upstream = nodes.find((n) => n.id === edge.from_node_id);
-			if (upstream && failed_nodes.has(upstream.id)) {
-				return `"${port.label}" is missing — upstream node "${upstream.label}" failed`;
-			}
+			if (upstream && failed_nodes.has(upstream.id)) return upstream;
 		}
-		return `"${port.label}" is missing — an upstream node may have failed`;
+		return undefined;
 	}
 
 	// Seed input nodes (including component nodes with no incoming edges)
@@ -366,7 +372,10 @@ export async function executeWorkflow(
 					throw new Error("Python function call not available");
 				const inputs = resolveInputs(node, edges, dataMap);
 				for (const port of node.inputs) {
-					if (port.required && inputs[port.id] === null) {
+					if (
+						inputs[port.id] === null &&
+						(port.required || failed_upstream(node, port))
+					) {
 						throw new Error(missing_input_message(node, port));
 					}
 				}
@@ -402,7 +411,10 @@ export async function executeWorkflow(
 			try {
 				const inputs = resolveInputs(node, edges, dataMap);
 				for (const port of node.inputs) {
-					if (port.required && inputs[port.id] === null) {
+					if (
+						inputs[port.id] === null &&
+						(port.required || failed_upstream(node, port))
+					) {
 						throw new Error(missing_input_message(node, port));
 					}
 				}

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -354,6 +354,15 @@ class TestWorkflowFromBind:
         node = result["nodes"][0]
         assert node["inputs"][0]["type"] == "text"
 
+    def test_parameters_without_defaults_are_required(self):
+        def with_default(required, optional="fallback"):
+            return required, optional
+
+        result = json.loads(_workflow_from_bind({"with_default": with_default}))
+        inputs = result["nodes"][0]["inputs"]
+        assert inputs[0]["required"] is True
+        assert inputs[1]["required"] is False
+
     def test_edges_resolve_by_function_name(self):
         result = json.loads(
             _workflow_from_bind(


### PR DESCRIPTION
## Description

Workflow functions generated from Python bindings did not mark parameters without defaults as required. As a result, a downstream function could execute with `None` after its upstream dependency failed.

This change records required Python parameters on generated workflow ports and also treats an explicit failed-upstream connection as blocking when executing legacy saved graphs that lack the new metadata. The error continues to name the failed upstream node.

Closes: #13630

## AI Disclosure

- [x] I used AI to reproduce the issue, draft and self-review the fix and tests, and prepare this pull request.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets #13630. I checked open pull requests before creating it and found no overlapping fix.

## Testing and Formatting Your Code

- `/Users/dawoodkhan/Desktop/Developer/gradio/.venv/bin/pytest test/test_workflow.py` (45 passed)
- `pnpm --filter @gradio/workflowcanvas test -- --run workflow/workflow-executor.test.ts` (26 passed)
- Focused Ruff checks and formatting on the changed Python files
- Focused Prettier formatting on the changed TypeScript and changeset files
- No Playwright tests were added
- Reproduced before the fix: generated required parameter lacked `required`; verified after the fix that it emits `required: true`

The isolated reproduction demo is running locally at `http://127.0.0.1:18080` for inspection.