### PR TITLE
Restore props lost in shared-prop partitioning

### DIFF
--- a/.changeset/calm-columns-appear.md
+++ b/.changeset/calm-columns-appear.md
@@ -1,0 +1,5 @@
+---
+"@gradio/column": patch
+---
+
+fix: forward Column variant props to its base component

--- a/js/column/Column.test.ts
+++ b/js/column/Column.test.ts
@@ -26,6 +26,14 @@ describe("Column", () => {
 		expect(container.querySelector(".my-col-class")).not.toBeNull();
 	});
 
+	test.each(["panel", "compact"] as const)(
+		"variant: %s is applied to the root div",
+		async (variant) => {
+			const { container } = await render(Column, { variant });
+			expect(container.querySelector(`.column.${variant}`)).not.toBeNull();
+		}
+	);
+
 	test("visible: true → container is visible", async () => {
 		const { container } = await render(Column, {
 			visible: true,
@@ -78,12 +86,6 @@ describe("Children / slot", () => {
 	});
 });
 
-test.todo(
-	"VISUAL: variant='panel' applies panel border, background fill, and padding to the column container — needs Playwright visual regression screenshot comparison"
-);
-test.todo(
-	"VISUAL: variant='compact' removes border-radius from direct child elements — needs Playwright visual regression screenshot comparison"
-);
 test.todo(
 	"VISUAL: scale prop controls flex-grow, making the column proportionally wider when scale > 1 — needs Playwright visual regression screenshot comparison"
 );

--- a/js/column/Index.svelte
+++ b/js/column/Index.svelte
@@ -13,7 +13,7 @@
 	);
 </script>
 
-<BaseColumn {...gradio.shared}>
+<BaseColumn {...gradio.shared} {...gradio.props}>
 	<slot />
 </BaseColumn>
 

--- a/js/column/Index.svelte
+++ b/js/column/Index.svelte
@@ -13,7 +13,7 @@
 	);
 </script>
 
-<BaseColumn {...gradio.shared} {...gradio.props}>
+<BaseColumn {...gradio.shared} variant={gradio.props.variant}>
 	<slot />
 </BaseColumn>
 

--- a/js/column/Index.svelte
+++ b/js/column/Index.svelte
@@ -13,7 +13,7 @@
 	);
 </script>
 
-<BaseColumn {...gradio.shared} variant={gradio.props.variant}>
+<BaseColumn {...gradio.shared} {...gradio.props}>
 	<slot />
 </BaseColumn>
 

--- a/js/dataset/Dataset.test.ts
+++ b/js/dataset/Dataset.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render, waitFor } from "@self/tootils/render";
+
+import Dataset from "./Index.svelte";
+import DatasetRootExample from "./DatasetRootExample.svelte";
+
+describe("Dataset", () => {
+	afterEach(() => cleanup());
+
+	test("forwards the shared root to example components", async () => {
+		const result = await render(Dataset, {
+			components: [{ name: "textbox", class_id: "textbox" }],
+			component_props: [{}],
+			headers: ["Example"],
+			samples: [["sample"]],
+			sample_labels: null,
+			value: null,
+			root: "/gradio-root",
+			proxy_url: null,
+			samples_per_page: 10,
+			layout: "gallery",
+			show_label: false,
+			load_component: () => ({
+				component: Promise.resolve({ default: DatasetRootExample }),
+				runtime: false
+			})
+		});
+
+		await waitFor(() => {
+			expect(result.getByTestId("dataset-root")).toHaveTextContent(
+				"/gradio-root"
+			);
+		});
+	});
+});

--- a/js/dataset/DatasetRootExample.svelte
+++ b/js/dataset/DatasetRootExample.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	let { root }: { root?: string } = $props();
+</script>
+
+<span data-testid="dataset-root">{root ?? "missing"}</span>

--- a/js/dataset/Index.svelte
+++ b/js/dataset/Index.svelte
@@ -54,6 +54,7 @@
 		onselect={(data) => gradio.dispatch("select", data)}
 		load_component={gradio.shared.load_component}
 		{...gradio.props}
+		root={gradio.shared.root}
 		{samples}
 	/>
 </Block>

--- a/js/dataset/types.ts
+++ b/js/dataset/types.ts
@@ -7,7 +7,6 @@ export interface DatasetProps {
 	samples: any[][] | null;
 	sample_labels: string[] | null;
 	value: number | null;
-	root: string;
 	proxy_url: null | string;
 	samples_per_page: number;
 

--- a/js/html/HTML.test.ts
+++ b/js/html/HTML.test.ts
@@ -128,4 +128,21 @@ describe("HTML", () => {
 
 		expect(view.queryByText("HTML label")).not.toBeInTheDocument();
 	});
+
+	test.each([
+		{ padding: true, expected: true },
+		{ padding: false, expected: false }
+	])(
+		"padding=$padding controls block padding",
+		async ({ padding, expected }) => {
+			const { container } = await render(HTML, {
+				...default_props,
+				padding
+			});
+			const block = container.querySelector(".block");
+
+			expect(block).not.toBeNull();
+			expect(block?.classList.contains("padded")).toBe(expected);
+		}
+	);
 });

--- a/js/html/Index.svelte
+++ b/js/html/Index.svelte
@@ -58,7 +58,7 @@
 	elem_id={gradio.shared.elem_id}
 	elem_classes={gradio.shared.elem_classes}
 	container={gradio.shared.container}
-	padding={gradio.props.padding !== false}
+	padding={gradio.shared.padding !== false}
 	overflow_behavior="visible"
 >
 	{#if gradio.shared.show_label && gradio.props.buttons && gradio.props.buttons.length > 0}

--- a/js/html/types.ts
+++ b/js/html/types.ts
@@ -13,7 +13,6 @@ export interface HTMLProps {
 	head: string | null;
 	component_class_name: string;
 	buttons: (string | CustomButton)[] | null;
-	padding: boolean;
 }
 
 export interface HTMLEvents {

--- a/js/json/Index.svelte
+++ b/js/json/Index.svelte
@@ -64,7 +64,7 @@
 	<JSON
 		value={gradio.props.value}
 		open={gradio.props.open}
-		theme_mode={gradio.props.theme_mode}
+		theme_mode={gradio.shared.theme_mode}
 		show_indices={gradio.props.show_indices}
 		show_copy_button={gradio.props.buttons == null
 			? true

--- a/js/json/JSON.test.ts
+++ b/js/json/JSON.test.ts
@@ -137,6 +137,15 @@ describe("JSON", () => {
 		});
 		expect(getByText('"a"')).toBeVisible();
 	});
+
+	test("theme_mode=dark applies the dark-mode class", async () => {
+		const { container } = await render(JSONOutput, {
+			...default_props,
+			theme_mode: "dark"
+		});
+
+		expect(container.querySelector(".json-node.root")).toHaveClass("dark-mode");
+	});
 });
 
 describe("Empty state", () => {

--- a/js/json/types.ts
+++ b/js/json/types.ts
@@ -8,7 +8,6 @@ export interface JSONProps {
 	height: number | string | undefined;
 	min_height: number | string | undefined;
 	max_height: number | string | undefined;
-	theme_mode: "system" | "light" | "dark";
 	buttons: (string | CustomButton)[];
 }
 

--- a/js/plot/Index.svelte
+++ b/js/plot/Index.svelte
@@ -65,7 +65,7 @@
 	/>
 	<Plot
 		value={gradio.props.value}
-		theme_mode={gradio.props.theme_mode}
+		theme_mode={gradio.shared.theme_mode}
 		show_label={gradio.shared.show_label}
 		caption={gradio.props.caption}
 		bokeh_version={gradio.props.bokeh_version}

--- a/js/plot/types.ts
+++ b/js/plot/types.ts
@@ -5,7 +5,6 @@ export type ThemeMode = "system" | "light" | "dark";
 
 export interface PlotProps {
 	value: null | string;
-	theme_mode: ThemeMode;
 	caption: string;
 	bokeh_version: string | null;
 	show_actions_button: boolean;

--- a/js/tabitem/Index.svelte
+++ b/js/tabitem/Index.svelte
@@ -20,7 +20,7 @@
 	interactive={gradio.shared.interactive}
 	id={gradio.props.id}
 	order={gradio.props.order}
-	scale={gradio.props.scale}
+	scale={gradio.shared.scale}
 	component_id={gradio.props.component_id}
 	onselect={(data) => gradio.dispatch("select", data)}
 >

--- a/js/tabitem/TabItem.test.ts
+++ b/js/tabitem/TabItem.test.ts
@@ -87,6 +87,18 @@ describe("TabItem", () => {
 			);
 		});
 	});
+
+	test("forwards shared scale through the component wrapper", async () => {
+		const { getByRole } = await render(TabItemHarness, {
+			use_index: true,
+			tab_scale: 2,
+			tab_selected: "t1"
+		});
+		const tabpanel = getByRole("tabpanel", { hidden: true });
+
+		expect(tabpanel).toHaveClass("grow-children");
+		expect(tabpanel).toHaveStyle({ flexGrow: "2" });
+	});
 });
 
 describe("Events: select", () => {

--- a/js/tabitem/TabItemHarness.svelte
+++ b/js/tabitem/TabItemHarness.svelte
@@ -2,7 +2,7 @@
 	import { setContext } from "svelte";
 	import { writable } from "svelte/store";
 	import { TABS } from "@gradio/tabs";
-	import { BaseTabItem } from "./Index.svelte";
+	import TabItem, { BaseTabItem } from "./Index.svelte";
 
 	let all = $props();
 	const cfg = (all as any).props ?? {};
@@ -23,15 +23,35 @@
 	});
 </script>
 
-<BaseTabItem
-	label="First Tab"
-	id={cfg.omit_id ? undefined : (cfg.tab_id ?? "t1")}
-	order={0}
-	visible={cfg.tab_visible ?? true}
-	interactive={true}
-	scale={0}
-	component_id={1}
-	onselect={(data) => cfg.on_tab_select?.(data)}
->
-	<div data-testid="tab-content">tab panel content</div>
-</BaseTabItem>
+{#if cfg.use_index}
+	<TabItem
+		shared_props={{
+			elem_id: "",
+			elem_classes: [],
+			label: "First Tab",
+			visible: cfg.tab_visible ?? true,
+			interactive: true,
+			scale: cfg.tab_scale ?? 0
+		}}
+		props={{
+			id: cfg.omit_id ? undefined : (cfg.tab_id ?? "t1"),
+			order: 0,
+			component_id: 1
+		}}
+	>
+		<div data-testid="tab-content">tab panel content</div>
+	</TabItem>
+{:else}
+	<BaseTabItem
+		label="First Tab"
+		id={cfg.omit_id ? undefined : (cfg.tab_id ?? "t1")}
+		order={0}
+		visible={cfg.tab_visible ?? true}
+		interactive={true}
+		scale={0}
+		component_id={1}
+		onselect={(data) => cfg.on_tab_select?.(data)}
+	>
+		<div data-testid="tab-content">tab panel content</div>
+	</BaseTabItem>
+{/if}

--- a/js/tabitem/types.ts
+++ b/js/tabitem/types.ts
@@ -8,7 +8,6 @@ export interface TabItemProps {
 	visible: boolean | "hidden";
 	interactive: boolean;
 	order: number;
-	scale: number;
 	component_id: number;
 }
 

--- a/js/textbox/Index.svelte
+++ b/js/textbox/Index.svelte
@@ -32,7 +32,7 @@
 
 	async function handle_input(value: string): Promise<void> {
 		if (!gradio.shared || !gradio.props) return;
-		gradio.props.validation_error = null;
+		gradio.shared.validation_error = null;
 		gradio.props.value = value;
 		await tick();
 		gradio.dispatch("input");
@@ -44,7 +44,7 @@
 
 	function handle_change(value: string): void {
 		if (!gradio.shared || !gradio.props) return;
-		gradio.props.validation_error = null;
+		gradio.shared.validation_error = null;
 		gradio.props.value = value;
 	}
 </script>

--- a/js/textbox/Textbox.test.ts
+++ b/js/textbox/Textbox.test.ts
@@ -53,6 +53,25 @@ describe("Textbox", () => {
 
 		expect(item.value).toBe("hi some text");
 	});
+
+	test.each(["input", "change"] as const)(
+		"%s clears the shared validation error",
+		async (event_name) => {
+			const result = await render(Textbox, {
+				...default_props,
+				value: "",
+				validation_error: "Required"
+			});
+			const textbox = result.getByRole("textbox");
+
+			expect(result.getByText("Required")).toBeVisible();
+			await fireEvent[event_name](textbox, { target: { value: "valid" } });
+
+			await waitFor(() => {
+				expect(result.queryByText("Required")).not.toBeInTheDocument();
+			});
+		}
+	);
 });
 
 describe("Props: type", () => {

--- a/js/textbox/types.ts
+++ b/js/textbox/types.ts
@@ -34,7 +34,6 @@ export interface TextboxProps {
 	autoscroll: boolean;
 	max_length: number;
 	html_attributes: InputHTMLAttributes;
-	validation_error: string | null;
 }
 
 type FullAutoFill =


### PR DESCRIPTION
## Description

The frontend separates reserved shared props from component-specific props. Several wrappers still read reserved values from `gradio.props`, or spread only `gradio.props` into an underlying component, so those values silently became `undefined` after the shared-props refactor.

This PR restores the affected forwarding paths:

- `Column.variant` reaches `BaseColumn`, restoring the `panel` and `compact` classes.
- `HTML.padding` is read from shared props.
- `JSON.theme_mode` and `Plot.theme_mode` are read from shared props.
- `TabItem.scale` is read from shared props.
- Textbox input/change handlers clear the shared `validation_error`.
- `Dataset.root` is explicitly forwarded alongside component props.

Focused regression tests cover the observable Column, HTML, JSON, TabItem, Textbox, and Dataset behavior. Component prop types no longer claim ownership of the affected reserved fields.

Credit to @deckar01 for identifying the shared-prop root cause and the other affected components, @ajayraj30002 for independently validating the Column direction, and @Mr-Neutr0n for the earlier fix proposed in #12889.

## Before / after Spaces
<!-- gradio-before-after-spaces -->
- [Before Column fix](https://huggingface.co/spaces/dawood/gradio-13623-before)
- [After Column fix](https://huggingface.co/spaces/dawood/gradio-13623-after)

Closes: #13623
Related: #12881

## AI Disclosure

- [x] I used AI to reproduce the issues, audit the shared/component prop boundary, draft and self-review the fixes and tests, and prepare this pull request.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets #13623 and follows up on the confirmed shared-prop regressions in #12881. I checked open pull requests before expanding the scope and found no overlapping PR; #12889 was closed without merging.

## Testing and Formatting Your Code

- Focused Vitest browser suite: 136 passed, 5 existing TODOs
- Svelte packaging/type checks passed for Column, Dataset, HTML, JSON, Plot, TabItem, and Textbox
- Focused Prettier formatting passed for every touched file
- CI is the full frontend and functional verification
