### PR TITLE
Use the browser-visible proxy URL in Colab

### DIFF
--- a/.changeset/kind-colabs-connect.md
+++ b/.changeset/kind-colabs-connect.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": patch
+"gradio": patch
+---
+
+Use the browser-visible proxy URL for API requests from apps embedded in Google Colab.

--- a/client/js/src/helpers/init_helpers.ts
+++ b/client/js/src/helpers/init_helpers.ts
@@ -66,10 +66,15 @@ export function map_names_to_ids(
 
 export function resolve_config_root(
 	root: string,
-	current_location: string
+	current_location: string,
+	prefer_current_location = false
 ): string {
-	const root_url = new URL(root, current_location);
 	const current_url = new URL(current_location);
+	if (prefer_current_location) {
+		return new URL(".", current_url).toString().replace(/\/$/, "");
+	}
+
+	const root_url = new URL(root, current_url);
 	if (root_url.hostname !== current_url.hostname) {
 		return root;
 	}
@@ -121,9 +126,14 @@ export async function resolve_config(
 		// The page was rendered by this Gradio server, so a same-host root may
 		// contain an internal protocol or port supplied by a reverse proxy. Keep
 		// the configured path, but use the browser-visible origin for requests
-		// made by the client itself (queue, upload, reset, etc.).
+		// made by the client itself (queue, upload, reset, etc.). Colab uses a
+		// different public hostname, so its browser-visible URL must be preferred.
 		const config = { ...window.gradio_config } as unknown as Config;
-		config.root = resolve_config_root(config.root, location.href);
+		config.root = resolve_config_root(
+			config.root,
+			location.href,
+			config.is_colab
+		);
 		return config;
 	} else if (endpoint) {
 		let config_url = join_urls(

--- a/client/js/src/test/init_helpers.test.ts
+++ b/client/js/src/test/init_helpers.test.ts
@@ -7,15 +7,7 @@ import {
 	resolve_config_root
 } from "../helpers/init_helpers";
 import { initialise_server } from "./server";
-import {
-	beforeAll,
-	afterEach,
-	afterAll,
-	it,
-	expect,
-	describe,
-	vi
-} from "vitest";
+import { beforeAll, afterEach, afterAll, it, expect, describe } from "vitest";
 import { Client } from "../client";
 import { INVALID_CREDENTIALS_MSG, MISSING_CREDENTIALS_MSG } from "../constants";
 import { config_response } from "./test_data";
@@ -58,31 +50,31 @@ describe("resolve_config", () => {
 		).toBe("https://runtime-id-7860.us-central1.colab.googleusercontent.com");
 	});
 
-	it("resolves a Colab config to the browser-visible proxy URL", async () => {
-		const internal_root =
-			"http://runtime-id.us-central1.c.colab-user-runtimes.internal:7860";
-		const public_root =
-			"https://runtime-id-7860.us-central1.colab.googleusercontent.com";
-		vi.stubGlobal("window", {
-			gradio_config: {
+	const in_browser = typeof window !== "undefined";
+
+	it.skipIf(!in_browser)(
+		"resolves a Colab config to the browser-visible proxy URL",
+		async () => {
+			const internal_root =
+				"http://runtime-id.us-central1.c.colab-user-runtimes.internal:7860";
+			window.gradio_config = {
 				...config_response,
 				is_colab: true,
 				root: internal_root
-			}
-		});
-		vi.stubGlobal("location", new URL(`${public_root}/`));
-		const fake_client = {
-			options: {},
-			deep_link: null
-		} as unknown as Client;
+			};
+			const fake_client = {
+				options: {},
+				deep_link: null
+			} as unknown as Client;
 
-		try {
-			const config = await resolve_config.call(fake_client, internal_root);
-			expect(config?.root).toBe(public_root);
-		} finally {
-			vi.unstubAllGlobals();
+			try {
+				const config = await resolve_config.call(fake_client, internal_root);
+				expect(config?.root).toBe(window.location.origin);
+			} finally {
+				delete (window as Partial<Window>).gradio_config;
+			}
 		}
-	});
+	);
 
 	it("requests /config without a Content-Type header and with same-origin credentials, so the cross-origin embed fetch is not blocked by CORS", async () => {
 		let captured_init: RequestInit | undefined;
@@ -106,8 +98,6 @@ describe("resolve_config", () => {
 		expect(header_names).not.toContain("content-type");
 		expect(captured_init?.credentials).toBe("same-origin");
 	});
-
-	const in_browser = typeof window !== "undefined";
 
 	it.skipIf(!in_browser)(
 		"uses the browser origin for a same-host config root behind a proxy",

--- a/client/js/src/test/init_helpers.test.ts
+++ b/client/js/src/test/init_helpers.test.ts
@@ -7,7 +7,15 @@ import {
 	resolve_config_root
 } from "../helpers/init_helpers";
 import { initialise_server } from "./server";
-import { beforeAll, afterEach, afterAll, it, expect, describe } from "vitest";
+import {
+	beforeAll,
+	afterEach,
+	afterAll,
+	it,
+	expect,
+	describe,
+	vi
+} from "vitest";
 import { Client } from "../client";
 import { INVALID_CREDENTIALS_MSG, MISSING_CREDENTIALS_MSG } from "../constants";
 import { config_response } from "./test_data";
@@ -38,6 +46,42 @@ describe("resolve_config", () => {
 				"https://host.example/page"
 			)
 		).toBe("https://remote.example/gradio");
+	});
+
+	it("uses the browser-visible URL for a Colab proxy root", () => {
+		expect(
+			resolve_config_root(
+				"http://runtime-id.us-central1.c.colab-user-runtimes.internal:7860",
+				"https://runtime-id-7860.us-central1.colab.googleusercontent.com/",
+				true
+			)
+		).toBe("https://runtime-id-7860.us-central1.colab.googleusercontent.com");
+	});
+
+	it("resolves a Colab config to the browser-visible proxy URL", async () => {
+		const internal_root =
+			"http://runtime-id.us-central1.c.colab-user-runtimes.internal:7860";
+		const public_root =
+			"https://runtime-id-7860.us-central1.colab.googleusercontent.com";
+		vi.stubGlobal("window", {
+			gradio_config: {
+				...config_response,
+				is_colab: true,
+				root: internal_root
+			}
+		});
+		vi.stubGlobal("location", new URL(`${public_root}/`));
+		const fake_client = {
+			options: {},
+			deep_link: null
+		} as unknown as Client;
+
+		try {
+			const config = await resolve_config.call(fake_client, internal_root);
+			expect(config?.root).toBe(public_root);
+		} finally {
+			vi.unstubAllGlobals();
+		}
 	});
 
 	it("requests /config without a Content-Type header and with same-origin credentials, so the cross-origin embed fetch is not blocked by CORS", async () => {


### PR DESCRIPTION
## Description

Google Colab renders Gradio with an internal runtime URL in `config.root`, while the browser can only reach Colab’s public proxy hostname. The client preserved that internal cross-host root after the SSR removal, so API requests repeatedly failed and the embedded app reconnected.

This change marks Colab as the one case where the browser-visible URL must win, while preserving the existing behavior for ordinary cross-host embeds.

## Before / after Spaces
<!-- gradio-before-after-spaces -->
- [Before fix](https://huggingface.co/spaces/dawood/gradio-13629-before)
- [After fix](https://huggingface.co/spaces/dawood/gradio-13629-after)

Closes: #13629

## AI Disclosure

- [x] I used AI to reproduce the issue, draft and self-review the fix and tests, and prepare this pull request.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets #13629. I checked open pull requests immediately before creating it and found no overlapping fix.

## Testing and Formatting Your Code

- Controlled Colab internal-versus-public hostname regression failed before the fix and passes after it
- Full `@gradio/client` browser suite: 148 passed, 9 skipped
- Full `@gradio/client` Node suite: 150 passed, 7 skipped
- Client TypeScript build passed
- Frontend production build passed
- Required frontend formatter completed
- No Playwright tests were added

Minimal demo (retained untracked):

```python
import gradio as gr

def greet(name: str) -> str:
    return f"Hello, {name}!"

demo = gr.Interface(fn=greet, inputs="text", outputs="text")
demo.launch(share=False, debug=True)
```

The local reproduction remains available at `http://127.0.0.1:7865`.