### PR TITLE
Add before and after Spaces to the issue fixer skill

### DIFF
--- a/.agents/skills/gradio-issue-fixer/SKILL.md
+++ b/.agents/skills/gradio-issue-fixer/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: gradio-issue-fixer
+description: Reproduce, diagnose, fix, verify, and draft-PR Gradio GitHub issues, including public before/after Hugging Face Spaces deployed with the hf CLI and linked in the PR description. Use when the user provides a gradio-app/gradio issue URL or issue number and wants an agent to create an isolated worktree, build a minimal untracked reproduction demo, confirm the bug, patch Gradio, verify the fix, and open a draft PR.
+---
+
+# Gradio Issue Fixer
+
+## Defaults
+
+- Use the local Gradio repository at `~/Desktop/Developer/gradio`.
+- Create issue worktrees under `~/Desktop/Developer/gradio-worktrees/issue-<number>`.
+- Use `gh` for GitHub issue, pull request, and CI operations.
+- Use the official Hugging Face `hf` CLI for Space operations.
+- Keep the reproduction demo and Space upload directories temporary and untracked.
+- Leave the verified local demo running at the end and report its URL.
+
+## Workflow
+
+1. Resolve the issue input.
+   - Accept either a bare issue number or a GitHub issue URL.
+   - Run `scripts/setup_gradio_issue.py <issue-or-url>` from this skill directory.
+   - Read the printed issue title, state, worktree path, branch name, and metadata file path.
+   - If the issue is closed, still inspect it unless the user explicitly asked to skip closed issues; closed regressions may still be reproducible.
+
+2. Read the issue and check for duplicate work.
+   - Use `gh issue view <number> --repo gradio-app/gradio --comments` when the script output is not enough.
+   - Extract the expected behavior, actual behavior, repro steps, affected component, likely version range, and any maintainer guidance.
+   - Search open pull requests for overlapping fixes and check whether someone already owns the issue. Do not open a duplicate PR.
+
+3. Build a minimal repro demo in the worktree.
+   - Put it in a clearly named untracked file such as `demo_issue_<number>.py`.
+   - Keep it small and focused on the reported behavior.
+   - Prefer Gradio APIs that match the issue report. Avoid unrelated dependencies.
+   - Run the demo from the worktree against the local package under test.
+
+4. Verify the bug before editing source.
+   - Exercise the demo exactly enough to observe the reported failure.
+   - If the issue no longer reproduces on current `origin/main`, stop immediately:
+     - Do not modify code or open a PR.
+     - Report the demo path, command, observed result, and any uncertainty.
+
+5. Fix the issue in Gradio.
+   - Keep the patch scoped to the failing behavior.
+   - Follow local Gradio patterns and tests.
+   - Add or update tests when practical, but keep the temporary demo untracked.
+   - Do not revert unrelated worktree changes unless the user explicitly asks.
+
+6. Rerun verification.
+   - Rerun the minimal demo and confirm the issue is fixed.
+   - Run the narrowest relevant Gradio tests for the changed area.
+   - Run the required formatter for every changed area.
+   - Record the exact command and failure reason for any test blocked by the environment.
+
+7. Prepare the branch and draft PR.
+   - Confirm the demo file is untracked with `git status --short`.
+   - Stage and commit only source and test changes needed for the fix.
+   - Push only the dedicated issue branch.
+   - Open a draft PR against `main` with `gh pr create --draft --repo gradio-app/gradio`.
+   - Use the repository PR template, complete the AI disclosure, and include `Closes: #<issue>`.
+   - Keep the main description concise: explain the root cause and the fix before the closing reference.
+
+8. Publish before and after Spaces with the `hf` CLI.
+   - Follow the [official Hugging Face CLI guide](https://huggingface.co/docs/huggingface_hub/en/guides/cli). Use the `hf` executable, not browser automation or the Python Hub API.
+   - Run `hf version` and `hf auth whoami`. If `hf` is unavailable, install it using the official guide. If authentication is unavailable, ask the user to run `hf auth login`; never print or commit tokens.
+   - Create two temporary upload directories containing the same minimal app and interaction path. Change only the Gradio dependency needed to demonstrate the comparison:
+     - Pin the before Space to the affected released version or other immutable baseline that reproduces the issue.
+     - Pin the after Space to the immutable preview wheel produced for the exact PR head SHA. Do not use a mutable branch reference.
+   - Create public Gradio Spaces with stable, issue-specific names and upload them:
+
+     ```bash
+     hf repos create <namespace>/gradio-<issue>-before --type space --sdk gradio --public --exist-ok
+     hf upload <namespace>/gradio-<issue>-before <before-directory> . --repo-type space
+     hf repos create <namespace>/gradio-<issue>-after --type space --sdk gradio --public --exist-ok
+     hf upload <namespace>/gradio-<issue>-after <after-directory> . --repo-type space
+     ```
+
+   - Wait for both deployments with `hf spaces wait <space-id> --timeout 10m`.
+   - Verify both public URLs return successfully and exercise the reproduction. Confirm the before Space shows the bug and the after Space shows the fix.
+   - Do not link a Space that is still building, fails to start, or does not demonstrate the intended comparison.
+
+9. Put the Space links in the PR description.
+   - Preserve every PR-template section.
+   - Insert the links directly after the main description and immediately before `Closes: #<issue>` using this layout:
+
+     ```markdown
+     ## Description
+
+     <root cause and fix summary>
+
+     ## Before / after Spaces
+
+     - [Before fix](https://huggingface.co/spaces/<namespace>/gradio-<issue>-before)
+     - [After fix](https://huggingface.co/spaces/<namespace>/gradio-<issue>-after)
+
+     Closes: #<issue>
+     ```
+
+   - Read the PR body back from GitHub and verify that both links are correct, the section appears exactly once, and it precedes the closing reference.
+
+10. Ensure CI passes and hand off.
+   - Poll required checks with `gh pr checks <pr> --required --watch` and fix failures until they pass.
+   - Leave the local demo running.
+   - Report the local URL, worktree, branch, demo path, PR URL, both Space URLs, and remaining non-required review checks.
+
+## Helper Script
+
+Use `scripts/setup_gradio_issue.py` for setup. It validates `gh`, `git`, and the local repository; resolves the issue number; reads issue metadata; fetches `origin/main`; creates a dedicated branch and worktree; and writes `.gradio_issue_metadata.json` in the worktree.
+
+```bash
+python3 .agents/skills/gradio-issue-fixer/scripts/setup_gradio_issue.py 12345
+```
+
+Optional flags:
+
+```bash
+--repo /path/to/gradio
+--worktrees-dir /path/to/worktrees
+--base origin/main
+--force
+```
+
+Use `--force` only when intentionally reusing an existing issue worktree.

--- a/.agents/skills/gradio-issue-fixer/scripts/setup_gradio_issue.py
+++ b/.agents/skills/gradio-issue-fixer/scripts/setup_gradio_issue.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Prepare a Gradio issue worktree for reproduction and fixing."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+DEFAULT_REPO = Path.home() / "Desktop" / "Developer" / "gradio"
+DEFAULT_WORKTREES_DIR = Path.home() / "Desktop" / "Developer" / "gradio-worktrees"
+GH_REPO = "gradio-app/gradio"
+
+
+def run(cmd: list[str], *, cwd: Path | None = None, capture: bool = False) -> str:
+    kwargs = {
+        "cwd": str(cwd) if cwd else None,
+        "text": True,
+        "check": True,
+    }
+    if capture:
+        kwargs.update({"stdout": subprocess.PIPE, "stderr": subprocess.PIPE})
+    try:
+        result = subprocess.run(cmd, **kwargs)
+    except subprocess.CalledProcessError as exc:
+        if capture and exc.stderr:
+            print(exc.stderr.strip(), file=sys.stderr)
+        raise
+    return result.stdout if capture else ""
+
+
+def require_binary(name: str) -> None:
+    if shutil.which(name) is None:
+        raise SystemExit(f"Missing required command: {name}")
+
+
+def parse_issue(value: str) -> int:
+    value = value.strip()
+    if value.isdigit():
+        return int(value)
+    match = re.search(r"github\.com/gradio-app/gradio/issues/(\d+)", value)
+    if match:
+        return int(match.group(1))
+    raise SystemExit("Expected a gradio-app/gradio issue number or issue URL.")
+
+
+def slugify(title: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", title.lower()).strip("-")
+    return slug[:48] or "issue"
+
+
+def ensure_repo(repo: Path) -> None:
+    if not repo.exists():
+        raise SystemExit(f"Repository does not exist: {repo}")
+    if not (repo / ".git").exists() and not run(
+        ["git", "rev-parse", "--is-inside-work-tree"], cwd=repo, capture=True
+    ).strip() == "true":
+        raise SystemExit(f"Not a git worktree: {repo}")
+
+
+def issue_json(number: int) -> dict:
+    raw = run(
+        [
+            "gh",
+            "issue",
+            "view",
+            str(number),
+            "--repo",
+            GH_REPO,
+            "--json",
+            "number,title,state,url,body,createdAt,updatedAt",
+        ],
+        capture=True,
+    )
+    return json.loads(raw)
+
+
+def worktree_exists(path: Path) -> bool:
+    return path.exists() and any(path.iterdir())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("issue", help="Gradio issue number or GitHub issue URL")
+    parser.add_argument("--repo", type=Path, default=DEFAULT_REPO)
+    parser.add_argument("--worktrees-dir", type=Path, default=DEFAULT_WORKTREES_DIR)
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+
+    require_binary("git")
+    require_binary("gh")
+
+    issue_number = parse_issue(args.issue)
+    repo = args.repo.expanduser().resolve()
+    worktrees_dir = args.worktrees_dir.expanduser().resolve()
+    ensure_repo(repo)
+
+    issue = issue_json(issue_number)
+    branch = f"fix/issue-{issue_number}-{slugify(issue['title'])}"
+    worktree = worktrees_dir / f"issue-{issue_number}"
+
+    run(["git", "fetch", "origin", "main"], cwd=repo)
+    worktrees_dir.mkdir(parents=True, exist_ok=True)
+
+    if worktree_exists(worktree):
+        if not args.force:
+            raise SystemExit(
+                f"Worktree already exists: {worktree}\n"
+                "Use --force only if you intend to reuse it."
+            )
+    else:
+        existing_branches = run(["git", "branch", "--list", branch], cwd=repo, capture=True)
+        if existing_branches.strip():
+            run(["git", "worktree", "add", str(worktree), branch], cwd=repo)
+        else:
+            run(["git", "worktree", "add", "-b", branch, str(worktree), args.base], cwd=repo)
+
+    metadata = {
+        "issue": issue,
+        "repo": str(repo),
+        "worktree": str(worktree),
+        "branch": branch,
+        "base": args.base,
+        "github_repo": GH_REPO,
+    }
+    metadata_path = worktree / ".gradio_issue_metadata.json"
+    metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Issue: #{issue_number} {issue['title']}")
+    print(f"State: {issue['state']}")
+    print(f"URL: {issue['url']}")
+    print(f"Worktree: {worktree}")
+    print(f"Branch: {branch}")
+    print(f"Metadata: {metadata_path}")
+    print()
+    print("Next:")
+    print(f"  cd {worktree}")
+    print(f"  gh issue view {issue_number} --repo {GH_REPO} --comments")
+    print(f"  create an untracked demo_issue_{issue_number}.py")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Description

Adds the `gradio-issue-fixer` skill to the repository and makes public before/after Hugging Face Spaces part of its standard issue-fix workflow. The instructions use the official `hf` CLI, pin the after Space to the exact PR-head preview wheel, verify both deployments, and place both links directly below the main PR description before the closing issue reference.

Closes: #13646

## AI Disclosure

- [x] I used AI to draft and self-review the skill instructions, validate the helper, and prepare this pull request.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets #13646. I checked for overlapping open issues and pull requests before creating it.

## Testing and Formatting Your Code

- `quick_validate.py .agents/skills/gradio-issue-fixer`: passed
- `setup_gradio_issue.py --help`: passed
- `bash scripts/format_frontend.sh`: formatting completed; the repository-wide TypeScript phase reports 15 unrelated existing errors in frontend utility and Prism declaration files
- Independent read-only forward test confirmed the intended `hf` CLI workflow and PR-description placement
