### PR TITLE
Respect custom `FRONTEND_DIR` in `gradio cc dev/build/install`

### DIFF
--- a/.changeset/eager-frogs-relate.md
+++ b/.changeset/eager-frogs-relate.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+Fix `gradio cc dev`, `gradio cc build`, and `gradio cc install` to respect a custom `FRONTEND_DIR` set on the component class, instead of assuming the frontend code lives in the `frontend` directory.

--- a/gradio/cli/commands/components/build.py
+++ b/gradio/cli/commands/components/build.py
@@ -16,7 +16,10 @@ from gradio.cli.commands.components._docs_utils import (
     get_deep,
 )
 from gradio.cli.commands.components.docs import run_command
-from gradio.cli.commands.components.install_component import _get_executable_path
+from gradio.cli.commands.components.install_component import (
+    _get_executable_path,
+    _get_frontend_dir,
+)
 from gradio.cli.commands.display import LivePanelDisplay
 
 gradio_template_path = Path(gradio.__file__).parent / "templates" / "frontend"  # type: ignore
@@ -128,16 +131,18 @@ def _build(
                     "node must be installed in order to run build command."
                 )
 
+            frontend_dir = _get_frontend_dir(component_directory)
+
             gradio_node_path = subprocess.run(
                 [node, "-e", "console.log(require.resolve('@gradio/preview'))"],
-                cwd=Path(component_directory / "frontend"),
+                cwd=frontend_dir,
                 check=False,
                 capture_output=True,
             )
 
             if gradio_node_path.returncode != 0:
                 raise ValueError(
-                    "Could not find `@gradio/preview`. Run `npm i -D @gradio/preview` in your frontend folder."
+                    f"Could not find `@gradio/preview`. Run `npm i -D @gradio/preview` in your frontend folder ({frontend_dir})."
                 )
 
             gradio_node_path = gradio_node_path.stdout.decode("utf-8").strip()

--- a/gradio/cli/commands/components/dev.py
+++ b/gradio/cli/commands/components/dev.py
@@ -10,7 +10,10 @@ from rich import print
 
 import gradio
 from gradio.analytics import custom_component_analytics
-from gradio.cli.commands.components.install_component import _get_executable_path
+from gradio.cli.commands.components.install_component import (
+    _get_executable_path,
+    _get_frontend_dir,
+)
 
 gradio_template_path = Path(gradio.__file__).parent / "templates" / "frontend"  # type: ignore
 
@@ -71,16 +74,18 @@ def _dev(
         "gradio", gradio_path, cli_arg_name="--gradio-path"
     )
 
+    frontend_dir = _get_frontend_dir(component_directory)
+
     gradio_node_path = subprocess.run(
         [node, "-e", "console.log(require.resolve('@gradio/preview'))"],
-        cwd=Path(component_directory / "frontend"),
+        cwd=frontend_dir,
         check=False,
         capture_output=True,
     )
 
     if gradio_node_path.returncode != 0:
         raise ValueError(
-            "Could not find `@gradio/preview`. Run `npm i -D @gradio/preview` in your frontend folder."
+            f"Could not find `@gradio/preview`. Run `npm i -D @gradio/preview` in your frontend folder ({frontend_dir})."
         )
 
     gradio_node_path = gradio_node_path.stdout.decode("utf-8").strip()
@@ -122,7 +127,7 @@ def _dev(
         )
 
         if "[orange3]Watching:[/]" in text:
-            text += f"'{str(component_directory / 'frontend').strip()}',"
+            text += f"'{str(frontend_dir).strip()}',"
         if "To create a public link" in text:
             continue
         print(text)

--- a/gradio/cli/commands/components/install_component.py
+++ b/gradio/cli/commands/components/install_component.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import importlib
+import inspect
 import shutil
 import subprocess
 from pathlib import Path
 from typing import Annotated
 
 from rich.markup import escape
+from tomlkit import parse
 from typer import Argument, Option
 
 from gradio.cli.commands.display import LivePanelDisplay
@@ -55,6 +58,38 @@ def _get_executable_path(
     return path
 
 
+def _get_frontend_dir(directory: Path) -> Path:
+    """Get the frontend directory of the custom component located in `directory`.
+
+    Custom components can override the location of their frontend code via the
+    FRONTEND_DIR class attribute, so the installed component class is inspected
+    to resolve the actual path. Falls back to the default `frontend` directory
+    if the component cannot be imported (e.g. it has not been installed yet).
+    """
+    default_frontend_dir = directory / "frontend"
+    try:
+        pyproject_toml = parse((directory / "pyproject.toml").read_text())
+        package_name = pyproject_toml["project"]["name"]  # type: ignore
+        module = importlib.import_module(package_name)  # type: ignore
+        from gradio.blocks import BlockContext
+        from gradio.components import Component
+
+        for name in dir(module):
+            if name.startswith("__"):
+                continue
+            value = getattr(module, name)
+            if (
+                inspect.isclass(value)
+                and issubclass(value, (BlockContext, Component))
+                and value.__module__.startswith(module.__name__)
+            ):
+                file_location = Path(inspect.getfile(value)).parent
+                return (file_location / value.FRONTEND_DIR).resolve()
+    except Exception:
+        return default_frontend_dir
+    return default_frontend_dir
+
+
 def _install_command(
     directory: Path, live: LivePanelDisplay, npm_install: str, pip_path: str | None
 ):
@@ -78,7 +113,7 @@ def _install_command(
     live.update(
         f":construction_worker: Installing javascript... [grey37]({npm_install})[/]"
     )
-    with set_directory(directory / "frontend"):
+    with set_directory(_get_frontend_dir(directory)):
         pipe = subprocess.run(
             npm_install.split(), capture_output=True, text=True, check=False
         )

--- a/gradio/cli/commands/components/install_component.py
+++ b/gradio/cli/commands/components/install_component.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import importlib
 import inspect
 import shutil
+import site
 import subprocess
 from pathlib import Path
 from typing import Annotated
 
+from rich import print
 from rich.markup import escape
 from tomlkit import parse
 from typer import Argument, Option
@@ -70,7 +72,18 @@ def _get_frontend_dir(directory: Path) -> Path:
     try:
         pyproject_toml = parse((directory / "pyproject.toml").read_text())
         package_name = pyproject_toml["project"]["name"]  # type: ignore
-        module = importlib.import_module(package_name)  # type: ignore
+    except Exception:
+        return default_frontend_dir
+    try:
+        try:
+            module = importlib.import_module(package_name)  # type: ignore
+        except ImportError:
+            # A package that was pip-installed after this process started (as
+            # happens during `gradio cc install`) is not importable until the
+            # site .pth files are re-processed.
+            importlib.invalidate_caches()
+            site.main()
+            module = importlib.import_module(package_name)  # type: ignore
         from gradio.blocks import BlockContext
         from gradio.components import Component
 
@@ -101,6 +114,10 @@ def _get_frontend_dir(directory: Path) -> Path:
         file_location = Path(inspect.getfile(component_class)).parent
         return (file_location / component_class.FRONTEND_DIR).resolve()
     except Exception:
+        print(
+            f":warning: Could not import `{package_name}` to check for a custom "
+            f"FRONTEND_DIR, assuming the frontend code is located in {default_frontend_dir}."
+        )
         return default_frontend_dir
 
 

--- a/gradio/cli/commands/components/install_component.py
+++ b/gradio/cli/commands/components/install_component.py
@@ -74,6 +74,7 @@ def _get_frontend_dir(directory: Path) -> Path:
         from gradio.blocks import BlockContext
         from gradio.components import Component
 
+        candidates = []
         for name in dir(module):
             if name.startswith("__"):
                 continue
@@ -83,11 +84,24 @@ def _get_frontend_dir(directory: Path) -> Path:
                 and issubclass(value, (BlockContext, Component))
                 and value.__module__.startswith(module.__name__)
             ):
-                file_location = Path(inspect.getfile(value)).parent
-                return (file_location / value.FRONTEND_DIR).resolve()
+                candidates.append(value)
+        if not candidates:
+            return default_frontend_dir
+
+        def overrides_frontend_dir(cls: type) -> bool:
+            return any(
+                "FRONTEND_DIR" in c.__dict__
+                for c in cls.__mro__
+                if c.__module__.startswith(module.__name__)
+            )
+
+        component_class = next(
+            (c for c in candidates if overrides_frontend_dir(c)), candidates[0]
+        )
+        file_location = Path(inspect.getfile(component_class)).parent
+        return (file_location / component_class.FRONTEND_DIR).resolve()
     except Exception:
         return default_frontend_dir
-    return default_frontend_dir
 
 
 def _install_command(

--- a/test/test_gradio_component_cli.py
+++ b/test/test_gradio_component_cli.py
@@ -6,7 +6,10 @@ import pytest
 
 from gradio.cli.commands.components.build import _build
 from gradio.cli.commands.components.create import _create, _create_utils
-from gradio.cli.commands.components.install_component import _get_executable_path
+from gradio.cli.commands.components.install_component import (
+    _get_executable_path,
+    _get_frontend_dir,
+)
 from gradio.cli.commands.components.publish import _get_version_from_file
 from gradio.cli.commands.components.show import _show
 from gradio.utils import core_gradio_components
@@ -81,6 +84,36 @@ def test_get_executable_path():
         match=r"The provided foo path \(/foo/bar/fum\) does not exist or is not a file.",
     ):
         _get_executable_path("foo", "/foo/bar/fum", "--foo-path")
+
+
+def test_get_frontend_dir_defaults_to_frontend_folder(tmp_path):
+    assert _get_frontend_dir(tmp_path) == tmp_path / "frontend"
+
+
+def test_get_frontend_dir_respects_frontend_dir_override(tmp_path, monkeypatch):
+    package_name = "gradio_frontenddirtest"
+    package_dir = tmp_path / package_name
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text(
+        textwrap.dedent(
+            """
+            from gradio.components import Textbox
+
+            class ZCustomComponent(Textbox):
+                FRONTEND_DIR = "../frontend/custom"
+            """
+        )
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            f"""
+            [project]
+            name = "{package_name}"
+            """
+        )
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    assert _get_frontend_dir(tmp_path) == (tmp_path / "frontend" / "custom").resolve()
 
 
 def test_raise_error_component_template_does_not_exist(tmp_path):

--- a/test/test_gradio_component_cli.py
+++ b/test/test_gradio_component_cli.py
@@ -99,6 +99,9 @@ def test_get_frontend_dir_respects_frontend_dir_override(tmp_path, monkeypatch):
             """
             from gradio.components import Textbox
 
+            class APlainComponent(Textbox):
+                pass
+
             class ZCustomComponent(Textbox):
                 FRONTEND_DIR = "../frontend/custom"
             """


### PR DESCRIPTION
Fixes #8162

## Root cause

`gradio cc dev` and `gradio cc build` hardcode `<component>/frontend` as the working directory when resolving `@gradio/preview` (and `gradio cc install` hardcodes it for the npm install step). If a component overrides `FRONTEND_DIR` on the component class, the commands fail with:

```
ValueError: Could not find `@gradio/preview`. Run `npm i -D @gradio/preview` in your frontend folder.
```

The node-side preview tool (`js/preview/src/examine.py`) already respects `FRONTEND_DIR`; only the Python CLI was out of sync.

## Fix

Added `_get_frontend_dir()` in `install_component.py`, which imports the installed component package (name from `pyproject.toml`), finds the component class, and resolves `FRONTEND_DIR` relative to the class's file — mirroring `examine.py`. Falls back to the default `frontend` directory if the component can't be imported, so the previous behavior is unchanged for standard layouts. `dev.py`, `build.py`, and the `install` npm step now use it, and the error message includes the directory that was checked.

## Verification

Reproduced per the issue: created a component from `SimpleTextbox`, moved `frontend/` to `frontend/textbox/`, set `FRONTEND_DIR = "../../frontend/textbox"`.

- Before: `gradio cc dev` and `gradio cc build` both raise the `@gradio/preview` ValueError.
- After: `gradio cc build --no-generate-docs` builds the frontend and wheel; `gradio cc dev` starts, watches `frontend/textbox`, and serves the demo (verified via HTTP and the app config); `gradio cc install` runs npm install in the correct folder.
- `python3 -m pytest test/test_gradio_component_cli.py` — 60 passed; the 4 `test_template_override_component` failures and `test_get_executable_path` failure are pre-existing local-environment failures, also present on untouched `main`.

Minimal repro component class change (demo component not committed):

```python
class MyTextbox(FormComponent):
    FRONTEND_DIR = "../../frontend/textbox"
    ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)