### PR TITLE
Allow frontend builds to skip offline assets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -492,6 +492,9 @@ and run the install scripts:
 bash scripts/install_gradio.sh
 bash scripts/build_frontend.sh
 ```
+
+To skip downloading assets used for offline support, pass
+`--no-download-offline-assets`.
   </td>
   <td>
   
@@ -499,6 +502,9 @@ bash scripts/build_frontend.sh
 scripts\install_gradio.bat
 scripts\build_frontend.bat
 ```
+
+To skip downloading assets used for offline support, pass
+`--no-download-offline-assets`.
   </td>
   </tr>
 </table>

--- a/scripts/build_frontend.bat
+++ b/scripts/build_frontend.bat
@@ -1,6 +1,20 @@
 @echo off
 setlocal EnableDelayedExpansion
 
+set "DOWNLOAD_OFFLINE_ASSETS=true"
+
+:parse_args
+if "%~1"=="" goto args_parsed
+if /I "%~1"=="--no-download-offline-assets" (
+    set "DOWNLOAD_OFFLINE_ASSETS=false"
+    shift
+    goto parse_args
+)
+echo Unknown argument: %~1
+exit /b 1
+
+:args_parsed
+
 :: Change to parent directory of script location
 cd /d "%~dp0.."
 
@@ -14,4 +28,6 @@ echo Building the frontend...
 pnpm i --frozen-lockfile --ignore-scripts
 pnpm build
 
-python scripts\download_offline_assets.py
+if /I "%DOWNLOAD_OFFLINE_ASSETS%"=="true" (
+    python scripts\download_offline_assets.py
+)

--- a/scripts/build_frontend.sh
+++ b/scripts/build_frontend.sh
@@ -3,6 +3,21 @@
 cd "$(dirname ${0})/.."
 source scripts/helpers.sh
 
+download_offline_assets=true
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--no-download-offline-assets)
+		download_offline_assets=false
+		;;
+	*)
+		echo "Unknown argument: $1"
+		exit 1
+		;;
+	esac
+	shift
+done
+
 pnpm_required
 
 python scripts/generate_theme.py
@@ -11,4 +26,6 @@ echo "Building the frontend..."
 pnpm i --frozen-lockfile --ignore-scripts
 pnpm build
 
-python scripts/download_offline_assets.py
+if [[ "$download_offline_assets" == true ]]; then
+	python scripts/download_offline_assets.py
+fi


### PR DESCRIPTION
Now that the frontend build is so fast, donwloading offline assets can be the bottleneck and is often not needed for basic UI builds. Adds a `--no-download-offline-assets` option to both frontend build scripts. With no arguments, the scripts continue downloading offline assets as before; developers can now opt out when they only need a local frontend build. The new option is also documented in `CONTRIBUTING.md`.
