### PR TITLE
Preserve filenames in JS client uploads and use handle_file in generated JS API snippets

### DIFF
--- a/.changeset/brave-files-remain.md
+++ b/.changeset/brave-files-remain.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": patch
+"gradio_client": patch
+---
+
+fix:Preserve original filenames and MIME types when uploading `File`/`Blob` objects via the JS client, and use `handle_file` in the auto-generated JavaScript API snippets

--- a/client/js/src/helpers/data.ts
+++ b/client/js/src/helpers/data.ts
@@ -155,7 +155,7 @@ export function handle_file(
 		// Return the File as-is so that its filename and MIME type are
 		// preserved when it is uploaded (see issue #10758).
 		return file_or_url;
-	} else if (file_or_url instanceof Buffer) {
+	} else if (globalThis.Buffer && file_or_url instanceof globalThis.Buffer) {
 		return new Blob([file_or_url as any]);
 	} else if (file_or_url instanceof Blob) {
 		return file_or_url;

--- a/client/js/src/helpers/data.ts
+++ b/client/js/src/helpers/data.ts
@@ -73,7 +73,10 @@ export async function walk_and_store_blobs(
 		return [
 			{
 				path: path,
-				blob: new Blob([data as any]),
+				// Preserve the original Blob/File so that filenames and MIME
+				// types survive the upload (see issue #10758). Only Buffers
+				// need to be converted to Blobs.
+				blob: data instanceof Blob ? data : new Blob([data as any]),
 				type
 			}
 		];
@@ -149,7 +152,9 @@ export function handle_file(
 			});
 		}
 	} else if (typeof File !== "undefined" && file_or_url instanceof File) {
-		return new Blob([file_or_url]);
+		// Return the File as-is so that its filename and MIME type are
+		// preserved when it is uploaded (see issue #10758).
+		return file_or_url;
 	} else if (file_or_url instanceof Buffer) {
 		return new Blob([file_or_url as any]);
 	} else if (file_or_url instanceof Blob) {

--- a/client/js/src/test/data.test.ts
+++ b/client/js/src/test/data.test.ts
@@ -97,6 +97,27 @@ describe("walk_and_store_blobs", () => {
 		expect(parts[0].path).toEqual(["0"]);
 	});
 
+	it("should preserve File instances (and their filenames)", async () => {
+		const file = new File(["test data"], "report.txt", {
+			type: "text/plain"
+		});
+		const parts = await walk_and_store_blobs([file]);
+
+		expect(parts).toHaveLength(1);
+		expect(parts[0].blob).toBe(file);
+		expect((parts[0].blob as File).name).toBe("report.txt");
+		expect((parts[0].blob as File).type).toBe("text/plain");
+	});
+
+	it("should preserve the MIME type of Blob instances", async () => {
+		const blob = new Blob(["test data"], { type: "image/png" });
+		const parts = await walk_and_store_blobs([blob]);
+
+		expect(parts).toHaveLength(1);
+		expect(parts[0].blob).toBe(blob);
+		expect(parts[0].blob && parts[0].blob.type).toBe("image/png");
+	});
+
 	it("should handle deep structures", async () => {
 		const image = new Blob([]);
 		const parts = await walk_and_store_blobs({ a: { b: { data: { image } } } });
@@ -371,11 +392,13 @@ describe("handle_file", () => {
 	);
 
 	it.skipIf(IS_NODE)(
-		"should handle a File object and return it as FileData",
+		"should handle a File object and return it unchanged, preserving its name and type",
 		() => {
 			const file = new File(["test image"], "test.png", { type: "image/png" });
-			const result = handle_file(file) as FileData;
-			expect(result).toBeInstanceOf(Blob);
+			const result = handle_file(file) as File;
+			expect(result).toBe(file);
+			expect(result.name).toBe("test.png");
+			expect(result.type).toBe("image/png");
 		}
 	);
 

--- a/client/python/gradio_client/snippet.py
+++ b/client/python/gradio_client/snippet.py
@@ -162,7 +162,8 @@ def generate_js_snippet(
 ) -> str:
     blob_params = [p for p in params if p.get("component") in BLOB_COMPONENTS]
 
-    lines = ['import { Client } from "@gradio/client";', ""]
+    imports = "Client, handle_file" if blob_params else "Client"
+    lines = [f'import {{ {imports} }} from "@gradio/client";', ""]
 
     for i, bp in enumerate(blob_params):
         example = bp.get("example_input", {})
@@ -183,7 +184,7 @@ def generate_js_snippet(
         name = p.get("parameter_name") or p.get("label", "input")
         component = p.get("component", "")
         if component in blob_component_names:
-            predict_args.append(f"\t\t{name}: example{component},")
+            predict_args.append(f"\t\t{name}: handle_file(example{component}),")
         else:
             value = _get_param_value(p)
             ptype = p.get("python_type", {}).get("type")

--- a/client/python/test/test_snippet.py
+++ b/client/python/test/test_snippet.py
@@ -6,11 +6,7 @@ from contextlib import contextmanager
 import gradio as gr
 
 from gradio_client import Client
-from gradio_client.snippet import (
-    _stringify_py,
-    generate_code_snippets,
-    generate_js_snippet,
-)
+from gradio_client.snippet import _stringify_py, generate_code_snippets
 
 
 @contextmanager
@@ -99,49 +95,6 @@ class TestSnippetExecution:
             namespace = {}
             exec(python_snippet, namespace)
             assert isinstance(namespace["result"], (int, float))
-
-
-class TestJsSnippet:
-    def test_js_snippet_uses_handle_file_for_blob_components(self):
-        """The generated JS snippet must wrap blobs of file-based components
-        in handle_file() (see issue #12077)."""
-        params = [
-            {
-                "label": "input_video",
-                "parameter_name": "input_video",
-                "component": "Video",
-                "example_input": {
-                    "url": "https://example.com/video.mp4",
-                    "meta": {"_type": "gradio.FileData"},
-                },
-                "python_type": {"type": "filepath"},
-            },
-            {
-                "label": "input_text",
-                "parameter_name": "input_text",
-                "component": "Textbox",
-                "example_input": "Hello!!",
-                "python_type": {"type": "string"},
-            },
-        ]
-        snippet = generate_js_snippet("/run_video", params, "http://127.0.0.1:7860/")
-        assert 'import { Client, handle_file } from "@gradio/client";' in snippet
-        assert "input_video: handle_file(exampleVideo)," in snippet
-        assert 'input_text: "Hello!!",' in snippet
-
-    def test_js_snippet_without_blob_components_has_no_handle_file(self):
-        params = [
-            {
-                "label": "name",
-                "parameter_name": "name",
-                "component": "Textbox",
-                "example_input": "Hello!!",
-                "python_type": {"type": "string"},
-            },
-        ]
-        snippet = generate_js_snippet("/greet", params, "http://127.0.0.1:7860/")
-        assert 'import { Client } from "@gradio/client";' in snippet
-        assert "handle_file" not in snippet
 
 
 class TestStringifyPy:

--- a/client/python/test/test_snippet.py
+++ b/client/python/test/test_snippet.py
@@ -6,7 +6,11 @@ from contextlib import contextmanager
 import gradio as gr
 
 from gradio_client import Client
-from gradio_client.snippet import _stringify_py, generate_code_snippets
+from gradio_client.snippet import (
+    _stringify_py,
+    generate_code_snippets,
+    generate_js_snippet,
+)
 
 
 @contextmanager
@@ -95,6 +99,49 @@ class TestSnippetExecution:
             namespace = {}
             exec(python_snippet, namespace)
             assert isinstance(namespace["result"], (int, float))
+
+
+class TestJsSnippet:
+    def test_js_snippet_uses_handle_file_for_blob_components(self):
+        """The generated JS snippet must wrap blobs of file-based components
+        in handle_file() (see issue #12077)."""
+        params = [
+            {
+                "label": "input_video",
+                "parameter_name": "input_video",
+                "component": "Video",
+                "example_input": {
+                    "url": "https://example.com/video.mp4",
+                    "meta": {"_type": "gradio.FileData"},
+                },
+                "python_type": {"type": "filepath"},
+            },
+            {
+                "label": "input_text",
+                "parameter_name": "input_text",
+                "component": "Textbox",
+                "example_input": "Hello!!",
+                "python_type": {"type": "string"},
+            },
+        ]
+        snippet = generate_js_snippet("/run_video", params, "http://127.0.0.1:7860/")
+        assert 'import { Client, handle_file } from "@gradio/client";' in snippet
+        assert "input_video: handle_file(exampleVideo)," in snippet
+        assert 'input_text: "Hello!!",' in snippet
+
+    def test_js_snippet_without_blob_components_has_no_handle_file(self):
+        params = [
+            {
+                "label": "name",
+                "parameter_name": "name",
+                "component": "Textbox",
+                "example_input": "Hello!!",
+                "python_type": {"type": "string"},
+            },
+        ]
+        snippet = generate_js_snippet("/greet", params, "http://127.0.0.1:7860/")
+        assert 'import { Client } from "@gradio/client";' in snippet
+        assert "handle_file" not in snippet
 
 
 class TestStringifyPy:


### PR DESCRIPTION
## Description

This PR fixes a cluster of related issues in the JS client (`@gradio/client`) blob/file upload path, plus the auto-generated "Use via API" JavaScript snippets.

Closes #12077
Closes #10758

### Issue #10758 — filenames lost when uploading `File` objects (reproduced, fixed)

**Root cause:** `handle_file()` in `client/js/src/helpers/data.ts` converted a `File` into a bare `new Blob([file])`, and `walk_and_store_blobs()` re-wrapped every Blob in another `new Blob([data])`. Both steps strip the filename and MIME type, so every browser upload arrived at the server as a multipart part named `"blob"`, and backends that read `os.path.basename(path)` saw `"blob"` instead of the original filename.

**Fix:** `handle_file()` now returns `File` objects unchanged, and `walk_and_store_blobs()` only wraps `Buffer`s (Blobs/Files are passed through as-is). `FormData.append("files", file)` then preserves the original filename, and the client also sets `orig_name` on the resulting `FileData` (that logic already existed but was unreachable because the `File` had been downgraded to a `Blob`).

### Issue #12077 — video blob on the JS API (snippet half reproduced, fixed; predict half no longer reproduces)

- **Generated JS snippet (reproduced, fixed):** the "Use via API" JavaScript snippet told users to pass the bare blob (`input_video: exampleVideo`) and did not import `handle_file`. `generate_js_snippet()` in `client/python/gradio_client/snippet.py` now emits `import { Client, handle_file } from "@gradio/client";` and wraps blob parameters as `input_video: handle_file(exampleVideo)`, matching the documented/recommended usage.
- **`VideoData.video Field required` pydantic error: does NOT reproduce on current `main`.** `gr.Video.preprocess` now accepts a plain `FileData` payload (not the old `VideoData` model), so both `handle_file(blob)` and even a bare blob for a `gr.Video` input succeed. No code change was needed (or made) for this half; it is covered by the reproduction script to guard against regression.


## Verification / reproduction

### 🧪 Test in your browser against a real Space

A minimal **public** Space has been set up for reviewing this PR: [`gradio/pr-13656-upload-test`](https://huggingface.co/spaces/gradio/pr-13656-upload-test) (safe to delete after merge). Its endpoints echo back the filename/size the backend actually received.

No npm/Node/token needed: save the file below as `test_pr13656.html`, **double-click to open it in your browser**, and hit **Run checks**. It loads the latest released `@gradio/client` from jsDelivr and this PR's build from the npm-previews CDN side by side, and runs the same three upload checks against each. (The PR-build URL is pinned to the current head commit `f91e911` — if new commits land, copy the fresh "Import Gradio JS Client from this PR via CDN" link from the gradio-pr-bot comment.)

<details>
<summary><b><code>test_pr13656.html</code></b> (click to expand)</summary>

```html
<!doctype html>
<meta charset="utf-8" />
<title>PR #13656 review — @gradio/client upload filename test</title>
<style>
	body { font-family: system-ui, sans-serif; margin: 2rem; max-width: 1100px; }
	.cols { display: flex; gap: 1.5rem; flex-wrap: wrap; }
	.col { flex: 1 1 480px; }
	pre { background: #f6f8fa; border: 1px solid #ddd; border-radius: 6px; padding: 1rem; white-space: pre-wrap; word-break: break-word; min-height: 16rem; font-size: 13px; }
	input { font-size: 1rem; padding: 0.3rem; width: 24rem; }
	button { font-size: 1rem; padding: 0.3rem 1rem; }
	.pass { color: #1a7f37; } .fail { color: #cf222e; } .warn { color: #9a6700; }
</style>

<h2>PR #13656 — upload filename preservation: published client vs PR build</h2>
<p>
	Space under test: <b>gradio/pr-13656-upload-test</b> (public — no token needed).
	Each endpoint echoes back the filename/size the backend actually received.
</p>
<p>
	<button id="run">Run checks</button>
</p>
<div class="cols">
	<div class="col"><h3>Published @gradio/client (latest release, jsDelivr)</h3><pre id="out-published">–</pre></div>
	<div class="col"><h3>This PR's build (npm-previews CDN)</h3><pre id="out-pr">–</pre></div>
</div>

<script type="module">
	const SPACE = "gradio/pr-13656-upload-test";
	const VERSIONS = [
		{
			el: "out-published",
			url: "https://cdn.jsdelivr.net/npm/@gradio/client/dist/index.min.js"
		},
		{
			el: "out-pr",
			// per-commit URL — if new commits land on the PR, copy the latest
			// "Import Gradio JS Client from this PR via CDN" link from the
			// gradio-pr-bot comment on the PR
			url: "https://huggingface.co/buckets/gradio/npm-previews/resolve/f91e911974db03431ad8d0255f8969662a799443/browser.js"
		}
	];

	const b64_to_bytes = (b64) =>
		Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));

	// 8x8 red PNG
	const PNG_BYTES = b64_to_bytes(
		"iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAEklEQVR4nGP8z4AdMOEQH6QSAM1BAQ/oQeJvAAAAAElFTkSuQmCC"
	);
	// tiny 1s 64x64 test-pattern mp4 (2746 bytes)
	const MP4_BYTES = b64_to_bytes("AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAAIZnJlZQAABx1tZGF0AAACrQYF//+p3EXpvebZSLeWLNgg2SPu73gyNjQgLSBjb3JlIDE2NSByMzIyMiBiMzU2MDVhIC0gSC4yNjQvTVBFRy00IEFWQyBjb2RlYyAtIENvcHlsZWZ0IDIwMDMtMjAyNSAtIGh0dHA6Ly93d3cudmlkZW9sYW4ub3JnL3gyNjQuaHRtbCAtIG9wdGlvbnM6IGNhYmFjPTEgcmVmPTMgZGVibG9jaz0xOjA6MCBhbmFseXNlPTB4MzoweDExMyBtZT1oZXggc3VibWU9NyBwc3k9MSBwc3lfcmQ9MS4wMDowLjAwIG1peGVkX3JlZj0xIG1lX3JhbmdlPTE2IGNocm9tYV9tZT0xIHRyZWxsaXM9MSA4eDhkY3Q9MSBjcW09MCBkZWFkem9uZT0yMSwxMSBmYXN0X3Bza2lwPTEgY2hyb21hX3FwX29mZnNldD0tMiB0aHJlYWRzPTIgbG9va2FoZWFkX3RocmVhZHM9MSBzbGljZWRfdGhyZWFkcz0wIG5yPTAgZGVjaW1hdGU9MSBpbnRlcmxhY2VkPTAgYmx1cmF5X2NvbXBhdD0wIGNvbnN0cmFpbmVkX2ludHJhPTAgYmZyYW1lcz0zIGJfcHlyYW1pZD0yIGJfYWRhcHQ9MSBiX2JpYXM9MCBkaXJlY3Q9MSB3ZWlnaHRiPTEgb3Blbl9nb3A9MCB3ZWlnaHRwPTIga2V5aW50PTI1MCBrZXlpbnRfbWluPTUgc2NlbmVjdXQ9NDAgaW50cmFfcmVmcmVzaD0wIHJjX2xvb2thaGVhZD00MCByYz1jcmYgbWJ0cmVlPTEgY3JmPTIzLjAgcWNvbXA9MC42MCBxcG1pbj0wIHFwbWF4PTY5IHFwc3RlcD00IGlwX3JhdGlvPTEuNDAgYXE9MToxLjAwAIAAAANGZYiEAJ/tc8NKcf4LWdj+Ao+CdzckNdvpzvRdYcUuCKL0wPPVziAHr3eUwOvaGaTUkF5qeN6lLC8eSex52ANeaiaFGTgB463TpNAs2bedCir6BzWyC548/mw0m8T/EblEyQJvbNeh3VNYhDrUel/FhJRWIB/MuNRFUMomrbmHH/n5MwebJabc9JTXBnjEEGrispnvZxOGsTgOE1tQH/97SQ+cKVQuIDjxhShVJSco9DeGZjbXxbqftxL7OBk4jng5pd3fsA2q6QQO6HaTaEznUsjSuEsIyABt6NDybeqOBi1hdd5lSay8SkX5HtQx9XwAR+IzrSM6rM6xik5lfi9bKErBMER7OHRcNa7tp6YSECwvWubQkTUHZnhasa3mXYBpV5s8wawlXVz4BABgBBDHfXAC8xAzE5UFgVNTb76fr1fPV0dU71Fn1VNXSwruwMPi5ubAroZMHzUkugD+10egXYcZn3fAajYNz/xgAYSg7G9RIvtIoNaO8uq/gDhHk7hca7oNlOFC1HD/Bv/bi/KA8cj5LDbBvOmnKcfDedhk5K1lWZCwpMx6/7rBGQwmYcW/tX0radIeNcT674NH3hVetzHnfg2iEcOyVrGnAkQWAs/Gf9Bbggq5pTu8g52L/GfHjPHrG3hOhPAeMV+UolLjtkIQ4nqsB2JS1bPO9HwY2qWcUxPfY3cLyKZWkbymg/b0XlGwBdVIRv4OEiCcKE+JWdstdSO6BRZYkbM5Rvsiyw75oXRwNDpXG1qKG/2D6f/2ynGfs+F+Sbwcjq4SzcDIiwI9HGhHlOaJ4QV0H9x4QwCGC2RBEvirwwEXh3QmPANFUUh0e0yRSM4o36hvgMjOOFZJvX94qOt3c47aiIQYw7zJE8MdmWGiX5NrhP3HIgAfnCSNGFKcHzuICuer95ju0jcIkCKfsdtBJt2awmcb2/gd9oKN7DXHjotO42lQzEIB+1llTCJ0aL8SaeHJI6FrTh+rWYZ442i2k+hLwwQWHEWm7kd0bW7bAwDR6h8aTERclMrkcKZa0wJzVgy7RRNj1Jshpxmi5YJfVgJ89zWYoErp3vA53gjMYaRi/UrXTiuZZ40ZUyaZXCUIQhTQroAUFOlJcnSwwQAAAJNBmiRsRn8aMv3/DiSEiaL4b+wi4c+HBgcUEt9/4nktD0+bv+k4UjdqV0NBiU+P+lxJKKhNhLN9V/+/9DXOjsqsgcXjmBf8of9OFYvOaN+bJcDODxsgB79bqa4QGXvnmbNk86jokt9/7nZsCFbMM1D/dcUsiAxr4HRkjeICRTI/4uuoRKp2VKi/ACE7yXC/66NwmYAAAABEQZ5CeIj/dmFQ6vFpV5y/aJ84FmvUQwS7HDtG8J29qe0842hT3rPXIFGfdfcvciCsJaRFC9+eIFRxGQTY6zAotXrfPGUAAAAXAZ5hdEZ/fqg9YkAmTAKGUgLCv7BbZYoAAAAcAZ5jakZ/ZpDl9oBjpJQCyK3dhxx2Aw6rRe4fvQAAA3Vtb292AAAAbG12aGQAAAAAAAAAAAAAAAAAAAPoAAAD6AABAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAACoHRyYWsAAABcdGtoZAAAAAMAAAAAAAAAAAAAAAEAAAAAAAAD6AAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAQAAAAEAAAAAAACRlZHRzAAAAHGVsc3QAAAAAAAAAAQAAA+gAABAAAAEAAAAAAhhtZGlhAAAAIG1kaGQAAAAAAAAAAAAAAAAAACgAAAAoAFXEAAAAAAAtaGRscgAAAAAAAAAAdmlkZQAAAAAAAAAAAAAAAFZpZGVvSGFuZGxlcgAAAAHDbWluZgAAABR2bWhkAAAAAQAAAAAAAAAAAAAAJGRpbmYAAAAcZHJlZgAAAAAAAAABAAAADHVybCAAAAABAAABg3N0YmwAAAC/c3RzZAAAAAAAAAABAAAAr2F2YzEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQABAAEgAAABIAAAAAAAAAAEVTGF2YzYyLjExLjEwMCBsaWJ4MjY0AAAAAAAAAAAAAAAY//8AAAA1YXZjQwFkAAr/4QAYZ2QACqzZRCbARAAAAwAEAAADACg8SJZYAQAGaOvjyyLA/fj4AAAAABBwYXNwAAAAAQAAAAEAAAAUYnRydAAAAAAAADioAAAAAAAAABhzdHRzAAAAAAAAAAEAAAAFAAAIAAAAABRzdHNzAAAAAAAAAAEAAAABAAAAOGN0dHMAAAAAAAAABQAAAAEAABAAAAAAAQAAKAAAAAABAAAQAAAAAAEAAAAAAAAAAQAACAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAUAAAABAAAAKHN0c3oAAAAAAAAAAAAAAAUAAAX7AAAAlwAAAEgAAAAbAAAAIAAAABRzdGNvAAAAAAAAAAEAAAAwAAAAYXVkdGEAAABZbWV0YQAAAAAAAAAhaGRscgAAAAAAAAAAbWRpcmFwcGwAAAAAAAAAAAAAAAAsaWxzdAAAACSpdG9vAAAAHGRhdGEAAAABAAAAAExhdmY2Mi4zLjEwMA==");

	async function run_checks(mod, print) {
		const { Client, handle_file } = mod;
		const app = await Client.connect(SPACE);

		const check = async (label, fn) => {
			try {
				const out = await fn();
				print(`[${label}] → ${JSON.stringify(out)}`, "pass");
			} catch (e) {
				print(`[${label}] rejected (${e?.constructor?.name}): ${e?.message ?? e}`, "fail");
			}
		};

		// #10758 — the headline check: does the backend see the original filename?
		await check("File upload — server-side filename", async () => {
			const file = new File([new Blob(["hello from the reviewer"])], "my_report_2024.txt", {
				type: "text/plain"
			});
			return (await app.predict("/predict_file", [handle_file(file)])).data;
		});

		// #9877 — raw Blob as gr.Image input (regression guard)
		await check("raw Blob as image input", async () => {
			const blob = new Blob([PNG_BYTES], { type: "image/png" });
			return (await app.predict("/predict_image", [blob])).data;
		});

		// #12077 — video blob via handle_file (regression guard)
		await check("video blob via handle_file", async () => {
			const blob = new Blob([MP4_BYTES], { type: "video/mp4" });
			return (await app.predict("/predict_video", [handle_file(blob)])).data;
		});
	}

	document.getElementById("run").onclick = async () => {
		for (const v of VERSIONS) {
			const el = document.getElementById(v.el);
			el.textContent = "";
			const print = (msg, cls) => {
				const line = document.createElement("div");
				if (cls) line.className = cls;
				line.textContent = msg;
				el.appendChild(line);
			};
			try {
				print(`importing ${v.url} …`);
				const mod = await import(v.url);
				await run_checks(mod, print);
			} catch (e) {
				print(`❌ failed to import/run: ${e?.message ?? e}`, "fail");
			}
		}
	};
</script>
```

</details>

#### What you should see

<img width="1147" height="638" alt="image" src="https://github.com/user-attachments/assets/2744785d-4103-4454-9dc3-8b5feb928a05" />


**Left column — published client (current behavior):**

- ❌ `File upload — server-side filename` → **`OK file basename=blob`** — the original name `my_report_2024.txt` is stripped in transit; the backend sees `"blob"`. This is issue #10758.
- ✅ `raw Blob as image input` → `OK image size=75 name=blob` (raw blobs upload fine; control).
- ❌ `video blob via handle_file` → **rejects with `ReferenceError: Buffer is not defined`** — the released `handle_file` references Node's `Buffer` unguarded, so the documented `handle_file(blob)` usage crashes in browsers.

**Right column — this PR's build:**

- ✅ `File upload — server-side filename` → **`OK file basename=my_report_2024.txt`** — the original filename survives to the backend.
- ✅ `raw Blob as image input` → `OK image size=75 name=blob` (no regression).
- ✅ `video blob via handle_file` → `OK video size=2746 name=blob` — `handle_file(blob)` works in browsers (blobs have no filename, so the generic name is expected here; the size confirms the bytes arrived intact).
