### PR TITLE
Fix JS client private-Space connections (hf_token alias) and replace raw TypeErrors/unhandled rejections with clear errors

### DIFF
--- a/.changeset/hip-pans-punch.md
+++ b/.changeset/hip-pans-punch.md
@@ -1,0 +1,5 @@
+---
+"@gradio/client": patch
+---
+
+Fix private Space connections and error handling in the JS client: accept the deprecated `hf_token` option as an alias for `token`, raise clear errors when a Space is private or missing, tolerate malformed `/info` payloads instead of crashing with "Cannot read properties of undefined (reading 'map')", and make `predict()` reject with real `Error` objects instead of plain status objects that surface as unhandled promise rejections.

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -25,6 +25,7 @@ import { submit } from "./utils/submit";
 import { RE_SPACE_NAME, process_endpoint } from "./helpers/api_info";
 import {
 	map_names_to_ids,
+	normalise_token_option,
 	resolve_cookies,
 	resolve_config,
 	get_jwt,
@@ -200,6 +201,7 @@ export class Client {
 		if (!options.events) {
 			options.events = ["data"];
 		}
+		normalise_token_option(options);
 
 		this.options = options;
 		this.current_payload = {};
@@ -230,8 +232,9 @@ export class Client {
 			await this.resolve_cookies();
 		}
 
-		await this._resolve_config().then(({ config }) =>
-			this._resolve_heartbeat(config)
+		await this._resolve_config().then(
+			(res: { config: Config } | undefined) =>
+				res?.config && this._resolve_heartbeat(res.config)
 		);
 
 		try {
@@ -400,7 +403,7 @@ export class Client {
 						load_status: "error",
 						detail: "NOT_FOUND"
 					});
-				throw Error(e);
+				throw e instanceof Error ? e : new Error(String(e));
 			}
 		}
 	}

--- a/client/js/src/constants.ts
+++ b/client/js/src/constants.ts
@@ -35,6 +35,16 @@ export const UNAUTHORIZED_MSG = "Not authorized to access this space. ";
 export const INVALID_CREDENTIALS_MSG = "Invalid credentials. Could not login. ";
 export const MISSING_CREDENTIALS_MSG =
 	"Login credentials are required to access this space.";
+export const PRIVATE_SPACE_MSG =
+	"Could not access this app (received a 401 response). If it is a private Hugging Face Space, pass a valid Hugging Face token to the `token` option of `Client.connect`. You can generate a token at https://huggingface.co/settings/tokens.";
+export const SPACE_NOT_FOUND_MSG = (space: string, status: number): string =>
+	`Space "${space}" could not be accessed (received a ${status} response from the Hugging Face API). ` +
+	"Check that the Space name is spelled correctly and that the Space exists. If the Space is private, " +
+	"pass a valid Hugging Face token to the `token` option of `Client.connect`. You can generate a token at https://huggingface.co/settings/tokens.";
+export const NO_API_INFO_MSG =
+	"No API information is available for this app. This can happen when the app's `/info` endpoint cannot be reached, or when the app is running a legacy version of Gradio that is not supported by this client. ";
+export const WS_PROTOCOL_MSG =
+	"This app appears to be running a legacy version of Gradio (3.x or earlier) that communicates over WebSockets, which is not supported by this version of @gradio/client. Please upgrade the app to a newer version of Gradio, or connect to it with @gradio/client version 0.x.";
 export const NODEJS_FS_ERROR_MSG =
 	"File system access is only available in Node.js environments";
 export const ROOT_URL_ERROR_MSG = "Root URL not found in client config";

--- a/client/js/src/helpers/api_info.ts
+++ b/client/js/src/helpers/api_info.ts
@@ -2,7 +2,8 @@ import {
 	HOST_URL,
 	INVALID_URL_MSG,
 	QUEUE_FULL_MSG,
-	SPACE_METADATA_ERROR_MSG
+	SPACE_METADATA_ERROR_MSG,
+	SPACE_NOT_FOUND_MSG
 } from "../constants";
 import type {
 	ApiData,
@@ -35,21 +36,36 @@ export async function process_endpoint(
 
 	if (RE_SPACE_NAME.test(_app_reference)) {
 		// app_reference is a HF space name
+		let res: Response;
 		try {
-			const res = await fetch(
+			res = await fetch(
 				`https://huggingface.co/api/spaces/${_app_reference}/${HOST_URL}`,
 				{ headers }
 			);
-
-			const _host = (await res.json()).host;
-
-			return {
-				space_id: app_reference,
-				...determine_protocol(_host)
-			};
 		} catch (e) {
 			throw new Error(SPACE_METADATA_ERROR_MSG);
 		}
+
+		if (res.status === 401 || res.status === 404) {
+			// the space does not exist, or it is private and the request was made
+			// without (or with an invalid) token
+			throw new Error(SPACE_NOT_FOUND_MSG(_app_reference, res.status));
+		}
+
+		let _host: string | undefined;
+		try {
+			_host = (await res.json()).host;
+		} catch (e) {
+			throw new Error(SPACE_METADATA_ERROR_MSG);
+		}
+		if (!_host) {
+			throw new Error(SPACE_METADATA_ERROR_MSG);
+		}
+
+		return {
+			space_id: app_reference,
+			...determine_protocol(_host)
+		};
 	}
 
 	if (RE_SPACE_DOMAIN.test(_app_reference)) {
@@ -98,7 +114,13 @@ export function transform_api_info(
 			transformed_info[category] = {};
 
 			Object.entries(api_info[category]).forEach(
-				([endpoint, { parameters, returns }]) => {
+				([endpoint, endpoint_info]) => {
+					// Guard against malformed or legacy `/info` payloads that are
+					// missing `parameters`/`returns` so that we surface a usable API
+					// description instead of crashing with
+					// "Cannot read properties of undefined (reading 'map')".
+					const parameters = endpoint_info?.parameters ?? [];
+					const returns = endpoint_info?.returns ?? [];
 					const dependencyIndex =
 						config.dependencies.find(
 							(dep) =>
@@ -108,22 +130,24 @@ export function transform_api_info(
 						api_map[endpoint.replace("/", "")] ||
 						-1;
 
-					const dependencyTypes =
+					const dependency =
 						dependencyIndex !== -1
 							? config.dependencies.find((dep) => dep.id == dependencyIndex)
-									?.types
+							: undefined;
+
+					const dependencyTypes =
+						dependencyIndex !== -1
+							? dependency?.types
 							: { generator: false, cancel: false };
 
 					if (
-						dependencyIndex !== -1 &&
-						config.dependencies.find((dep) => dep.id == dependencyIndex)?.inputs
-							?.length !== parameters.length
+						dependency &&
+						Array.isArray(dependency.inputs) &&
+						dependency.inputs.length !== parameters.length
 					) {
-						const components = config.dependencies
-							.find((dep) => dep.id == dependencyIndex)!
-							.inputs.map(
-								(input) => config.components.find((c) => c.id === input)?.type
-							);
+						const components = dependency.inputs.map(
+							(input) => config.components.find((c) => c.id === input)?.type
+						);
 
 						try {
 							components.forEach((comp, idx) => {

--- a/client/js/src/helpers/api_info.ts
+++ b/client/js/src/helpers/api_info.ts
@@ -63,7 +63,7 @@ export async function process_endpoint(
 		}
 
 		return {
-			space_id: app_reference,
+			space_id: _app_reference,
 			...determine_protocol(_host)
 		};
 	}

--- a/client/js/src/helpers/init_helpers.ts
+++ b/client/js/src/helpers/init_helpers.ts
@@ -1,10 +1,11 @@
-import type { Config } from "../types";
+import type { ClientOptions, Config } from "../types";
 import {
 	CONFIG_ERROR_MSG,
 	CONFIG_URL,
 	INVALID_CREDENTIALS_MSG,
 	LOGIN_URL,
 	MISSING_CREDENTIALS_MSG,
+	PRIVATE_SPACE_MSG,
 	SPACE_METADATA_ERROR_MSG,
 	UNAUTHORIZED_MSG
 } from "../constants";
@@ -50,6 +51,22 @@ export async function get_jwt(
 		return jwt || false;
 	} catch (e) {
 		return false;
+	}
+}
+
+/**
+ * The `hf_token` option was renamed to `token`, but a lot of existing code
+ * (and the Python client) still uses `hf_token`. Accept it as an alias so
+ * that authenticated requests are not silently sent without credentials,
+ * which previously surfaced as "Could not resolve app config" errors when
+ * connecting to private Spaces.
+ */
+export function normalise_token_option(options: ClientOptions): void {
+	if (options.hf_token && !options.token) {
+		options.token = options.hf_token;
+		console.warn(
+			"The `hf_token` option has been renamed to `token`. Support for `hf_token` will be removed in a future version of @gradio/client."
+		);
 	}
 }
 
@@ -153,7 +170,14 @@ async function handleConfigResponse(
 	authorized: boolean
 ): Promise<Config> {
 	if (response?.status === 401 && !authorized) {
-		const error_data = await response.json();
+		let error_data: any = null;
+		try {
+			error_data = await response.json();
+		} catch (e) {
+			// Unauthenticated requests to private Spaces receive a non-JSON 401
+			// page from the Hugging Face proxy rather than a Gradio auth payload.
+			throw new Error(PRIVATE_SPACE_MSG);
+		}
 		const auth_message = error_data?.detail?.auth_message;
 		throw new Error(auth_message || MISSING_CREDENTIALS_MSG);
 	} else if (response?.status === 401 && authorized) {
@@ -172,7 +196,9 @@ async function handleConfigResponse(
 		throw new Error(UNAUTHORIZED_MSG);
 	}
 
-	throw new Error(CONFIG_ERROR_MSG);
+	throw new Error(
+		`${CONFIG_ERROR_MSG}(received status ${response?.status} when fetching the app config)`
+	);
 }
 
 export async function resolve_cookies(this: Client): Promise<void> {

--- a/client/js/src/test/api_info.test.ts
+++ b/client/js/src/test/api_info.test.ts
@@ -1,7 +1,7 @@
 import {
 	INVALID_URL_MSG,
 	QUEUE_FULL_MSG,
-	SPACE_METADATA_ERROR_MSG
+	SPACE_NOT_FOUND_MSG
 } from "../constants";
 import { beforeAll, afterEach, afterAll, it, expect, describe } from "vitest";
 import {
@@ -10,7 +10,8 @@ import {
 	get_type,
 	process_endpoint,
 	join_urls,
-	map_data_to_params
+	map_data_to_params,
+	transform_api_info
 } from "../helpers/api_info";
 import { initialise_server } from "./server";
 import { transformed_api_info } from "./test_data";
@@ -471,19 +472,13 @@ describe("process_endpoint", () => {
 		expect(result).toEqual(expected);
 	});
 
-	it("should throw an error when fetching space metadata fails", async () => {
+	it("should throw a clear error when the space does not exist or is private", async () => {
 		const app_reference = "hmb/bye_world";
 		const token = "hf_token";
 
-		try {
-			await process_endpoint(app_reference, token);
-		} catch (error) {
-			if (error instanceof Error) {
-				expect(error.message).toEqual(SPACE_METADATA_ERROR_MSG);
-			} else {
-				expect.fail("Error should not be unknown.");
-			}
-		}
+		await expect(process_endpoint(app_reference, token)).rejects.toThrow(
+			SPACE_NOT_FOUND_MSG(app_reference, 404)
+		);
 	});
 
 	it("should return the correct data when app_reference is a valid space domain", async () => {
@@ -697,5 +692,38 @@ describe("map_data_params", () => {
 		expect(() => map_data_to_params(data, endpoint_info)).toThrowError(
 			"No value provided for required parameter: param1"
 		);
+	});
+});
+
+describe("transform_api_info", () => {
+	it("defaults parameters and returns to empty arrays when an endpoint entry is malformed", () => {
+		const api_info = {
+			named_endpoints: {
+				// missing `parameters` and `returns`, as returned by some legacy
+				// or misbehaving apps (see issue #10945)
+				"/predict": {}
+			},
+			unnamed_endpoints: {}
+		} as any;
+		const config = {
+			dependencies: [
+				{
+					id: 0,
+					api_name: "predict",
+					inputs: [1],
+					outputs: [2],
+					types: { generator: false, cancel: false }
+				}
+			],
+			components: [
+				{ id: 1, type: "textbox", props: {} },
+				{ id: 2, type: "textbox", props: {} }
+			]
+		} as any;
+
+		const result = transform_api_info(api_info, config, { predict: 0 });
+
+		expect(result.named_endpoints["/predict"].parameters).toEqual([]);
+		expect(result.named_endpoints["/predict"].returns).toEqual([]);
 	});
 });

--- a/client/js/src/test/init.test.ts
+++ b/client/js/src/test/init.test.ts
@@ -15,7 +15,7 @@ import {
 	response_api_info
 } from "./test_data";
 import { initialise_server } from "./server";
-import { SPACE_METADATA_ERROR_MSG } from "../constants";
+import { SPACE_NOT_FOUND_MSG } from "../constants";
 
 const app_reference = "hmb/hello_world";
 const broken_app_reference = "hmb/bye_world";
@@ -87,12 +87,28 @@ describe("Client class", () => {
 			});
 		});
 
+		test("connecting successfully to a private running app with the deprecated hf_token option", async () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const app = await Client.connect("hmb/secret_world", {
+				hf_token: "hf_123"
+			});
+
+			expect(app.config).toEqual({
+				...config_response,
+				root: "https://hmb-secret-world.hf.space"
+			});
+			expect(warn).toHaveBeenCalledWith(
+				expect.stringContaining("`hf_token` option has been renamed")
+			);
+			warn.mockRestore();
+		});
+
 		test("unsuccessfully attempting to connect to a private running app", async () => {
 			await expect(
 				Client.connect("hmb/secret_world", {
 					token: "hf_bad_token"
 				})
-			).rejects.toThrowError(SPACE_METADATA_ERROR_MSG);
+			).rejects.toThrowError(SPACE_NOT_FOUND_MSG("hmb/secret_world", 401));
 		});
 
 		test("viewing the api info of a running app", async () => {
@@ -139,7 +155,9 @@ describe("Client class", () => {
 		test("creating a duplicate of a broken app", async () => {
 			const duplicate = Client.duplicate(broken_app_reference);
 
-			await expect(duplicate).rejects.toThrow(SPACE_METADATA_ERROR_MSG);
+			await expect(duplicate).rejects.toThrow(
+				SPACE_NOT_FOUND_MSG(broken_app_reference, 404)
+			);
 		});
 	});
 

--- a/client/js/src/test/submit.test.ts
+++ b/client/js/src/test/submit.test.ts
@@ -162,8 +162,6 @@ describe("predict error handling", () => {
 				1000,
 				"predict() never settled for an unknown endpoint"
 			)
-		).rejects.toThrow(
-			"There is no endpoint matching that name of fn_index matching that number."
-		);
+		).rejects.toThrow('No endpoint matching "nonexistent_endpoint" was found');
 	});
 });

--- a/client/js/src/types.ts
+++ b/client/js/src/types.ts
@@ -323,6 +323,11 @@ export interface DuplicateOptions extends ClientOptions {
 
 export interface ClientOptions {
 	token?: `hf_${string}`;
+	/**
+	 * @deprecated Use `token` instead. Kept as an alias so that code written
+	 * for older versions of the client keeps working.
+	 */
+	hf_token?: `hf_${string}`;
 	status_callback?: SpaceStatusCallback | null;
 	auth?: [string, string] | null;
 	with_null_state?: boolean;

--- a/client/js/src/utils/duplicate.ts
+++ b/client/js/src/utils/duplicate.ts
@@ -8,6 +8,7 @@ import { Client } from "../client";
 import { SPACE_METADATA_ERROR_MSG } from "../constants";
 import {
 	get_cookie_header,
+	normalise_token_option,
 	parse_and_set_cookies
 } from "../helpers/init_helpers";
 import { process_endpoint } from "../helpers/api_info";
@@ -16,6 +17,7 @@ export async function duplicate(
 	app_reference: string,
 	options: DuplicateOptions
 ): Promise<Client> {
+	normalise_token_option(options);
 	const { token, private: _private, hardware, timeout, auth } = options;
 
 	if (hardware && !hardware_types.includes(hardware)) {

--- a/client/js/src/utils/predict.ts
+++ b/client/js/src/utils/predict.ts
@@ -37,7 +37,20 @@ export async function predict<T = unknown>(
 
 		if (message.type === "status") {
 			if (message.stage === "error") {
-				throw message;
+				// Throw a real `Error` (rather than the raw status object) so that
+				// uncaught failures surface a readable message instead of
+				// crashing Node with `ERR_UNHANDLED_REJECTION ... reason "#<Object>"`.
+				// The status fields are preserved on the error for callers that
+				// inspect them.
+				const { message: error_message, ...status } = message;
+				const error = new Error(
+					(typeof error_message === "string"
+						? error_message
+						: error_message && JSON.stringify(error_message)) ||
+						"An unknown error occurred while making a prediction."
+				);
+				Object.assign(error, status);
+				throw error;
 			}
 			if (message.stage === "complete") {
 				status_complete = true;

--- a/client/js/src/utils/submit.ts
+++ b/client/js/src/utils/submit.ts
@@ -640,7 +640,7 @@ export function submit(
 				type: "status",
 				stage: "error",
 				message: e instanceof Error ? e.message : String(e),
-				queue: true,
+				queue: !skip_queue(fn_index, config),
 				endpoint: _endpoint,
 				fn_index,
 				time: new Date()
@@ -763,7 +763,11 @@ function get_endpoint_info(
 		const trimmed_endpoint = endpoint.replace(/^\//, "");
 
 		fn_index = api_map[trimmed_endpoint];
-		endpoint_info = api_info.named_endpoints[endpoint.trim()];
+		// named endpoints are keyed with a leading slash in the API info, but
+		// accept endpoint names passed without one (e.g. "predict")
+		endpoint_info =
+			api_info.named_endpoints[endpoint.trim()] ??
+			api_info.named_endpoints[`/${trimmed_endpoint}`];
 		dependency = config.dependencies.find(
 			(dep) => dep.id == api_map[trimmed_endpoint]
 		);

--- a/client/js/src/utils/submit.ts
+++ b/client/js/src/utils/submit.ts
@@ -19,11 +19,13 @@ import {
 } from "../helpers/api_info";
 import {
 	BROKEN_CONNECTION_MSG,
+	NO_API_INFO_MSG,
 	QUEUE_FULL_MSG,
 	SSE_URL,
 	SSE_DATA_URL,
 	RESET_URL,
-	CANCEL_URL
+	CANCEL_URL,
+	WS_PROTOCOL_MSG
 } from "../constants";
 import { apply_diff_stream, close_stream } from "./stream";
 import { Client } from "../client";
@@ -60,7 +62,7 @@ export function submit(
 
 		const that = this;
 
-		if (!api_info) throw new Error("No API found");
+		if (!api_info) throw new Error(NO_API_INFO_MSG);
 		if (!config) throw new Error("Could not resolve app config");
 
 		let { fn_index, endpoint_info, dependency } = get_endpoint_info(
@@ -75,7 +77,7 @@ export function submit(
 		let stream: EventSource | null;
 		let protocol = config.protocol ?? "ws";
 		if (protocol === "ws") {
-			throw new Error("WebSocket protocol is not supported in this version");
+			throw new Error(WS_PROTOCOL_MSG);
 		}
 		let event_id_final = "";
 		let event_id_cb: () => string = () => event_id_final;
@@ -630,6 +632,22 @@ export function submit(
 			}
 		});
 
+		// Surface internal failures (e.g. malformed payloads or configs) as an
+		// error event instead of leaving the returned iterator hanging forever
+		// with an unhandled promise rejection.
+		job.catch((e) => {
+			fire_event({
+				type: "status",
+				stage: "error",
+				message: e instanceof Error ? e.message : String(e),
+				queue: true,
+				endpoint: _endpoint,
+				fn_index,
+				time: new Date()
+			});
+			close();
+		});
+
 		let done = false;
 		const values: (IteratorResult<GradioEvent> | PromiseLike<never>)[] = [];
 		const resolvers: ((
@@ -735,12 +753,12 @@ function get_endpoint_info(
 } {
 	let fn_index: number;
 	let endpoint_info: EndpointInfo<JsApiData>;
-	let dependency: Dependency;
+	let dependency: Dependency | undefined;
 
 	if (typeof endpoint === "number") {
 		fn_index = endpoint;
 		endpoint_info = api_info.unnamed_endpoints[fn_index];
-		dependency = config.dependencies.find((dep) => dep.id == endpoint)!;
+		dependency = config.dependencies.find((dep) => dep.id == endpoint);
 	} else {
 		const trimmed_endpoint = endpoint.replace(/^\//, "");
 
@@ -748,12 +766,20 @@ function get_endpoint_info(
 		endpoint_info = api_info.named_endpoints[endpoint.trim()];
 		dependency = config.dependencies.find(
 			(dep) => dep.id == api_map[trimmed_endpoint]
-		)!;
+		);
 	}
 
-	if (typeof fn_index !== "number") {
+	if (typeof fn_index !== "number" || !dependency) {
+		const valid_endpoints = config.dependencies
+			.filter((dep) => dep.api_name)
+			.map((dep) => `"/${dep.api_name}"`)
+			.join(", ");
 		throw new Error(
-			"There is no endpoint matching that name of fn_index matching that number."
+			`No endpoint matching ${JSON.stringify(endpoint)} was found. ` +
+				(valid_endpoints
+					? `Valid named endpoints are: ${valid_endpoints}. `
+					: "This app exposes no named endpoints. ") +
+				"An fn_index (number) of an existing dependency can also be used."
 		);
 	}
 	return { fn_index, endpoint_info, dependency };


### PR DESCRIPTION
## Description

Fixes two related `@gradio/client` bugs around connecting to Hugging Face Spaces and error handling.

Closes #9214
Closes #10945

### Issue #9214 — "Could not resolve app config" when connecting to a private Space with a token

**Root cause(s):**
- The `hf_token` option (used in the issue's reproduction, in lots of existing user code, and still the name used by the Python client) was renamed to `token` with no alias, so `Client.connect(space, { hf_token })` silently sends **unauthenticated** requests. For a private Space, the `https://huggingface.co/api/spaces/<space>/host` lookup then fails and every downstream step breaks with vague errors.
- When that host lookup failed (401/404), `process_endpoint` swallowed the real cause and threw the generic "Space metadata could not be loaded."
- Unauthenticated requests to a private Space's `*.hf.space/config` receive a non-JSON 401 page, which crashed `handleConfigResponse` with a raw JSON parse error.
- `_resolve_config` rethrew failures as `throw Error(e)` (yielding `"Error: Error: ..."` strings) and, when a `status_callback` was set, returned `undefined`, crashing `init()` with `Cannot destructure property 'config' of undefined`.

**Fix:**
- `hf_token` is accepted again as a **deprecated alias** for `token` (typed as deprecated, one-line console warning), applied in both `Client` and `duplicate`.
- 401/404 responses from the HF `/host` API now raise a clear, actionable error naming the Space and suggesting to pass a valid `token` if the Space is private.
- Non-JSON 401 config responses raise a clear "private Space → pass `token`" error instead of a JSON `SyntaxError`; other config failures now include the HTTP status.
- `_resolve_config` failures propagate the original `Error`, and `init()` no longer crashes on an undefined result.

### Issue #10945 — JS client dies with `Cannot read properties of undefined (reading 'map')` / `ERR_UNHANDLED_REJECTION ... reason "#<Object>"` (MusicGen Space, follow-up to #5044)

**Root cause(s):**
- `transform_api_info` assumed every `/info` endpoint entry has `parameters`/`returns` arrays. Malformed or legacy payloads killed `view_api()` with `Cannot read properties of undefined (reading 'map')`, leaving the client without any `api_info`.
- `predict()` threw the raw **status object** on error (`throw message`), so uncaught failures crash Node with `ERR_UNHANDLED_REJECTION ... The promise rejected with the reason "#<Object>"` — the exact crash in the issue.
- `submit()` with an fn_index that has no matching dependency deref'd `undefined` inside an un-awaited promise chain: an **unhandled TypeError rejection** plus a `predict()` promise that hangs forever.
- Assorted vague errors: `"No API found"`, `"There is no endpoint matching that name of fn_index matching that number."`, `"WebSocket protocol is not supported in this version"`.

**Fix:**
- `transform_api_info` defaults missing `parameters`/`returns` to `[]` and guards the dependency lookups, so malformed/legacy `/info` payloads no longer crash config/API resolution.
- `predict()` rejects with a real `Error` (status fields preserved on the error object for callers that inspect them).
- `submit()`'s internal job promise now has a failure handler that surfaces internal exceptions as an `error` status event and closes the iterator — no more unhandled rejections or hangs.
- Unknown endpoints/fn_indices raise an error listing the valid named endpoints; missing `api_info` and legacy WebSocket-protocol apps get explanatory messages (legacy Gradio 3.x apps are still unsupported, but now say so clearly).

> Note: the real `facebook/MusicGen` Space has since been upgraded to Gradio 5.49.1, so the *original* legacy-protocol scenario no longer exists on that Space; the crash modes it exposed (plain-object rejection from `predict`, the `reading 'map'` TypeError on malformed `/info`, hang + unhandled rejection on bad fn_index) all still reproduced on `main` and are what this PR fixes. The reporter's exact call against today's MusicGen Space now rejects with a catchable `Error` instead of crashing the process.

---

## 🧪 How to test this PR against a real private Space

A minimal **private** Space has been set up for reviewing this PR: [`gradio/pr-13657-private-space-test`](https://huggingface.co/spaces/gradio/pr-13657-private-space-test) (members of the `gradio` org can access it; safe to delete after merge). You'll need an HF token that can read the `gradio` org — any of your normal tokens from https://huggingface.co/settings/tokens will probably do.

<details>
<summary><b><code>test_pr13657.html</code></b> (click to expand)</summary>

```html
<!doctype html>
<meta charset="utf-8" />
<title>PR #13657 review — @gradio/client private-Space test</title>
<style>
	body { font-family: system-ui, sans-serif; margin: 2rem; max-width: 1100px; }
	.cols { display: flex; gap: 1.5rem; flex-wrap: wrap; }
	.col { flex: 1 1 480px; }
	pre { background: #f6f8fa; border: 1px solid #ddd; border-radius: 6px; padding: 1rem; white-space: pre-wrap; word-break: break-word; min-height: 20rem; font-size: 13px; }
	input { font-size: 1rem; padding: 0.3rem; width: 24rem; }
	button { font-size: 1rem; padding: 0.3rem 1rem; }
	.pass { color: #1a7f37; } .fail { color: #cf222e; } .warn { color: #9a6700; }
</style>

<h2>PR #13657 — connect to a private Space: published client vs PR build</h2>
<p>
	Space under test: <b>gradio/pr-13657-private-space-test</b> (private, <code>gradio</code> org).
	Enter an HF token that can read the <code>gradio</code> org — the token stays in this page.
</p>
<p>
	<input id="token" type="password" placeholder="hf_..." />
	<button id="run">Run checks</button>
</p>
<div class="cols">
	<div class="col"><h3>Published @gradio/client (latest release, jsDelivr)</h3><pre id="out-published">–</pre></div>
	<div class="col"><h3>This PR's build (npm-previews CDN)</h3><pre id="out-pr">–</pre></div>
</div>

<script type="module">
	const SPACE = "gradio/pr-13657-private-space-test";
	const VERSIONS = [
		{
			el: "out-published",
			url: "https://cdn.jsdelivr.net/npm/@gradio/client/dist/index.min.js"
		},
		{
			el: "out-pr",
			// per-commit URL — if new commits land on the PR, copy the latest
			// "Import Gradio JS Client from this PR via CDN" link from the
			// gradio-pr-bot comment on the PR
			url: "https://huggingface.co/buckets/gradio/npm-previews/resolve/04137baf217ff2a43a75422c6ddf8bb385153c99/browser.js"
		}
	];

	async function run_checks(Client, print) {
		const token = document.getElementById("token").value.trim();

		const check = async (label, fn) => {
			try {
				const out = await fn();
				print(`✅ [${label}] resolved: ${JSON.stringify(out)}`, "pass");
			} catch (e) {
				print(`❌ [${label}] rejected (${e?.constructor?.name}): ${e?.message ?? e}`, "fail");
			}
		};

		// 1. `hf_token` option name — what issue #9214 (and the Python client) uses
		await check("connect with hf_token + predict", async () => {
			const app = await Client.connect(SPACE, { hf_token: token });
			return (await app.predict("/greet", ["reviewer"])).data;
		});

		// 2. current `token` option name (control — works on both versions)
		await check("connect with token + predict", async () => {
			const app = await Client.connect(SPACE, { token });
			return (await app.predict("/greet", ["reviewer"])).data;
		});

		// 3. no token at all — what error does a user see?
		await check("connect with no token", () => Client.connect(SPACE));

		// 4. non-existent endpoint — how does predict() reject?
		await check("predict on bad endpoint", async () => {
			const app = await Client.connect(SPACE, { token });
			return (await app.predict("/does_not_exist", ["x"])).data;
		});
	}

	document.getElementById("run").onclick = async () => {
		for (const v of VERSIONS) {
			const el = document.getElementById(v.el);
			el.textContent = "";
			const print = (msg, cls) => {
				const line = document.createElement("div");
				if (cls) line.className = cls;
				line.textContent = msg;
				el.appendChild(line);
			};

			// surface the hf_token deprecation warning (console.warn) in the page
			const orig_warn = console.warn;
			console.warn = (...a) => { print(`⚠️  ${a.join(" ")}`, "warn"); orig_warn(...a); };
			try {
				print(`importing ${v.url} …`);
				const { Client } = await import(v.url);
				await run_checks(Client, print);
			} catch (e) {
				print(`❌ failed to import/run: ${e?.message ?? e}`, "fail");
			} finally {
				console.warn = orig_warn;
			}
		}
	};
</script>
```

</details>

### What you should see

<img width="1147" height="638" alt="image" src="https://github.com/user-attachments/assets/0b8372df-6f01-4053-b69d-1146173aa8b6" />


**Left column — published client (current behavior):**

- ❌ `connect with hf_token + predict` rejects with the vague **`Space metadata could not be loaded.`** — the `hf_token` option is silently ignored, so the private Space looks nonexistent. This is issue #9214.
- ✅ `connect with token + predict` resolves with `Hello, reviewer! …` (control: the Space and your token are fine).
- ❌ `connect with no token` gives the same unhelpful `Space metadata could not be loaded.`, with no hint that a token is needed.
- ❌ `predict on bad endpoint` gives `There is no endpoint matching that name of fn_index matching that number.` — no hint what the valid endpoints are. (In the issue #10945 scenario this path could also reject with a plain object or hang; see the repro script above.)

**Right column — this PR's build:**

- ⚠️ A one-line deprecation warning: `The 'hf_token' option has been renamed to 'token'. …`
- ✅ `connect with hf_token + predict` resolves with `Hello, reviewer! …` — `hf_token` authenticates again.
- ✅ `connect with token + predict` still resolves (no regression).
- ❌ `connect with no token` rejects with an actionable error: **`Space "gradio/pr-13657-private-space-test" could not be accessed (received a 401 response from the Hugging Face API). … If the Space is private, pass a valid Hugging Face token to the 'token' option of Client.connect. …`**
- ❌ `predict on bad endpoint` rejects with an error that lists the valid endpoints: `No endpoint matching "/does_not_exist" was found. Valid named endpoints are: …, "/greet", … An fn_index (number) of an existing dependency can also be used.`

(The ❌/✅ prefixes above are exactly what the page renders — the two ❌ rows in the right column are the *desired* clear rejections.)
