### PR TITLE
Fix ColorPicker dispatching blur while the user is still using the picker dialog

### DIFF
--- a/.changeset/giant-lemons-sleep.md
+++ b/.changeset/giant-lemons-sleep.md
@@ -1,0 +1,6 @@
+---
+"@gradio/colorpicker": patch
+"gradio": patch
+---
+
+fix:Fix ColorPicker dispatching blur while the user is still using the picker dialog

--- a/js/colorpicker/ColorPicker.test.ts
+++ b/js/colorpicker/ColorPicker.test.ts
@@ -119,6 +119,20 @@ describe("Dialog", () => {
 			result.queryByRole("button", { name: "Hex" })
 		).not.toBeInTheDocument();
 	});
+
+	test("clicking the component's empty area outside the dialog closes the picker", async () => {
+		const result = await render(ColorPicker, default_props);
+
+		await open_picker(result);
+		expect(result.getByRole("button", { name: "Hex" })).toBeInTheDocument();
+
+		const swatch = result.getByRole("button", { name: "Color Picker" });
+		await fireEvent.mouseDown(swatch.parentElement!);
+
+		expect(
+			result.queryByRole("button", { name: "Hex" })
+		).not.toBeInTheDocument();
+	});
 });
 
 describe("Props: interactive", () => {

--- a/js/colorpicker/ColorPicker.test.ts
+++ b/js/colorpicker/ColorPicker.test.ts
@@ -99,6 +99,7 @@ describe("Dialog", () => {
 		expect(result.getByRole("button", { name: "Hex" })).toBeInTheDocument();
 
 		const swatch = result.getByRole("button", { name: "Color Picker" });
+		await fireEvent.mouseDown(swatch);
 		await fireEvent.click(swatch);
 
 		expect(

--- a/js/colorpicker/ColorPicker.test.ts
+++ b/js/colorpicker/ColorPicker.test.ts
@@ -485,6 +485,32 @@ describe("Events", () => {
 		expect(blur).toHaveBeenCalledTimes(1);
 	});
 
+	test("blur: not emitted when clicking a non-focusable area inside the dialog", async () => {
+		const result = await render(ColorPicker, default_props);
+		await open_picker(result);
+
+		const input = result.getByRole("textbox");
+		input.focus();
+		const blur = result.listen("blur");
+
+		// fireEvent can't reproduce the browser's default mousedown action
+		// (blurring the active element when the target has no focusable
+		// ancestor), so emulate it, honoring preventDefault as browsers do.
+		const dialog = result.container.querySelector(".color-picker")!;
+		const mousedown = new MouseEvent("mousedown", {
+			bubbles: true,
+			cancelable: true
+		});
+		dialog.dispatchEvent(mousedown);
+		if (!mousedown.defaultPrevented) {
+			(document.activeElement as HTMLElement | null)?.blur();
+		}
+
+		expect(blur).not.toHaveBeenCalled();
+		expect(result.getByRole("button", { name: "Hex" })).toBeInTheDocument();
+		expect(document.activeElement).toBe(input);
+	});
+
 	test("blur: emitted when clicking outside closes the dialog while focus is inside", async () => {
 		const result = await render(ColorPicker, default_props);
 

--- a/js/colorpicker/ColorPicker.test.ts
+++ b/js/colorpicker/ColorPicker.test.ts
@@ -447,9 +447,65 @@ describe("Events", () => {
 
 		const swatch = result.getByRole("button", { name: "Color Picker" });
 		swatch.focus();
-		await fireEvent.blur(swatch);
+		swatch.blur();
 
 		expect(blur).toHaveBeenCalledTimes(1);
+	});
+
+	test("blur: not emitted when focus moves into the dialog, emitted when focus leaves", async () => {
+		const result = await render(ColorPicker, default_props);
+		const blur = result.listen("blur");
+
+		const swatch = result.getByRole("button", { name: "Color Picker" });
+		swatch.focus();
+		await open_picker(result);
+
+		const input = result.getByRole("textbox");
+		input.focus();
+
+		expect(blur).not.toHaveBeenCalled();
+
+		input.blur();
+
+		expect(blur).toHaveBeenCalledTimes(1);
+	});
+
+	test("blur: emitted when clicking outside closes the dialog while focus is inside", async () => {
+		const result = await render(ColorPicker, default_props);
+
+		const swatch = result.getByRole("button", { name: "Color Picker" });
+		swatch.focus();
+		await open_picker(result);
+		result.getByRole("textbox").focus();
+
+		const blur = result.listen("blur");
+		await fireEvent.mouseDown(document.body);
+
+		expect(blur).toHaveBeenCalledTimes(1);
+	});
+
+	test("focus: emitted once while focus stays within the component", async () => {
+		const result = await render(ColorPicker, default_props);
+		const focus = result.listen("focus");
+
+		const swatch = result.getByRole("button", { name: "Color Picker" });
+		swatch.focus();
+		await open_picker(result);
+		result.getByRole("textbox").focus();
+
+		expect(focus).toHaveBeenCalledTimes(1);
+	});
+
+	test("focus: re-emitted when focus returns after blur", async () => {
+		const result = await render(ColorPicker, default_props);
+		const focus = result.listen("focus");
+
+		const swatch = result.getByRole("button", { name: "Color Picker" });
+		swatch.focus();
+		swatch.blur();
+		swatch.focus();
+
+		expect(focus).toHaveBeenCalledTimes(2);
 	});
 });
 

--- a/js/colorpicker/shared/Colorpicker.svelte
+++ b/js/colorpicker/shared/Colorpicker.svelte
@@ -219,7 +219,20 @@
 	/>
 
 	{#if dialog_open}
-		<div class="color-picker" use:click_outside={handle_click_outside}>
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div
+			class="color-picker"
+			onmousedown={(e) => {
+				// Keep focus where it is, as Dropdown does for its options:
+				// letting focus fall to body (padding clicks, or button clicks
+				// on browsers where buttons don't take focus) fires a premature
+				// blur. Only the text input needs mouse focus.
+				if (!(e.target instanceof HTMLInputElement)) {
+					e.preventDefault();
+				}
+			}}
+			use:click_outside={handle_click_outside}
+		>
 			<div
 				class="color-gradient"
 				role="slider"

--- a/js/colorpicker/shared/Colorpicker.svelte
+++ b/js/colorpicker/shared/Colorpicker.svelte
@@ -35,6 +35,9 @@
 
 	let eyedropper_supported = false;
 
+	let wrapper: HTMLDivElement;
+	let has_focus = false;
+
 	let sl_wrap: HTMLDivElement;
 	let hue_wrap: HTMLDivElement;
 
@@ -156,8 +159,31 @@
 		eyedropper_supported = window !== undefined && !!window.EyeDropper;
 	});
 
-	function handle_click_outside(): void {
+	function handle_focusin(): void {
+		if (!has_focus) {
+			has_focus = true;
+			on_focus();
+		}
+	}
+
+	function handle_focusout(event: FocusEvent): void {
+		if (event.relatedTarget && wrapper.contains(event.relatedTarget as Node)) {
+			return;
+		}
+		if (has_focus) {
+			has_focus = false;
+			on_blur();
+		}
+	}
+
+	function handle_click_outside(event: MouseEvent): void {
 		dialog_open = false;
+		// Closing removes the focused element with the dialog, so no focusout
+		// fires; dispatch blur here unless focus is moving back to the swatch.
+		if (has_focus && !wrapper.contains(event.target as Node)) {
+			has_focus = false;
+			on_blur();
+		}
 	}
 
 	$effect(() => {
@@ -166,95 +192,100 @@
 </script>
 
 <BlockTitle {show_label} {info}>{label}</BlockTitle>
-<button
-	class="dialog-button"
-	aria-label={label}
-	style:background={value}
-	{disabled}
-	onfocus={on_focus}
-	onblur={on_blur}
-	onclick={() => {
-		update_mouse_from_color(value);
-		dialog_open = !dialog_open;
-	}}
-/>
 
 <svelte:window onmousemove={handle_move} onmouseup={handle_end} />
 
-{#if dialog_open}
-	<div class="color-picker" use:click_outside={handle_click_outside}>
-		<div
-			class="color-gradient"
-			role="slider"
-			aria-label="Saturation and brightness"
-			aria-valuetext={value}
-			tabindex="0"
-			onmousedown={handle_sl_down}
-			style="--hue:{hue}"
-			bind:this={sl_wrap}
-		>
-			<div
-				class="marker"
-				style:transform="translate({sl_marker_pos[0]}px,{sl_marker_pos[1]}px)"
-				style:background={value}
-			/>
-		</div>
-		<div
-			class="hue-slider"
-			role="slider"
-			aria-label="Hue"
-			aria-valuemin={0}
-			aria-valuemax={360}
-			aria-valuenow={Math.round(hue)}
-			tabindex="0"
-			onmousedown={handle_hue_down}
-			bind:this={hue_wrap}
-		>
-			<div
-				class="marker"
-				style:background={"hsl(" + hue + ", 100%, 50%)"}
-				style:transform="translateX({hue_marker_pos}px)"
-			/>
-		</div>
+<div
+	bind:this={wrapper}
+	onfocusin={handle_focusin}
+	onfocusout={handle_focusout}
+>
+	<button
+		class="dialog-button"
+		aria-label={label}
+		style:background={value}
+		{disabled}
+		onclick={() => {
+			update_mouse_from_color(value);
+			dialog_open = !dialog_open;
+		}}
+	/>
 
-		<div class="input">
-			<button class="swatch" style:background={value}></button>
-			<div>
-				<div class="input-wrap">
-					<input
-						type="text"
-						bind:value={color_string}
-						onchange={(e) => {
-							value = normalize_color(e.currentTarget.value);
-						}}
-						onkeydown={(e) => {
-							if (e.key === "Enter") {
-								on_submit();
-							}
-						}}
-					/>
-					<button class="eyedropper" onclick={request_eyedropper}>
-						{#if eyedropper_supported}
-							<Eyedropper />
-						{/if}
-					</button>
-				</div>
+	{#if dialog_open}
+		<div class="color-picker" use:click_outside={handle_click_outside}>
+			<div
+				class="color-gradient"
+				role="slider"
+				aria-label="Saturation and brightness"
+				aria-valuetext={value}
+				tabindex="0"
+				onmousedown={handle_sl_down}
+				style="--hue:{hue}"
+				bind:this={sl_wrap}
+			>
+				<div
+					class="marker"
+					style:transform="translate({sl_marker_pos[0]}px,{sl_marker_pos[1]}px)"
+					style:background={value}
+				/>
+			</div>
+			<div
+				class="hue-slider"
+				role="slider"
+				aria-label="Hue"
+				aria-valuemin={0}
+				aria-valuemax={360}
+				aria-valuenow={Math.round(hue)}
+				tabindex="0"
+				onmousedown={handle_hue_down}
+				bind:this={hue_wrap}
+			>
+				<div
+					class="marker"
+					style:background={"hsl(" + hue + ", 100%, 50%)"}
+					style:transform="translateX({hue_marker_pos}px)"
+				/>
+			</div>
 
-				<div class="buttons">
-					{#each modes as [label, value]}
-						<button
-							class="button"
-							class:active={current_mode === value}
-							onclick={() => {
-								current_mode = value;
-							}}>{label}</button
-						>
-					{/each}
+			<div class="input">
+				<button class="swatch" style:background={value}></button>
+				<div>
+					<div class="input-wrap">
+						<input
+							type="text"
+							bind:value={color_string}
+							onchange={(e) => {
+								value = normalize_color(e.currentTarget.value);
+							}}
+							onkeydown={(e) => {
+								if (e.key === "Enter") {
+									on_submit();
+								}
+							}}
+						/>
+						<button class="eyedropper" onclick={request_eyedropper}>
+							{#if eyedropper_supported}
+								<Eyedropper />
+							{/if}
+						</button>
+					</div>
+
+					<div class="buttons">
+						{#each modes as [label, value]}
+							<button
+								class="button"
+								class:active={current_mode === value}
+								onclick={() => {
+									current_mode = value;
+								}}>{label}</button
+							>
+						{/each}
+					</div>
 				</div>
 			</div>
 		</div>
-	</div>
-{/if}
+	{/if}
+</div>
 
 <style>
 	.dialog-button {

--- a/js/colorpicker/shared/Colorpicker.svelte
+++ b/js/colorpicker/shared/Colorpicker.svelte
@@ -36,6 +36,7 @@
 	let eyedropper_supported = false;
 
 	let wrapper: HTMLDivElement;
+	let dialog_button: HTMLButtonElement;
 	let has_focus = false;
 
 	let sl_wrap: HTMLDivElement;
@@ -179,7 +180,7 @@
 	function handle_click_outside(event: MouseEvent): void {
 		// click_outside is bound to the dialog, so the swatch (outside it, but
 		// inside the component) triggers this too; let its onclick handle the toggle.
-		if (wrapper.contains(event.target as Node)) {
+		if (dialog_button.contains(event.target as Node)) {
 			return;
 		}
 		dialog_open = false;
@@ -207,6 +208,7 @@
 >
 	<button
 		class="dialog-button"
+		bind:this={dialog_button}
 		aria-label={label}
 		style:background={value}
 		{disabled}

--- a/js/colorpicker/shared/Colorpicker.svelte
+++ b/js/colorpicker/shared/Colorpicker.svelte
@@ -177,10 +177,15 @@
 	}
 
 	function handle_click_outside(event: MouseEvent): void {
+		// click_outside is bound to the dialog, so the swatch (outside it, but
+		// inside the component) triggers this too; let its onclick handle the toggle.
+		if (wrapper.contains(event.target as Node)) {
+			return;
+		}
 		dialog_open = false;
-		// Closing removes the focused element with the dialog, so no focusout
-		// fires; dispatch blur here unless focus is moving back to the swatch.
-		if (has_focus && !wrapper.contains(event.target as Node)) {
+		// The focused element is removed with the dialog, so no focusout fires;
+		// dispatch blur here instead.
+		if (has_focus) {
 			has_focus = false;
 			on_blur();
 		}


### PR DESCRIPTION
## Description

`gr.ColorPicker` dispatches its `blur` event as soon as the user clicks anything inside the opened picker dialog (the gradient area, the hue slider, or the hex text input), even though the user is still interacting with the component. On top of that, when the dialog is then closed by clicking outside, no `blur` fires at all: the focused element is removed together with the dialog, and browsers do not fire `focusout` for removed elements. So in the common flow "open, pick a color, click away", the only `blur` the app ever sees is the premature one.

The `focus`/`blur` handlers were added in #12862 on the swatch button only. That works for single-element components like Textbox, but the ColorPicker expands into a dialog full of focusable elements, so focus legitimately moves off the button during normal use. This PR treats the swatch button and the dialog as one focus scope: a wrapper element listens to `focusin`/`focusout` and only dispatches `focus`/`blur` when focus actually enters or leaves the component, with an explicit `blur` dispatch when an outside click closes the dialog while focus is inside it.

The dialog also adopts the `preventDefault()`-on-`mousedown` trick Dropdown uses for its options, except on the hex text input, which needs mouse focus for the caret. Without it, clicking a non-focusable area of the dialog, or any of its buttons on browsers where buttons don't take focus on click (Safari, and Firefox on macOS), drops focus to `body` and fires a premature `blur` while the picker is still open.

## Before / after Spaces

- [Before fix](https://huggingface.co/spaces/hysts-debug/gradio-12896-before)
- [After fix](https://huggingface.co/spaces/hysts-debug/gradio-12896-after)

Closes: #12896

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small.

Not adhering to this guideline will result in the PR being closed.

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

