### PR TITLE
Upload recorded audio only once to fix intermittent Content-Length errors when loading recordings

### DIFF
--- a/.changeset/thin-webs-prove.md
+++ b/.changeset/thin-webs-prove.md
@@ -1,0 +1,6 @@
+---
+"@gradio/audio": patch
+"gradio": patch
+---
+
+fix:Upload recorded audio only once to fix intermittent Content-Length errors when loading recordings

--- a/js/audio/README.md
+++ b/js/audio/README.md
@@ -57,7 +57,7 @@ BasePlayer:
 	export let dispatch: (event: any, detail?: any) => void;
 	export let dispatch_blob: (
 		blobs: Uint8Array[] | Blob[],
-		event: "stream" | "change" | "stop_recording"
+		event: "stream" | "change"
 	) => Promise<void> = () => Promise.resolve();
 	export let interactive = false;
 	export let waveform_settings = {};

--- a/js/audio/audio.test.ts
+++ b/js/audio/audio.test.ts
@@ -20,6 +20,7 @@ import {
 import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
 import Audio from "./";
 import WaveSurfer from "wavesurfer.js";
+import RecordPlugin from "wavesurfer.js/dist/plugins/record.js";
 import type { ILoadingStatus as LoadingStatus } from "@gradio/statustracker";
 import { setupi18n } from "../core/src/i18n";
 
@@ -409,6 +410,73 @@ describe("Events: upload via file input", () => {
 			expect(error).toHaveBeenCalledTimes(1);
 		});
 		expect(error).toHaveBeenCalledWith("File too large");
+	});
+});
+
+function make_wav_blob(): Blob {
+	const sample_rate = 8000;
+	const num_samples = 800;
+	const buffer = new ArrayBuffer(44 + num_samples * 2);
+	const view = new DataView(buffer);
+	const write_string = (offset: number, s: string): void => {
+		for (let i = 0; i < s.length; i++) {
+			view.setUint8(offset + i, s.charCodeAt(i));
+		}
+	};
+	write_string(0, "RIFF");
+	view.setUint32(4, 36 + num_samples * 2, true);
+	write_string(8, "WAVE");
+	write_string(12, "fmt ");
+	view.setUint32(16, 16, true);
+	view.setUint16(20, 1, true);
+	view.setUint16(22, 1, true);
+	view.setUint32(24, sample_rate, true);
+	view.setUint32(28, sample_rate * 2, true);
+	view.setUint16(32, 2, true);
+	view.setUint16(34, 16, true);
+	write_string(36, "data");
+	view.setUint32(40, num_samples * 2, true);
+	return new Blob([buffer], { type: "audio/wav" });
+}
+
+describe("Events: microphone recording", () => {
+	setupi18n();
+	let record_create: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		record_create = vi.spyOn(RecordPlugin, "create");
+	});
+	afterEach(() => {
+		record_create.mockRestore();
+		cleanup();
+	});
+
+	test("finishing a recording uploads the audio exactly once", async () => {
+		const upload = vi.fn(async (file_data: any[]) => file_data);
+		const { listen, get_data } = await render(Audio, {
+			...default_props,
+			sources: ["microphone"],
+			value: null,
+			root: "https://example.com",
+			client: {
+				upload,
+				stream: async () => ({ onmessage: null, close: () => {} })
+			}
+		});
+
+		const stop_recording = listen("stop_recording");
+		const input = listen("input");
+
+		await waitFor(() => expect(record_create).toHaveBeenCalled());
+		const record = record_create.mock.results[0].value as any;
+		record.emit("record-end", make_wav_blob());
+
+		await waitFor(() => {
+			expect(stop_recording).toHaveBeenCalledTimes(1);
+		});
+		expect(upload).toHaveBeenCalledTimes(1);
+		expect(input).toHaveBeenCalledTimes(1);
+		expect((await get_data()).value).toBeTruthy();
 	});
 });
 

--- a/js/audio/interactive/InteractiveAudio.svelte
+++ b/js/audio/interactive/InteractiveAudio.svelte
@@ -149,7 +149,7 @@
 
 	const dispatch_blob = async (
 		blobs: Uint8Array[] | Blob[],
-		event: "stream" | "change" | "stop_recording"
+		event: "stream" | "change"
 	): Promise<void> => {
 		let _audio_blob = new File(to_blob_parts(blobs), "audio.wav", {
 			type: "audio/wav"
@@ -166,10 +166,8 @@
 		)[0];
 		if (event === "stream") {
 			onstream?.(value);
-		} else if (event === "change") {
+		} else {
 			onchange?.(value);
-		} else if (event === "stop_recording") {
-			onstop_recording?.();
 		}
 	};
 
@@ -207,14 +205,13 @@
 			recorder.addEventListener("dataavailable", (event) => {
 				audio_chunks.push(event.data);
 			});
+			recorder.addEventListener("stop", async () => {
+				recording = false;
+				await dispatch_blob(audio_chunks, "change");
+				onstop_recording?.();
+				audio_chunks = [];
+			});
 		}
-		recorder.addEventListener("stop", async () => {
-			recording = false;
-			recorder.stop();
-			await dispatch_blob(audio_chunks, "change");
-			await dispatch_blob(audio_chunks, "stop_recording");
-			audio_chunks = [];
-		});
 		inited = true;
 	}
 
@@ -283,7 +280,6 @@
 			if (pending) {
 				submit_pending_stream_on_pending_end = true;
 			}
-			await dispatch_blob(audio_chunks, "stop_recording");
 			onclear?.();
 			mode = "";
 		}

--- a/js/audio/player/AudioPlayer.svelte
+++ b/js/audio/player/AudioPlayer.svelte
@@ -38,7 +38,7 @@
 		i18n: I18nFormatter;
 		dispatch_blob?: (
 			blobs: Uint8Array[] | Blob[],
-			event: "stream" | "change" | "stop_recording"
+			event: "stream" | "change"
 		) => Promise<void>;
 		interactive?: boolean;
 		editable?: boolean;

--- a/js/audio/recorder/AudioRecorder.svelte
+++ b/js/audio/recorder/AudioRecorder.svelte
@@ -31,7 +31,7 @@
 		i18n: I18nFormatter;
 		dispatch_blob: (
 			blobs: Uint8Array[] | Blob[],
-			event: "stream" | "change" | "stop_recording"
+			event: "stream" | "change"
 		) => Promise<void> | undefined;
 		waveform_settings: Record<string, any>;
 		waveform_options?: WaveformOptions;
@@ -99,7 +99,7 @@
 			if (audio_buffer)
 				await process_audio(audio_buffer).then(async (audio: Uint8Array) => {
 					await dispatch_blob([audio], "change");
-					await dispatch_blob([audio], "stop_recording");
+					onstoprecording?.();
 				});
 		} catch (e) {
 			console.error(e);
@@ -201,7 +201,7 @@
 			await process_audio(decodedData, start, end).then(
 				async (trimmedAudio: Uint8Array) => {
 					await dispatch_blob([trimmedAudio], "change");
-					await dispatch_blob([trimmedAudio], "stop_recording");
+					onstoprecording?.();
 					recordingWaveform?.destroy();
 					create_recording_waveform();
 				}


### PR DESCRIPTION
## Description

When a microphone recording ends (and when a recording is trimmed), the Audio component uploads the exact same blob to the server twice in a row. The `dispatch_blob` helper couples "upload the blob" with "fire one event", so firing both `change` and `stop_recording` was written as two calls, each performing a full `POST /upload`:

- `js/audio/recorder/AudioRecorder.svelte` (`record_end_callback` and `handle_trim_audio`)
- `js/audio/interactive/InteractiveAudio.svelte` (the MediaRecorder `stop` handler)

The double upload is what causes the long-standing intermittent failures when loading recorded audio (#7490, #8878, #9739, and now #13659, analyzed by @Corginyan in https://github.com/gradio-app/gradio/issues/7490#issuecomment-5002604265). On the server, uploads are stored at `upload_dir / sha256(content) / filename`, so both uploads target the same path. After the first upload sets `value`, the player immediately GETs the file to render the waveform. Meanwhile the second upload rewrites that same file, and when the inline `os.rename` in `upload_fn` fails (always on Windows because the destination already exists, or on Linux when the temp dir and cache dir are on different filesystems) the rewrite happens through a non-atomic background `shutil.move`, truncating the file while it is being served. The result is `h11._util.LocalProtocolError: Too little data for declared Content-Length` and a waveform that never renders. Longer recordings widen the copy window, matching the reports that long recordings fail more often.

The fix uploads once and then fires the `stop_recording` callback directly, which is the pattern the Video/Image webcam components and `MinimalAudioRecorder` already use:

- `AudioRecorder.svelte`: after the single `change` upload, call the (previously unused but already wired) `onstoprecording` prop instead of a second upload.
- `InteractiveAudio.svelte`: same for the MediaRecorder `stop` handler, which also moves back into the non-streaming branch (where it lived before the 5.0 rewrite) so that stopping a stream does not fire `stop_recording` twice. Also removes the recorder's `stop()` call on itself inside its own `stop` event handler (commented out in 5.x, accidentally re-enabled in the 6.0 merge) and a dead `dispatch_blob(audio_chunks, "stop_recording")` in the streaming `stop()` path (`audio_chunks` is always empty in streaming mode).
- `dispatch_blob`'s event union narrows to `"stream" | "change"` since no caller dispatches `stop_recording` through it anymore.

As a side effect, this also stops the second call from clobbering `initial_value` (used for reset) with the just-uploaded value.

A unit test mounts the Audio component, emits `record-end` on the WaveSurfer record plugin with a synthesized WAV blob, and asserts the client `upload` is called exactly once while `stop_recording` and `input` still fire once. Before the fix it fails with `upload` called 2 times.

Closes: #13659

## Before / after Spaces

The double upload is deterministic, so it is easy to see in the browser: open a Space, open the DevTools Network tab filtered to `upload`, record a clip, and press stop.

- [Before fix](https://huggingface.co/spaces/hysts-debug/gradio-13659-before) (gradio 6.20.0 release): every recording stop sends two identical `POST /upload` requests.
- [After fix](https://huggingface.co/spaces/hysts-debug/gradio-13659-after) (wheel built from this PR at 84c3fec): exactly one `POST /upload`, while `change` / `stop_recording` / `input` still fire once each (counters shown in the app).

The Content-Length error itself is timing-dependent and easiest to reproduce on Windows, or with `GRADIO_TEMP_DIR` on a different filesystem, where the second upload's rewrite goes through a non-atomic background copy.

## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`


