### PR TITLE
Keep fullscreen component controls inside the visible viewport when the page has a scrollbar

### DIFF
--- a/.changeset/nice-parks-peel.md
+++ b/.changeset/nice-parks-peel.md
@@ -1,0 +1,6 @@
+---
+"@gradio/atoms": patch
+"gradio": patch
+---
+
+fix:Keep fullscreen component controls inside the visible viewport when the page has a scrollbar

--- a/.changeset/nice-parks-peel.md
+++ b/.changeset/nice-parks-peel.md
@@ -1,5 +1,6 @@
 ---
 "@gradio/atoms": patch
+"@gradio/dataframe": patch
 "gradio": patch
 ---
 

--- a/js/atoms/src/Block.svelte
+++ b/js/atoms/src/Block.svelte
@@ -218,8 +218,11 @@
 		position: fixed;
 		top: 0;
 		left: 0;
-		width: 100vw;
-		height: 100vh;
+		/* Percentages resolve against the viewport minus any classic window
+		scrollbar; 100vw/100vh would extend beneath it and hide the top-right
+		controls (#11982) */
+		width: 100%;
+		height: 100%;
 		z-index: 1000;
 		overflow: auto;
 	}
@@ -239,10 +242,10 @@
 		}
 		100% {
 			position: fixed;
-			top: 0vh;
-			left: 0vw;
-			width: 100vw;
-			height: 100vh;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
 			z-index: 1000;
 		}
 	}

--- a/js/atoms/src/Block.svelte
+++ b/js/atoms/src/Block.svelte
@@ -31,11 +31,67 @@
 	let placeholder_height = 0;
 	let placeholder_width = 0;
 	let preexpansionBoundingRect: DOMRect | null = null;
+	let portal_parent: (Node & ParentNode) | null = null;
+	let portal_marker: Comment | null = null;
 
 	function handleKeydown(event: KeyboardEvent): void {
 		if (fullscreen && event.key === "Escape") {
 			fullscreen = false;
 		}
+	}
+
+	// A `position: fixed` element is only laid out against the viewport when no
+	// ancestor establishes a containing block for fixed descendants. Anything
+	// with a transform, filter, backdrop-filter, perspective, contain or
+	// container-type does establish one — `gr.Sidebar` always sets a transform,
+	// for instance — and then top/left/width/height resolve against that
+	// ancestor instead. Rather than enumerate those properties, measure a probe
+	// in the block's own position: if a fixed probe pinned to the top left does
+	// not fill the viewport, the block needs to be moved out.
+	function needs_portal(): boolean {
+		const parent = element.parentNode;
+		if (!parent) return false;
+		const probe = document.createElement("div");
+		probe.style.cssText =
+			"position: fixed; top: 0; left: 0; width: 100%; height: 100%; visibility: hidden; pointer-events: none;";
+		parent.insertBefore(probe, element);
+		const { top, left, width, height } = probe.getBoundingClientRect();
+		probe.remove();
+		const root = document.documentElement;
+		return (
+			Math.round(top) !== 0 ||
+			Math.round(left) !== 0 ||
+			Math.round(width) !== root.clientWidth ||
+			Math.round(height) !== root.clientHeight
+		);
+	}
+
+	// Moves the block to the app container (which carries the theme variables)
+	// so that its fixed positioning resolves against the viewport. The
+	// placeholder that reserves the block's space stays behind in the original
+	// parent, and `exit_portal` puts the block back where it came from.
+	function enter_portal(): void {
+		const root = element.getRootNode();
+		const target =
+			element.closest(".gradio-container") ??
+			(root instanceof ShadowRoot ? root : document.body);
+		if (!element.parentNode || element.parentNode === target) return;
+		portal_parent = element.parentNode;
+		portal_marker = document.createComment("fullscreen block");
+		portal_parent.insertBefore(portal_marker, element);
+		target.appendChild(element);
+	}
+
+	function exit_portal(): void {
+		if (!portal_parent) return;
+		const marker =
+			portal_marker && portal_marker.parentNode === portal_parent
+				? portal_marker
+				: null;
+		portal_parent.insertBefore(element, marker);
+		marker?.remove();
+		portal_parent = null;
+		portal_marker = null;
 	}
 
 	$: if (fullscreen !== old_fullscreen) {
@@ -44,8 +100,12 @@
 			preexpansionBoundingRect = element.getBoundingClientRect();
 			placeholder_height = element.offsetHeight;
 			placeholder_width = element.offsetWidth;
+			if (needs_portal()) {
+				enter_portal();
+			}
 			window.addEventListener("keydown", handleKeydown);
 		} else {
+			exit_portal();
 			preexpansionBoundingRect = null;
 			window.removeEventListener("keydown", handleKeydown);
 		}

--- a/js/atoms/src/Block.svelte
+++ b/js/atoms/src/Block.svelte
@@ -40,41 +40,52 @@
 		}
 	}
 
+	// The app container carries the theme variables, so keep the block inside it.
+	function portal_target(): Node & ParentNode {
+		const root = element.getRootNode();
+		return (
+			element.closest(".gradio-container") ??
+			(root instanceof ShadowRoot ? root : document.body)
+		);
+	}
+
+	// Measures where a `position: fixed` element pinned to the top left at a
+	// 100% size lands when it is a child of `parent`.
+	function fixed_probe_rect(parent: Node & ParentNode): DOMRect {
+		const probe = document.createElement("div");
+		probe.style.cssText =
+			"position: fixed; top: 0; left: 0; width: 100%; height: 100%; visibility: hidden; pointer-events: none;";
+		parent.appendChild(probe);
+		const rect = probe.getBoundingClientRect();
+		probe.remove();
+		return rect;
+	}
+
 	// A `position: fixed` element is only laid out against the viewport when no
 	// ancestor establishes a containing block for fixed descendants. Anything
 	// with a transform, filter, backdrop-filter, perspective, contain or
 	// container-type does establish one — `gr.Sidebar` always sets a transform,
 	// for instance — and then top/left/width/height resolve against that
-	// ancestor instead. Rather than enumerate those properties, measure a probe
-	// in the block's own position: if a fixed probe pinned to the top left does
-	// not fill the viewport, the block needs to be moved out.
-	function needs_portal(): boolean {
+	// ancestor instead. Rather than enumerate those properties, compare a probe
+	// where the block currently is with one in the container it would move to.
+	function needs_portal(target: Node & ParentNode): boolean {
 		const parent = element.parentNode;
-		if (!parent) return false;
-		const probe = document.createElement("div");
-		probe.style.cssText =
-			"position: fixed; top: 0; left: 0; width: 100%; height: 100%; visibility: hidden; pointer-events: none;";
-		parent.insertBefore(probe, element);
-		const { top, left, width, height } = probe.getBoundingClientRect();
-		probe.remove();
-		const root = document.documentElement;
+		if (!parent || parent === target) return false;
+		const here = fixed_probe_rect(parent);
+		const there = fixed_probe_rect(target);
 		return (
-			Math.round(top) !== 0 ||
-			Math.round(left) !== 0 ||
-			Math.round(width) !== root.clientWidth ||
-			Math.round(height) !== root.clientHeight
+			Math.abs(here.top - there.top) > 1 ||
+			Math.abs(here.left - there.left) > 1 ||
+			Math.abs(here.width - there.width) > 1 ||
+			Math.abs(here.height - there.height) > 1
 		);
 	}
 
-	// Moves the block to the app container (which carries the theme variables)
-	// so that its fixed positioning resolves against the viewport. The
-	// placeholder that reserves the block's space stays behind in the original
-	// parent, and `exit_portal` puts the block back where it came from.
-	function enter_portal(): void {
-		const root = element.getRootNode();
-		const target =
-			element.closest(".gradio-container") ??
-			(root instanceof ShadowRoot ? root : document.body);
+	// Moves the block to the app container so that its fixed positioning
+	// resolves against the viewport. The placeholder that reserves the block's
+	// space stays behind in the original parent, and `exit_portal` puts the
+	// block back where it came from.
+	function enter_portal(target: Node & ParentNode): void {
 		if (!element.parentNode || element.parentNode === target) return;
 		portal_parent = element.parentNode;
 		portal_marker = document.createComment("fullscreen block");
@@ -100,8 +111,9 @@
 			preexpansionBoundingRect = element.getBoundingClientRect();
 			placeholder_height = element.offsetHeight;
 			placeholder_width = element.offsetWidth;
-			if (needs_portal()) {
-				enter_portal();
+			const target = portal_target();
+			if (needs_portal(target)) {
+				enter_portal(target);
 			}
 			window.addEventListener("keydown", handleKeydown);
 		} else {

--- a/js/dataframe/standalone/Index.svelte
+++ b/js/dataframe/standalone/Index.svelte
@@ -584,8 +584,11 @@
 		position: fixed;
 		top: 0;
 		left: 0;
-		width: 100vw;
-		height: 100vh;
+		/* Percentages resolve against the viewport minus any classic window
+		scrollbar; 100vw/100vh would extend beneath it and hide the top-right
+		controls (#11982) */
+		width: 100%;
+		height: 100%;
 		z-index: 1000;
 		overflow: auto;
 		border-radius: 0;

--- a/js/image/Image.test.ts
+++ b/js/image/Image.test.ts
@@ -389,8 +389,11 @@ describe("Props: buttons (static mode)", () => {
 			expect(block.getBoundingClientRect().right).toBeLessThanOrEqual(
 				visible_width
 			);
-			const wrapper = block.querySelector(".icon-button-wrapper");
-			expect(wrapper?.getBoundingClientRect().right).toBeLessThanOrEqual(
+			const wrapper = block.querySelector(
+				".icon-button-wrapper"
+			) as HTMLElement;
+			expect(wrapper).toBeTruthy();
+			expect(wrapper.getBoundingClientRect().right).toBeLessThanOrEqual(
 				visible_width
 			);
 		} finally {

--- a/js/image/Image.test.ts
+++ b/js/image/Image.test.ts
@@ -345,6 +345,61 @@ describe("Props: buttons (static mode)", () => {
 		});
 	});
 
+	test("fullscreen block does not extend beneath the window scrollbar", async () => {
+		// Reserve a 16px scrollbar gutter so the window scrollbar takes layout
+		// space, as classic (non-overlay) scrollbars do on Windows (#11982).
+		// The box-sizing rule mirrors the app's global reset.css, which is not
+		// loaded in the test environment.
+		const style = document.createElement("style");
+		style.textContent =
+			"html { scrollbar-gutter: stable; } ::-webkit-scrollbar { width: 16px; } * { box-sizing: border-box; }";
+		document.head.appendChild(style);
+		const filler = document.createElement("div");
+		filler.style.height = "5000px";
+		document.body.appendChild(filler);
+		// A fixed element spanning left:0/right:0 measures the visible viewport
+		// width, which excludes the scrollbar gutter.
+		const probe = document.createElement("div");
+		probe.style.cssText = "position: fixed; left: 0; right: 0; height: 1px;";
+		document.body.appendChild(probe);
+
+		try {
+			const visible_width = probe.getBoundingClientRect().width;
+			expect(visible_width).toBeLessThan(window.innerWidth);
+
+			const { getByLabelText } = await render(Image, {
+				...default_props,
+				interactive: true,
+				value: fake_value,
+				buttons: ["fullscreen"]
+			});
+
+			await fireEvent.click(getByLabelText("Fullscreen"));
+			const block = await waitFor(() => {
+				const el = document.querySelector(".block.fullscreen");
+				expect(el).toBeTruthy();
+				// Wait out the pop-out animation: the block must have reached
+				// its final, (at least) full-viewport width before measuring.
+				expect(el?.getBoundingClientRect().width).toBeGreaterThanOrEqual(
+					visible_width - 1
+				);
+				return el as HTMLElement;
+			});
+
+			expect(block.getBoundingClientRect().right).toBeLessThanOrEqual(
+				visible_width
+			);
+			const wrapper = block.querySelector(".icon-button-wrapper");
+			expect(wrapper?.getBoundingClientRect().right).toBeLessThanOrEqual(
+				visible_width
+			);
+		} finally {
+			style.remove();
+			filler.remove();
+			probe.remove();
+		}
+	});
+
 	test("empty buttons array shows no action buttons", async () => {
 		const { queryByLabelText } = await render(Image, {
 			...default_props,


### PR DESCRIPTION
## Description

In fullscreen mode, the top-right control buttons of `gr.Image` (Download, Remove Image, exit fullscreen) can end up partially hidden behind the window's vertical scrollbar, making them hard or impossible to click. This was reported on Windows, where classic scrollbars take up viewport space.

The fullscreen mode introduced in #11177 renders the block as `position: fixed` with `width: 100vw; height: 100vh`. Viewport units include the width of a classic window scrollbar, so the fixed block extends beneath the scrollbar, and the absolutely positioned button wrapper at the block's right edge lands under it. The page behind keeps its scrollbar because `Block` leaves a placeholder that preserves the page height. This also explains why the issue only showed up with high resolution images: a large image makes the page behind tall enough to have a scrollbar in the first place.

The fix replaces the viewport units with percentages. For a fixed-position element, percentage sizes resolve against the initial containing block, which excludes classic scrollbars, so the block now stops at the visible viewport edge. When there is no scrollbar (or the browser uses overlay scrollbars), `100%` and `100vw` resolve to the same size, so nothing changes in that case. The same substitution is applied to the final frame of the pop-out animation. Since the fix is in `Block`, it applies to every component with fullscreen support, not just `gr.Image`.

Verified with the reproduction from the issue in a browser with classic scrollbars: before the fix the fullscreen block was 1280px wide while the visible viewport was 1265px, clipping 14px off the button wrapper; after the fix the block is 1265px wide and the buttons are fully visible and clickable. The added unit test reserves a scrollbar gutter on the test page and asserts that the fullscreen block and its button wrapper stay within the visible viewport; it fails on `main`.

The issue also reports wrong `Image.select()` coordinates in fullscreen mode; that part was already fixed separately in #13532.

Closes: #11982

## Follow-up after review

@abidlabs found two gaps in the fix above and pushed b7737a677 and 0c18c86a5.

`js/dataframe/standalone/Index.svelte` does not use `Block` and carries its own copy of the `.fullscreen` rule, so the same substitution was needed there.

The containing block reasoning above is also incomplete. Percentages on a fixed-position element resolve against the initial containing block only when no ancestor establishes a containing block for fixed descendants. An ancestor with a `transform`, `filter`, `backdrop-filter`, `perspective`, `contain` or `container-type` does establish one, and `gr.Sidebar` always sets a `transform`, so a fullscreen block inside a sidebar sized itself to the sidebar instead of the viewport. `top`/`left` already resolved against the sidebar before this PR, so that case was partly broken either way, but the sizing half was a regression from the substitution. `Block` now probes for this when entering fullscreen, comparing a fixed 100% probe in the block's current parent against one in `.gradio-container`, and moves the block up to the container only when the two disagree, so the common path keeps its DOM position and any ancestor-scoped styles.

## Before / after Spaces

- [Before fix](https://huggingface.co/spaces/hysts-debug/gradio-11982-before)
- [After fix](https://huggingface.co/spaces/hysts-debug/gradio-11982-after)

Note: the bug only shows when the window scrollbar takes up viewport space (Windows default; on macOS set System Settings > Appearance > Show scroll bars to "Always") and the page behind is tall enough to scroll. Use the direct app URLs ([before](https://hysts-debug-gradio-11982-before.hf.space) / [after](https://hysts-debug-gradio-11982-after.hf.space)) rather than the embedded view on the Space page: the embedded app runs in an iframe whose window scrollbar belongs to the outer page, so the bug cannot be observed there.


## AI Disclosure

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`




