### PR TITLE
Strip `<style>` and `<link>` elements when sanitizing HTML in the frontend

### DIFF
--- a/.changeset/every-cases-itch.md
+++ b/.changeset/every-cases-itch.md
@@ -1,0 +1,6 @@
+---
+"@gradio/sanitize": patch
+"gradio": patch
+---
+
+fix:Strip `<style>` and `<link>` elements when sanitizing HTML in the frontend

--- a/js/sanitize/browser.ts
+++ b/js/sanitize/browser.ts
@@ -8,7 +8,7 @@ const should_open_link_in_new_tab = (link: string | null): boolean => {
 // <style> elements and stylesheet <link>s apply to the whole document once
 // injected, so drop them, matching the server-side sanitize-html defaults.
 const configuration = Amuchina.getDefaultConfiguration();
-configuration.allowElements = configuration.allowElements?.filter(
+configuration.allowElements = (configuration.allowElements ?? []).filter(
 	(element: string) =>
 		element !== "style" && element !== "svg:style" && element !== "link"
 );

--- a/js/sanitize/browser.ts
+++ b/js/sanitize/browser.ts
@@ -12,9 +12,9 @@ configuration.allowElements = (configuration.allowElements ?? []).filter(
 	(element: string) =>
 		element !== "style" && element !== "svg:style" && element !== "link"
 );
+const amuchina = new Amuchina(configuration);
 
 export function sanitize(source: string): string {
-	const amuchina = new Amuchina(configuration);
 	const node = new DOMParser().parseFromString(source, "text/html");
 	const sanitized_node = amuchina.sanitize(node);
 	walk_nodes(sanitized_node.body, "A", (node) => {

--- a/js/sanitize/browser.ts
+++ b/js/sanitize/browser.ts
@@ -5,8 +5,16 @@ const should_open_link_in_new_tab = (link: string | null): boolean => {
 	return !!href && !href.startsWith("#");
 };
 
+// <style> elements and stylesheet <link>s apply to the whole document once
+// injected, so drop them, matching the server-side sanitize-html defaults.
+const configuration = Amuchina.getDefaultConfiguration();
+configuration.allowElements = configuration.allowElements?.filter(
+	(element: string) =>
+		element !== "style" && element !== "svg:style" && element !== "link"
+);
+
 export function sanitize(source: string): string {
-	const amuchina = new Amuchina();
+	const amuchina = new Amuchina(configuration);
 	const node = new DOMParser().parseFromString(source, "text/html");
 	const sanitized_node = amuchina.sanitize(node);
 	walk_nodes(sanitized_node.body, "A", (node) => {

--- a/js/sanitize/sanitize.test.ts
+++ b/js/sanitize/sanitize.test.ts
@@ -26,4 +26,35 @@ describe("sanitize", () => {
 		expect(link?.getAttribute("target")).toBeNull();
 		expect(link?.getAttribute("rel")).toBeNull();
 	});
+
+	test("removes style elements and their content", () => {
+		const result = sanitize(
+			"<p>hello</p><style>body { background: red; }</style>"
+		);
+
+		expect(result).toBe("<p>hello</p>");
+	});
+
+	test("removes style elements inside svg", () => {
+		const result = sanitize(
+			"<svg><style>body { background: red; }</style><circle r='1'></circle></svg>"
+		);
+
+		expect(result).not.toContain("<style>");
+		expect(result).toContain("<circle");
+	});
+
+	test("removes link elements", () => {
+		const result = sanitize(
+			'<p>hello</p><link rel="stylesheet" href="https://example.com/style.css">'
+		);
+
+		expect(result).toBe("<p>hello</p>");
+	});
+
+	test("keeps style attributes", () => {
+		const result = sanitize('<p style="color: red;">hello</p>');
+
+		expect(result).toBe('<p style="color: red;">hello</p>');
+	});
 });

--- a/js/sanitize/sanitize.test.ts
+++ b/js/sanitize/sanitize.test.ts
@@ -53,8 +53,13 @@ describe("sanitize", () => {
 	});
 
 	test("keeps style attributes", () => {
-		const result = sanitize('<p style="color: red;">hello</p>');
+		const node = new DOMParser().parseFromString(
+			sanitize('<p style="color: red;">hello</p>'),
+			"text/html"
+		);
 
-		expect(result).toBe('<p style="color: red;">hello</p>');
+		const p = node.querySelector("p");
+		expect(p?.getAttribute("style")).toBe("color: red;");
+		expect(p?.textContent).toBe("hello");
 	});
 });


### PR DESCRIPTION
## Description

When a chatbot message contains an HTML `<style>` tag, the CSS inside it is applied to the entire Gradio app, even with `sanitize_html=True` (the default). The reason is that the browser-side sanitizer (`@gradio/sanitize`, backed by amuchina) uses amuchina's default allowlist, which permits `<style>` elements. Once the sanitized HTML is injected into the DOM, a `<style>` element applies document-wide, so message content can restyle the whole page.

A note on reproducing this, since it explains why the issue looked unreproducible at first: `sanitize()` parses the input with `DOMParser` and returns only `body.innerHTML`. If the message is a bare HTML document, the parser moves the `<style>` into `<head>` and it gets dropped by accident. But if any text precedes the HTML (as in the reporter's actual case, `"Explain following code: <!DOCTYPE html>..."`), marked emits a `<p>` first, the parser stays in body context, and the `<style>` survives into the sanitized output.

This PR configures amuchina to drop `<style>` (both HTML and SVG namespaces) and `<link>`, which is the same global-restyling vector via `rel="stylesheet"`. This also makes the browser sanitizer consistent with the server-side (SSR) one, which uses sanitize-html and already strips `<style>` and `<link>` by default, so SSR output and client rendering no longer disagree.

Notes on scope:

- The `style` attribute (inline styles) is unaffected; a test guards this.
- Only element sanitization changes. Users who intentionally want raw `<style>` blocks can still use `sanitize_html=False` or `gr.HTML`, which does not sanitize.
- Unlike the earlier attempt in #12551 (Python-side escaping), this does not affect HTML that is properly formatted inside markdown code fences.

Closes: #11168

## Testing

Added tests to `js/sanitize/sanitize.test.ts` covering `<style>` removal (element and content), `<style>` inside `<svg>`, `<link>` removal, and preservation of `style` attributes. The removal tests fail without the fix. Also verified end to end with the exact payload from the issue: on a source build without the fix, the message injects a `<style>` element into the document and the page background turns `#f4f1ec`; with the fix the element is dropped and the page styling is unchanged, while the message text still renders. The markdown, chatbot, and statustracker frontend suites (109 tests) also pass.

## Before / after Spaces

- [Before fix](https://huggingface.co/spaces/hysts-debug/gradio-11168-before)
- [After fix](https://huggingface.co/spaces/hysts-debug/gradio-11168-after)

Both Spaces run the same minimal app with the reproduction message from the issue. The before Space runs the released Gradio 6.20.0 and the page turns beige; the after Space runs the preview wheel built for this PR and keeps the default styling.

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

