### PR TITLE
Workflow UX improvements, and fix `gradio skills add` clobbering skills via symlinked dirs

### DIFF
--- a/.changeset/lazy-links-resolve.md
+++ b/.changeset/lazy-links-resolve.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:cli: don't delete the installed skill when an agent's skills directory is a symlink to the central location

--- a/.changeset/quick-tabs-open.md
+++ b/.changeset/quick-tabs-open.md
@@ -1,5 +1,6 @@
 ---
+"@gradio/workflowcanvas": minor
 "gradio": minor
 ---
 
-feat:workflow: various UX improvements, including opening the write-access link in a browser tab automatically when a `gr.Workflow` is launched locally
+feat:workflow: various UX improvements, including opening the write-access link in a browser tab automatically when a `gr.Workflow` is launched locally, and calling vision-language models through chat completions so `image-text-to-text` model nodes work

--- a/.changeset/quick-tabs-open.md
+++ b/.changeset/quick-tabs-open.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:workflow: various UX improvements, including opening the write-access link in a browser tab automatically when a `gr.Workflow` is launched locally

--- a/demo/workflow_vlm_html_comparison/requirements.txt
+++ b/demo/workflow_vlm_html_comparison/requirements.txt
@@ -1,0 +1,1 @@
+playwright

--- a/demo/workflow_vlm_html_comparison/run.py
+++ b/demo/workflow_vlm_html_comparison/run.py
@@ -18,7 +18,7 @@ import gradio as gr
 def render_html(html: str) -> dict:
     """Screenshot generated HTML so the branches can be compared visually."""
     try:
-        from playwright.sync_api import sync_playwright
+        from playwright.sync_api import sync_playwright  # ty: ignore[unresolved-import]
     except ImportError as e:
         raise gr.Error(
             "Rendering needs Playwright: pip install playwright "

--- a/demo/workflow_vlm_html_comparison/run.py
+++ b/demo/workflow_vlm_html_comparison/run.py
@@ -1,0 +1,49 @@
+import os
+import re
+import tempfile
+
+import gradio as gr
+
+# Side-by-side comparison of two recent vision-language models on the same
+# screenshot-to-webpage task: one uploaded screenshot plus a shared instruction
+# fan out to thinkingmachines/Inkling and moonshotai/Kimi-K2.7-Code as plain
+# model nodes, each branch ending in the generated HTML *and* a screenshot of
+# that HTML rendered in a real browser — so the two models can be compared
+# visually against the original, not just by reading their code.
+#
+# The only bound function is the renderer: driving a browser isn't an inference
+# task, so it has no model node equivalent.
+
+
+def render_html(html: str) -> dict:
+    """Screenshot generated HTML so the branches can be compared visually."""
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as e:
+        raise gr.Error(
+            "Rendering needs Playwright: pip install playwright "
+            "&& playwright install chromium"
+        ) from e
+
+    # Models often return the file inside a fenced block despite being asked
+    # for bare HTML; left in place, the fence renders as stray text.
+    html = re.sub(r"^\s*```[a-zA-Z]*\n", "", html or "")
+    html = re.sub(r"\n```\s*$", "", html)
+
+    path = os.path.join(
+        tempfile.gettempdir(), f"workflow_render_{os.urandom(8).hex()}.png"
+    )
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page(viewport={"width": 1280, "height": 800})
+        page.set_content(html or "<html></html>")
+        page.wait_for_timeout(300)
+        page.screenshot(path=path, full_page=True)
+        browser.close()
+    return {"path": path, "url": f"/gradio_api/file={path}", "is_file": True}
+
+
+demo = gr.Workflow(graph="workflow.json", bind={"render_html": render_html})
+
+if __name__ == "__main__":
+    demo.launch()

--- a/demo/workflow_vlm_html_comparison/workflow.json
+++ b/demo/workflow_vlm_html_comparison/workflow.json
@@ -1,0 +1,372 @@
+{
+	"schema_version": "2",
+	"name": "Inkling vs Kimi K2.7 Code — screenshot to webpage",
+	"references": [
+		{
+			"id": "ref_screenshot",
+			"label": "Screenshot",
+			"role": "reference",
+			"asset_type": "image",
+			"inputs": [
+				{
+					"id": "in",
+					"label": "Image",
+					"type": "image"
+				}
+			],
+			"outputs": [
+				{
+					"id": "out",
+					"label": "Image",
+					"type": "image"
+				}
+			],
+			"x": 60,
+			"y": 200,
+			"width": 220,
+			"height": 122,
+			"data": {}
+		},
+		{
+			"id": "ref_instructions",
+			"label": "Instructions",
+			"role": "reference",
+			"asset_type": "text",
+			"inputs": [
+				{
+					"id": "in",
+					"label": "Text",
+					"type": "text"
+				}
+			],
+			"outputs": [
+				{
+					"id": "out",
+					"label": "Text",
+					"type": "text"
+				}
+			],
+			"x": 60,
+			"y": 420,
+			"width": 220,
+			"height": 165,
+			"data": {
+				"out": "Recreate this webpage as a single self-contained HTML file with inline CSS. Match the layout, colors, spacing, and text as closely as you can. Output only HTML, with no explanation."
+			}
+		}
+	],
+	"operators": [
+		{
+			"id": "op_inkling",
+			"label": "Inkling",
+			"role": "operator",
+			"kind": "model",
+			"inputs": [
+				{
+					"id": "image",
+					"label": "Image",
+					"type": "image",
+					"required": true
+				},
+				{
+					"id": "text",
+					"label": "Prompt",
+					"type": "text"
+				}
+			],
+			"outputs": [
+				{
+					"id": "out_0",
+					"label": "HTML",
+					"type": "text",
+					"output_index": 0
+				}
+			],
+			"x": 400,
+			"y": 120,
+			"width": 220,
+			"height": 139,
+			"data": {},
+			"model_id": "thinkingmachines/Inkling",
+			"pipeline_tag": "image-text-to-text",
+			"endpoint": "chat_completion"
+		},
+		{
+			"id": "op_kimi",
+			"label": "Kimi K2.7 Code",
+			"role": "operator",
+			"kind": "model",
+			"inputs": [
+				{
+					"id": "image",
+					"label": "Image",
+					"type": "image",
+					"required": true
+				},
+				{
+					"id": "text",
+					"label": "Prompt",
+					"type": "text"
+				}
+			],
+			"outputs": [
+				{
+					"id": "out_0",
+					"label": "HTML",
+					"type": "text",
+					"output_index": 0
+				}
+			],
+			"x": 400,
+			"y": 500,
+			"width": 220,
+			"height": 139,
+			"data": {},
+			"model_id": "moonshotai/Kimi-K2.7-Code",
+			"pipeline_tag": "image-text-to-text",
+			"endpoint": "chat_completion"
+		},
+		{
+			"id": "op_render_inkling",
+			"label": "Render Inkling",
+			"role": "operator",
+			"kind": "fn",
+			"fn": "render_html",
+			"inputs": [
+				{
+					"id": "in_html",
+					"label": "html",
+					"type": "text",
+					"required": true
+				}
+			],
+			"outputs": [
+				{
+					"id": "out_0",
+					"label": "Render",
+					"type": "image"
+				}
+			],
+			"x": 740,
+			"y": 220,
+			"width": 220,
+			"height": 116,
+			"data": {}
+		},
+		{
+			"id": "op_render_kimi",
+			"label": "Render Kimi",
+			"role": "operator",
+			"kind": "fn",
+			"fn": "render_html",
+			"inputs": [
+				{
+					"id": "in_html",
+					"label": "html",
+					"type": "text",
+					"required": true
+				}
+			],
+			"outputs": [
+				{
+					"id": "out_0",
+					"label": "Render",
+					"type": "image"
+				}
+			],
+			"x": 740,
+			"y": 600,
+			"width": 220,
+			"height": 116,
+			"data": {}
+		}
+	],
+	"subjects": [
+		{
+			"id": "sub_html_inkling",
+			"label": "Inkling HTML",
+			"role": "subject",
+			"asset_type": "text",
+			"inputs": [
+				{
+					"id": "in",
+					"label": "Text",
+					"type": "text"
+				}
+			],
+			"outputs": [
+				{
+					"id": "out",
+					"label": "Text",
+					"type": "text"
+				}
+			],
+			"x": 1080,
+			"y": 60,
+			"width": 220,
+			"height": 161,
+			"data": {
+				"in": ""
+			}
+		},
+		{
+			"id": "sub_page_inkling",
+			"label": "Inkling Page",
+			"role": "subject",
+			"asset_type": "image",
+			"inputs": [
+				{
+					"id": "in",
+					"label": "Image",
+					"type": "image"
+				}
+			],
+			"outputs": [
+				{
+					"id": "out",
+					"label": "Image",
+					"type": "image"
+				}
+			],
+			"x": 1080,
+			"y": 260,
+			"width": 220,
+			"height": 105,
+			"data": {}
+		},
+		{
+			"id": "sub_html_kimi",
+			"label": "Kimi HTML",
+			"role": "subject",
+			"asset_type": "text",
+			"inputs": [
+				{
+					"id": "in",
+					"label": "Text",
+					"type": "text"
+				}
+			],
+			"outputs": [
+				{
+					"id": "out",
+					"label": "Text",
+					"type": "text"
+				}
+			],
+			"x": 1080,
+			"y": 440,
+			"width": 220,
+			"height": 161,
+			"data": {
+				"in": ""
+			}
+		},
+		{
+			"id": "sub_page_kimi",
+			"label": "Kimi Page",
+			"role": "subject",
+			"asset_type": "image",
+			"inputs": [
+				{
+					"id": "in",
+					"label": "Image",
+					"type": "image"
+				}
+			],
+			"outputs": [
+				{
+					"id": "out",
+					"label": "Image",
+					"type": "image"
+				}
+			],
+			"x": 1080,
+			"y": 640,
+			"width": 220,
+			"height": 105,
+			"data": {}
+		}
+	],
+	"edges": [
+		{
+			"id": "e_shot_inkling",
+			"from_node_id": "ref_screenshot",
+			"from_port_id": "out",
+			"to_node_id": "op_inkling",
+			"to_port_id": "image",
+			"type": "image"
+		},
+		{
+			"id": "e_shot_kimi",
+			"from_node_id": "ref_screenshot",
+			"from_port_id": "out",
+			"to_node_id": "op_kimi",
+			"to_port_id": "image",
+			"type": "image"
+		},
+		{
+			"id": "e_instr_inkling",
+			"from_node_id": "ref_instructions",
+			"from_port_id": "out",
+			"to_node_id": "op_inkling",
+			"to_port_id": "text",
+			"type": "text"
+		},
+		{
+			"id": "e_instr_kimi",
+			"from_node_id": "ref_instructions",
+			"from_port_id": "out",
+			"to_node_id": "op_kimi",
+			"to_port_id": "text",
+			"type": "text"
+		},
+		{
+			"id": "e_inkling_html",
+			"from_node_id": "op_inkling",
+			"from_port_id": "out_0",
+			"to_node_id": "sub_html_inkling",
+			"to_port_id": "in",
+			"type": "text"
+		},
+		{
+			"id": "e_inkling_render",
+			"from_node_id": "op_inkling",
+			"from_port_id": "out_0",
+			"to_node_id": "op_render_inkling",
+			"to_port_id": "in_html",
+			"type": "text"
+		},
+		{
+			"id": "e_inkling_page",
+			"from_node_id": "op_render_inkling",
+			"from_port_id": "out_0",
+			"to_node_id": "sub_page_inkling",
+			"to_port_id": "in",
+			"type": "image"
+		},
+		{
+			"id": "e_kimi_html",
+			"from_node_id": "op_kimi",
+			"from_port_id": "out_0",
+			"to_node_id": "sub_html_kimi",
+			"to_port_id": "in",
+			"type": "text"
+		},
+		{
+			"id": "e_kimi_render",
+			"from_node_id": "op_kimi",
+			"from_port_id": "out_0",
+			"to_node_id": "op_render_kimi",
+			"to_port_id": "in_html",
+			"type": "text"
+		},
+		{
+			"id": "e_kimi_page",
+			"from_node_id": "op_render_kimi",
+			"from_port_id": "out_0",
+			"to_node_id": "sub_page_kimi",
+			"to_port_id": "in",
+			"type": "image"
+		}
+	]
+}

--- a/gradio/cli/commands/skills.py
+++ b/gradio/cli/commands/skills.py
@@ -86,10 +86,15 @@ def _create_symlink(
     central_skill_path: Path,
     force: bool,
     skill_id: str = SKILL_ID,
-) -> Path:
+) -> Path | None:
     agent_skills_dir = agent_skills_dir.expanduser().resolve()
     agent_skills_dir.mkdir(parents=True, exist_ok=True)
     link_path = agent_skills_dir / skill_id
+    if link_path == central_skill_path:
+        # The agent's skills dir is itself a symlink to the central location
+        # (e.g. .claude/skills -> ../.agents/skills), so the skill is already
+        # visible there and linking would clobber it with a link to itself.
+        return None
     _remove_existing(link_path, force)
     link_path.symlink_to(os.path.relpath(central_skill_path, agent_skills_dir))
     return link_path
@@ -370,7 +375,8 @@ def skills_add(
             link_path = _create_symlink(
                 agent_target, central_skill_path, force, skill_id=skill_id
             )
-            print(f"Created symlink: {link_path}")
+            if link_path is not None:
+                print(f"Created symlink: {link_path}")
         return
 
     if dest:
@@ -406,8 +412,10 @@ def skills_add(
     for agent_target in agent_targets:
         # Create symlinks for both skills
         link_path = _create_symlink(agent_target, central_skill_path, force)
-        print(f"Created symlink: {link_path}")
+        if link_path is not None:
+            print(f"Created symlink: {link_path}")
         hf_link_path = _create_symlink(
             agent_target, central_hf_skill_path, force, skill_id=HF_SKILL_ID
         )
-        print(f"Created symlink: {hf_link_path}")
+        if hf_link_path is not None:
+            print(f"Created symlink: {hf_link_path}")

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import base64
 import inspect
 import json
 import logging
+import mimetypes
 import os
 import re
 import secrets
@@ -422,6 +424,28 @@ def _img_url(a) -> str:
     return a.get("url") or a.get("path", "") if isinstance(a, dict) else a
 
 
+def _chat_image_url(a) -> str:
+    """Return an image reference a provider can actually resolve.
+
+    Chat completions send images by reference, and the provider — not this
+    process — is what dereferences them. A local path or a relative
+    `/gradio_api/file=` URL is meaningless there, so those are inlined as a
+    data URI. Absolute http(s) URLs are passed through, though note the
+    provider still has to be able to fetch them.
+    """
+    src = (a.get("path") or a.get("url") or "") if isinstance(a, dict) else a
+    if not isinstance(src, str) or not src:
+        return ""
+    if src.startswith(("data:", "http://", "https://")):
+        return src
+    src = src.removeprefix("/gradio_api/file=")
+    if not os.path.isfile(src):
+        return src
+    mime = mimetypes.guess_type(src)[0] or "image/png"
+    with open(src, "rb") as f:
+        return f"data:{mime};base64,{base64.b64encode(f.read()).decode()}"
+
+
 def _classify_error(e: Exception) -> dict:
     http_status: int | None = None
     response = getattr(e, "response", None)
@@ -805,7 +829,25 @@ _INFERENCE_ENDPOINT_SCHEMAS: dict[str, dict] = {
             {"id": "out_0", "label": "Answer", "type": "text", "output_index": 0}
         ],
     },
+    # Vision-language models are served as `conversational`, so they're called
+    # through chat completions rather than a task-specific endpoint. Port order
+    # matches the canvas's image-text-to-text template (image, then prompt).
+    "chat_completion": {
+        "inputs": [
+            {"id": "image", "label": "Image", "type": "image"},
+            {"id": "text", "label": "Prompt", "type": "text"},
+        ],
+        "outputs": [
+            {"id": "out_0", "label": "Text", "type": "text", "output_index": 0}
+        ],
+    },
 }
+
+
+# Generous by default: vision-language models are asked to emit whole files
+# (an HTML page, a long transcription), and reasoning models spend part of the
+# budget before their first visible token.
+_CHAT_MAX_TOKENS = 8192
 
 
 _ENDPOINT_OUTPUT_EXT: dict[str, str] = {
@@ -848,7 +890,10 @@ _PIPELINE_TAG_TO_ENDPOINT: dict[str, str] = {
     "audio-classification": "audio_classification",
     "visual-question-answering": "visual_question_answering",
     "document-question-answering": "document_question_answering",
-    "image-text-to-text": "visual_question_answering",
+    # Not visual_question_answering: the Hub routes every image-text-to-text
+    # model as `conversational`, and no provider serves the VQA task at all,
+    # so a task-specific call fails for every model carrying this tag.
+    "image-text-to-text": "chat_completion",
 }
 
 
@@ -890,6 +935,9 @@ def _dispatch_model_endpoint(client, endpoint: str, kwargs: dict) -> str:
         p["id"] for p in _INFERENCE_ENDPOINT_SCHEMAS.get(endpoint, {}).get("inputs", [])
     ]
     clean: dict = {}
+    # Chat images are dereferenced by the provider, not locally, so they need a
+    # different reference than the task endpoints' server-side reads.
+    to_url = _chat_image_url if endpoint == "chat_completion" else _img_url
     for k, v in kwargs.items():
         if v is None or v == "":
             continue
@@ -898,7 +946,7 @@ def _dispatch_model_endpoint(client, endpoint: str, kwargs: dict) -> str:
             # positional port IDs from workflows saved before endpoint schemas
             k = schema_ids[int(legacy.group(1))]
         clean[k] = (
-            _img_url(v) if isinstance(v, dict) and ("url" in v or "path" in v) else v
+            to_url(v) if isinstance(v, dict) and ("url" in v or "path" in v) else v
         )
     for key, sep in _ENDPOINT_LIST_KWARGS.get(endpoint, {}).items():
         if isinstance(clean.get(key), str):
@@ -908,6 +956,26 @@ def _dispatch_model_endpoint(client, endpoint: str, kwargs: dict) -> str:
         return _dispatch_model_endpoint(
             client, "text_classification", {"text": clean.get("text", "")}
         )
+    if endpoint == "chat_completion":
+        content = []
+        if clean.get("text"):
+            content.append({"type": "text", "text": clean["text"]})
+        image_url = _chat_image_url(clean.get("image"))
+        if image_url:
+            content.append({"type": "image_url", "image_url": {"url": image_url}})
+        if not content:
+            raise ValueError("Connect a prompt or an image to this model.")
+        response = client.chat_completion(
+            [{"role": "user", "content": content}], max_tokens=_CHAT_MAX_TOKENS
+        )
+        text = (response.choices[0].message.content or "").strip()
+        if not text:
+            raise ValueError(
+                f"{getattr(client, 'model', 'The model')} returned no text. "
+                "Reasoning models can spend the whole token budget before "
+                "answering; try a shorter prompt or a smaller image."
+            )
+        return json.dumps([text])
     if endpoint == "text_generation":
         clean.setdefault("max_new_tokens", 512)
         try:

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -846,8 +846,11 @@ _INFERENCE_ENDPOINT_SCHEMAS: dict[str, dict] = {
 
 # Generous by default: vision-language models are asked to emit whole files
 # (an HTML page, a long transcription), and reasoning models spend part of the
-# budget before their first visible token.
-_CHAT_MAX_TOKENS = 8192
+# budget before their first visible token — reasoning counts against this cap,
+# and a dense screenshot can cost thousands of tokens before any output.
+# Bounded by the canvas executor's 300s per-node timeout: at the ~100 tok/s
+# these models stream, a larger cap would be cut off mid-answer anyway.
+_CHAT_MAX_TOKENS = 16384
 
 
 _ENDPOINT_OUTPUT_EXT: dict[str, str] = {
@@ -965,15 +968,42 @@ def _dispatch_model_endpoint(client, endpoint: str, kwargs: dict) -> str:
             content.append({"type": "image_url", "image_url": {"url": image_url}})
         if not content:
             raise ValueError("Connect a prompt or an image to this model.")
-        response = client.chat_completion(
-            [{"role": "user", "content": content}], max_tokens=_CHAT_MAX_TOKENS
-        )
-        text = (response.choices[0].message.content or "").strip()
+        # Streamed, not buffered: the router's gateway times out a non-streaming
+        # request at ~120s, which a vision model writing a whole file routinely
+        # exceeds — reasoning alone can outlast it. Streaming keeps bytes moving,
+        # so the request is bounded by the model, not by an idle proxy.
+        parts: list[str] = []
+        reasoned = 0
+        finish_reason = None
+        for chunk in client.chat_completion(
+            [{"role": "user", "content": content}],
+            max_tokens=_CHAT_MAX_TOKENS,
+            stream=True,
+        ):
+            if not chunk.choices:
+                continue
+            choice = chunk.choices[0]
+            delta = getattr(choice, "delta", None)
+            if delta is not None:
+                if delta.content:
+                    parts.append(delta.content)
+                reasoned += len(getattr(delta, "reasoning_content", None) or "")
+            if choice.finish_reason:
+                finish_reason = choice.finish_reason
+        text = "".join(parts).strip()
         if not text:
+            model_name = getattr(client, "model", None) or "The model"
+            if finish_reason == "length":
+                # Reasoning is billed against max_tokens, so a model can hit the
+                # cap while still thinking and return no visible answer at all.
+                raise ValueError(
+                    f"{model_name} hit the {_CHAT_MAX_TOKENS}-token limit "
+                    f"({reasoned} characters of reasoning) before producing an "
+                    "answer. Simplify the prompt or use a smaller image, or "
+                    "raise gradio.workflow._CHAT_MAX_TOKENS."
+                )
             raise ValueError(
-                f"{getattr(client, 'model', 'The model')} returned no text. "
-                "Reasoning models can spend the whole token budget before "
-                "answering; try a shorter prompt or a smaller image."
+                f"{model_name} returned no text (finish_reason={finish_reason})."
             )
         return json.dumps([text])
     if endpoint == "text_generation":

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -31,7 +31,7 @@ from gradio.context import Context
 from gradio.helpers import special_args as _special_args
 from gradio.oauth import OAuthProfile, OAuthToken
 from gradio.route_utils import Request
-from gradio.utils import get_space
+from gradio.utils import colab_check, get_space
 
 if TYPE_CHECKING:
     from gradio.workflow_api import WorkflowEndpointManager
@@ -305,6 +305,50 @@ def _request_has_write_token(request: Request | None) -> bool:
     if query_value:
         return secrets.compare_digest(query_value, WRITE_TOKEN)
     return False
+
+
+def _should_auto_open_browser() -> bool:
+    """Whether `launch()` should open a browser tab on the write-access link
+    without being asked, the way `jupyter notebook` opens its token URL.
+
+    Only done when a browser on this machine is plausibly the right place to
+    open it, so headless servers, containers, CI and remote kernels keep the
+    old print-the-link-only behavior. Set `GRADIO_WORKFLOW_INBROWSER=false` to
+    opt out, or pass `inbrowser=` explicitly to bypass this entirely.
+    """
+    env = os.getenv("GRADIO_WORKFLOW_INBROWSER", "").strip().lower()
+    if env in ("0", "false", "no", "off"):
+        return False
+    if env in ("1", "true", "yes", "on"):
+        return True
+    if get_space() is not None:
+        # No write token to hand out, and no browser on the Space's container.
+        return False
+    if "PYTEST_CURRENT_TEST" in os.environ or os.getenv("CI", "").lower() in (
+        "1",
+        "true",
+    ):
+        return False
+    if colab_check():
+        # The kernel runs on Google's machine, so a tab would open there.
+        return False
+    if os.environ.get("BROWSER"):
+        # Explicitly configured (e.g. VS Code Remote forwards this back to the
+        # local machine), and `webbrowser` honors it first.
+        return True
+    if os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY"):
+        return False
+    if sys.platform.startswith("linux") and not (
+        os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
+    ):
+        # Headless Linux: `webbrowser` may fall back to a terminal browser and
+        # take over the console the app is logging to.
+        return False
+    try:
+        webbrowser.get()
+    except webbrowser.Error:
+        return False
+    return True
 
 
 # Shared instance: whoami(cache=True) caches per token on the HfApi instance,
@@ -1828,8 +1872,10 @@ class Workflow(Blocks):
         to `allowed_paths` so those URLs resolve.
 
         Locally, editing requires the write token: the full edit link is printed
-        after the standard launch output (and used for `inbrowser`). Plain
-        local/share URLs open the app read-only."""
+        after the standard launch output, and — unless `inbrowser` is passed
+        explicitly — opened in a browser tab automatically (like `jupyter
+        notebook` does with its token URL). Plain local/share URLs open the app
+        read-only. See `_should_auto_open_browser` for when the tab is opened."""
         if args:
             names = list(inspect.signature(super().launch).parameters)
             kwargs.update(dict(zip(names, args)))
@@ -1846,7 +1892,15 @@ class Workflow(Blocks):
         # replicate Blocks.launch()'s blocking behavior ourselves below.
         prevent_thread_lock = bool(kwargs.get("prevent_thread_lock", False))
         debug = bool(kwargs.get("debug", False))
-        inbrowser = bool(kwargs.get("inbrowser", False))
+        # `inbrowser` defaults to opening the write-access link, but only when
+        # the caller didn't say either way — an explicit `inbrowser=False` still
+        # means "don't open anything".
+        explicit_inbrowser = kwargs.get("inbrowser")
+        inbrowser = (
+            bool(explicit_inbrowser)
+            if explicit_inbrowser is not None
+            else _should_auto_open_browser()
+        )
         kwargs["inbrowser"] = False
 
         real_block_thread = self.block_thread
@@ -1862,8 +1916,9 @@ class Workflow(Blocks):
             sep = "&" if "?" in local_url else "?"
             write_url = f"{local_url}{sep}write_token={WRITE_TOKEN}"
             if not kwargs.get("quiet", False):
+                opening = " — opening it in your browser" if inbrowser else ""
                 print(
-                    f"\n* Workflow write-access link (keep private as it lets you edit the workflow that all users see): {write_url}"
+                    f"\n* Workflow write-access link (keep private as it lets you edit the workflow that all users see){opening}: {write_url}"
                 )
         if inbrowser:
             webbrowser.open(

--- a/js/workflowcanvas/workflow/model-api.ts
+++ b/js/workflowcanvas/workflow/model-api.ts
@@ -52,5 +52,8 @@ export const PIPELINE_TAG_TO_ENDPOINT: Record<string, string> = {
 	"automatic-speech-recognition": "automatic_speech_recognition",
 	"audio-classification": "audio_classification",
 	"visual-question-answering": "visual_question_answering",
-	"document-question-answering": "document_question_answering"
+	"document-question-answering": "document_question_answering",
+	// Vision-language models are served as `conversational`, so they go through
+	// chat completions rather than a task-specific endpoint.
+	"image-text-to-text": "chat_completion"
 };

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -199,6 +199,49 @@ class TestLaunchWriteTokenLink:
         assert "write_token" not in out
 
 
+class TestLaunchInBrowser:
+    """The write-access link is opened automatically, but only when a browser on
+    this machine is plausibly the right place for it."""
+
+    def _launch(self, tmp_path, monkeypatch, **kwargs):
+        wf = Workflow(graph=str(tmp_path / "wf.json"))
+        monkeypatch.setattr(
+            gr.Blocks,
+            "launch",
+            lambda *a, **kw: (None, "http://127.0.0.1:7860/", None),
+        )
+        opened = []
+        monkeypatch.setattr(workflow_module.webbrowser, "open", opened.append)
+        wf.launch(prevent_thread_lock=True, **kwargs)
+        return opened
+
+    def test_explicit_true_opens_the_write_url(self, tmp_path, monkeypatch):
+        opened = self._launch(tmp_path, monkeypatch, inbrowser=True)
+        assert opened == [f"http://127.0.0.1:7860/?write_token={WRITE_TOKEN}"]
+
+    def test_explicit_false_never_opens(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GRADIO_WORKFLOW_INBROWSER", "true")
+        assert self._launch(tmp_path, monkeypatch, inbrowser=False) == []
+
+    def test_not_opened_under_pytest_by_default(self, tmp_path, monkeypatch):
+        # PYTEST_CURRENT_TEST is set for us, standing in for the CI/automation
+        # case this suppression exists for.
+        assert self._launch(tmp_path, monkeypatch) == []
+
+    def test_env_opt_out_beats_everything_else(self, monkeypatch):
+        monkeypatch.setenv("GRADIO_WORKFLOW_INBROWSER", "false")
+        monkeypatch.setenv("BROWSER", "/usr/bin/firefox")
+        assert workflow_module._should_auto_open_browser() is False
+
+    @pytest.mark.parametrize("env", ["CI", "SSH_CONNECTION"])
+    def test_remote_and_automated_contexts_suppress_it(self, env, monkeypatch):
+        monkeypatch.delenv("GRADIO_WORKFLOW_INBROWSER", raising=False)
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv("BROWSER", raising=False)
+        monkeypatch.setenv(env, "1" if env == "CI" else "1.2.3.4 22 5.6.7.8 22")
+        assert workflow_module._should_auto_open_browser() is False
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Token resolution
 # ─────────────────────────────────────────────────────────────────────────────
@@ -441,6 +484,82 @@ class TestDispatchModelEndpoint:
         _dispatch_model_endpoint(client, "zero_shot_classification", {"text": "hello"})
         client.text_classification.assert_called_once_with(text="hello")
         client.zero_shot_classification.assert_not_called()
+
+    @staticmethod
+    def _chunks(*, content="", reasoning="", finish_reason="stop"):
+        """Streamed chat-completion chunks, shaped like the router's."""
+        deltas = [SimpleNamespace(content=content, reasoning_content=reasoning)]
+        return [
+            SimpleNamespace(
+                choices=[SimpleNamespace(delta=d, finish_reason=None)],
+            )
+            for d in deltas
+        ] + [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content="", reasoning_content=""),
+                        finish_reason=finish_reason,
+                    )
+                ]
+            )
+        ]
+
+    def test_chat_completion_shapes_a_multimodal_message(self, tmp_path):
+        image = tmp_path / "shot.png"
+        image.write_bytes(b"\x89PNG\r\n\x1a\n")
+        client = MagicMock()
+        client.chat_completion.return_value = self._chunks(content="<html></html>")
+
+        out = _dispatch_model_endpoint(
+            client,
+            "chat_completion",
+            {"image": {"path": str(image)}, "text": "rebuild this page"},
+        )
+
+        assert json.loads(out) == ["<html></html>"]
+        kwargs = client.chat_completion.call_args.kwargs
+        assert kwargs["stream"] is True
+        content = client.chat_completion.call_args.args[0][0]["content"]
+        assert content[0] == {"type": "text", "text": "rebuild this page"}
+        # Local files are inlined: the provider fetches image URLs itself and
+        # cannot reach a path on this machine.
+        assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+    def test_chat_completion_passes_through_remote_image_urls(self):
+        client = MagicMock()
+        client.chat_completion.return_value = self._chunks(content="ok")
+        _dispatch_model_endpoint(
+            client,
+            "chat_completion",
+            {"image": {"url": "https://example.com/a.png"}, "text": "what is this?"},
+        )
+        content = client.chat_completion.call_args.args[0][0]["content"]
+        assert content[1]["image_url"] == {"url": "https://example.com/a.png"}
+
+    def test_chat_completion_without_image_or_prompt_raises(self):
+        client = MagicMock()
+        with pytest.raises(ValueError, match="Connect a prompt or an image"):
+            _dispatch_model_endpoint(client, "chat_completion", {})
+        client.chat_completion.assert_not_called()
+
+    def test_chat_completion_blames_the_token_limit_when_only_reasoning(self):
+        client = MagicMock()
+        client.chat_completion.return_value = self._chunks(
+            reasoning="thinking" * 10, finish_reason="length"
+        )
+        with pytest.raises(ValueError, match="token limit"):
+            _dispatch_model_endpoint(
+                client, "chat_completion", {"text": "rebuild this page"}
+            )
+
+    def test_chat_completion_reports_finish_reason_when_empty(self):
+        client = MagicMock()
+        client.chat_completion.return_value = self._chunks(
+            finish_reason="content_filter"
+        )
+        with pytest.raises(ValueError, match="content_filter"):
+            _dispatch_model_endpoint(client, "chat_completion", {"text": "hello"})
 
     def test_unsupported_endpoint_raises_clear_error(self):
         from huggingface_hub import InferenceClient


### PR DESCRIPTION
Addresses some of the suggestions from #13665. Running list of what's in this PR (more to come):

* **Launching a `gr.Workflow` locally now opens the write-access link in a new browser tab by default**, the way `jupyter notebook` opens its token URL — so you land in an editable canvas instead of a read-only one. The link is still printed in the terminal. The tab is only opened when a browser on the machine running the app is plausibly the right place for it, so Spaces, headless Linux, containers, CI/pytest, Colab, and SSH sessions keep the previous print-only behavior. An explicit `inbrowser=` argument still wins, and `GRADIO_WORKFLOW_INBROWSER=false` opts out.

* **Vision-language models now work as plain model nodes.** `image-text-to-text` was mapped to the `visual_question_answering` endpoint, which no Inference Provider serves for any model on the Hub — the router routes every model carrying that tag as `conversational` — so a VLM model node always failed with `Task 'visual-question-answering' not supported for provider 'together'`. There's now a `chat_completion` endpoint schema (image + prompt → text) that `image-text-to-text` maps to, on both the Python and canvas side. Local images are inlined as data URIs, since the provider rather than the app dereferences them and so can't reach a local path or a relative `/gradio_api/file=` URL.

* **Chat completions are streamed**, because the router 504s a *non-streaming* request that takes longer than ~120s to respond, and a vision model writing a whole file routinely exceeds that — a reasoning model can spend the entire window before its first visible token, so for some inputs no buffered request can succeed at any `max_tokens`. Measured: the same request 504s at 121s buffered and runs 308s to completion when streamed. Reported upstream separately; streaming means it no longer reaches users. `max_tokens` defaults to 16384, sized to the canvas executor's 300s per-node timeout at the ~100 tok/s these models stream.

* **Truncation is reported accurately.** Reasoning counts against `max_tokens`, so a model can hit the cap while still thinking and return no content at all — previously surfaced as a guess ("try a shorter prompt"). It now names the limit and the reasoning volume, e.g. `hit the 16384-token limit (57283 characters of reasoning) before producing an answer`. Verified against `thinkingmachines/Inkling` and `moonshotai/Kimi-K2.7-Code`; `demo/workflow_vlm_html_comparison` compares the two on screenshot → webpage.

* **`gradio skills add` no longer deletes the skill it just installed** when the target agent's skills directory is a symlink to the central location — e.g. `.claude/skills -> ../.agents/skills`, one way to share a single skills directory across agents. `Path.resolve()` followed the link, so the symlink path collapsed onto the freshly-installed skill: `--force` replaced it with a link pointing at itself, and without `--force` the install reported its own output as a pre-existing conflict. Linking is now skipped when the resolved link path is the central skill path, since the skill is already reachable there. (Unrelated to the workflow changes above, but found while installing the Gradio skill to build a workflow.)

Unrelated but also added a VLM workflow demo locally, here it is on Spaces: https://huggingface.co/spaces/abidlabs/vlm-screenshot-to-webpage