### PR TITLE
Fix crash when a streaming `gr.ChatInterface` function yields nothing

### DIFF
--- a/.changeset/five-days-join.md
+++ b/.changeset/five-days-join.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix crash when a streaming `gr.ChatInterface` function yields nothing

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -973,10 +973,7 @@ class ChatInterface(Blocks):
                 else:
                     yield first_response, history_, *additional_outputs
             except StopAsyncIteration:
-                if not self.additional_outputs:
-                    yield None, history
-                else:
-                    yield None, history, *([skip()] * len(self.additional_outputs))
+                yield None, history, *[skip() for _ in self.additional_outputs]
             async for response in generator:
                 if self.additional_outputs:
                     response, *additional_outputs = response

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -44,7 +44,7 @@ from gradio.components.multimodal_textbox import MultimodalPostprocess, Multimod
 from gradio.events import Dependency, EditData, SelectData
 from gradio.flagging import ChatCSVLogger
 from gradio.helpers import create_examples as Examples  # noqa: N812
-from gradio.helpers import special_args, update
+from gradio.helpers import skip, special_args, update
 from gradio.i18n import I18nData
 from gradio.layouts import Accordion, Column, Group, Row
 
@@ -972,8 +972,11 @@ class ChatInterface(Blocks):
                     yield first_response, history_
                 else:
                     yield first_response, history_, *additional_outputs
-            except StopIteration:
-                yield None, history
+            except StopAsyncIteration:
+                if not self.additional_outputs:
+                    yield None, history
+                else:
+                    yield None, history, *([skip()] * len(self.additional_outputs))
             async for response in generator:
                 if self.additional_outputs:
                     response, *additional_outputs = response

--- a/test/test_chat_interface.py
+++ b/test/test_chat_interface.py
@@ -33,6 +33,18 @@ async def async_stream(message, history):
         yield message[: i + 1]
 
 
+def stream_or_nothing(message, history):
+    if message == "skip":
+        return
+    yield f"history_len={len(history)}"
+
+
+async def async_stream_or_nothing(message, history):
+    if message == "skip":
+        return
+    yield f"history_len={len(history)}"
+
+
 def count(message, history):
     return str(len(history))
 
@@ -297,6 +309,40 @@ class TestAPI:
             job = client.submit("hello")
             wait([job])
             assert job.outputs() == ["h", "he", "hel", "hell", "hello"]
+
+    def test_streaming_api_empty_generator(self, connect):
+        chatbot = gr.ChatInterface(stream_or_nothing).queue()
+        with connect(chatbot) as client:
+            assert client.predict("hello") == "history_len=0"
+            assert client.predict("skip") is None
+            # The skipped turn must leave the history intact and still record
+            # the user message, so the next turn sees three messages.
+            assert client.predict("hello") == "history_len=3"
+
+    def test_streaming_api_empty_generator_async(self, connect):
+        chatbot = gr.ChatInterface(async_stream_or_nothing).queue()
+        with connect(chatbot) as client:
+            assert client.predict("hello") == "history_len=0"
+            assert client.predict("skip") is None
+            assert client.predict("hello") == "history_len=3"
+
+    def test_streaming_api_empty_generator_with_additional_outputs(self, connect):
+        def stream_or_nothing_with_extra(message, history):
+            if message == "skip":
+                return
+            yield message, "extra"
+
+        with gr.Blocks() as demo:
+            code = gr.Code(render=False)
+            gr.ChatInterface(
+                stream_or_nothing_with_extra,
+                additional_outputs=[code],
+                api_name="chat",
+            )
+            code.render()
+        with connect(demo) as client:
+            assert client.predict("hello", api_name="/chat") == ("hello", "extra")
+            assert client.predict("skip", api_name="/chat") == (None, gr.skip())
 
     def test_non_streaming_api(self, connect):
         chatbot = gr.ChatInterface(double)


### PR DESCRIPTION
## Description

A streaming `gr.ChatInterface` crashed with `RuntimeError: async generator raised StopAsyncIteration` whenever the chat function returned before yielding anything, instead of simply producing no bot response.

`_stream_fn` fetches the first item with `await utils.async_iteration(generator)` but guarded it with `except StopIteration`. Nothing in that block can raise `StopIteration`: `async_iteration` is `await anext(iterator)`, which raises `StopAsyncIteration`, and for sync chat functions `SyncToAsyncIterator.run_sync_iterator_async` has already converted `StopIteration` into `StopAsyncIteration`. So the guard never fired, the `StopAsyncIteration` escaped the `_stream_fn` async generator frame, and Python turned it into a `RuntimeError`.

The guard has been dead since #5116, which converted `_stream_fn` from a sync generator to an async one and changed `next(generator)` to `await async_iteration(generator)` without updating the `except` clause alongside it. Before that commit the guard worked, so an empty generator producing no response was the original intended behaviour rather than something new.

This corrects the exception type and, while the handler is finally reachable again, brings it in line with the rest of the method. The handler still yields the history, because that is what keeps the chatbot populated: if the handler yielded nothing at all, `postprocess_data` would emit `None` for every output, and the frontend applies a `null` chatbot value as an empty chat, wiping the conversation. A normal generator avoids that because the final payload of a generating run has its `None` placeholders replaced with the last real value, but a generator that yields nothing never enters generating mode, so that substitution never happens.

The other change is the output count. The event's outputs are `[null_component, chatbot] + additional_outputs`, and every other branch in `_stream_fn` already varies its yield accordingly, but this branch always yielded two values. It predates `additional_outputs` (#10071) by more than a year, and since it was unreachable by then it was never updated. With `additional_outputs` configured it therefore raised `ValueError: A function didn't return enough output values` instead of the `RuntimeError`. The additional outputs get `gr.skip()` so a turn that produced no response leaves them untouched rather than clearing them.

Closes: #13663

## Testing

Three cases added to `TestAPI` in `test/test_chat_interface.py`, covering a sync generator, an async generator, and a generator used with `additional_outputs`. Each asserts that normal input still streams and that the empty case produces no response. The first two also assert that the skipped turn leaves the history intact and still records the user message, so the following turn sees three messages.

All three fail on `main` with the `RuntimeError` above. They also fail on the two tempting partial fixes: catching `StopAsyncIteration` but returning instead of yielding drops the history (`history_len=2` where 3 is expected), and only widening the `except` clause leaves the `additional_outputs` case raising the `ValueError`.

The reproduction in the issue is enough for a manual check: sending `skip` now leaves the message in the chat with no bot reply and the textbox re-enabled, instead of erroring out.

## Before / after Spaces

- [Before fix](https://huggingface.co/spaces/hysts-debug/gradio-13663-before)
- [After fix](https://huggingface.co/spaces/hysts-debug/gradio-13663-after)

Same app on both. Send `hello`, then `skip`.

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

