### PR TITLE
workflow: refactor task logic for external providers

### DIFF
--- a/.changeset/dirty-pets-shine.md
+++ b/.changeset/dirty-pets-shine.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:workflow: refactor task type logic
+feat:workflow: refactor task logic for external providers

--- a/.changeset/dirty-pets-shine.md
+++ b/.changeset/dirty-pets-shine.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:workflow: refactor task type logic

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -824,8 +824,21 @@ _CHAT_VISION_TASKS = frozenset({
 
 
 def _vision_message(image_val: object, prompt: str) -> list:
+    url = _img_url(image_val)
+    # Local paths (no public URL) can't be fetched by an external provider.
+    # Inline them as a data URI so the same workflow runs locally and on Spaces.
+    if isinstance(url, str) and url and not url.startswith(("http://", "https://", "data:")):
+        import base64
+        import mimetypes
+        try:
+            with open(url, "rb") as f:
+                b64 = base64.b64encode(f.read()).decode()
+            mime = mimetypes.guess_type(url)[0] or "image/jpeg"
+            url = f"data:{mime};base64,{b64}"
+        except OSError:
+            pass  # fall through with original url; provider will surface the error
     return [
-        {"type": "image_url", "image_url": {"url": _img_url(image_val)}},
+        {"type": "image_url", "image_url": {"url": url}},
         {"type": "text", "text": prompt or "Describe this image."},
     ]
 

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -843,8 +843,7 @@ def _raw_inference(model_id: str, hf_token: str | None, a0, a1) -> str:
     tasks not covered by InferenceClient's specialized methods still work."""
     def resolve(v):
         return _img_url(v) if isinstance(v, dict) and ("url" in v or "path" in v) else v
-    a0v, a1v = resolve(a0), resolve(a1)
-    payload = a0v if not a1v else [a0v, a1v]
+    payload = resolve(a0) if a1 == "" else [resolve(a0), resolve(a1)]
     headers = {"Authorization": f"Bearer {hf_token}"} if hf_token else {}
     resp = httpx.post(
         f"https://api-inference.huggingface.co/models/{model_id}",
@@ -907,13 +906,17 @@ def _dispatch_model_endpoint(client, endpoint: str, kwargs: dict) -> str:
         return _dispatch_model_endpoint(
             client, "text_classification", {"text": clean.get("text", "")}
         )
+    if endpoint in {
+        "visual_question_answering",
+        "document_question_answering",
+        "image_to_text",
+    }:
+        image = clean.get("image") or clean.get("document")
+        prompt = clean.get("question") or ""
+        return _chat(client, _vision_message(image, prompt))
     if endpoint == "text_generation":
         try:
-            r = client.chat_completion(
-                [{"role": "user", "content": clean.get("prompt", "")}],
-                max_tokens=512,
-            )
-            result = r.choices[0].message.content
+            return _chat(client, clean.get("prompt", ""))
         except Exception:
             clean.setdefault("max_new_tokens", 512)
             result = fn(**clean)

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -823,11 +823,16 @@ _CHAT_VISION_TASKS = frozenset({
 })
 
 
-def _vision_message(image_val: object, prompt: str) -> list:
+def _vision_message(image_val: object, prompt: str):
+    """Build chat content from an image and prompt. If no image is provided,
+    returns the prompt as plain text so the request degrades to text-only chat
+    rather than sending a malformed vision message with an empty image URL."""
     url = _img_url(image_val)
+    if not url:
+        return prompt or ""
     # Local paths (no public URL) can't be fetched by an external provider.
     # Inline them as a data URI so the same workflow runs locally and on Spaces.
-    if isinstance(url, str) and url and not url.startswith(("http://", "https://", "data:")):
+    if isinstance(url, str) and not url.startswith(("http://", "https://", "data:")):
         import base64
         import mimetypes
         try:
@@ -856,7 +861,10 @@ def _raw_inference(model_id: str, hf_token: str | None, a0, a1) -> str:
     tasks not covered by InferenceClient's specialized methods still work."""
     def resolve(v):
         return _img_url(v) if isinstance(v, dict) and ("url" in v or "path" in v) else v
-    payload = resolve(a0) if a1 == "" else [resolve(a0), resolve(a1)]
+    # Treat None and "" as missing (both can arrive from JSON payloads / the
+    # positional args scaffold); real values like 0 or False must survive.
+    a1_missing = a1 is None or a1 == ""
+    payload = resolve(a0) if a1_missing else [resolve(a0), resolve(a1)]
     headers = {"Authorization": f"Bearer {hf_token}"} if hf_token else {}
     resp = httpx.post(
         f"https://api-inference.huggingface.co/models/{model_id}",

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -815,12 +815,14 @@ _ENDPOINT_LIST_KWARGS: dict[str, dict[str, str]] = {
 # multimodal models expose these via chat_completion with a vision message,
 # and that path works across every provider. The legacy specialized methods
 # (visual_question_answering, image_to_text) only work on hf-inference.
-_CHAT_VISION_TASKS = frozenset({
-    "image-text-to-text",
-    "visual-question-answering",
-    "document-question-answering",
-    "image-to-text",
-})
+_CHAT_VISION_TASKS = frozenset(
+    {
+        "image-text-to-text",
+        "visual-question-answering",
+        "document-question-answering",
+        "image-to-text",
+    }
+)
 
 
 def _vision_message(image_val: object, prompt: str):
@@ -835,6 +837,7 @@ def _vision_message(image_val: object, prompt: str):
     if isinstance(url, str) and not url.startswith(("http://", "https://", "data:")):
         import base64
         import mimetypes
+
         try:
             with open(url, "rb") as f:
                 b64 = base64.b64encode(f.read()).decode()
@@ -859,8 +862,10 @@ def _raw_inference(model_id: str, hf_token: str | None, a0, a1) -> str:
     """Raw POST to HF's inference API for any model with inference enabled.
     The API handles pipeline dispatch server-side based on the model card, so
     tasks not covered by InferenceClient's specialized methods still work."""
+
     def resolve(v):
         return _img_url(v) if isinstance(v, dict) and ("url" in v or "path" in v) else v
+
     # Treat None and "" as missing (both can arrive from JSON payloads / the
     # positional args scaffold); real values like 0 or False must survive.
     a1_missing = a1 is None or a1 == ""

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -799,12 +799,8 @@ _PIPELINE_TAG_TO_ENDPOINT: dict[str, str] = {
     "image-classification": "image_classification",
     "object-detection": "object_detection",
     "image-segmentation": "image_segmentation",
-    "image-to-text": "image_to_text",
     "automatic-speech-recognition": "automatic_speech_recognition",
     "audio-classification": "audio_classification",
-    "visual-question-answering": "visual_question_answering",
-    "document-question-answering": "document_question_answering",
-    "image-text-to-text": "visual_question_answering",
 }
 
 
@@ -814,6 +810,53 @@ _ENDPOINT_LIST_KWARGS: dict[str, dict[str, str]] = {
     "zero_shot_classification": {"candidate_labels": r"[\n,]"},
     "sentence_similarity": {"other_sentences": r"\n"},
 }
+
+# Tasks that produce a text answer from an image (+ optional prompt). Modern
+# multimodal models expose these via chat_completion with a vision message,
+# and that path works across every provider. The legacy specialized methods
+# (visual_question_answering, image_to_text) only work on hf-inference.
+_CHAT_VISION_TASKS = frozenset({
+    "image-text-to-text",
+    "visual-question-answering",
+    "document-question-answering",
+    "image-to-text",
+})
+
+
+def _vision_message(image_val: object, prompt: str) -> list:
+    return [
+        {"type": "image_url", "image_url": {"url": _img_url(image_val)}},
+        {"type": "text", "text": prompt or "Describe this image."},
+    ]
+
+
+def _chat(client, content) -> str:
+    r = client.chat_completion(
+        messages=[{"role": "user", "content": content}], max_tokens=512
+    )
+    return json.dumps([r.choices[0].message.content])
+
+
+def _raw_inference(model_id: str, hf_token: str | None, a0, a1) -> str:
+    """Raw POST to HF's inference API for any model with inference enabled.
+    The API handles pipeline dispatch server-side based on the model card, so
+    tasks not covered by InferenceClient's specialized methods still work."""
+    def resolve(v):
+        return _img_url(v) if isinstance(v, dict) and ("url" in v or "path" in v) else v
+    a0v, a1v = resolve(a0), resolve(a1)
+    payload = a0v if not a1v else [a0v, a1v]
+    headers = {"Authorization": f"Bearer {hf_token}"} if hf_token else {}
+    resp = httpx.post(
+        f"https://api-inference.huggingface.co/models/{model_id}",
+        headers=headers,
+        json={"inputs": payload},
+        timeout=60,
+    )
+    resp.raise_for_status()
+    try:
+        return json.dumps([resp.json()])
+    except Exception:
+        return json.dumps([resp.text])
 
 
 def get_model_endpoints(
@@ -865,19 +908,15 @@ def _dispatch_model_endpoint(client, endpoint: str, kwargs: dict) -> str:
             client, "text_classification", {"text": clean.get("text", "")}
         )
     if endpoint == "text_generation":
-        clean.setdefault("max_new_tokens", 512)
         try:
+            r = client.chat_completion(
+                [{"role": "user", "content": clean.get("prompt", "")}],
+                max_tokens=512,
+            )
+            result = r.choices[0].message.content
+        except Exception:
+            clean.setdefault("max_new_tokens", 512)
             result = fn(**clean)
-        except Exception as inner:
-            msg = str(inner).lower()
-            if "not supported" in msg and "conversational" in msg:
-                r = client.chat_completion(
-                    [{"role": "user", "content": clean.get("prompt", "")}],
-                    max_tokens=512,
-                )
-                result = r.choices[0].message.content
-            else:
-                raise
     else:
         result = fn(**clean)
     ext = _ENDPOINT_OUTPUT_EXT.get(endpoint)
@@ -961,6 +1000,9 @@ def call_model(
             depth_img = _Image.open(_io.BytesIO(resp.content))
             return json.dumps([_save_tmp(depth_img, "png")])
 
+        if task in _CHAT_VISION_TASKS:
+            return _chat(client, _vision_message(a0, a1))
+
         endpoint = _PIPELINE_TAG_TO_ENDPOINT.get(task)
         if endpoint:
             # Positional args from legacy saved workflows and the browser
@@ -972,28 +1014,10 @@ def call_model(
             }
             return _dispatch_model_endpoint(client, endpoint, kwargs)
 
-        # Fallback for tasks not handled above: chat_completion (works for most
-        # text models across providers), then a raw POST as last resort.
-        try:
-            r = client.chat_completion(
-                [{"role": "user", "content": a0}], max_tokens=512
-            )
-            return json.dumps([r.choices[0].message.content])
-        except Exception:
-            pass
-        headers = {"Authorization": f"Bearer {hf_token}"} if hf_token else {}
-        fallback_resp = httpx.post(
-            f"https://api-inference.huggingface.co/models/{model_id}",
-            headers=headers,
-            json={"inputs": a0 if not a1 else [a0, a1]},
-            timeout=60,
-        )
-        fallback_resp.raise_for_status()
-        try:
-            parsed = fallback_resp.json()
-        except Exception:
-            parsed = fallback_resp.text
-        return json.dumps([parsed])
+        # Unknown/new task — HF's raw inference API dispatches server-side
+        # based on the model card, so anything with inference enabled works
+        # without waiting for InferenceClient to add a method for it.
+        return _raw_inference(model_id, hf_token, a0, a1)
     except Exception as e:
         logger.error(
             "call_model failed for %s (task=%s): %s",


### PR DESCRIPTION
## Description

the workflow was breaking when you tried to use models on providers like Together or Fireworks. i was getting 403s for Kimi-K3 which gave me an error "task not supported for provider"

the code was calling funcs like client.visual_question_answering(...) which only work on hf-inference

the fix

two routing changes in gradio/workflow.py:

1. vision tasks now go through chat_completion with a vision message

rerouted image-text-to-text, visual-question-answering, document-question-answering, and image-to-text away from the InferenceClient methods and onto chat_completion with an OpenAI-style vision content array:

```
{ "role": "user", "content": [
    { "type": "image_url", "image_url": { "url": "..." } },
    { "type": "text", "text": "..." }
]}

```
The specialised methods only work on hf-inference. `chat_completion` is the contract every provider implements, so provider="auto" routing stops 403ing when it lands on Together/Fireworks/etc.

2. text-generation tries chat_completion first, falls back to text_generation only if that fails

3. unknown task fallback goes to HF's raw inference API

If we don't recognise the pipeline_tag and no specialised endpoint matches, `_raw_inference`() POSTs directly to `api-inference.huggingface.co`.  so any future task or unusual model works without waiting for InferenceClient to expose a method

4. local image paths are base64-encoded into data URIs before being sent to external provider

When a vision workflow runs locally, images sit at tmp paths which extneral providers can't access. if the resolved URL isn't http(s):// or already a data: URI, read the file, base64-encode it