### PR TITLE
Stop deep-copying chat messages so components work as chat content again

### DIFF
--- a/.changeset/good-sloths-like.md
+++ b/.changeset/good-sloths-like.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Stop deep-copying chat messages so components work as chat content again

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -5,7 +5,6 @@ This file defines a useful high-level abstraction to build Gradio chatbots: Chat
 from __future__ import annotations
 
 import builtins
-import dataclasses
 import inspect
 import os
 import warnings
@@ -900,9 +899,8 @@ class ChatInterface(Blocks):
                 message_dicts.append(msg.model_dump())
             elif isinstance(msg, ChatMessage):
                 msg.role = role
-                message_dicts.append(
-                    dataclasses.asdict(msg, dict_factory=utils.dict_factory)
-                )
+                # Not dataclasses.asdict: it deep-copies the field values.
+                message_dicts.append(utils.shallow_asdict(msg))
             elif isinstance(msg, (str, Component)):
                 message_dicts.append({"role": role, "content": msg})
             elif (

--- a/gradio/chat_interface.py
+++ b/gradio/chat_interface.py
@@ -5,7 +5,6 @@ This file defines a useful high-level abstraction to build Gradio chatbots: Chat
 from __future__ import annotations
 
 import builtins
-import copy
 import dataclasses
 import inspect
 import os
@@ -879,7 +878,8 @@ class ChatInterface(Blocks):
         role: Literal["user", "assistant"] = "user",
     ) -> list[MessageDict]:
         message_dicts = self._message_as_message_dict(message, role)
-        history = copy.deepcopy(history)
+        # Shallow on purpose: messages can hold values that are not deep-copyable.
+        history = list(history)
         history.extend(message_dicts)  # type: ignore
         return history
 

--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -501,8 +501,8 @@ class Chatbot(Component):
             chat_message.unrender()
             component = import_component_and_data(type(chat_message).__name__)
             if component:
-                # Don't mutate the caller's component: a streaming handler yields
-                # the same history repeatedly, so this runs again on the next pass.
+                # Don't rewrite the caller's constructor args: a streaming handler
+                # yields the same history repeatedly, so this runs again next pass.
                 constructor_args = {**chat_message.constructor_args, "render": False}
                 component = chat_message.__class__(**constructor_args)
                 constructor_args.pop("value", None)

--- a/gradio/components/chatbot.py
+++ b/gradio/components/chatbot.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import copy
 import inspect
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
@@ -502,9 +501,11 @@ class Chatbot(Component):
             chat_message.unrender()
             component = import_component_and_data(type(chat_message).__name__)
             if component:
-                chat_message.constructor_args["render"] = False
-                component = chat_message.__class__(**chat_message.constructor_args)
-                chat_message.constructor_args.pop("value", None)
+                # Don't mutate the caller's component: a streaming handler yields
+                # the same history repeatedly, so this runs again on the next pass.
+                constructor_args = {**chat_message.constructor_args, "render": False}
+                component = chat_message.__class__(**constructor_args)
+                constructor_args.pop("value", None)
                 config = component.get_config()
                 component_name = type(chat_message).__name__.lower()
                 value = config.get("value", None)
@@ -518,7 +519,7 @@ class Chatbot(Component):
                 return ComponentMessage(
                     component=component_name,
                     value=value,
-                    constructor_args=chat_message.constructor_args,
+                    constructor_args=constructor_args,
                     props=config,
                 )
         elif isinstance(chat_message, dict) and "path" in chat_message:
@@ -544,7 +545,6 @@ class Chatbot(Component):
     def _postprocess(
         self, message: MessageDict | Message | ChatMessage | NormalizedMessageDict
     ) -> list[Message] | None:
-        message = copy.deepcopy(message)
         role = message["role"] if isinstance(message, dict) else message.role  # type: ignore[possibly-unbound-attribute]
         metadata = (
             message.get("metadata") if isinstance(message, dict) else message.metadata  # type: ignore[possibly-unbound-attribute]

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import copy
 import inspect
 import os
 import platform
@@ -1013,8 +1012,10 @@ class Queue:
                     )
 
             elif response:
-                output = copy.deepcopy(response)
                 for e, event in enumerate(awake_events):
+                    # Copy per event because "data" is replaced below and the
+                    # message is serialized later; only that key changes.
+                    output = dict(response)
                     if batch and "data" in output:
                         output["data"] = list(zip(*response.get("data"), strict=False))[
                             e

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import copy
+import dataclasses
 import functools
 import hashlib
 import importlib
@@ -1963,6 +1964,16 @@ def dict_factory(items):
         else:
             d[key] = value
     return d
+
+
+def shallow_asdict(obj) -> dict:
+    """
+    Like dataclasses.asdict, but without deep-copying the field values, which
+    fails for values such as bokeh figures.
+    """
+    return dict_factory(
+        [(f.name, getattr(obj, f.name)) for f in dataclasses.fields(obj)]
+    )
 
 
 def get_function_description(fn: Callable) -> tuple[str, dict[str, str], list[str]]:

--- a/test/components/test_chatbot.py
+++ b/test/components/test_chatbot.py
@@ -121,6 +121,25 @@ class TestChatbot:
         )
         assert chatbot.avatar_images[1] is None
 
+    def test_component_content_created_inside_blocks_context(self):
+        """Such a component's `parent` is a Blocks graph, which holds a lock."""
+        with gr.Blocks():
+            chatbot = gr.Chatbot(
+                value=[gr.ChatMessage(role="assistant", content=gr.Plot())]
+            )
+        assert chatbot.value[0]["content"][0]["component"] == "plot"
+
+    def test_component_content_is_not_mutated_by_postprocess(self):
+        """Postprocessing is repeated for every yield of a streaming handler."""
+        chatbot = gr.Chatbot()
+        message = gr.ChatMessage(
+            role="assistant", content=gr.Image("test/test_files/bus.png")
+        )
+        first = chatbot.postprocess([message]).model_dump()  # type: ignore
+        second = chatbot.postprocess([message]).model_dump()  # type: ignore
+        assert first == second
+        assert first[0]["content"][0]["value"] is not None
+
     def test_reasoning_tags_single_block(self):
         """Test reasoning_tags with a single thinking block"""
         chatbot = gr.Chatbot(reasoning_tags=[("<thinking>", "</thinking>")])

--- a/test/components/test_chatbot.py
+++ b/test/components/test_chatbot.py
@@ -1,5 +1,6 @@
 import gradio as gr
 from gradio import utils
+from gradio.components.chatbot import MessageDict
 
 
 class TestChatbot:
@@ -124,7 +125,9 @@ class TestChatbot:
     def test_component_content_created_inside_blocks_context(self):
         """Such a component's `parent` is a Blocks graph, which holds a lock."""
         with gr.Blocks():
-            chatbot = gr.Chatbot(value=[{"role": "assistant", "content": gr.Plot()}])
+            # Built inside the block on purpose: that is what gives it a parent.
+            message: MessageDict = {"role": "assistant", "content": gr.Plot()}
+            chatbot = gr.Chatbot(value=[message])
         assert chatbot.value[0]["content"][0]["component"] == "plot"
 
     def test_component_content_is_not_mutated_by_postprocess(self):

--- a/test/components/test_chatbot.py
+++ b/test/components/test_chatbot.py
@@ -124,9 +124,7 @@ class TestChatbot:
     def test_component_content_created_inside_blocks_context(self):
         """Such a component's `parent` is a Blocks graph, which holds a lock."""
         with gr.Blocks():
-            chatbot = gr.Chatbot(
-                value=[gr.ChatMessage(role="assistant", content=gr.Plot())]
-            )
+            chatbot = gr.Chatbot(value=[{"role": "assistant", "content": gr.Plot()}])
         assert chatbot.value[0]["content"][0]["component"] == "plot"
 
     def test_component_content_is_not_mutated_by_postprocess(self):

--- a/test/test_chat_interface.py
+++ b/test/test_chat_interface.py
@@ -377,15 +377,22 @@ class TestAPI:
                 raise RuntimeError("cannot be deep-copied")
 
         def mock_chat_fn(msg, history):
-            return gr.Plot(UncopyablePlotData(type="bokeh", plot="{}"))
+            plot = gr.Plot(UncopyablePlotData(type="bokeh", plot="{}"))
+            if msg == "wrapped":
+                return gr.ChatMessage(role="assistant", content=plot)
+            return plot
 
         chatbot = gr.ChatInterface(mock_chat_fn, api_name="chat")
         with connect(chatbot) as client:
-            for _ in range(2):
-                # A deep copy raising inside the queue leaves the request hanging
-                # rather than erroring, hence the timeout.
-                result = client.submit("hello", api_name="/chat").result(timeout=5)
-                assert result["value"]["type"] == "bokeh"
+            # A deep copy raising inside the queue leaves the request hanging
+            # rather than erroring, hence the timeouts. The second turn matters
+            # because that is the one copying a history that already holds the
+            # component, and a wrapped component leaves the chat function by a
+            # different route than a bare one.
+            bare = client.submit("bare", api_name="/chat").result(timeout=5)
+            assert bare["value"]["type"] == "bokeh"
+            wrapped = client.submit("wrapped", api_name="/chat").result(timeout=5)
+            assert wrapped["role"] == "assistant"
 
     def test_multiple_messages(self, connect):
         def multiple_messages(msg, history):

--- a/test/test_chat_interface.py
+++ b/test/test_chat_interface.py
@@ -2,10 +2,12 @@ import tempfile
 import warnings
 from concurrent.futures import wait
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 from gradio_client import handle_file
+from typing_extensions import Self
 
 import gradio as gr
 from gradio.components.chatbot import Message, TextMessage
@@ -371,7 +373,7 @@ class TestAPI:
         """Bokeh figures, for one, raise when deep-copied."""
 
         class UncopyablePlotData(PlotData):
-            def __deepcopy__(self, memo):
+            def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Self:
                 raise RuntimeError("cannot be deep-copied")
 
         def mock_chat_fn(msg, history):

--- a/test/test_chat_interface.py
+++ b/test/test_chat_interface.py
@@ -9,6 +9,7 @@ from gradio_client import handle_file
 
 import gradio as gr
 from gradio.components.chatbot import Message, TextMessage
+from gradio.components.plot import PlotData
 
 
 def invalid_fn(message):
@@ -365,6 +366,24 @@ class TestAPI:
                 api_name="/chat",
             )
             assert result["value"] == "test/test_files/audio_sample.wav"
+
+    def test_component_that_cannot_be_deep_copied(self, connect):
+        """Bokeh figures, for one, raise when deep-copied."""
+
+        class UncopyablePlotData(PlotData):
+            def __deepcopy__(self, memo):
+                raise RuntimeError("cannot be deep-copied")
+
+        def mock_chat_fn(msg, history):
+            return gr.Plot(UncopyablePlotData(type="bokeh", plot="{}"))
+
+        chatbot = gr.ChatInterface(mock_chat_fn, api_name="chat")
+        with connect(chatbot) as client:
+            for _ in range(2):
+                # A deep copy raising inside the queue leaves the request hanging
+                # rather than erroring, hence the timeout.
+                result = client.submit("hello", api_name="/chat").result(timeout=30)
+                assert result["value"]["type"] == "bokeh"
 
     def test_multiple_messages(self, connect):
         def multiple_messages(msg, history):

--- a/test/test_chat_interface.py
+++ b/test/test_chat_interface.py
@@ -382,7 +382,7 @@ class TestAPI:
             for _ in range(2):
                 # A deep copy raising inside the queue leaves the request hanging
                 # rather than erroring, hence the timeout.
-                result = client.submit("hello", api_name="/chat").result(timeout=30)
+                result = client.submit("hello", api_name="/chat").result(timeout=5)
                 assert result["value"]["type"] == "bokeh"
 
     def test_multiple_messages(self, connect):


### PR DESCRIPTION
## Description

A Gradio component used as chat content crashes the app if the component, or the value it holds, cannot be deep-copied. Two ways to hit it: any component built inside a `with gr.Blocks()` block (its `parent` is copied too, so the copy walks into the Blocks graph and its locks), and `gr.Plot` holding a bokeh figure (bokeh figures raise under `copy.deepcopy`). Both start failing in 5.9.0.

Four deep copies sit in the path a chat message takes, and none of them needs to be deep:

- **`Chatbot._postprocess`** deep-copied the whole message. That was not defensive: `_postprocess_content` mutates the component it is handed, setting `render` and popping `"value"` out of its `constructor_args`. Since a streaming handler yields the same history over and over, the copy was what kept the second pass from finding a component with no value. `_postprocess_content` now builds its own dict of constructor args and leaves the caller's component alone, so the deep copy is no longer needed.
- **`ChatInterface._append_message_to_history`** deep-copied the history so that appending would not mutate the caller's list. Only the list is appended to, so `list(history)` does the job.
- **`ChatInterface._message_as_message_dict`** turned a returned `gr.ChatMessage` into a dict with `dataclasses.asdict`, which deep-copies every leaf value before `dict_factory` ever sees it. That is the route a chat function takes when it attaches `metadata`, the only way to render a thought, so a plot returned as a thought was still broken. `utils.shallow_asdict` does the same conversion without the recursion; `ChatMessage` has no nested dataclasses (`metadata` and `options` are TypedDicts), so the output is unchanged.
- **`Queue.process_events`** deep-copied the response before fanning the completion message out to batched events. Only the top-level `"data"` key is replaced, so a shallow copy per event is enough. This site is why the `gr.ChatInterface` case shows up as a hang rather than an error: it runs after the prediction, so no completion message reaches the client. Moving the copy inside the loop also fixes a smaller problem, since the old code shared one dict across every event in a batch and overwrote `"data"` in place while `send_message` serializes later.

Dropping the copy in `Chatbot._postprocess` means `chat_message.unrender()` acts on the real component again instead of on a throwaway copy, which is what that call was there for. Checked that a component passed as chat content no longer leaks into the config.

It also takes real work out of the streaming path, since `Chatbot.postprocess` runs once per yield over the whole history. A 100-message text history goes from 1.02 ms to 0.27 ms per pass here.

Closes: #13675

## Testing

`test/components/test_chatbot.py`

- `test_component_content_created_inside_blocks_context` — the crash itself; fails on `main` with `TypeError: cannot pickle '_thread.lock' object`.
- `test_component_content_is_not_mutated_by_postprocess` — postprocessing the same message twice gives the same result, which is the invariant the deep copy used to provide.

`test/test_chat_interface.py`

- `test_component_that_cannot_be_deep_copied` — end to end through the queue, with a value that raises on `__deepcopy__` standing in for a bokeh figure so the suite does not need bokeh. Two turns, one returning a bare component and one returning it wrapped in a `gr.ChatMessage`, which covers the `ChatInterface`, `asdict` and `Queue` sites. On `main` the request never completes, hence the explicit client timeout.

Reverting each of the four sites in turn makes exactly the expected test fail, and reintroducing the mutation in `_postprocess_content` (with the deep copy still gone) is caught only by `test_component_content_is_not_mutated_by_postprocess`.

Locally: `test/components/`, `test/test_chat_interface.py`, `test/test_components.py`, `test/test_utils.py` and `test/test_blocks.py` are green (492 passed), and the real bokeh case was checked by hand — three `Chatbot.postprocess` passes keep the plot payload, and a `gr.ChatInterface` returning `gr.Plot(bokeh_figure)` runs several turns over the API.

## Before / after Spaces

The same minimal app on the released 6.20.0 and on this PR's preview wheel:

- [Before fix](https://huggingface.co/spaces/hysts-debug/gradio-13675-before) — the initial-value case reports `TypeError: cannot pickle '_thread.lock' object`, and sending a message fails
- [After fix](https://huggingface.co/spaces/hysts-debug/gradio-13675-after) — both work

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`



