### PR TITLE
Only remount a plot when its payload changes

### DIFF
--- a/.changeset/tender-eggs-cut.md
+++ b/.changeset/tender-eggs-cut.md
@@ -1,0 +1,6 @@
+---
+"@gradio/plot": patch
+"gradio": patch
+---
+
+fix:Only remount a plot when its payload changes

--- a/js/plot/Plot.test.ts
+++ b/js/plot/Plot.test.ts
@@ -10,6 +10,9 @@ const matplotlib_value = {
 	chart: "bar"
 };
 
+const other_matplotlib_plot =
+	"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+
 // layout has no height on purpose: this is the autosize path.
 const plotly_autosize_value = {
 	type: "plotly",
@@ -299,6 +302,40 @@ describe("Plotly", () => {
 			expect(plot.querySelector(".main-svg")).toBeTruthy();
 			expect(plot.offsetHeight).toBeGreaterThan(0);
 		});
+	});
+});
+
+describe("Remounting", () => {
+	afterEach(() => cleanup());
+
+	// Regression for #10107: the chatbot delivers the same plot as a new object.
+	test("an unchanged payload in a new object does not remount the plot", async () => {
+		const { set_data, getByTestId } = await render(Plot, {
+			...default_props,
+			value: matplotlib_value
+		});
+		await waitFor(() => expect(getByTestId("matplotlib")).toBeInTheDocument());
+		const before = getByTestId("matplotlib");
+
+		await set_data({ value: { ...matplotlib_value } });
+
+		expect(getByTestId("matplotlib")).toBe(before);
+	});
+
+	// The remount itself is deliberate (#9781) and has to survive the fix above.
+	test("a changed payload does remount the plot", async () => {
+		const { set_data, getByTestId } = await render(Plot, {
+			...default_props,
+			value: matplotlib_value
+		});
+		await waitFor(() => expect(getByTestId("matplotlib")).toBeInTheDocument());
+		const before = getByTestId("matplotlib");
+
+		await set_data({
+			value: { ...matplotlib_value, plot: other_matplotlib_plot }
+		});
+
+		await waitFor(() => expect(getByTestId("matplotlib")).not.toBe(before));
 	});
 });
 

--- a/js/plot/shared/Plot.svelte
+++ b/js/plot/shared/Plot.svelte
@@ -47,11 +47,18 @@
 
 	const is_browser = typeof window !== "undefined";
 	let _type = $state(null);
+	let _plot = $state(null);
+	let _chart = $state(null);
 
 	$effect(() => {
 		let type = value?.type;
+		let plot = value?.plot;
+		let chart = value?.chart;
 		untrack(() => {
-			key = key + 1;
+			// Remount only on a payload change; the prop's identity churns (#10107).
+			if (type !== _type || plot !== _plot || chart !== _chart) {
+				key = key + 1;
+			}
 			if (type !== _type) {
 				PlotComponent = null;
 			}
@@ -66,6 +73,8 @@
 				}
 			}
 			_type = type;
+			_plot = plot;
+			_chart = chart;
 		});
 		on_change();
 	});


### PR DESCRIPTION
## Description

A `gr.Plot` inside a `gr.Chatbot` message was torn down and rebuilt on every streaming update of the chat history. With a bokeh plot that shows up as flickering and as the view flipping between the top and the bottom of the conversation while the reply streams: re-embedding clears the container, so the message height collapses to 0 and grows back on every update. It does land at the bottom once the reply finishes, but everything in between is unusable.

`js/plot/shared/Plot.svelte` wraps the plot in `{#key key}` and its `$effect` incremented `key` on every run. The effect depends on the `value` prop, and `gr.Chatbot` rebuilds its message objects on every update, so `value` arrived as a fresh object holding the same payload roughly 30 times per streamed reply and each one forced a full remount.

The remount is deliberate (added in #9781 so a plot change renders cleanly), so this keeps it and only gates it: `key` now advances when the payload changes (`type`, `plot`, or altair's `chart`) rather than when the prop's object identity changes. `PlotData` is fully described by those fields, and the plot type components already track `value` in place through `$derived`, so nothing else had to move.

Measured with the issue's app on a bokeh plot, over one plain-text turn (31 streaming yields) after the plot was displayed:

| | plot remounts | max distance from bottom |
|---|---|---|
| before | 33 | 493 px |
| after | 0 | 26 px (transient, ends at 0) |

Plotly and matplotlib also went from 33 remounts to 0. They kept their height across the remount, so they never showed the scroll jump, only the wasted re-render.

Closes: #10107

## Testing

Two tests in `js/plot/Plot.test.ts`: an unchanged payload delivered as a new object keeps the same plot element, and a changed payload still replaces it (that second one guards #9781's remount). The first test fails on `main` and passes with this change.

The rest of the frontend unit suite passes locally (77 files, 2137 tests), as do the chatbot tests.

`gr.Plot` renders through only two paths, standalone via `js/plot/Index.svelte` and inside the chatbot via `js/chatbot/shared/Component.svelte`, and both are covered above. Standalone plots see no behaviour change beyond skipping a redundant re-render when the backend re-sends an identical plot. The `change` event still fires exactly as before; it was never tied to the remount.

Two things this deliberately leaves alone. The chatbot's autoscroll still uses a fixed `tick()` + 300 ms timeout, which is fine once the plot stops collapsing its height (the 26 px above is normal lag while content grows). And a wide bokeh figure still overflows the chat bubble, which hannahblair noted on the issue; that is a layout question separate from the scroll reset.

## Before / after Spaces

Same app on both, so the only difference is which gradio it installs. Send `plot`, then send anything else and watch the chat area while the reply streams.

- [Before fix](https://huggingface.co/spaces/hysts-debug/gradio-10107-before) (released 6.20.0)
- [After fix](https://huggingface.co/spaces/hysts-debug/gradio-10107-after) (preview wheel for this PR)

Driving both with the same Playwright probe: 80 plot remounts and up to 600 px away from the bottom on the before Space, 0 remounts and 26 px on the after Space.

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to... investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
