### PR TITLE
AGENTS.md: tell agents not to create changeset files manually

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ Follow these rules when creating or contributing to pull requests:
 
 7. **Submit against `main`.** All PRs target the `main` branch.
 
+8. **Don't write changeset files.** A GitHub Action adds a `.changeset/*.md` file to your branch for you (it appears as an "add changeset" commit from `gradio-pr-bot`). It uses your PR title as the changelog entry and works out the affected packages from the files you changed, so putting a good title on the PR is all that's needed. Writing the file yourself is redundant, and because the bot leaves an existing changeset alone, a hand-written one silently becomes the changelog entry instead of your title. If the entry genuinely needs to differ from the title, use the links in the bot's PR comment to adjust the version bump or the changelog text.
+
 ## Code Style
 
 - Python code is formatted with `ruff`. Run `bash scripts/format_backend.sh`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,9 @@ Follow these rules when creating or contributing to pull requests:
 
 6. **PR title and description should be clear and written in English.** The title should concisely describe *what* the PR does. The description should explain *why*.
 
-7. **Submit against `main`.** All PRs target the `main` branch.
+7. **Don't write changeset files.** A GitHub Action adds `.changeset/*.md` to your branch from the PR title, so a good title is all that's needed. The bot leaves an existing changeset alone, so a hand-written one silently replaces your title in the changelog.
 
-8. **Don't write changeset files.** A GitHub Action adds a `.changeset/*.md` file to your branch for you (it appears as an "add changeset" commit from `gradio-pr-bot`). It uses your PR title as the changelog entry and works out the affected packages from the files you changed, so putting a good title on the PR is all that's needed. Writing the file yourself is redundant, and because the bot leaves an existing changeset alone, a hand-written one silently becomes the changelog entry instead of your title. If the entry genuinely needs to differ from the title, use the links in the bot's PR comment to adjust the version bump or the changelog text.
+8. **Submit against `main`.** All PRs target the `main` branch.
 
 ## Code Style
 


### PR DESCRIPTION
## Description

Adds one rule to the Pull Request Rules in `AGENTS.md`: don't hand-write `.changeset/*.md` files. The `generate-changeset` action already adds one to the branch, using the PR title as the changelog entry and inferring the affected packages from the changed files.

Worth stating explicitly because a hand-written changeset doesn't just add noise — the bot leaves an existing changeset alone rather than overwriting it, so the manual file quietly becomes the changelog entry in place of the PR title. An agent writing one has silently taken over the changelog without anyone deciding that.

What the added text is based on:
- `gradio-pr-bot` commits "add changeset" on PRs that didn't include one (#13668, #13660, #13661).
- The generated summary is the PR title verbatim: #13660's `.changeset/thin-webs-prove.md` reads `fix:Upload recorded audio only once to fix intermittent Content-Length errors when loading recordings`, matching its title exactly; same for #13661.
- The package list is derived per PR from the changed files (`@gradio/audio` for #13660; `@gradio/atoms` + `@gradio/dataframe` for #13661).
- When a changeset is already present the bot adds no commit of its own and reports the existing file — observed on #13681, which included a manual changeset.

No issue for this one, per the template's "unless the fix is very small" — this is a docs-only change requested by a maintainer, so it isn't an unsolicited drive-by edit of the kind the busywork rule is aimed at.

Closes: N/A

## AI Disclosure

- [x] I used AI to... investigate how the changeset action behaves, draft the wording, and write this PR description. Reviewed by me; the behavioral claims above were each checked against the workflow files and merged PR history rather than assumed.

## Testing and Formatting Your Code

Docs-only, no code paths touched. `prettier --check AGENTS.md` passes with the repo config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)