### PR TITLE
Fix: recover unpublished Gradio 6.21.0 release

### DIFF
--- a/.changeset/bright-results-spend.md
+++ b/.changeset/bright-results-spend.md
@@ -1,0 +1,13 @@
+---
+"@gradio/client": patch
+"@gradio/core": patch
+"@gradio/upload": patch
+"@gradio/utils": patch
+"@self/app": patch
+"@self/spa": patch
+"gradio": patch
+---
+
+pr: #13601
+
+feat: Preserve browser-visible proxy origins for frontend assets and API requests, and retain app-level FastAPI root paths.

--- a/.changeset/calm-buttons-render.md
+++ b/.changeset/calm-buttons-render.md
@@ -1,0 +1,8 @@
+---
+"@gradio/html": patch
+"gradio": patch
+---
+
+pr: #13613
+
+fix: Rerun HTML mount behavior when `gr.render` replaces an unkeyed component

--- a/.changeset/fresh-clients-tag.md
+++ b/.changeset/fresh-clients-tag.md
@@ -1,0 +1,7 @@
+---
+"gradio_client": patch
+---
+
+pr: #13614
+
+fix:Restore Git tags for Python `gradio_client` releases

--- a/.changeset/great-ears-grab.md
+++ b/.changeset/great-ears-grab.md
@@ -1,0 +1,7 @@
+---
+"gradio": minor
+---
+
+pr: #13606
+
+feat:Fix spurious separators from empty tokens in `HighlightedText` with `combine_adjacent=True`

--- a/.changeset/itchy-steaks-walk.md
+++ b/.changeset/itchy-steaks-walk.md
@@ -1,0 +1,8 @@
+---
+"@gradio/code": patch
+"gradio": patch
+---
+
+pr: #13605
+
+fix:Fix `gr.Code` not rendering when it has no initial value

--- a/.changeset/pink-news-relax.md
+++ b/.changeset/pink-news-relax.md
@@ -1,0 +1,7 @@
+---
+"gradio": patch
+---
+
+pr: #13607
+
+fix:Fix `gr.State` passing its callable default to event handlers instead of the called value

--- a/.changeset/quiet-chains-continue.md
+++ b/.changeset/quiet-chains-continue.md
@@ -1,0 +1,9 @@
+---
+"@gradio/client": patch
+"@gradio/core": patch
+"gradio": patch
+---
+
+pr: #13620
+
+feat: Fix chained events after cancellation and while the browser tab is hidden.

--- a/.changeset/shy-grapes-grab.md
+++ b/.changeset/shy-grapes-grab.md
@@ -1,0 +1,8 @@
+---
+"@gradio/workflowcanvas": minor
+"gradio": minor
+---
+
+pr: #13590
+
+feat:workflow: fix error banner and textarea visibility

--- a/.changeset/solid-cloths-invent.md
+++ b/.changeset/solid-cloths-invent.md
@@ -16,10 +16,11 @@
 "@self/app": minor
 "@self/component-test": minor
 "@self/spa": minor
-"@self/spaces-test": minor
 "@self/tootils": minor
 "gradio": minor
 "website": minor
 ---
+
+pr: #13329
 
 feat:Make builds go zoom zoom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,5 @@
 # gradio
 
-## 6.21.0
-
-### Features
-
-- [#13601](https://github.com/gradio-app/gradio/pull/13601) [`0ee5cc8`](https://github.com/gradio-app/gradio/commit/0ee5cc80e2915e5a1b074c892490a62f165cd80d) - Preserve browser-visible proxy origins for frontend assets and API requests, and retain app-level FastAPI root paths.  Thanks @abidlabs!
-- [#13620](https://github.com/gradio-app/gradio/pull/13620) [`5200235`](https://github.com/gradio-app/gradio/commit/520023532b66d6fa327da04701da3e02c554fa6e) - Fix chained events after cancellation and while the browser tab is hidden.  Thanks @abidlabs!
-- [#13606](https://github.com/gradio-app/gradio/pull/13606) [`04c5527`](https://github.com/gradio-app/gradio/commit/04c552732c461771d935496533289c82e652330f) - Fix spurious separators from empty tokens in `HighlightedText` with `combine_adjacent=True`.  Thanks @hysts!
-- [#13590](https://github.com/gradio-app/gradio/pull/13590) [`d5ef897`](https://github.com/gradio-app/gradio/commit/d5ef8972dfaa1d4e051f0bb31dc16807a63398d5) - workflow: fix error banner and textarea visibility.  Thanks @hannahblair!
-
-### Fixes
-
-- [#13613](https://github.com/gradio-app/gradio/pull/13613) [`195593e`](https://github.com/gradio-app/gradio/commit/195593ed271795ce21ea8f94b7ec9e441ffd5227) - Rerun HTML mount behavior when `gr.render` replaces an unkeyed component.  Thanks @abidlabs!
-- [#13605](https://github.com/gradio-app/gradio/pull/13605) [`f3889bf`](https://github.com/gradio-app/gradio/commit/f3889bfa9eb8bc61ed680bd2b9baafc41d4fe866) - Fix `gr.Code` not rendering when it has no initial value.  Thanks @hysts!
-- [#13607](https://github.com/gradio-app/gradio/pull/13607) [`c287b7b`](https://github.com/gradio-app/gradio/commit/c287b7bdccdebd7cebf2db66024e06d9dc9a79ba) - Fix `gr.State` passing its callable default to event handlers instead of the called value.  Thanks @hysts!
-
 ## 6.20.0
 
 ### Features

--- a/client/js/CHANGELOG.md
+++ b/client/js/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @gradio/client
 
-## 2.3.2
-
-### Features
-
-- [#13601](https://github.com/gradio-app/gradio/pull/13601) [`0ee5cc8`](https://github.com/gradio-app/gradio/commit/0ee5cc80e2915e5a1b074c892490a62f165cd80d) - Preserve browser-visible proxy origins for frontend assets and API requests, and retain app-level FastAPI root paths.  Thanks @abidlabs!
-- [#13620](https://github.com/gradio-app/gradio/pull/13620) [`5200235`](https://github.com/gradio-app/gradio/commit/520023532b66d6fa327da04701da3e02c554fa6e) - Fix chained events after cancellation and while the browser tab is hidden.  Thanks @abidlabs!
-
 ## 2.3.1
 
 ### Fixes

--- a/client/js/package.json
+++ b/client/js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gradio/client",
-	"version": "2.3.2",
+	"version": "2.3.1",
 	"description": "Gradio API client",
 	"type": "module",
 	"main": "dist/index.cjs",

--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -1,11 +1,5 @@
 # gradio_client
 
-## 2.5.1
-
-### Fixes
-
-- [#13614](https://github.com/gradio-app/gradio/pull/13614) [`643fb05`](https://github.com/gradio-app/gradio/commit/643fb05b51ba5b04be925ec59ab3ee9f2e50ebe5) - Restore Git tags for Python `gradio_client` releases.  Thanks @abidlabs!
-
 ## 2.5.0
 
 ### Features

--- a/client/python/gradio_client/CHANGELOG.md
+++ b/client/python/gradio_client/CHANGELOG.md
@@ -1,11 +1,5 @@
 # gradio_client
 
-## 2.5.1
-
-### Fixes
-
-- [#13614](https://github.com/gradio-app/gradio/pull/13614) [`643fb05`](https://github.com/gradio-app/gradio/commit/643fb05b51ba5b04be925ec59ab3ee9f2e50ebe5) - Restore Git tags for Python `gradio_client` releases.  Thanks @abidlabs!
-
 ## 2.5.0
 
 ### Features

--- a/client/python/gradio_client/package.json
+++ b/client/python/gradio_client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gradio_client",
-	"version": "2.5.1",
+	"version": "2.5.0",
 	"description": "",
 	"python": "true",
 	"main_changeset": true,

--- a/gradio/CHANGELOG.md
+++ b/gradio/CHANGELOG.md
@@ -1,20 +1,5 @@
 # gradio
 
-## 6.21.0
-
-### Features
-
-- [#13601](https://github.com/gradio-app/gradio/pull/13601) [`0ee5cc8`](https://github.com/gradio-app/gradio/commit/0ee5cc80e2915e5a1b074c892490a62f165cd80d) - Preserve browser-visible proxy origins for frontend assets and API requests, and retain app-level FastAPI root paths.  Thanks @abidlabs!
-- [#13620](https://github.com/gradio-app/gradio/pull/13620) [`5200235`](https://github.com/gradio-app/gradio/commit/520023532b66d6fa327da04701da3e02c554fa6e) - Fix chained events after cancellation and while the browser tab is hidden.  Thanks @abidlabs!
-- [#13606](https://github.com/gradio-app/gradio/pull/13606) [`04c5527`](https://github.com/gradio-app/gradio/commit/04c552732c461771d935496533289c82e652330f) - Fix spurious separators from empty tokens in `HighlightedText` with `combine_adjacent=True`.  Thanks @hysts!
-- [#13590](https://github.com/gradio-app/gradio/pull/13590) [`d5ef897`](https://github.com/gradio-app/gradio/commit/d5ef8972dfaa1d4e051f0bb31dc16807a63398d5) - workflow: fix error banner and textarea visibility.  Thanks @hannahblair!
-
-### Fixes
-
-- [#13613](https://github.com/gradio-app/gradio/pull/13613) [`195593e`](https://github.com/gradio-app/gradio/commit/195593ed271795ce21ea8f94b7ec9e441ffd5227) - Rerun HTML mount behavior when `gr.render` replaces an unkeyed component.  Thanks @abidlabs!
-- [#13605](https://github.com/gradio-app/gradio/pull/13605) [`f3889bf`](https://github.com/gradio-app/gradio/commit/f3889bfa9eb8bc61ed680bd2b9baafc41d4fe866) - Fix `gr.Code` not rendering when it has no initial value.  Thanks @hysts!
-- [#13607](https://github.com/gradio-app/gradio/pull/13607) [`c287b7b`](https://github.com/gradio-app/gradio/commit/c287b7bdccdebd7cebf2db66024e06d9dc9a79ba) - Fix `gr.State` passing its callable default to event handlers instead of the called value.  Thanks @hysts!
-
 ## 6.20.0
 
 ### Features

--- a/gradio/package.json
+++ b/gradio/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gradio",
-	"version": "6.21.0",
+	"version": "6.20.0",
 	"description": "This is the package.json",
 	"python": "true"
 }

--- a/js/_spaces-test/CHANGELOG.md
+++ b/js/_spaces-test/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/client@2.3.2
-
-## 0.0.1
-
-### Dependency updates
-
 - @gradio/client@2.3.1
 
 ## 0.0.1

--- a/js/accordion/CHANGELOG.md
+++ b/js/accordion/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.5.39
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/atoms@0.26.0
 

--- a/js/annotatedimage/CHANGELOG.md
+++ b/js/annotatedimage/CHANGELOG.md
@@ -4,14 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.12.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/app/CHANGELOG.md
+++ b/js/app/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @self/app
 
-## 2.2.3
-
-### Features
-
-- [#13601](https://github.com/gradio-app/gradio/pull/13601) [`0ee5cc8`](https://github.com/gradio-app/gradio/commit/0ee5cc80e2915e5a1b074c892490a62f165cd80d) - Preserve browser-visible proxy origins for frontend assets and API requests, and retain app-level FastAPI root paths.  Thanks @abidlabs!
-
-### Dependency updates
-
-- @gradio/client@2.3.2
-- @gradio/core@1.9.1
-
 ## 2.2.2
 
 ### Dependency updates

--- a/js/app/package.json
+++ b/js/app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@self/app",
-	"version": "2.2.3",
+	"version": "2.2.2",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",

--- a/js/atoms/CHANGELOG.md
+++ b/js/atoms/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ## 0.26.0
 
-### Dependency updates
-
-- @gradio/utils@0.13.1
-
-## 0.26.0
-
 ### Features
 
 - [#13543](https://github.com/gradio-app/gradio/pull/13543) [`0533483`](https://github.com/gradio-app/gradio/commit/0533483bccdee38f334a598f18297e8c02966343) - Migrate Image components to Svelte 5.  Thanks @dawoodkhan82!

--- a/js/audio/CHANGELOG.md
+++ b/js/audio/CHANGELOG.md
@@ -4,14 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.24.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/button@0.8.1
 - @gradio/icons@0.16.0

--- a/js/browserstate/CHANGELOG.md
+++ b/js/browserstate/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ## 0.4.0
 
-### Dependency updates
-
-- @gradio/utils@0.13.1
-
-## 0.4.0
-
 ### Features
 
 - [#13526](https://github.com/gradio-app/gradio/pull/13526) [`53cb4ca`](https://github.com/gradio-app/gradio/commit/53cb4cae1ec3521e9170d12867253516413ba37a) - Run `pnpm lint` and `pnpm ts:check` on CI.  Thanks @abidlabs!

--- a/js/button/CHANGELOG.md
+++ b/js/button/CHANGELOG.md
@@ -4,14 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.8.1
-
-### Dependency updates
-
 - @gradio/image@0.28.0
 - @gradio/client@2.3.1
 - @gradio/upload@0.18.1

--- a/js/chatbot/CHANGELOG.md
+++ b/js/chatbot/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 ## 0.32.0
 
-### Dependency updates
-
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.32.0
-
 ### Features
 
 - [#13543](https://github.com/gradio-app/gradio/pull/13543) [`0533483`](https://github.com/gradio-app/gradio/commit/0533483bccdee38f334a598f18297e8c02966343) - Migrate Image components to Svelte 5.  Thanks @dawoodkhan82!

--- a/js/checkbox/CHANGELOG.md
+++ b/js/checkbox/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.8.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/atoms@0.26.0
 

--- a/js/checkboxgroup/CHANGELOG.md
+++ b/js/checkboxgroup/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.12.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/atoms@0.26.0
 

--- a/js/code/CHANGELOG.md
+++ b/js/code/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @gradio/code
 
-## 0.18.2
-
-### Fixes
-
-- [#13605](https://github.com/gradio-app/gradio/pull/13605) [`f3889bf`](https://github.com/gradio-app/gradio/commit/f3889bfa9eb8bc61ed680bd2b9baafc41d4fe866) - Fix `gr.Code` not rendering when it has no initial value.  Thanks @hysts!
-
-### Dependency updates
-
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
 ## 0.18.1
 
 ### Dependency updates

--- a/js/code/package.json
+++ b/js/code/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gradio/code",
-	"version": "0.18.2",
+	"version": "0.18.1",
 	"description": "Gradio UI packages",
 	"type": "module",
 	"author": "",

--- a/js/colorpicker/CHANGELOG.md
+++ b/js/colorpicker/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.5.14
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/column/CHANGELOG.md
+++ b/js/column/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.4.0
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 
 ## 0.4.0

--- a/js/core/CHANGELOG.md
+++ b/js/core/CHANGELOG.md
@@ -1,18 +1,5 @@
 # @gradio/core
 
-## 1.9.1
-
-### Features
-
-- [#13601](https://github.com/gradio-app/gradio/pull/13601) [`0ee5cc8`](https://github.com/gradio-app/gradio/commit/0ee5cc80e2915e5a1b074c892490a62f165cd80d) - Preserve browser-visible proxy origins for frontend assets and API requests, and retain app-level FastAPI root paths.  Thanks @abidlabs!
-- [#13620](https://github.com/gradio-app/gradio/pull/13620) [`5200235`](https://github.com/gradio-app/gradio/commit/520023532b66d6fa327da04701da3e02c554fa6e) - Fix chained events after cancellation and while the browser tab is hidden.  Thanks @abidlabs!
-
-### Dependency updates
-
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
 ## 1.9.0
 
 ### Features

--- a/js/core/package.json
+++ b/js/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gradio/core",
-	"version": "1.9.1",
+	"version": "1.9.0",
 	"type": "module",
 	"devDependencies": {
 		"@gradio/accordion": "workspace:^",

--- a/js/dataframe/CHANGELOG.md
+++ b/js/dataframe/CHANGELOG.md
@@ -4,14 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.24.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/button@0.8.1
 - @gradio/icons@0.16.0

--- a/js/dataset/CHANGELOG.md
+++ b/js/dataset/CHANGELOG.md
@@ -4,14 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.7.1
-
-### Dependency updates
-
 - @gradio/atoms@0.26.0
 - @gradio/client@2.3.1
 - @gradio/upload@0.18.1

--- a/js/datetime/CHANGELOG.md
+++ b/js/datetime/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.4.10
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/dialogue/CHANGELOG.md
+++ b/js/dialogue/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.4.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/downloadbutton/CHANGELOG.md
+++ b/js/downloadbutton/CHANGELOG.md
@@ -4,13 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-
-## 0.5.1
-
-### Dependency updates
-
 - @gradio/button@0.8.1
 - @gradio/client@2.3.1
 

--- a/js/draggable/CHANGELOG.md
+++ b/js/draggable/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.4.0
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 
 ## 0.4.0

--- a/js/dropdown/CHANGELOG.md
+++ b/js/dropdown/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.14.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/fallback/CHANGELOG.md
+++ b/js/fallback/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.6.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/atoms@0.26.0
 

--- a/js/file/CHANGELOG.md
+++ b/js/file/CHANGELOG.md
@@ -4,14 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.15.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/fileexplorer/CHANGELOG.md
+++ b/js/fileexplorer/CHANGELOG.md
@@ -4,14 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.7.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/form/CHANGELOG.md
+++ b/js/form/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.4.1
-
-### Dependency updates
-
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0
 

--- a/js/gallery/CHANGELOG.md
+++ b/js/gallery/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 ## 0.19.0
 
-### Dependency updates
-
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.19.0
-
 ### Features
 
 - [#13566](https://github.com/gradio-app/gradio/pull/13566) [`79b9171`](https://github.com/gradio-app/gradio/commit/79b91718b5c972c174ed042d8b04443bc2274076) - Gallery Download All.  Thanks @dawoodkhan82!

--- a/js/group/CHANGELOG.md
+++ b/js/group/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.3.7
-
-### Dependency updates
-
 - @gradio/utils@0.13.0
 
 ## 0.3.6

--- a/js/highlightedtext/CHANGELOG.md
+++ b/js/highlightedtext/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.12.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/html/CHANGELOG.md
+++ b/js/html/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @gradio/html
 
-## 0.13.2
-
-### Fixes
-
-- [#13613](https://github.com/gradio-app/gradio/pull/13613) [`195593e`](https://github.com/gradio-app/gradio/commit/195593ed271795ce21ea8f94b7ec9e441ffd5227) - Rerun HTML mount behavior when `gr.render` replaces an unkeyed component.  Thanks @abidlabs!
-
-### Dependency updates
-
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-
 ## 0.13.1
 
 ### Fixes

--- a/js/html/package.json
+++ b/js/html/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gradio/html",
-	"version": "0.13.2",
+	"version": "0.13.1",
 	"description": "Gradio UI packages",
 	"type": "module",
 	"author": "",

--- a/js/image/CHANGELOG.md
+++ b/js/image/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 ## 0.28.0
 
-### Dependency updates
-
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.28.0
-
 ### Features
 
 - [#13543](https://github.com/gradio-app/gradio/pull/13543) [`0533483`](https://github.com/gradio-app/gradio/commit/0533483bccdee38f334a598f18297e8c02966343) - Migrate Image components to Svelte 5.  Thanks @dawoodkhan82!

--- a/js/imageeditor/CHANGELOG.md
+++ b/js/imageeditor/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 ## 0.20.0
 
-### Dependency updates
-
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.20.0
-
 ### Features
 
 - [#13543](https://github.com/gradio-app/gradio/pull/13543) [`0533483`](https://github.com/gradio-app/gradio/commit/0533483bccdee38f334a598f18297e8c02966343) - Migrate Image components to Svelte 5.  Thanks @dawoodkhan82!

--- a/js/imageslider/CHANGELOG.md
+++ b/js/imageslider/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 ## 0.7.0
 
-### Dependency updates
-
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.7.0
-
 ### Features
 
 - [#13543](https://github.com/gradio-app/gradio/pull/13543) [`0533483`](https://github.com/gradio-app/gradio/commit/0533483bccdee38f334a598f18297e8c02966343) - Migrate Image components to Svelte 5.  Thanks @dawoodkhan82!

--- a/js/json/CHANGELOG.md
+++ b/js/json/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.8.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/label/CHANGELOG.md
+++ b/js/label/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.7.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/markdown/CHANGELOG.md
+++ b/js/markdown/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.14.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/model3D/CHANGELOG.md
+++ b/js/model3D/CHANGELOG.md
@@ -4,14 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.18.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/multimodaltextbox/CHANGELOG.md
+++ b/js/multimodaltextbox/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 ## 0.14.0
 
-### Dependency updates
-
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.14.0
-
 ### Features
 
 - [#13543](https://github.com/gradio-app/gradio/pull/13543) [`0533483`](https://github.com/gradio-app/gradio/commit/0533483bccdee38f334a598f18297e8c02966343) - Migrate Image components to Svelte 5.  Thanks @dawoodkhan82!

--- a/js/nativeplot/CHANGELOG.md
+++ b/js/nativeplot/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.12.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/navbar/CHANGELOG.md
+++ b/js/navbar/CHANGELOG.md
@@ -4,13 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-- @gradio/core@1.9.1
-
-## 0.3.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/atoms@0.26.0
 - @gradio/core@1.9.0

--- a/js/number/CHANGELOG.md
+++ b/js/number/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.9.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/atoms@0.26.0
 

--- a/js/paramviewer/CHANGELOG.md
+++ b/js/paramviewer/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.10.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/atoms@0.26.0
 

--- a/js/plot/CHANGELOG.md
+++ b/js/plot/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ## 0.12.1
 
-### Dependency updates
-
-- @gradio/utils@0.13.1
-
-## 0.12.1
-
 ### Fixes
 
 - [#13540](https://github.com/gradio-app/gradio/pull/13540) [`98de45e`](https://github.com/gradio-app/gradio/commit/98de45e708305563f79614221aede2bf5d863922) - Fix gr.Plot collapsing to zero height for autosize Plotly figures.  Thanks @hysts!

--- a/js/radio/CHANGELOG.md
+++ b/js/radio/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.12.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/atoms@0.26.0
 

--- a/js/row/CHANGELOG.md
+++ b/js/row/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.4.0
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 
 ## 0.4.0

--- a/js/sidebar/CHANGELOG.md
+++ b/js/sidebar/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.2.10
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/atoms@0.26.0
 

--- a/js/simpledropdown/CHANGELOG.md
+++ b/js/simpledropdown/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.5.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/simpleimage/CHANGELOG.md
+++ b/js/simpleimage/CHANGELOG.md
@@ -4,14 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.10.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/simpletextbox/CHANGELOG.md
+++ b/js/simpletextbox/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.4.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/slider/CHANGELOG.md
+++ b/js/slider/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.8.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/atoms@0.26.0
 

--- a/js/spa/CHANGELOG.md
+++ b/js/spa/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @self/spa
 
-## 1.5.2
-
-### Features
-
-- [#13601](https://github.com/gradio-app/gradio/pull/13601) [`0ee5cc8`](https://github.com/gradio-app/gradio/commit/0ee5cc80e2915e5a1b074c892490a62f165cd80d) - Preserve browser-visible proxy origins for frontend assets and API requests, and retain app-level FastAPI root paths.  Thanks @abidlabs!
-
-### Dependency updates
-
-- @gradio/client@2.3.2
-- @gradio/core@1.9.1
-
 ## 1.5.1
 
 ### Fixes

--- a/js/spa/package.json
+++ b/js/spa/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@self/spa",
-	"version": "1.5.2",
+	"version": "1.5.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/js/state/CHANGELOG.md
+++ b/js/state/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.2.4
-
-### Dependency updates
-
 - @gradio/utils@0.13.0
 
 ## 0.2.3

--- a/js/statustracker/CHANGELOG.md
+++ b/js/statustracker/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.15.1
-
-### Dependency updates
-
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0
 

--- a/js/statustracker/package.json
+++ b/js/statustracker/package.json
@@ -18,7 +18,7 @@
 	"dependencies": {
 		"@gradio/atoms": "workspace:^",
 		"@gradio/icons": "workspace:^",
-		"@gradio/sanitize": "^0.2.0",
+		"@gradio/sanitize": "workspace:^",
 		"@gradio/utils": "workspace:^"
 	},
 	"devDependencies": {

--- a/js/tabitem/CHANGELOG.md
+++ b/js/tabitem/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.8.2
-
-### Dependency updates
-
 - @gradio/tabs@0.9.0
 
 ## 0.8.1

--- a/js/tabs/CHANGELOG.md
+++ b/js/tabs/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ## 0.9.0
 
-### Dependency updates
-
-- @gradio/utils@0.13.1
-
-## 0.9.0
-
 ### Features
 
 - [#13543](https://github.com/gradio-app/gradio/pull/13543) [`0533483`](https://github.com/gradio-app/gradio/commit/0533483bccdee38f334a598f18297e8c02966343) - Migrate Image components to Svelte 5.  Thanks @dawoodkhan82!

--- a/js/textbox/CHANGELOG.md
+++ b/js/textbox/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.14.1
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/icons@0.16.0
 - @gradio/atoms@0.26.0

--- a/js/timer/CHANGELOG.md
+++ b/js/timer/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.5.1
-
-### Dependency updates
-
 - @gradio/utils@0.13.0
 
 ## 0.5.0

--- a/js/tootils/CHANGELOG.md
+++ b/js/tootils/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/utils@0.13.1
-
-## 0.15.0
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 
 ## 0.15.0

--- a/js/upload/CHANGELOG.md
+++ b/js/upload/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @gradio/upload
 
-## 0.18.2
-
-### Features
-
-- [#13601](https://github.com/gradio-app/gradio/pull/13601) [`0ee5cc8`](https://github.com/gradio-app/gradio/commit/0ee5cc80e2915e5a1b074c892490a62f165cd80d) - Preserve browser-visible proxy origins for frontend assets and API requests, and retain app-level FastAPI root paths.  Thanks @abidlabs!
-
-### Dependency updates
-
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-
 ## 0.18.1
 
 ### Fixes

--- a/js/upload/package.json
+++ b/js/upload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gradio/upload",
-	"version": "0.18.2",
+	"version": "0.18.1",
 	"description": "Gradio UI packages",
 	"type": "module",
 	"main": "src/index.ts",

--- a/js/uploadbutton/CHANGELOG.md
+++ b/js/uploadbutton/CHANGELOG.md
@@ -4,14 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.10.1
-
-### Dependency updates
-
 - @gradio/button@0.8.1
 - @gradio/client@2.3.1
 - @gradio/upload@0.18.1

--- a/js/utils/CHANGELOG.md
+++ b/js/utils/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @gradio/utils
 
-## 0.13.1
-
-### Features
-
-- [#13601](https://github.com/gradio-app/gradio/pull/13601) [`0ee5cc8`](https://github.com/gradio-app/gradio/commit/0ee5cc80e2915e5a1b074c892490a62f165cd80d) - Preserve browser-visible proxy origins for frontend assets and API requests, and retain app-level FastAPI root paths.  Thanks @abidlabs!
-
 ## 0.13.0
 
 ### Features

--- a/js/utils/package.json
+++ b/js/utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gradio/utils",
-	"version": "0.13.1",
+	"version": "0.13.0",
 	"description": "Gradio UI packages",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/js/vibeeditor/CHANGELOG.md
+++ b/js/vibeeditor/CHANGELOG.md
@@ -4,13 +4,6 @@
 
 ### Dependency updates
 
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-
-## 0.3.12
-
-### Dependency updates
-
 - @gradio/statustracker@0.15.1
 - @gradio/atoms@0.26.0
 - @gradio/client@2.3.1

--- a/js/video/CHANGELOG.md
+++ b/js/video/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 ## 0.22.0
 
-### Dependency updates
-
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-- @gradio/upload@0.18.2
-
-## 0.22.0
-
 ### Features
 
 - [#13543](https://github.com/gradio-app/gradio/pull/13543) [`0533483`](https://github.com/gradio-app/gradio/commit/0533483bccdee38f334a598f18297e8c02966343) - Migrate Image components to Svelte 5.  Thanks @dawoodkhan82!

--- a/js/workflowcanvas/CHANGELOG.md
+++ b/js/workflowcanvas/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @gradio/workflowcanvas
 
-## 0.6.0
-
-### Features
-
-- [#13590](https://github.com/gradio-app/gradio/pull/13590) [`d5ef897`](https://github.com/gradio-app/gradio/commit/d5ef8972dfaa1d4e051f0bb31dc16807a63398d5) - workflow: fix error banner and textarea visibility.  Thanks @hannahblair!
-
-### Dependency updates
-
-- @gradio/client@2.3.2
-- @gradio/utils@0.13.1
-
 ## 0.5.0
 
 ### Features

--- a/js/workflowcanvas/package.json
+++ b/js/workflowcanvas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gradio/workflowcanvas",
-	"version": "0.6.0",
+	"version": "0.5.0",
 	"description": "Gradio Workflow Canvas component",
 	"type": "module",
 	"author": "",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2291,8 +2291,8 @@ importers:
         specifier: workspace:^
         version: link:../icons
       '@gradio/sanitize':
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: workspace:^
+        version: link:../sanitize
       '@gradio/utils':
         specifier: workspace:^
         version: link:../utils
@@ -3602,9 +3602,6 @@ packages:
 
   '@formatjs/intl-localematcher@0.6.2':
     resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
-
-  '@gradio/sanitize@0.2.0':
-    resolution: {integrity: sha512-fb8v4s/YHhCRF+4d3xTAtaW2z9G2xUJBlWpKwc0vAK7GL/eSKLtNKnWNjgkiRIHzpwT4PZEvWa7WxuTMoJgj+Q==}
 
   '@huggingface/hub@1.1.2':
     resolution: {integrity: sha512-Jf4GhvVj9ABDw4Itb3BV1T7f22iewuZva476qTicQ4kOTbosuUuFDhsVH7ZH6rVNgg20Ll9kaNBF5CXjySIT+w==}
@@ -9680,11 +9677,6 @@ snapshots:
   '@formatjs/intl-localematcher@0.6.2':
     dependencies:
       tslib: 2.8.1
-
-  '@gradio/sanitize@0.2.0':
-    dependencies:
-      amuchina: 1.0.12
-      sanitize-html: 2.17.0
 
   '@huggingface/hub@1.1.2':
     dependencies:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ audioop-lts<=0.2.2; python_version >= "3.13" # this is a replacement for the bui
 brotli>=1.1.0
 fastapi>=0.115.2,<1.0
 groovy~=0.1
-gradio_client==2.5.1
+gradio_client==2.5.0
 hf-gradio>=0.4.1,<1.0
 httpx>=0.24.1,<1.0
 huggingface_hub>=1.16.0,<2.0


### PR DESCRIPTION
## Description

Recover the unpublished Gradio 6.21.0 release after #13609 updated the repository's release metadata but the package publishing jobs did not run.

- revert only the generated release metadata from #13609, preserving the feature and fix commits included in that release
- restore the consumed changesets and their original PR attribution so Changesets can regenerate the release from 6.20.0
- repair the mixed ignored/non-ignored changeset that prevented `changeset status` from completing
- make `@gradio/statustracker` consume `@gradio/sanitize` through the workspace so the release lockfile can resolve the pending package version

The release workflow was regenerated in a disposable worktree. It produced Gradio 6.21.0, produced `gradio_client` 2.6.0 from the currently pending client changesets, and consumed every release changeset.

Closes: #13689

## AI Disclosure

- [x] I used AI to diagnose the failed release, prepare and self-review the recovery changes, run validation, and draft this PR.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This recovery targets and closes #13689.

## Testing and Formatting Your Code

- `GITHUB_TOKEN=*** pnpm ci:version` in a disposable worktree
- `pnpm install --lockfile-only --offline --frozen-lockfile`
- `git diff --check`
- `bash scripts/format_frontend.sh` (formatting passed; its repository-wide `pnpm ts:check` step reports 16 pre-existing errors in files untouched by this PR)

## Operational note

While preparing this branch, the repository's configured push refspec unexpectedly mapped the first branch push to `main`. The recovery commit was immediately reverted by c3c5c67f4, restoring `main` to the exact tree it had before that push, and the recovery commit was then pushed explicitly to `refs/heads/codex/recover-6-21`.
