### PR TITLE
Let embedded apps shrink back after stretched content stops needing the room

### DIFF
--- a/.changeset/dull-corners-shout.md
+++ b/.changeset/dull-corners-shout.md
@@ -1,0 +1,6 @@
+---
+"@gradio/core": patch
+"gradio": patch
+---
+
+fix:Let embedded apps shrink back after stretched content stops needing the room

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -28,6 +28,7 @@
 	import * as screen_recorder from "./screen_recorder";
 
 	import { DependencyManager } from "./dependency";
+	import { create_resize_state, next_frame_height } from "./resize";
 	type AddNewMessage = (
 		title: string,
 		message: string,
@@ -403,42 +404,35 @@
 		return container.children[container.children.length - 1] as HTMLElement;
 	}
 
-	let last_reported_height = 0;
-	let consecutive_grows = 0;
+	const resize_state = create_resize_state();
+	let mutation_observer: MutationObserver | null = null;
+
+	// Drop the `fill_height` stretch for a single synchronous measurement. It is
+	// restored before anything is painted, so the collapsed state is never shown.
+	function measure_unstretched_bottom(el: HTMLElement): number {
+		const previous = el.style.flexGrow;
+		el.style.flexGrow = "0";
+		const bottom = el.getBoundingClientRect().bottom;
+		el.style.flexGrow = previous;
+		// Drop the records for our own two style writes so they don't re-trigger us.
+		mutation_observer?.takeRecords();
+		return bottom;
+	}
 
 	function handle_resize(): void {
 		if (!("parentIFrame" in window)) return;
-		const box = root_container.children[0].getBoundingClientRect();
+		const el = root_container.children[0] as HTMLElement;
+		const box = el?.getBoundingClientRect();
 		if (!box) return;
-		const next = box.bottom + footer_height + 32;
-		const viewport = window.innerHeight;
 
-		// Ignore sub-pixel echoes from our own resize.
-		if (Math.abs(next - last_reported_height) < 2) {
-			consecutive_grows = 0;
-			return;
-		}
+		const next = next_frame_height(resize_state, {
+			stretched_bottom: box.bottom,
+			measure_unstretched_bottom: () => measure_unstretched_bottom(el),
+			footer_height,
+			viewport: window.innerHeight
+		});
 
-		if (next > last_reported_height) {
-			// Content sized in viewport-relative units (`vh`/`%`) or stretched by
-			// `fill_height` grows to fill whatever height the iframe is given, so its
-			// measured bottom just tracks the viewport. Requesting a larger size in
-			// that case feeds back into an unbounded growth loop (#12089, #12992).
-			// (a) If the content merely fills the viewport (no real overflow), don't grow.
-			if (next > viewport && box.bottom <= viewport + 2) return;
-			// (b) Circuit breaker: if we keep growing tick after tick, the content is
-			// tracking the iframe we just grew (a feedback loop), not genuinely taller
-			// content. Stop growing so the height stays bounded. Legitimate content
-			// (late-loading images, revealed blocks) settles within a few grows.
-			consecutive_grows += 1;
-			if (consecutive_grows > 4) return;
-		} else {
-			// Shrinking to fit shorter content is always safe and breaks any loop.
-			consecutive_grows = 0;
-		}
-
-		last_reported_height = next;
-		window.parentIFrame?.size(next);
+		if (next !== null) window.parentIFrame?.size(next);
 	}
 
 	function screen_recording(): void {
@@ -459,10 +453,10 @@
 			window.parentIFrame?.autoResize(false);
 		}
 
-		const mut = new MutationObserver(handle_resize);
+		mutation_observer = new MutationObserver(handle_resize);
 		const res = new ResizeObserver(handle_resize);
 
-		mut.observe(root_container, {
+		mutation_observer.observe(root_container, {
 			childList: true,
 			subtree: true,
 			attributes: true
@@ -479,7 +473,8 @@
 		}
 
 		return () => {
-			mut.disconnect();
+			mutation_observer?.disconnect();
+			mutation_observer = null;
 			res.disconnect();
 			if (reconnect_interval) clearInterval(reconnect_interval);
 		};

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -421,12 +421,11 @@
 
 	function handle_resize(): void {
 		if (!("parentIFrame" in window)) return;
-		const el = root_container.children[0] as HTMLElement;
-		const box = el?.getBoundingClientRect();
-		if (!box) return;
+		const el = root_container.children[0] as HTMLElement | undefined;
+		if (!el) return;
 
 		const next = next_frame_height(resize_state, {
-			stretched_bottom: box.bottom,
+			stretched_bottom: el.getBoundingClientRect().bottom,
 			measure_unstretched_bottom: () => measure_unstretched_bottom(el),
 			footer_height,
 			viewport: window.innerHeight

--- a/js/core/src/resize.test.ts
+++ b/js/core/src/resize.test.ts
@@ -71,17 +71,15 @@ class Frame {
 }
 
 describe("next_frame_height", () => {
-	test("sizes the frame to the content", () => {
+	test("follows content that grows and shrinks again", () => {
 		const frame = new Frame(800);
 		frame.settle(rigid(108));
 		expect(frame.viewport).toBe(161);
-	});
-
-	test("grows for content that genuinely overflows", () => {
-		const frame = new Frame(800);
-		frame.settle(rigid(108));
 		frame.settle(rigid(1000));
 		expect(frame.viewport).toBe(1053);
+		// Content that does not stretch is not held to the parent's height.
+		frame.settle(rigid(108));
+		expect(frame.viewport).toBe(161);
 	});
 
 	// gradio-app/gradio#8771

--- a/js/core/src/resize.test.ts
+++ b/js/core/src/resize.test.ts
@@ -186,4 +186,18 @@ describe("next_frame_height", () => {
 		frame.settle(stretchy(700, 0), 20);
 		expect(frame.viewport).toBe(800);
 	});
+
+	test("gives up after a few grows when the content keeps outgrowing the frame", () => {
+		const frame = new Frame(800);
+		let needs = 900;
+		const creeping: Content = () => {
+			needs += 100;
+			return { stretched_bottom: needs, unstretched_bottom: needs };
+		};
+		for (let i = 0; i < 20; i++) {
+			frame.tick(creeping);
+			frame.apply();
+		}
+		expect(frame.reports.length).toBeLessThanOrEqual(5);
+	});
 });

--- a/js/core/src/resize.test.ts
+++ b/js/core/src/resize.test.ts
@@ -6,10 +6,7 @@ interface Content {
 	(viewport: number): { stretched_bottom: number; unstretched_bottom: number };
 }
 
-/**
- * Content stretched by `fill_height`: it fills the frame when it fits, and
- * overflows by its own height when it does not.
- */
+/** `fill_height` content: fills the frame when it fits, overflows when it does not. */
 function stretchy(needs: number, footer = 21): Content {
 	return (viewport) => ({
 		stretched_bottom: Math.max(needs, viewport - footer - FRAME_SLACK),
@@ -17,7 +14,6 @@ function stretchy(needs: number, footer = 21): Content {
 	});
 }
 
-/** Content with a height of its own, unaffected by the height of the frame. */
 function rigid(needs: number): Content {
 	return () => ({ stretched_bottom: needs, unstretched_bottom: needs });
 }
@@ -28,11 +24,8 @@ const viewport_sized: Content = (viewport) => ({
 	unstretched_bottom: viewport
 });
 
-/**
- * The app inside a frame the parent resizes on request. The parent does not
- * apply a size the moment it is asked, so ticks in between still see the old
- * viewport - the case that makes this logic tricky.
- */
+/** The parent does not apply a size the moment it is asked, so ticks in between
+ * still see the old viewport. That delay is what makes this logic tricky. */
 class Frame {
 	viewport: number;
 	footer: number;
@@ -60,7 +53,6 @@ class Frame {
 		return next;
 	}
 
-	/** The parent gets round to applying the last size we asked for. */
 	apply(): void {
 		if (this.requested !== null) {
 			this.viewport = Math.ceil(this.requested);
@@ -68,7 +60,6 @@ class Frame {
 		}
 	}
 
-	/** Run the observer loop, with ticks landing either side of the parent. */
 	settle(content: Content, rounds = 8): void {
 		for (let i = 0; i < rounds; i++) {
 			this.tick(content);
@@ -107,20 +98,15 @@ describe("next_frame_height", () => {
 		}
 	});
 
-	// A tick between asking for a smaller frame and the parent applying it still
-	// sees the old, tall viewport. Reading that as the content's own height grows
-	// the frame straight back, which left #8771 fixed only on the first toggle.
 	test("does not grow back while its own shrink request is in flight", () => {
 		const frame = new Frame(800);
 		frame.settle(stretchy(747));
 		frame.settle(stretchy(1127));
 		const grown = frame.viewport;
 
-		// The accordion closes and we ask for the smaller frame.
 		frame.tick(stretchy(747));
 		expect(frame.requested).toBe(800);
 
-		// More ticks arrive before the parent has resized anything.
 		expect(frame.tick(stretchy(747))).toBe(null);
 		expect(frame.tick(stretchy(747))).toBe(null);
 		expect(frame.viewport).toBe(grown);
@@ -134,7 +120,6 @@ describe("next_frame_height", () => {
 		const frame = new Frame(800);
 		frame.settle(stretchy(747));
 		frame.settle(stretchy(1127));
-		// The content now needs almost nothing, but the parent asked for 800.
 		frame.settle(stretchy(100));
 		expect(frame.viewport).toBe(800);
 	});
@@ -148,7 +133,6 @@ describe("next_frame_height", () => {
 		frame.settle(stretchy(1347));
 		expect(frame.viewport).toBe(1400);
 
-		// Overflow and come back: we return to 1400, not to 800.
 		frame.settle(stretchy(1800));
 		expect(frame.viewport).toBeGreaterThan(1800);
 		frame.settle(stretchy(600));
@@ -175,8 +159,7 @@ describe("next_frame_height", () => {
 		expect(frame.reports).toEqual([]);
 	});
 
-	// gradio-app/gradio#12992: `fill_height` with `footer_links=[]`, where no
-	// footer height masks the slack the app adds to its own measurement.
+	// gradio-app/gradio#12992 (`fill_height` with `footer_links=[]`)
 	test("does not grow for stretched content when there is no footer", () => {
 		const frame = new Frame(800, 0);
 		frame.settle(stretchy(700, 0), 20);

--- a/js/core/src/resize.test.ts
+++ b/js/core/src/resize.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test, vi } from "vitest";
+import { create_resize_state, next_frame_height, FRAME_SLACK } from "./resize";
+import type { ResizeState } from "./resize";
+
+interface Content {
+	(viewport: number): { stretched_bottom: number; unstretched_bottom: number };
+}
+
+/**
+ * Content stretched by `fill_height`: it fills the frame when it fits, and
+ * overflows by its own height when it does not.
+ */
+function stretchy(needs: number, footer = 21): Content {
+	return (viewport) => ({
+		stretched_bottom: Math.max(needs, viewport - footer - FRAME_SLACK),
+		unstretched_bottom: needs
+	});
+}
+
+/** Content with a height of its own, unaffected by the height of the frame. */
+function rigid(needs: number): Content {
+	return () => ({ stretched_bottom: needs, unstretched_bottom: needs });
+}
+
+/** `height: 100vh` content: its bottom tracks the frame, stretched or not. */
+const viewport_sized: Content = (viewport) => ({
+	stretched_bottom: viewport,
+	unstretched_bottom: viewport
+});
+
+/**
+ * The app inside a frame the parent resizes on request. The parent does not
+ * apply a size the moment it is asked, so ticks in between still see the old
+ * viewport - the case that makes this logic tricky.
+ */
+class Frame {
+	viewport: number;
+	footer: number;
+	state: ResizeState = create_resize_state();
+	requested: number | null = null;
+	reports: number[] = [];
+
+	constructor(viewport: number, footer = 21) {
+		this.viewport = viewport;
+		this.footer = footer;
+	}
+
+	tick(content: Content): number | null {
+		const m = content(this.viewport);
+		const next = next_frame_height(this.state, {
+			stretched_bottom: m.stretched_bottom,
+			measure_unstretched_bottom: () => m.unstretched_bottom,
+			footer_height: this.footer,
+			viewport: this.viewport
+		});
+		if (next !== null) {
+			this.requested = next;
+			this.reports.push(next);
+		}
+		return next;
+	}
+
+	/** The parent gets round to applying the last size we asked for. */
+	apply(): void {
+		if (this.requested !== null) {
+			this.viewport = Math.ceil(this.requested);
+			this.requested = null;
+		}
+	}
+
+	/** Run the observer loop, with ticks landing either side of the parent. */
+	settle(content: Content, rounds = 8): void {
+		for (let i = 0; i < rounds; i++) {
+			this.tick(content);
+			this.tick(content);
+			this.apply();
+			this.tick(content);
+		}
+	}
+}
+
+describe("next_frame_height", () => {
+	test("sizes the frame to the content", () => {
+		const frame = new Frame(800);
+		frame.settle(rigid(108));
+		expect(frame.viewport).toBe(161);
+	});
+
+	test("grows for content that genuinely overflows", () => {
+		const frame = new Frame(800);
+		frame.settle(rigid(108));
+		frame.settle(rigid(1000));
+		expect(frame.viewport).toBe(1053);
+	});
+
+	// gradio-app/gradio#8771
+	test("returns to the parent's height every time content is revealed and hidden", () => {
+		const frame = new Frame(800);
+		frame.settle(stretchy(747));
+		expect(frame.viewport).toBe(800);
+
+		for (let i = 0; i < 5; i++) {
+			frame.settle(stretchy(1127)); // an accordion opens
+			expect(frame.viewport).toBeGreaterThan(1100);
+			frame.settle(stretchy(747)); // and closes again
+			expect(frame.viewport).toBe(800);
+		}
+	});
+
+	// A tick between asking for a smaller frame and the parent applying it still
+	// sees the old, tall viewport. Reading that as the content's own height grows
+	// the frame straight back, which left #8771 fixed only on the first toggle.
+	test("does not grow back while its own shrink request is in flight", () => {
+		const frame = new Frame(800);
+		frame.settle(stretchy(747));
+		frame.settle(stretchy(1127));
+		const grown = frame.viewport;
+
+		// The accordion closes and we ask for the smaller frame.
+		frame.tick(stretchy(747));
+		expect(frame.requested).toBe(800);
+
+		// More ticks arrive before the parent has resized anything.
+		expect(frame.tick(stretchy(747))).toBe(null);
+		expect(frame.tick(stretchy(747))).toBe(null);
+		expect(frame.viewport).toBe(grown);
+
+		frame.apply();
+		expect(frame.viewport).toBe(800);
+		expect(frame.tick(stretchy(747))).toBe(null);
+	});
+
+	test("never shrinks below the height the parent gave us", () => {
+		const frame = new Frame(800);
+		frame.settle(stretchy(747));
+		frame.settle(stretchy(1127));
+		// The content now needs almost nothing, but the parent asked for 800.
+		frame.settle(stretchy(100));
+		expect(frame.viewport).toBe(800);
+	});
+
+	test("adopts a new floor when the parent resizes the frame itself", () => {
+		const frame = new Frame(800);
+		frame.settle(stretchy(747));
+
+		// The window is resized, so the parent gives us 1400 of its own accord.
+		frame.viewport = 1400;
+		frame.settle(stretchy(1347));
+		expect(frame.viewport).toBe(1400);
+
+		// Overflow and come back: we return to 1400, not to 800.
+		frame.settle(stretchy(1800));
+		expect(frame.viewport).toBeGreaterThan(1800);
+		frame.settle(stretchy(600));
+		expect(frame.viewport).toBe(1400);
+	});
+
+	test("does not measure the unstretched height while the frame is not grown", () => {
+		const state = create_resize_state();
+		const measure = vi.fn(() => 108);
+		next_frame_height(state, {
+			stretched_bottom: 108,
+			measure_unstretched_bottom: measure,
+			footer_height: 21,
+			viewport: 800
+		});
+		expect(measure).not.toHaveBeenCalled();
+	});
+
+	// gradio-app/gradio#12089
+	test("does not grow for content sized in viewport units", () => {
+		const frame = new Frame(800);
+		frame.settle(viewport_sized);
+		expect(frame.viewport).toBe(800);
+		expect(frame.reports).toEqual([]);
+	});
+
+	// gradio-app/gradio#12992: `fill_height` with `footer_links=[]`, where no
+	// footer height masks the slack the app adds to its own measurement.
+	test("does not grow for stretched content when there is no footer", () => {
+		const frame = new Frame(800, 0);
+		frame.settle(stretchy(700, 0), 20);
+		expect(frame.viewport).toBe(800);
+	});
+});

--- a/js/core/src/resize.test.ts
+++ b/js/core/src/resize.test.ts
@@ -139,6 +139,27 @@ describe("next_frame_height", () => {
 		expect(frame.viewport).toBe(1400);
 	});
 
+	test("adopts the parent's height when it resizes while a request is in flight", () => {
+		const frame = new Frame(800);
+		frame.settle(stretchy(747));
+		frame.settle(stretchy(1127));
+
+		// We ask for a smaller frame, but the window is resized before the parent
+		// applies it, so the frame moves somewhere we never asked for.
+		frame.tick(stretchy(747));
+		expect(frame.requested).toBe(800);
+		frame.viewport = 1400;
+		frame.requested = null;
+
+		frame.settle(stretchy(1347));
+		expect(frame.viewport).toBe(1400);
+
+		// The content shrinks again: we come back to the parent's height, not the
+		// one it had before the resize.
+		frame.settle(stretchy(600));
+		expect(frame.viewport).toBe(1400);
+	});
+
 	test("does not measure the unstretched height while the frame is not grown", () => {
 		const state = create_resize_state();
 		const measure = vi.fn(() => 108);

--- a/js/core/src/resize.ts
+++ b/js/core/src/resize.ts
@@ -1,32 +1,22 @@
-/**
- * Height reporting for apps embedded in an auto-sizing iframe (Hugging Face
- * Spaces). The decision is kept separate from the DOM so it can be tested.
- */
+/** Height reporting for apps embedded in an auto-sizing iframe (Spaces). */
 
 /** Reported on top of the content so its bottom is not clipped. */
 export const FRAME_SLACK = 32;
 
 export interface ResizeState {
-	/** The height we last asked the parent frame for. */
 	last_reported_height: number;
-	/** How many ticks in a row we have asked to grow. */
 	consecutive_grows: number;
 	/** The height the parent frame gave us of its own accord. */
 	base_height: number;
 	/** A size we asked for that the parent has not applied yet. */
 	awaiting_height: number | null;
-	/** The viewport at the moment we asked, so we can tell when it moves. */
+	/** The viewport when we asked, so we can tell when the frame moves. */
 	viewport_at_request: number;
 }
 
 export interface Measurement {
-	/** Bottom of the measured element as it is laid out right now. */
 	stretched_bottom: number;
-	/**
-	 * Bottom of the measured element with `fill_height` stretching removed, i.e.
-	 * how much room the content actually needs. Only called when it can change
-	 * the outcome, because measuring it forces a reflow.
-	 */
+	/** Forces a reflow, so it is only called when it can change the outcome. */
 	measure_unstretched_bottom: () => number;
 	footer_height: number;
 	viewport: number;
@@ -42,18 +32,14 @@ export function create_resize_state(): ResizeState {
 	};
 }
 
-/**
- * Decide what height to ask the parent frame for, updating `state`. Returns
- * `null` to leave the frame alone.
- */
+/** The height to ask the parent frame for, or `null` to leave it alone. */
 export function next_frame_height(
 	state: ResizeState,
 	m: Measurement
 ): number | null {
-	// Learn the height the parent wants us to have. Until a size we asked for has
-	// actually been applied, the viewport still shows the old height, and reading
-	// that as a parent-driven resize would pin `base_height` to a height we are
-	// in the middle of giving back.
+	// Until a size we asked for has been applied, the viewport still shows the old
+	// height; reading that as a parent-driven resize would pin `base_height` to a
+	// height we are in the middle of giving back.
 	if (state.awaiting_height !== null) {
 		const landed = Math.abs(m.viewport - state.awaiting_height) < 2;
 		const moved = Math.abs(m.viewport - state.viewport_at_request) >= 2;
@@ -63,16 +49,13 @@ export function next_frame_height(
 	}
 
 	let bottom = m.stretched_bottom;
+	// In a frame we grew ourselves, `fill_height` content fills whatever height it
+	// is given, so only the unstretched bottom says whether it still needs the
+	// room. Keyed off the current frame, not the last request: right after asking
+	// to shrink, the frame is still tall.
 	if (m.viewport > state.base_height + 2) {
-		// The frame we are laid out in is taller than the one the parent wants us
-		// to have, because we grew it earlier. Content stretched by `fill_height`
-		// fills whatever height the frame has, so `stretched_bottom` cannot say
-		// whether the content still needs the extra room - the unstretched bottom
-		// can. This has to key off the current frame rather than what we last
-		// asked for: right after we request a shrink, the frame is still tall.
 		const unstretched = m.measure_unstretched_bottom();
 		if (unstretched < bottom) {
-			// Give the room back, but never more than we took.
 			bottom = Math.max(
 				unstretched,
 				state.base_height - m.footer_height - FRAME_SLACK

--- a/js/core/src/resize.ts
+++ b/js/core/src/resize.ts
@@ -1,0 +1,113 @@
+/**
+ * Height reporting for apps embedded in an auto-sizing iframe (Hugging Face
+ * Spaces). The decision is kept separate from the DOM so it can be tested.
+ */
+
+/** Reported on top of the content so its bottom is not clipped. */
+export const FRAME_SLACK = 32;
+
+export interface ResizeState {
+	/** The height we last asked the parent frame for. */
+	last_reported_height: number;
+	/** How many ticks in a row we have asked to grow. */
+	consecutive_grows: number;
+	/** The height the parent frame gave us of its own accord. */
+	base_height: number;
+	/** A size we asked for that the parent has not applied yet. */
+	awaiting_height: number | null;
+	/** The viewport at the moment we asked, so we can tell when it moves. */
+	viewport_at_request: number;
+}
+
+export interface Measurement {
+	/** Bottom of the measured element as it is laid out right now. */
+	stretched_bottom: number;
+	/**
+	 * Bottom of the measured element with `fill_height` stretching removed, i.e.
+	 * how much room the content actually needs. Only called when it can change
+	 * the outcome, because measuring it forces a reflow.
+	 */
+	measure_unstretched_bottom: () => number;
+	footer_height: number;
+	viewport: number;
+}
+
+export function create_resize_state(): ResizeState {
+	return {
+		last_reported_height: 0,
+		consecutive_grows: 0,
+		base_height: 0,
+		awaiting_height: null,
+		viewport_at_request: 0
+	};
+}
+
+/**
+ * Decide what height to ask the parent frame for, updating `state`. Returns
+ * `null` to leave the frame alone.
+ */
+export function next_frame_height(
+	state: ResizeState,
+	m: Measurement
+): number | null {
+	// Learn the height the parent wants us to have. Until a size we asked for has
+	// actually been applied, the viewport still shows the old height, and reading
+	// that as a parent-driven resize would pin `base_height` to a height we are
+	// in the middle of giving back.
+	if (state.awaiting_height !== null) {
+		const landed = Math.abs(m.viewport - state.awaiting_height) < 2;
+		const moved = Math.abs(m.viewport - state.viewport_at_request) >= 2;
+		if (landed || moved) state.awaiting_height = null;
+	} else if (Math.abs(m.viewport - state.last_reported_height) >= 2) {
+		state.base_height = m.viewport;
+	}
+
+	let bottom = m.stretched_bottom;
+	if (m.viewport > state.base_height + 2) {
+		// The frame we are laid out in is taller than the one the parent wants us
+		// to have, because we grew it earlier. Content stretched by `fill_height`
+		// fills whatever height the frame has, so `stretched_bottom` cannot say
+		// whether the content still needs the extra room - the unstretched bottom
+		// can. This has to key off the current frame rather than what we last
+		// asked for: right after we request a shrink, the frame is still tall.
+		const unstretched = m.measure_unstretched_bottom();
+		if (unstretched < bottom) {
+			// Give the room back, but never more than we took.
+			bottom = Math.max(
+				unstretched,
+				state.base_height - m.footer_height - FRAME_SLACK
+			);
+		}
+	}
+
+	const next = bottom + m.footer_height + FRAME_SLACK;
+
+	// Ignore sub-pixel echoes from our own resize.
+	if (Math.abs(next - state.last_reported_height) < 2) {
+		state.consecutive_grows = 0;
+		return null;
+	}
+
+	if (next > state.last_reported_height) {
+		// Content sized in viewport-relative units (`vh`/`%`) or stretched by
+		// `fill_height` grows to fill whatever height the iframe is given, so its
+		// measured bottom just tracks the viewport. Requesting a larger size in
+		// that case feeds back into an unbounded growth loop (#12089, #12992).
+		// (a) If the content merely fills the viewport (no real overflow), don't grow.
+		if (next > m.viewport && bottom <= m.viewport + 2) return null;
+		// (b) Circuit breaker: if we keep growing tick after tick, the content is
+		// tracking the iframe we just grew (a feedback loop), not genuinely taller
+		// content. Stop growing so the height stays bounded. Legitimate content
+		// (late-loading images, revealed blocks) settles within a few grows.
+		state.consecutive_grows += 1;
+		if (state.consecutive_grows > 4) return null;
+	} else {
+		// Shrinking to fit shorter content is always safe and breaks any loop.
+		state.consecutive_grows = 0;
+	}
+
+	state.last_reported_height = next;
+	state.awaiting_height = next;
+	state.viewport_at_request = m.viewport;
+	return next;
+}

--- a/js/core/src/resize.ts
+++ b/js/core/src/resize.ts
@@ -43,7 +43,13 @@ export function next_frame_height(
 	if (state.awaiting_height !== null) {
 		const landed = Math.abs(m.viewport - state.awaiting_height) < 2;
 		const moved = Math.abs(m.viewport - state.viewport_at_request) >= 2;
-		if (landed || moved) state.awaiting_height = null;
+		if (landed) {
+			state.awaiting_height = null;
+		} else if (moved) {
+			// Somewhere we never asked for, so the parent moved us itself.
+			state.awaiting_height = null;
+			state.base_height = m.viewport;
+		}
 	} else if (Math.abs(m.viewport - state.last_reported_height) >= 2) {
 		state.base_height = m.viewport;
 	}


### PR DESCRIPTION

## Description

On Spaces, opening the "Additional Inputs" accordion of a `gr.ChatInterface` and closing it again leaves the chatbot permanently taller: the frame stays expanded and the chatbot soaks up the space the accordion gave back, pushing the textbox out of view.

`handle_resize()` in `js/core/src/Blocks.svelte` sizes the parent frame from the bottom of `root_container.children[0]`. With `fill_height=True` that element stretches to whatever height the frame has, so once the frame has grown, its measured bottom no longer says how much room the content needs. Traced on `main` with the frame starting at 800px:

```
initial      next=800.0   last=800.0   bottom=747.0  viewport=800   -> skip (echo)
open         next=1180.1  last=800.0   bottom=1127.1 viewport=800   -> size(1180.1)
after grow   next=1181.0  last=1180.1  bottom=1128.0 viewport=1181  -> skip (echo)
closed       next=1181.0  last=1180.1  bottom=1128.0 viewport=1181  -> skip (echo)
```

`bottom` is identical whether the accordion is open or closed, so `next` never drops below `last_reported_height` and the shrink branch is unreachable.

The fix takes a second measurement with the stretch removed, only while the frame is taller than the height the parent gave us. The inline `flex-grow` is restored synchronously, before anything is painted. Three rules keep it conservative:

- it is only ever used to shrink, never to grow;
- the app never gives back more than it took, so it cannot shrink below the height the parent chose. That height is re-learned when the parent resizes the frame itself;
- a size the app has asked for but the parent has not applied yet is not read as a parent-driven resize. Ticks in that window still see the old, tall viewport.

All four guards from #13563 are unchanged, and #12089 and #12992 behave exactly as they do on `main` (see Testing). The decision moves as-is into `js/core/src/resize.ts` so it can be tested: the conditions and their comments are unchanged, and the `Blocks.svelte` diff is that move plus the new measurement.

Closes: #8771

This looks like the cause of #11061 as well, which reports the same "once you collapse the height doesn't go back" and was closed for lack of a reproduction. It only shows when the app is embedded in a frame that follows its content height, so it is invisible when the app is opened directly.

## Testing

`js/core/src/resize.test.ts` is new, and is the first test coverage for this logic. It drives the decision through a model of the frame in which the parent applies a requested size a few ticks late, which is where this gets difficult. Five of its ten tests fail if the corresponding logic is removed: four cover this change, and one covers the circuit breaker from #13563, which had no test at all. The rest pin #12089, #12992 and the shrink floor.

The unit tests cannot cover the measurement itself, so I also checked the browser: the app in an iframe driven by iframe-resizer v4, the same handshake Spaces uses, at 1280x900 with the frame starting at 800px, toggling the accordion 25 times with uneven waits (0.1s to 3s).

| | on `main` | with this PR |
|---|---|---|
| `gr.ChatInterface` + accordion | stuck tall from the first toggle, 0/25 returned | 25/25 returned to 800 |
| `height: 100vh` (#12089) | bounded, settles 483-1283 across runs | unchanged |
| `fill_height` + `footer_links=[]` (#12992) | 800, one report | unchanged |
| short app, no `fill_height` | shrinks to 161, grows to 1075 when content is added | unchanged |

The `100vh` case settles at a different height from run to run on `main` too, so I compared several runs of each rather than a single number.

## Before / after Spaces

- [Before fix](https://huggingface.co/spaces/hysts-debug/gradio-8771-before) (released 6.21.0)
- [After fix](https://huggingface.co/spaces/hysts-debug/gradio-8771-after) (this PR's preview wheel)

Same app in both, only the installed gradio differs. Open "Additional Inputs" and close it again.

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to... investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`


