### PR TITLE
Fix release CI regressions for assets and bundles

### DIFF
--- a/.changeset/sixty-radios-turn.md
+++ b/.changeset/sixty-radios-turn.md
@@ -1,0 +1,6 @@
+---
+"@gradio/paramviewer": minor
+"gradio": minor
+---
+
+feat:Fix release CI regressions for assets and bundles

--- a/gradio/cli/commands/components/_create_utils.py
+++ b/gradio/cli/commands/components/_create_utils.py
@@ -273,14 +273,12 @@ def copy_svelte_to_deps(package_json: dict):
 def _modify_js_deps(
     package_json: dict,
     key: Literal["dependencies", "devDependencies"],
-    gradio_dir: Path,
+    component_root: Path,
 ):
     for dep in package_json.get(key, []):
         # if current working directory is the gradio repo, use the local version of the dependency'
         if not _in_test_dir() and dep.startswith("@gradio/"):
-            package_json[key][dep] = _get_js_dependency_version(
-                dep, gradio_dir / "_frontend_code" / gradio.__version__
-            )
+            package_json[key][dep] = _get_js_dependency_version(dep, component_root)
     return package_json
 
 
@@ -294,15 +292,24 @@ def delete_contents(directory: str | Path) -> None:
             shutil.rmtree(child)
 
 
-def _download_from_hub(destination: Path):
+def _download_from_hub() -> Path:
     version = gradio.__version__
 
-    snapshot_download(
-        repo_id="gradio/frontend",
-        allow_patterns=f"{version}/**",
-        local_dir=destination,
-        repo_type="dataset",
+    return Path(
+        snapshot_download(
+            repo_id="gradio/frontend",
+            allow_patterns=f"{version}/**",
+            repo_type="dataset",
+        )
     )
+
+
+def _get_component_root(component: ComponentFiles) -> Path:
+    gradio_dir = Path(inspect.getfile(gradio)).parent
+    component_root = gradio_dir / "_frontend_code" / gradio.__version__
+    if (component_root / component.js_dir).exists():
+        return component_root
+    return _download_from_hub() / gradio.__version__
 
 
 def _create_frontend(
@@ -314,12 +321,7 @@ def _create_frontend(
     frontend = directory / "frontend"
     frontend.mkdir(exist_ok=True)
 
-    p = Path(inspect.getfile(gradio)).parent
-
-    component_source = p / "_frontend_code"
-    if not component_source.exists():
-        component_source.mkdir(exist_ok=True)
-        _download_from_hub(component_source)
+    component_root = _get_component_root(component)
 
     def ignore(_src, names):
         ignored = []
@@ -336,15 +338,19 @@ def _create_frontend(
 
     # Replace once we figure out bug with svelte-package
     shutil.copytree(
-        str(p / "_frontend_code" / gradio.__version__ / component.js_dir),
+        str(component_root / component.js_dir),
         frontend,
         dirs_exist_ok=True,
         ignore=ignore,
     )
     source_package_json = json.loads(Path(frontend / "package.json").read_text())
     source_package_json["name"] = package_name
-    source_package_json = _modify_js_deps(source_package_json, "dependencies", p)
-    source_package_json = _modify_js_deps(source_package_json, "devDependencies", p)
+    source_package_json = _modify_js_deps(
+        source_package_json, "dependencies", component_root
+    )
+    source_package_json = _modify_js_deps(
+        source_package_json, "devDependencies", component_root
+    )
     source_package_json = copy_svelte_to_deps(source_package_json)
 
     (frontend / "package.json").write_text(json.dumps(source_package_json, indent=2))

--- a/gradio/cli/commands/components/create.py
+++ b/gradio/cli/commands/components/create.py
@@ -113,7 +113,7 @@ def _create(
         _create_utils._create_backend(name, component, directory, package_name)
         live.update(":snake: Created backend code", add_sleep=0.2)
         p = Path(inspect.getfile(gradio)).parent
-        component_source = p / "_frontend_code"
+        component_source = p / "_frontend_code" / gradio.__version__ / component.js_dir
         if not component_source.exists():
             live.update(
                 ":fast_down_button: Downloading frontend code from Hugging Face Hub. Set HF_HUB_DISABLE_PROGRESS_BARS to disable progress bars.",

--- a/js/paramviewer/ParamViewer.svelte
+++ b/js/paramviewer/ParamViewer.svelte
@@ -1,33 +1,34 @@
 <script module lang="ts">
-	import Prism from "prismjs";
+	type PrismApi = typeof import("prismjs");
 
-	// `prismjs/components/*` are side-effect scripts: each does
-	// `Prism.languages.x = ...` against a bare global and declares no imports of
-	// its own, so nothing in the module graph orders them after prismjs. As
-	// *static* imports the bundler is free to hoist them into a chunk that
-	// evaluates before the assignment below, and rolldown compounds it by
-	// emitting prismjs as a lazily-invoked CommonJS factory — so importing it
-	// does not initialise it either, and `window.Prism` stayed undefined. Every
-	// docs page then died during hydration on `ReferenceError: Prism is not
-	// defined` (#13677).
-	//
-	// Dynamic imports are not hoisted, so the global below is guaranteed to be in
-	// place before any grammar runs.
-	(globalThis as any).Prism = Prism;
+	let prism: PrismApi | null = null;
+	let prism_languages: Promise<PrismApi> | null = null;
 
-	// Awaited here rather than gated behind a promise: the component must not
-	// render before the grammars are registered. prismjs schedules its own
-	// `highlightAll()` on a rAF as soon as it loads, and without a grammar
-	// `highlightElement` overwrites the element with `encode(textContent)` —
-	// which strips the server's highlighting *and* the hydration comments the
-	// `{@html}` blocks own. Anything derived later then repaints into detached
-	// nodes, so the types stay plain until the component is recreated.
-	try {
-		await import("prismjs/components/prism-python");
-		await import("prismjs/components/prism-typescript");
-	} catch (e) {
-		// `highlight` already falls back to plain text without a grammar.
-		console.error("failed to load Prism grammars", e);
+	function load_prism_languages(): Promise<PrismApi> {
+		if (prism_languages) return prism_languages;
+
+		prism_languages = (async () => {
+			// Prism checks this pre-existing global while its module evaluates.
+			// Manual mode prevents its scheduled highlightAll() from rewriting
+			// Svelte's hydration markers before the grammars are ready.
+			(globalThis as any).Prism = { manual: true };
+			const prism_module = await import("prismjs");
+			const loaded_prism =
+				(
+					prism_module as unknown as {
+						default?: PrismApi;
+					}
+				).default ?? (prism_module as PrismApi);
+			loaded_prism.manual = true;
+			(globalThis as any).Prism = loaded_prism;
+			// @ts-expect-error Prism component modules do not ship declarations.
+			await import("prismjs/components/prism-python");
+			// @ts-expect-error Prism component modules do not ship declarations.
+			await import("prismjs/components/prism-typescript");
+			prism = loaded_prism;
+			return loaded_prism;
+		})();
+		return prism_languages;
 	}
 </script>
 
@@ -60,8 +61,23 @@
 	let component_root: HTMLElement;
 	let all_open = $state(false);
 	let lang: "python" | "typescript" = "python";
+	let prism_ready = $state(prism !== null);
 
-	let _docs = $derived(highlight_code(docs, lang));
+	$effect(() => {
+		let active = true;
+		load_prism_languages()
+			.then(() => {
+				if (active) prism_ready = true;
+			})
+			.catch((e) => {
+				console.error("failed to load Prism grammars", e);
+			});
+		return () => {
+			active = false;
+		};
+	});
+
+	let _docs = $derived(highlight_code(docs, lang, prism_ready));
 
 	function create_slug(name: string, anchor_links: string | boolean): string {
 		let prefix = "param-";
@@ -72,8 +88,8 @@
 	}
 
 	function highlight(code: string, lang: "python" | "typescript"): string {
-		let highlighted = Prism.languages[lang]
-			? Prism.highlight(code, Prism.languages[lang], lang)
+		let highlighted = prism?.languages[lang]
+			? prism.highlight(code, prism.languages[lang], lang)
 			: code;
 
 		for (const link of linkify) {
@@ -88,7 +104,8 @@
 
 	function highlight_code(
 		_docs: typeof docs,
-		lang: "python" | "typescript"
+		lang: "python" | "typescript",
+		_prism_ready: boolean
 	): Param[] {
 		if (!_docs) {
 			return [];

--- a/js/paramviewer/ParamViewer.test.ts
+++ b/js/paramviewer/ParamViewer.test.ts
@@ -1,5 +1,5 @@
 import { test, describe, afterEach, expect, vi } from "vitest";
-import { cleanup, render, fireEvent } from "@self/tootils/render";
+import { cleanup, render, fireEvent, waitFor } from "@self/tootils/render";
 
 import ParamViewer from "./Index.svelte";
 
@@ -37,7 +37,9 @@ describe("ParamViewer", () => {
 	test("renders parameter types alongside names", async () => {
 		const { getByText } = await render(ParamViewer, default_props);
 
-		expect(getByText("float")).toBeVisible();
+		await waitFor(() => {
+			expect(getByText("float")).toBeVisible();
+		});
 	});
 
 	test("renders header text when provided", async () => {

--- a/test/test_docker/test_reverse_proxy/test_reverse_proxy.py
+++ b/test/test_docker/test_reverse_proxy/test_reverse_proxy.py
@@ -58,8 +58,7 @@ def test_load_assets(launch_services):
             assert len(asset_response.text) > 0
             if main_asset.endswith(".js"):
                 js_asset_found = True
-                first_line = asset_response.text.split(";")[0]
-                sub_assets = re.findall(asset_regex, first_line)
+                sub_assets = re.findall(asset_regex, asset_response.text)
                 assert len(sub_assets) > 1
                 random.shuffle(sub_assets)
                 for sub_asset in sub_assets[:5]:

--- a/test/test_docker/test_reverse_proxy_fastapi_mount/test_reverse_proxy_fastapi_mount.py
+++ b/test/test_docker/test_reverse_proxy_fastapi_mount/test_reverse_proxy_fastapi_mount.py
@@ -58,8 +58,7 @@ def test_load_assets(launch_services):
             assert len(asset_response.text) > 0
             if main_asset.endswith(".js"):
                 js_asset_found = True
-                first_line = asset_response.text.split(";")[0]
-                sub_assets = re.findall(asset_regex, first_line)
+                sub_assets = re.findall(asset_regex, asset_response.text)
                 assert len(sub_assets) > 1
                 random.shuffle(sub_assets)
                 for sub_asset in sub_assets[:5]:

--- a/test/test_docker/test_reverse_proxy_fastapi_mount_root_path/test_reverse_proxy_fastapi_mount_root_path.py
+++ b/test/test_docker/test_reverse_proxy_fastapi_mount_root_path/test_reverse_proxy_fastapi_mount_root_path.py
@@ -71,8 +71,7 @@ def test_load_assets(launch_services):
             assert len(asset_response.text) > 0
             if main_asset.endswith(".js"):
                 js_asset_found = True
-                first_line = asset_response.text.split(";")[0]
-                sub_assets = re.findall(asset_regex, first_line)
+                sub_assets = re.findall(asset_regex, asset_response.text)
                 assert len(sub_assets) > 1
                 random.shuffle(sub_assets)
                 for sub_asset in sub_assets[:5]:

--- a/test/test_docker/test_reverse_proxy_root_path/test_reverse_proxy_root_path.py
+++ b/test/test_docker/test_reverse_proxy_root_path/test_reverse_proxy_root_path.py
@@ -58,8 +58,7 @@ def test_load_assets(launch_services):
             assert len(asset_response.text) > 0
             if main_asset.endswith(".js"):
                 js_asset_found = True
-                first_line = asset_response.text.split(";")[0]
-                sub_assets = re.findall(asset_regex, first_line)
+                sub_assets = re.findall(asset_regex, asset_response.text)
                 assert len(sub_assets) > 1
                 random.shuffle(sub_assets)
                 for sub_asset in sub_assets[:5]:

--- a/test/test_gradio_component_cli.py
+++ b/test/test_gradio_component_cli.py
@@ -22,6 +22,51 @@ core = [
 ]
 
 
+def test_component_root_downloads_missing_version_to_snapshot_cache(
+    tmp_path, monkeypatch
+):
+    package_dir = tmp_path / "package"
+    (package_dir / "_frontend_code").mkdir(parents=True)
+    snapshot_dir = tmp_path / "snapshot"
+    expected_root = snapshot_dir / "test-version"
+    (expected_root / "image").mkdir(parents=True)
+    download_count = 0
+
+    def download():
+        nonlocal download_count
+        download_count += 1
+        return snapshot_dir
+
+    monkeypatch.setattr(
+        _create_utils.inspect, "getfile", lambda _module: package_dir / "__init__.py"
+    )
+    monkeypatch.setattr(_create_utils.gradio, "__version__", "test-version")
+    monkeypatch.setattr(_create_utils, "_download_from_hub", download)
+
+    component = _create_utils._get_component_code("Image")
+    assert _create_utils._get_component_root(component) == expected_root
+    assert download_count == 1
+
+
+def test_component_root_uses_complete_local_component(tmp_path, monkeypatch):
+    package_dir = tmp_path / "package"
+    expected_root = package_dir / "_frontend_code" / "test-version"
+    (expected_root / "image").mkdir(parents=True)
+
+    monkeypatch.setattr(
+        _create_utils.inspect, "getfile", lambda _module: package_dir / "__init__.py"
+    )
+    monkeypatch.setattr(_create_utils.gradio, "__version__", "test-version")
+    monkeypatch.setattr(
+        _create_utils,
+        "_download_from_hub",
+        lambda: pytest.fail("complete local component should not be downloaded"),
+    )
+
+    component = _create_utils._get_component_code("Image")
+    assert _create_utils._get_component_root(component) == expected_root
+
+
 @pytest.mark.serial
 @pytest.mark.flaky
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Fixes the CI regressions exposed by the 6.22.0 release PR (#13696):

- makes component-template downloads use the Hugging Face snapshot cache, avoiding cross-worker races when a new Gradio version is not packaged locally
- discovers reverse-proxy sub-assets throughout generated JavaScript instead of assuming they appear before the first semicolon
- loads ParamViewer Prism grammars per component without module-level `await`, keeping the frontend benchmark below its failure threshold

Issue: N/A — omitted at the submitter request for this CI follow-up.

## AI Disclosure

- [x] I used AI to inspect CI logs, implement and test the fixes, and draft this description. I reviewed the complete diff and targeted test results.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This is a focused CI follow-up to #13696. No separate issue was created at the submitter request.

## Testing and Formatting Your Code

- `pytest test/test_gradio_component_cli.py -k 'component_root' -q`
- `pytest test/test_gradio_component_cli.py -k 'do_not_replace_class_name_in_import_statement or build_fails_if_component_not_installed or fallback_template_app' -n 3 --reruns 0 -q`
- `CI=1 npx vitest run --config .config/vitest.config.ts js/paramviewer/ParamViewer.test.ts`
- `pnpm build`
- frontend benchmark: 252 KB transferred JavaScript (+17.8%, below the 25% failure threshold)
- targeted Ruff and Prettier checks

The full frontend type-check still reports pre-existing errors outside the changed ParamViewer files. Docker was unavailable locally, so the reverse-proxy container matrix is delegated to CI.
