### PR TITLE
Emit a `required` array in MCP tool input schemas

### DIFF
--- a/.changeset/public-kids-kneel.md
+++ b/.changeset/public-kids-kneel.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
-feat:Emit a `required` array in MCP tool input schemas
+fix:Emit a `required` array in MCP tool input schemas

--- a/.changeset/public-kids-kneel.md
+++ b/.changeset/public-kids-kneel.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Emit a `required` array in MCP tool input schemas

--- a/gradio/mcp.py
+++ b/gradio/mcp.py
@@ -1270,6 +1270,13 @@ class GradioMCPServer:
                 for p in endpoint_info["parameters"]
             },
         }
+        required = [
+            p["parameter_name"]
+            for p in endpoint_info["parameters"]
+            if not p.get("parameter_has_default", False)
+        ]
+        if required:
+            schema["required"] = required
         return self.simplify_filedata_schema(schema)
 
     async def get_complete_schema(self, request) -> JSONResponse:

--- a/test/test_mcp.py
+++ b/test/test_mcp.py
@@ -139,6 +139,39 @@ def test_simplify_filedata_schema(test_mcp_app):
     assert test_schema == old_schema
 
 
+def test_input_schema_marks_parameters_without_defaults_as_required():
+    with gr.Blocks() as demo:
+
+        @gr.api
+        def mixed(a: str, b: int = 3, c: str | None = None) -> str:
+            return a
+
+        @gr.api
+        def all_optional(a: int = 1) -> int:
+            return a
+
+        no_default = gr.Textbox(label="No Default")
+        with_default = gr.Textbox("hello", label="With Default")
+        output = gr.Textbox()
+
+        def concat(first: str, second: str) -> str:
+            return first + second
+
+        gr.Button().click(concat, [no_default, with_default], output)
+
+    server = GradioMCPServer(demo)
+
+    schema, _ = server.get_input_schema("mixed")
+    assert schema["required"] == ["a"]
+
+    # A component with an initial value counts as a default for its parameter.
+    schema, _ = server.get_input_schema("concat")
+    assert schema["required"] == ["first"]
+
+    schema, _ = server.get_input_schema("all_optional")
+    assert "required" not in schema
+
+
 def test_tool_prefix_character_replacement(test_mcp_app):
     test_cases = [
         ("test-space", "test_space_test_tool"),

--- a/test/test_mcp.py
+++ b/test/test_mcp.py
@@ -147,6 +147,10 @@ def test_input_schema_marks_parameters_without_defaults_as_required():
             return a
 
         @gr.api
+        def multiple_required(a: str, b: int, c: bool = False) -> str:
+            return a
+
+        @gr.api
         def all_optional(a: int = 1) -> int:
             return a
 
@@ -163,6 +167,9 @@ def test_input_schema_marks_parameters_without_defaults_as_required():
 
     schema, _ = server.get_input_schema("mixed")
     assert schema["required"] == ["a"]
+
+    schema, _ = server.get_input_schema("multiple_required")
+    assert schema["required"] == ["a", "b"]
 
     # A component with an initial value counts as a default for its parameter.
     schema, _ = server.get_input_schema("concat")


### PR DESCRIPTION

## Description

`GradioMCPServer.get_input_schema` built the JSON Schema for every published MCP tool but never emitted a `required` array. JSON Schema treats an absent `required` as "nothing is required", so every argument of every tool a Gradio MCP server publishes was advertised as optional, including arguments with no default that the function cannot run without. An MCP client could omit a mandatory argument and produce a call that looked schema-valid.

The data needed was already there: each entry of `endpoint_info["parameters"]` carries `parameter_has_default`, and every other consumer of the API info already derives required-ness from it (`gradio_client`'s `view_api` output, `gradio/cli/commands/skills.py`). This fixes the MCP path to do the same, listing parameters whose `parameter_has_default` is false. The key is omitted entirely when nothing is required, matching what pydantic and FastMCP produce.

Worth noting that this only changes what is *advertised*, not what is *accepted*. The MCP call path already goes through `gradio_client.utils.construct_args`, which raises `No value provided for required argument: <name>` when a parameter without a default is omitted. So the schema was under-describing behaviour the server already enforced, and clients had no way to know which arguments they had to supply.

Before:

```json
{
  "type": "object",
  "properties": {
    "word": {"type": "string", "description": "The word to repeat"}
  }
}
```

After:

```json
{
  "type": "object",
  "properties": {
    "word": {"type": "string", "description": "The word to repeat"}
  },
  "required": ["word"]
}
```

One thing I noticed while investigating but did not touch, in case it is useful: `/gradio_api/openapi.json` has the same omission. `gradio/routes.py` fills the request body's `properties` from the condensed endpoint info but never sets `required`, even though `_condense_info` already computes `"required": not param["parameter_has_default"]` for each parameter. Happy to fix it here too or open a separate issue, whichever you prefer.

Closes: #13670

## Testing

Added `test_input_schema_marks_parameters_without_defaults_as_required` to `test/test_mcp.py`, covering a `@gr.api` endpoint with mixed required/defaulted parameters, an endpoint with two required parameters, a component-backed event (where an initial component value is what supplies the default), and an all-optional endpoint where the `required` key should be absent. It fails on `main` with `KeyError: 'required'`.

`test/test_mcp.py` and `test/test_server.py` pass locally. I also checked the round trip through the real MCP SDK client against a launched app and confirmed `required` arrives intact, and that `simplify_filedata_schema` still reports the same FileData positions with the new key present.

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

