### PR TITLE
Recalculate the sidebar overlap amount on resize

### DIFF
--- a/.changeset/tricky-buttons-think.md
+++ b/.changeset/tricky-buttons-think.md
@@ -1,0 +1,6 @@
+---
+"@gradio/sidebar": patch
+"gradio": patch
+---
+
+fix:Recalculate the sidebar overlap amount on resize

--- a/js/sidebar/Sidebar.test.ts
+++ b/js/sidebar/Sidebar.test.ts
@@ -1,5 +1,5 @@
 import { test, describe, afterEach, expect } from "vitest";
-import { cleanup, render, fireEvent } from "@self/tootils/render";
+import { cleanup, render, fireEvent, waitFor } from "@self/tootils/render";
 
 import Sidebar from "./Index.svelte";
 import SidebarWithChild from "./WithChild.svelte";
@@ -320,6 +320,48 @@ describe("Children / slot", () => {
 		});
 		// {#if visible} removes the entire sidebar from the DOM, including slot children
 		expect(queryByTestId("slot-content")).not.toBeInTheDocument();
+	});
+});
+
+describe("Parent overlap", () => {
+	let wrap: HTMLElement;
+
+	const overlap = (): number =>
+		parseFloat(
+			document.documentElement.style.getPropertyValue("--overlap-amount")
+		);
+
+	afterEach(() => {
+		cleanup();
+		wrap?.remove();
+		document.documentElement.style.removeProperty("--overlap-amount");
+	});
+
+	test("--overlap-amount is recalculated on resize", async () => {
+		// .sidebar-parent turns this variable into padding, but the padding is
+		// forced to 0 below the 768px breakpoint and the test viewport is
+		// narrower than that, so the variable is what can be asserted here.
+		wrap = document.createElement("div");
+		wrap.className = "wrap";
+		document.body.appendChild(wrap);
+
+		await render(
+			Sidebar,
+			{ width: 320, visible: true, open: true, position: "left" },
+			{ container: wrap }
+		);
+
+		await waitFor(() => expect(overlap()).toBeGreaterThan(0));
+
+		// Opening up space to the left of .wrap is what rotating a tablet to
+		// landscape does: the sidebar now fits beside the content.
+		wrap.style.marginLeft = "900px";
+		window.dispatchEvent(new Event("resize"));
+		await waitFor(() => expect(overlap()).toBe(0));
+
+		wrap.style.marginLeft = "0px";
+		window.dispatchEvent(new Event("resize"));
+		await waitFor(() => expect(overlap()).toBeGreaterThan(0));
 	});
 });
 

--- a/js/sidebar/Sidebar.test.ts
+++ b/js/sidebar/Sidebar.test.ts
@@ -343,6 +343,8 @@ describe("Parent overlap", () => {
 		// narrower than that, so the variable is what can be asserted here.
 		wrap = document.createElement("div");
 		wrap.className = "wrap";
+		// Flush left, so the starting overlap does not depend on ambient CSS.
+		wrap.style.marginLeft = "0px";
 		document.body.appendChild(wrap);
 
 		await render(

--- a/js/sidebar/shared/Sidebar.svelte
+++ b/js/sidebar/shared/Sidebar.svelte
@@ -45,13 +45,6 @@
 		sidebar_div.closest(".wrap")?.classList.add("sidebar-parent");
 		check_overlap();
 		window.addEventListener("resize", check_overlap);
-		const update_parent_overlap = (): void => {
-			document.documentElement.style.setProperty(
-				"--overlap-amount",
-				`${overlap_amount}px`
-			);
-		};
-		update_parent_overlap();
 		mounted = true;
 		const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
 		prefersReducedMotion = mediaQuery.matches;
@@ -63,6 +56,13 @@
 			window.removeEventListener("resize", check_overlap);
 			mediaQuery.removeEventListener("change", updateMotionPreference);
 		};
+	});
+
+	$effect(() => {
+		document.documentElement.style.setProperty(
+			"--overlap-amount",
+			`${overlap_amount}px`
+		);
 	});
 
 	// We need to wait for the component to be mounted before we can set the open state


### PR DESCRIPTION
## Description

`gr.Sidebar` pushes the main content aside by writing an `--overlap-amount` CSS variable on `document.documentElement`, which `.sidebar-parent` turns into `padding-left` / `padding-right`. The variable was written exactly once, from a one-shot call inside `onMount`. The `resize` listener recomputes `overlap_amount`, but nothing ever wrote the new value out, so the padding stayed frozen at whatever the layout was when the app first rendered.

The case in the issue is a stale value that is far too large. Below the 768px breakpoint the sidebar is `width: 100vw`, so an app that loads on a tablet in portrait computes a viewport-sized overlap. Rotating to landscape leaves the content with several hundred pixels of padding and no way to get rid of it short of a reload.

A stale value can also be too small, which leaves content sitting *under* the sidebar. `.wrap`'s left edge does not move monotonically as the window widens, so a frozen `--overlap-amount` stops covering the sidebar at some widths. Loading the app at around 1000px and then widening it, the content's left edge ends up behind the sidebar at several widths and stays there once the layout settles. With the fix it does not.

`overlap_amount` has been `$state` since the Svelte 5 migration, so the fix is to write the variable from an `$effect` instead of once at mount. It is placed after `onMount` so the first write still happens after the initial `check_overlap()`, keeping mount behaviour identical.

Closes: #12620

## Testing

Added a regression test to `js/sidebar/Sidebar.test.ts` that mounts the sidebar inside a `.wrap`, changes the space available beside it, dispatches `resize`, and asserts `--overlap-amount` follows, including the way back. Against `main` it fails with `expected 444 to be +0`; with the fix the file is 25 passed | 4 todo.

```
CI=1 npx vitest run --config .config/vitest.config.ts js/sidebar/Sidebar.test.ts
```

To see it in a browser, load an app with an open `gr.Sidebar` and then resize the window. Both directions of the bug show up:

- Load at roughly 700px wide, where the sidebar covers the page, then widen. Before this change the content keeps the padding computed for the narrow window.
- Load at roughly 1000px wide, then widen gradually. Before this change the content's left edge slides behind the sidebar at some widths and stays there.

## Before / after Spaces

The same minimal app on the released 6.22.0 and on this PR's preview wheel. The player embedded in the Space page does not resize the way a real window does, so open the app itself and resize the browser window slowly:

- Before fix: [Space](https://huggingface.co/spaces/hysts-debug/gradio-12620-before) / [app](https://hysts-debug-gradio-12620-before.hf.space)
- After fix: [Space](https://huggingface.co/spaces/hysts-debug/gradio-12620-after) / [app](https://hysts-debug-gradio-12620-after.hf.space)

### Loaded narrow, then widened

<table>
<tr><th width="50%">Before</th><th width="50%">After</th></tr>
<tr>
<td><video src="https://github.com/user-attachments/assets/b17c2953-a605-402d-900b-2dad43029aa8" controls></video></td>
<td><video src="https://github.com/user-attachments/assets/9caf46e6-bb48-4317-a968-c7f812e34ddd" controls></video></td>
</tr>
</table>

### Loaded at around 1000px, then widened gradually

<table>
<tr><th width="50%">Before</th><th width="50%">After</th></tr>
<tr>
<td><video src="https://github.com/user-attachments/assets/6443b3fa-b174-4deb-9c33-ee6c0e8c552f" controls></video></td>
<td><video src="https://github.com/user-attachments/assets/ed516e33-3596-485a-98e5-c20dafc8e49d" controls></video></td>
</tr>
</table>

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
