### PR TITLE
Pass args after `--` through to the app in reload mode

### DIFF
--- a/gradio/cli/cli.py
+++ b/gradio/cli/cli.py
@@ -94,6 +94,6 @@ demo.launch()"""
         hf_login()
 
         sys.argv = ["gradio", str(demo_path)]
-        typer.run(reload)
+        reload()
     else:
-        typer.run(reload)
+        reload()

--- a/gradio/cli/commands/__init__.py
+++ b/gradio/cli/commands/__init__.py
@@ -5,7 +5,7 @@ from .components import app as custom_component
 from .deploy_space import deploy
 from .hf_login import hf_login
 from .load import load_app
-from .reload import main as reload
+from .reload import run as reload
 from .sketch import launch as sketch
 from .skills import skills_app
 from .upload_mcp import main as upload_mcp

--- a/gradio/cli/commands/reload.py
+++ b/gradio/cli/commands/reload.py
@@ -104,6 +104,7 @@ def _setup_config(
 
 
 def main(
+    ctx: typer.Context,
     demo_path: Path,
     demo_name: str = "",
     watch_dirs: list[str] | None = None,
@@ -132,8 +133,10 @@ def main(
     if "GRADIO_VIBE_MODE" in os.environ:
         env_vars["GRADIO_VIBE_MODE"] = os.environ["GRADIO_VIBE_MODE"]
 
+    # Anything the reload CLI does not recognise belongs to the user's script,
+    # e.g. `gradio app.py --name Gretel` for a script that uses argparse.
     popen = subprocess.Popen(
-        [sys.executable, "-u", path],
+        [sys.executable, "-u", path, *ctx.args],
         env=env_vars,
     )
     if popen.poll() is None:
@@ -143,5 +146,22 @@ def main(
             pass
 
 
+def build_app() -> typer.Typer:
+    """Build the `gradio app.py [...]` CLI.
+
+    Unlike `typer.run(main)`, this leaves unrecognised arguments alone so they
+    can be forwarded to the user's script instead of erroring out.
+    """
+    app = typer.Typer(add_completion=False)
+    app.command(
+        context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
+    )(main)
+    return app
+
+
+def run() -> None:
+    build_app()()
+
+
 if __name__ == "__main__":
-    typer.run(main)
+    run()

--- a/gradio/cli/commands/reload.py
+++ b/gradio/cli/commands/reload.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import threading
 from pathlib import Path
+from typing import Annotated
 
 import typer
 from rich import print
@@ -104,12 +105,18 @@ def _setup_config(
 
 
 def main(
-    ctx: typer.Context,
     demo_path: Path,
     demo_name: str = "",
     watch_dirs: list[str] | None = None,
     encoding: str = "utf-8",
     watch_library: bool = False,
+    app_args: Annotated[
+        list[str] | None,
+        typer.Argument(
+            metavar="[-- APP_ARGS...]",
+            help="Arguments to pass to your app, placed after a `--` separator.",
+        ),
+    ] = None,
 ):
     signal.signal(signal.SIGINT, lambda _signum, _frame: _handle_interrupt())
     signal.signal(signal.SIGTERM, lambda _signum, _frame: _handle_interrupt())
@@ -133,10 +140,10 @@ def main(
     if "GRADIO_VIBE_MODE" in os.environ:
         env_vars["GRADIO_VIBE_MODE"] = os.environ["GRADIO_VIBE_MODE"]
 
-    # Anything the reload CLI does not recognise belongs to the user's script,
-    # e.g. `gradio app.py --name Gretel` for a script that uses argparse.
+    # Everything after `--` belongs to the user's script, e.g.
+    # `gradio app.py -- --name Gretel` for a script that uses argparse.
     popen = subprocess.Popen(
-        [sys.executable, "-u", path, *ctx.args],
+        [sys.executable, "-u", path, *(app_args or [])],
         env=env_vars,
     )
     if popen.poll() is None:
@@ -147,15 +154,9 @@ def main(
 
 
 def build_app() -> typer.Typer:
-    """Build the `gradio app.py [...]` CLI.
-
-    Unlike `typer.run(main)`, this leaves unrecognised arguments alone so they
-    can be forwarded to the user's script instead of erroring out.
-    """
+    """Build the `gradio app.py [-- ...]` CLI."""
     app = typer.Typer(add_completion=False)
-    app.command(
-        context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
-    )(main)
+    app.command()(main)
     return app
 
 

--- a/guides/11_other-tutorials/developing-faster-with-reload-mode.md
+++ b/guides/11_other-tutorials/developing-faster-with-reload-mode.md
@@ -97,7 +97,15 @@ if __name__ == "__main__":
     demo.launch()
 ```
 
-Which you could run like this: `gradio run.py --name Gretel`
+Which you could run like this: `gradio run.py -- --name Gretel`
+
+Everything after the `--` separator is passed straight through to your app, so your app's arguments are yours to name — including ones that happen to match a `gradio` option:
+
+```bash
+gradio run.py --demo-name my_demo -- --demo-name production
+```
+
+Here `gradio` reads the first `--demo-name`, and your app receives the second.
 
 As a small aside, this auto-reloading happens if you change your `run.py` source code or the Gradio source code. Meaning that this can be useful if you decide to [contribute to Gradio itself](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) ✅
 

--- a/guides/cn/07_other-tutorials/developing-faster-with-reload-mode.md
+++ b/guides/cn/07_other-tutorials/developing-faster-with-reload-mode.md
@@ -99,7 +99,7 @@ if __name__ == "__main__":
     demo.launch()
 ```
 
-您可以像这样运行它：`gradio run.py --name Gretel`
+您可以像这样运行它：`gradio run.py -- --name Gretel`（`--` 之后的所有参数都会直接传递给您的应用）
 
 作为一个小提示，只要更改了 `run.py` 源代码或 Gradio 源代码，自动重新加载就会发生。这意味着如果您决定[为 Gradio 做贡献](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md)，这将非常有用 ✅
 

--- a/test/test_reload.py
+++ b/test/test_reload.py
@@ -1,10 +1,12 @@
 import dataclasses
+import subprocess
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
 import gradio as gr
-from gradio.cli.commands.reload import _setup_config
+from gradio.cli.commands.reload import _setup_config, build_app
 from gradio.http_server import Server
 
 
@@ -52,6 +54,55 @@ class TestReload:
     def test_config_watch_app(self, config):
         demo_dir = str(Path("demo/calculator/run.py").resolve().parent)
         assert demo_dir in config.watch_dirs
+
+
+class TestReloadCliArgs:
+    """`gradio app.py --name Gretel` must forward `--name Gretel` to the script."""
+
+    @pytest.fixture
+    def child_argv(self, monkeypatch):
+        """Invoke the reload CLI and capture the argv it launches the app with."""
+        recorded: list[tuple[list[str], dict]] = []
+
+        class FakePopen:
+            def __init__(self, args, **kwargs):
+                recorded.append((args, kwargs))
+
+            def poll(self):
+                return 0
+
+            def wait(self):
+                return 0
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+
+        def invoke(*args: str) -> tuple[list[str], dict]:
+            result = CliRunner().invoke(build_app(), list(args))
+            assert result.exit_code == 0, result.output
+            return recorded[-1]
+
+        return invoke
+
+    def test_unknown_args_are_forwarded_to_the_app(self, child_argv):
+        argv, _ = child_argv("demo/calculator/run.py", "--name", "Gretel")
+        assert argv[-2:] == ["--name", "Gretel"]
+
+    def test_unknown_flags_and_positionals_are_forwarded(self, child_argv):
+        argv, _ = child_argv("demo/calculator/run.py", "--verbose", "extra", "-x")
+        assert argv[-3:] == ["--verbose", "extra", "-x"]
+
+    def test_no_extra_args_by_default(self, child_argv):
+        argv, _ = child_argv("demo/calculator/run.py")
+        assert str(argv[-1]).endswith("run.py")
+
+    def test_reload_options_are_still_consumed(self, child_argv):
+        argv, kwargs = child_argv(
+            "demo/calculator/run.py", "--demo-name", "my_demo", "--name", "Gretel"
+        )
+        assert "--demo-name" not in argv
+        assert "my_demo" not in argv
+        assert kwargs["env"]["GRADIO_WATCH_DEMO_NAME"] == "my_demo"
+        assert argv[-2:] == ["--name", "Gretel"]
 
 
 def test_reassign_pending_event_fns():

--- a/test/test_reload.py
+++ b/test/test_reload.py
@@ -60,13 +60,17 @@ class TestReloadCliArgs:
     """`gradio app.py -- --name Gretel` forwards `--name Gretel` to the script."""
 
     @pytest.fixture
-    def child_argv(self, monkeypatch):
-        """Invoke the reload CLI and capture the argv it launches the app with."""
-        recorded: list[tuple[list[str], dict]] = []
+    def run_cli(self, monkeypatch):
+        """Run the reload CLI without launching anything.
+
+        Returns the CliRunner result plus the argv and env the app would have
+        been launched with.
+        """
+        launched: list[tuple[list[str], dict]] = []
 
         class FakePopen:
             def __init__(self, args, **kwargs):
-                recorded.append((args, kwargs))
+                launched.append((args, kwargs))
 
             def poll(self):
                 return 0
@@ -76,91 +80,42 @@ class TestReloadCliArgs:
 
         monkeypatch.setattr(subprocess, "Popen", FakePopen)
 
-        def invoke(*args: str) -> tuple[list[str], dict]:
+        def invoke(*args: str):
             result = CliRunner().invoke(build_app(), list(args))
-            assert result.exit_code == 0, result.output
-            return recorded[-1]
+            argv, kwargs = launched[-1] if launched else ([], {})
+            return result, argv, kwargs
 
         return invoke
 
-    @pytest.fixture
-    def run_cli(self, monkeypatch):
-        """Invoke the reload CLI without launching anything, and return the result."""
-
-        class FakePopen:
-            def __init__(self, args, **kwargs):
-                pass
-
-            def poll(self):
-                return 0
-
-            def wait(self):
-                return 0
-
-        monkeypatch.setattr(subprocess, "Popen", FakePopen)
-        return lambda *args: CliRunner().invoke(build_app(), list(args))
-
-    @staticmethod
-    def _flat(output: str) -> str:
-        """Normalise CLI error text for matching.
-
-        Rich wraps it across panel lines, and Click versions differ on the exact
-        punctuation ("No such option: --x" vs "No such option '--x'."), so only
-        the stable parts of a message are worth asserting on.
-        """
-        return " ".join(output.replace("\u2502", " ").replace("'", "").split())
-
-    def test_args_after_separator_are_forwarded_to_the_app(self, child_argv):
-        argv, _ = child_argv("demo/calculator/run.py", "--", "--name", "Gretel")
-        assert argv[-2:] == ["--name", "Gretel"]
-
-    def test_flags_and_positionals_after_separator_are_forwarded(self, child_argv):
-        argv, _ = child_argv(
-            "demo/calculator/run.py", "--", "--verbose", "extra", "-x", "--y=1"
+    def test_args_after_separator_are_forwarded_to_the_app(self, run_cli):
+        result, argv, _ = run_cli(
+            "demo/calculator/run.py", "--", "--verbose", "--name", "Gretel"
         )
-        assert argv[-4:] == ["--verbose", "extra", "-x", "--y=1"]
+        assert result.exit_code == 0, result.output
+        assert argv[-3:] == ["--verbose", "--name", "Gretel"]
 
-    def test_separator_itself_is_not_forwarded(self, child_argv):
-        argv, _ = child_argv("demo/calculator/run.py", "--", "--name", "Gretel")
-        assert "--" not in argv
-
-    def test_only_the_first_separator_is_consumed(self, child_argv):
-        """A script that itself uses `--` still receives it."""
-        argv, _ = child_argv("demo/calculator/run.py", "--", "-a", "--", "-b")
-        assert argv[-3:] == ["-a", "--", "-b"]
-
-    def test_no_extra_args_by_default(self, child_argv):
-        argv, _ = child_argv("demo/calculator/run.py")
-        assert str(argv[-1]).endswith("run.py")
-
-    def test_reload_options_are_consumed_before_the_separator(self, child_argv):
-        """The same option name can be given to gradio and to the app."""
-        argv, kwargs = child_argv(
+    def test_gradio_and_the_app_can_use_the_same_option_name(self, run_cli):
+        result, argv, kwargs = run_cli(
             "demo/calculator/run.py",
             "--demo-name",
-            "my_demo",
+            "mine",
             "--",
             "--demo-name",
             "theirs",
         )
-        assert kwargs["env"]["GRADIO_WATCH_DEMO_NAME"] == "my_demo"
+        assert result.exit_code == 0, result.output
+        assert kwargs["env"]["GRADIO_WATCH_DEMO_NAME"] == "mine"
         assert argv[-2:] == ["--demo-name", "theirs"]
 
-    def test_unknown_option_before_the_separator_is_an_error(self, run_cli):
-        """Options are not silently forwarded, so adding one to gradio later
-        cannot change what an existing command means."""
-        result = run_cli("demo/calculator/run.py", "--name", "Gretel")
+    def test_unknown_option_is_an_error_not_silently_forwarded(self, run_cli):
+        """Nothing is swept up implicitly, so adding an option to the reload CLI
+        later cannot change what an existing command means."""
+        result, _, _ = run_cli("demo/calculator/run.py", "--name", "Gretel")
         assert result.exit_code != 0
-        output = self._flat(result.output)
-        assert "No such option" in output
-        assert "--name" in output
-
-    def test_a_mistyped_reload_option_is_still_suggested(self, run_cli):
-        result = run_cli("demo/calculator/run.py", "--demo-nam", "my_demo")
-        assert result.exit_code != 0
-        output = self._flat(result.output)
-        assert "Did you mean" in output
-        assert "--demo-name" in output
+        # Rich wraps the message across panel lines.
+        assert "No such option" in " ".join(
+            result.output.replace("\u2502", " ").split()
+        )
 
 
 def test_reassign_pending_event_fns():

--- a/test/test_reload.py
+++ b/test/test_reload.py
@@ -57,7 +57,7 @@ class TestReload:
 
 
 class TestReloadCliArgs:
-    """`gradio app.py --name Gretel` must forward `--name Gretel` to the script."""
+    """`gradio app.py -- --name Gretel` forwards `--name Gretel` to the script."""
 
     @pytest.fixture
     def child_argv(self, monkeypatch):
@@ -83,26 +83,84 @@ class TestReloadCliArgs:
 
         return invoke
 
-    def test_unknown_args_are_forwarded_to_the_app(self, child_argv):
-        argv, _ = child_argv("demo/calculator/run.py", "--name", "Gretel")
+    @pytest.fixture
+    def run_cli(self, monkeypatch):
+        """Invoke the reload CLI without launching anything, and return the result."""
+
+        class FakePopen:
+            def __init__(self, args, **kwargs):
+                pass
+
+            def poll(self):
+                return 0
+
+            def wait(self):
+                return 0
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        return lambda *args: CliRunner().invoke(build_app(), list(args))
+
+    @staticmethod
+    def _flat(output: str) -> str:
+        """Normalise CLI error text for matching.
+
+        Rich wraps it across panel lines, and Click versions differ on the exact
+        punctuation ("No such option: --x" vs "No such option '--x'."), so only
+        the stable parts of a message are worth asserting on.
+        """
+        return " ".join(output.replace("\u2502", " ").replace("'", "").split())
+
+    def test_args_after_separator_are_forwarded_to_the_app(self, child_argv):
+        argv, _ = child_argv("demo/calculator/run.py", "--", "--name", "Gretel")
         assert argv[-2:] == ["--name", "Gretel"]
 
-    def test_unknown_flags_and_positionals_are_forwarded(self, child_argv):
-        argv, _ = child_argv("demo/calculator/run.py", "--verbose", "extra", "-x")
-        assert argv[-3:] == ["--verbose", "extra", "-x"]
+    def test_flags_and_positionals_after_separator_are_forwarded(self, child_argv):
+        argv, _ = child_argv(
+            "demo/calculator/run.py", "--", "--verbose", "extra", "-x", "--y=1"
+        )
+        assert argv[-4:] == ["--verbose", "extra", "-x", "--y=1"]
+
+    def test_separator_itself_is_not_forwarded(self, child_argv):
+        argv, _ = child_argv("demo/calculator/run.py", "--", "--name", "Gretel")
+        assert "--" not in argv
+
+    def test_only_the_first_separator_is_consumed(self, child_argv):
+        """A script that itself uses `--` still receives it."""
+        argv, _ = child_argv("demo/calculator/run.py", "--", "-a", "--", "-b")
+        assert argv[-3:] == ["-a", "--", "-b"]
 
     def test_no_extra_args_by_default(self, child_argv):
         argv, _ = child_argv("demo/calculator/run.py")
         assert str(argv[-1]).endswith("run.py")
 
-    def test_reload_options_are_still_consumed(self, child_argv):
+    def test_reload_options_are_consumed_before_the_separator(self, child_argv):
+        """The same option name can be given to gradio and to the app."""
         argv, kwargs = child_argv(
-            "demo/calculator/run.py", "--demo-name", "my_demo", "--name", "Gretel"
+            "demo/calculator/run.py",
+            "--demo-name",
+            "my_demo",
+            "--",
+            "--demo-name",
+            "theirs",
         )
-        assert "--demo-name" not in argv
-        assert "my_demo" not in argv
         assert kwargs["env"]["GRADIO_WATCH_DEMO_NAME"] == "my_demo"
-        assert argv[-2:] == ["--name", "Gretel"]
+        assert argv[-2:] == ["--demo-name", "theirs"]
+
+    def test_unknown_option_before_the_separator_is_an_error(self, run_cli):
+        """Options are not silently forwarded, so adding one to gradio later
+        cannot change what an existing command means."""
+        result = run_cli("demo/calculator/run.py", "--name", "Gretel")
+        assert result.exit_code != 0
+        output = self._flat(result.output)
+        assert "No such option" in output
+        assert "--name" in output
+
+    def test_a_mistyped_reload_option_is_still_suggested(self, run_cli):
+        result = run_cli("demo/calculator/run.py", "--demo-nam", "my_demo")
+        assert result.exit_code != 0
+        output = self._flat(result.output)
+        assert "Did you mean" in output
+        assert "--demo-name" in output
 
 
 def test_reassign_pending_event_fns():


### PR DESCRIPTION
Closes #9955

The reload-mode guide documents passing your app's own command line arguments through `gradio`, but it errored out:

```
$ gradio run.py --name Gretel
Usage: gradio [OPTIONS] {demo_path}
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ No such option: --name (Possible options: --demo-name)                       │
╰──────────────────────────────────────────────────────────────────────────────╯
```

## Root cause

Two independent problems in `gradio/cli/commands/reload.py`:

1. `cli.py` dispatched to reload mode with `typer.run(reload)`, which parses the whole command line strictly — any option the reload CLI does not itself define is rejected.
2. Even if it had been accepted, the app was launched as `subprocess.Popen([sys.executable, "-u", path])`, so the extra arguments never reached the script.

## Fix

`main` now declares the forwarded arguments explicitly, and they are appended to the child argv:

```python
app_args: Annotated[
    list[str] | None,
    typer.Argument(
        metavar="[-- APP_ARGS...]",
        help="Arguments to pass to your app, placed after a `--` separator.",
    ),
] = None,
```

Everything after a `--` separator goes to the app:

```bash
gradio run.py -- --name Gretel
```

## Note on the approach — this changed during review

The first version of this PR forwarded *every* unrecognised argument implicitly (`allow_extra_args` + `ignore_unknown_options`), so the guide's documented `gradio run.py --name Gretel` worked verbatim. That fixed the reported case but was not future-proof, and we decided against it:

- **Adding any reload option later would silently change what existing commands mean.** `gradio app.py --queue 4` forwards `--queue 4` to the app today; the day gradio gains a `--queue`, gradio would consume it instead and the app would receive nothing — no error, no warning. I verified this by temporarily adding a `--queue` option to the reload CLI: the bare form flipped from `app_args=['--queue','4']` to `queue=4` with an empty argv.
- **A mistyped reload option was silently forwarded.** `ignore_unknown_options` discards Click's "Did you mean" machinery, so `--demo-nam my_demo` went to the app instead of being flagged.

Requiring `--` fixes both, because the split is *positional* rather than name-based and so cannot collide with any option gradio adds in future. There is no parser-level alternative that makes the bare form safe: at parse time gradio cannot know which options the app declares, and it cannot find out without executing the app.

Consequences worth being explicit about:

- `gradio run.py --name Gretel` (no `--`) still errors — now with a normal "No such option" and a suggestion, rather than passing silently. The guide is updated to teach the `--` form.
- Both sides can use the same option name at once: `gradio run.py --demo-name mine -- --demo-name theirs` gives gradio `mine` and the app `theirs`.
- Because the forwarded args are a declared argument rather than swept-up extras, they appear in `--help`: `Usage: gradio [OPTIONS] DEMO_PATH [-- APP_ARGS...]`. The previous approach was invisible there.

A named marker such as `--kwargs` was considered and has the same forward-compatibility property, since both split positionally. `--` won because it needs no code, is the convention users already know from `npm run x --` / `pytest` / `cargo run --`, and cannot itself be shadowed by an app that happens to define a `--kwargs` option.

## Verification

`TestReloadCliArgs` in `test/test_reload.py` patches `subprocess.Popen` and drives the CLI through `CliRunner`, covering the three things this PR decides: args after `--` reach the app, gradio and the app can use the same option name at once, and an unknown option is an error rather than silently forwarded.

```
python -m pytest test/test_reload.py -q
# 8 passed
```

End to end with this demo (**not committed**):

```python
import argparse

import gradio as gr

parser = argparse.ArgumentParser()
parser.add_argument("--name", type=str, default="User")
args, unknown = parser.parse_known_args()
print(f"[demo] parsed --name = {args.name!r}, unknown = {unknown!r}")

with gr.Blocks() as demo:
    gr.Markdown(f"# Greetings {args.name}!")
    inp = gr.Textbox()
    out = gr.Textbox()

    inp.change(fn=lambda x: x, inputs=inp, outputs=out)

if __name__ == "__main__":
    demo.launch()
```

`gradio demo.py -- --name Gretel` serves a page containing `Greetings Gretel!`, and the script logs `parsed --name = 'Gretel', unknown = []`.

## Docs

`guides/11_other-tutorials/developing-faster-with-reload-mode.md` now shows the `--` form and the same-name-on-both-sides example. The Chinese translation's command was corrected to match; its surrounding prose was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
