### PR TITLE
Support compound file extensions in file_types

### DIFF
--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -702,13 +702,18 @@ def get_extension(encoding: str) -> str | None:
 
 def is_valid_file(file_path: str, file_types: list[str]) -> bool:
     mime_type = get_mimetype(file_path)
+    file_name = Path(file_path).name.lower()
     for file_type in file_types:
         if file_type == "file":
             return True
         if file_type.startswith("."):
-            file_type = file_type.lstrip(".").lower()
-            file_ext = Path(file_path).suffix.lstrip(".").lower()
-            if file_type == file_ext:
+            # Match against the tail of the filename rather than `Path.suffix`,
+            # which only ever returns the last component -- so a compound
+            # extension like ".nii.gz" or ".tar.gz" could never match. The
+            # length check keeps a file literally named ".gz" from counting as
+            # a ".gz" file, matching the old `Path.suffix` behaviour.
+            file_type = file_type.lower()
+            if len(file_name) > len(file_type) and file_name.endswith(file_type):
                 return True
         elif mime_type is not None and mime_type.startswith(f"{file_type}/"):
             return True

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -707,11 +707,6 @@ def is_valid_file(file_path: str, file_types: list[str]) -> bool:
         if file_type == "file":
             return True
         if file_type.startswith("."):
-            # Match against the tail of the filename rather than `Path.suffix`,
-            # which only ever returns the last component -- so a compound
-            # extension like ".nii.gz" or ".tar.gz" could never match. The
-            # length check keeps a file literally named ".gz" from counting as
-            # a ".gz" file, matching the old `Path.suffix` behaviour.
             file_type = file_type.lower()
             if len(file_name) > len(file_type) and file_name.endswith(file_type):
                 return True

--- a/client/python/test/test_utils.py
+++ b/client/python/test/test_utils.py
@@ -99,12 +99,12 @@ def test_decode_base64_to_file(media_data):
         ("/home/user/scans/brain.nii", [".nii.gz"], False),
         ("/home/user/archives/src.tar.gz", [".tar.gz"], True),
         ("/home/user/archives/src.zip", [".tar.gz"], False),
-        # A compound extension must not stop the plain one from matching
         ("/home/user/scans/brain.nii.gz", [".gz"], True),
-        # The extension has to be a real suffix, not just a substring
         ("/home/user/notes/my.js.txt", [".js"], False),
         # A file whose whole name is the extension has no extension
         ("/home/user/archives/.gz", [".gz"], False),
+        ("/home/user/scans/.nii.gz", [".nii.gz"], False),
+        ("/home/user/scans/nii.gz", [".nii.gz"], False),
     ],
 )
 def test_is_valid_file_type(path_or_url, file_types, expected_result):

--- a/client/python/test/test_utils.py
+++ b/client/python/test/test_utils.py
@@ -92,6 +92,19 @@ def test_decode_base64_to_file(media_data):
         ("/home/user/images/photo.WebP", ["image"], True),
         ("C:\\Users\\user\\images\\photo.webp", ["image", "video"], True),
         ("C:\\Users\\user\\images\\photo.WEBP", ["image", "video"], True),
+        # Compound extensions
+        ("/home/user/scans/brain.nii.gz", [".nii.gz"], True),
+        ("/home/user/scans/brain.NII.GZ", [".nii.gz"], True),
+        ("/home/user/scans/brain.nii.gz", [".nii"], False),
+        ("/home/user/scans/brain.nii", [".nii.gz"], False),
+        ("/home/user/archives/src.tar.gz", [".tar.gz"], True),
+        ("/home/user/archives/src.zip", [".tar.gz"], False),
+        # A compound extension must not stop the plain one from matching
+        ("/home/user/scans/brain.nii.gz", [".gz"], True),
+        # The extension has to be a real suffix, not just a substring
+        ("/home/user/notes/my.js.txt", [".js"], False),
+        # A file whose whole name is the extension has no extension
+        ("/home/user/archives/.gz", [".gz"], False),
     ],
 )
 def test_is_valid_file_type(path_or_url, file_types, expected_result):

--- a/demo/file_component_events/run.py
+++ b/demo/file_component_events/run.py
@@ -92,6 +92,21 @@ with gr.Blocks() as demo:
                 [num_load_btn_6],
                 [del_file_data, num_load_btn_6],
             )
+    with gr.Row():
+        with gr.Column():
+            file_component_compound = gr.File(
+                label="Upload Compound Extension File", file_types=[".nii.gz"]
+            )
+        with gr.Column():
+            output_file_7 = gr.File(label="Upload Compound Extension File Output")
+            num_load_btn_7 = gr.Number(
+                label="# Load Upload Compound Extension File", value=0
+            )
+            file_component_compound.upload(
+                lambda s, n: (s, n + 1),
+                [file_component_compound, num_load_btn_7],
+                [output_file_7, num_load_btn_7],
+            )
     # f = gr.File(label="Upload many File", file_count="multiple")
     # # f.delete(delete_file)
     # f.delete(delete_file, inputs=None, outputs=None)

--- a/js/spa/test/file_component_events.spec.ts
+++ b/js/spa/test/file_component_events.spec.ts
@@ -40,6 +40,38 @@ test("File component properly handles invalid file_types.", async ({
 	await error_modal_showed(page);
 });
 
+test("File component accepts a compound extension in file_types.", async ({
+	page
+}) => {
+	const locator = page.locator("input[type=file]").nth(6);
+	await drag_and_drop_file(
+		page,
+		locator,
+		"./test/files/alphabet.txt",
+		"brain.nii.gz",
+		"application/gzip"
+	);
+
+	await expect(
+		page.getByLabel("# Load Upload Compound Extension File")
+	).toHaveValue("1");
+});
+
+test("File component rejects a partial match of a compound extension in file_types.", async ({
+	page
+}) => {
+	const locator = page.locator("input[type=file]").nth(6);
+	await drag_and_drop_file(
+		page,
+		locator,
+		"./test/files/alphabet.txt",
+		"brain.nii",
+		"application/octet-stream"
+	);
+
+	await error_modal_showed(page);
+});
+
 test("Delete event is fired correctly", async ({ page }) => {
 	const locator = page.locator("input[type=file]").nth(5);
 	await drag_and_drop_file(

--- a/js/spa/test/file_component_events.spec.ts
+++ b/js/spa/test/file_component_events.spec.ts
@@ -57,6 +57,15 @@ test("File component accepts a compound extension in file_types.", async ({
 	).toHaveValue("1");
 });
 
+test("File component widens the accept attribute for a compound extension.", async ({
+	page
+}) => {
+	await expect(page.locator("input[type=file]").nth(6)).toHaveAttribute(
+		"accept",
+		".nii.gz, .gz"
+	);
+});
+
 test("File component rejects a partial match of a compound extension in file_types.", async ({
 	page
 }) => {

--- a/js/upload/src/Upload.svelte
+++ b/js/upload/src/Upload.svelte
@@ -224,14 +224,11 @@
 		const files_to_load = files.filter((file) => {
 			const file_name = file.name.toLowerCase();
 			const file_extension = "." + file_name.split(".").pop();
-			if (
-				file_extension &&
-				is_valid_mimetype(accept_file_types, file_name, file.type)
-			) {
+			if (is_valid_mimetype(accept_file_types, file_name, file.type)) {
 				return true;
 			}
 			if (
-				file_extension && Array.isArray(filetype)
+				Array.isArray(filetype)
 					? filetype.includes(file_extension)
 					: file_extension === filetype
 			) {

--- a/js/upload/src/Upload.svelte
+++ b/js/upload/src/Upload.svelte
@@ -222,10 +222,11 @@
 
 	async function load_files_from_upload(files: File[]): Promise<void> {
 		const files_to_load = files.filter((file) => {
-			const file_extension = "." + file.name.toLowerCase().split(".").pop();
+			const file_name = file.name.toLowerCase();
+			const file_extension = "." + file_name.split(".").pop();
 			if (
 				file_extension &&
-				is_valid_mimetype(accept_file_types, file_extension, file.type)
+				is_valid_mimetype(accept_file_types, file_name, file.type)
 			) {
 				return true;
 			}

--- a/js/upload/src/index.ts
+++ b/js/upload/src/index.ts
@@ -1,4 +1,4 @@
 export { default as Upload } from "./Upload.svelte";
 export { default as ModifyUpload } from "./ModifyUpload.svelte";
 export { default as UploadProgress } from "./UploadProgress.svelte";
-export { create_drag, is_valid_mimetype } from "./utils";
+export { create_drag, is_valid_mimetype, to_accept_attribute } from "./utils";

--- a/js/upload/src/utils.test.ts
+++ b/js/upload/src/utils.test.ts
@@ -1,5 +1,47 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { create_drag } from "./utils";
+import { create_drag, is_valid_mimetype } from "./utils";
+
+describe("is_valid_mimetype", () => {
+	test("matches compound extensions", () => {
+		expect(is_valid_mimetype(".nii.gz", "brain.nii.gz", "")).toBe(true);
+		expect(is_valid_mimetype(".tar.gz", "src.tar.gz", "")).toBe(true);
+		expect(is_valid_mimetype(".nii.gz", "brain.nii", "")).toBe(false);
+		expect(is_valid_mimetype(".nii", "brain.nii.gz", "")).toBe(false);
+	});
+
+	test("a compound extension does not stop the plain one from matching", () => {
+		expect(is_valid_mimetype(".gz", "brain.nii.gz", "")).toBe(true);
+	});
+
+	test("still matches plain extensions, and is case insensitive", () => {
+		expect(is_valid_mimetype(".png", "photo.png", "")).toBe(true);
+		expect(is_valid_mimetype(".png", "photo.PNG", "")).toBe(true);
+		expect(is_valid_mimetype(".png", "photo.jpg", "")).toBe(false);
+	});
+
+	test("the extension has to be a real suffix, not just a substring", () => {
+		expect(is_valid_mimetype(".js", "my.js.txt", "")).toBe(false);
+	});
+
+	test("still accepts a bare extension in place of a filename", () => {
+		expect(is_valid_mimetype(".png", ".png", "")).toBe(true);
+		expect(is_valid_mimetype(".png", ".jpg", "")).toBe(false);
+	});
+
+	test("still matches mime categories and wildcards", () => {
+		expect(is_valid_mimetype("image/*", "photo.png", "image/png")).toBe(true);
+		expect(is_valid_mimetype("image/*", "clip.mp4", "video/mp4")).toBe(false);
+		expect(is_valid_mimetype("*", "anything.xyz", "")).toBe(true);
+		expect(is_valid_mimetype(null, "anything.xyz", "")).toBe(true);
+	});
+
+	test("accepts a comma-separated string or an array", () => {
+		expect(is_valid_mimetype(".png, .nii.gz", "brain.nii.gz", "")).toBe(true);
+		expect(is_valid_mimetype([".png", ".nii.gz"], "brain.nii.gz", "")).toBe(
+			true
+		);
+	});
+});
 
 describe("create_drag", () => {
 	afterEach(() => {

--- a/js/upload/src/utils.test.ts
+++ b/js/upload/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { create_drag, is_valid_mimetype } from "./utils";
+import { create_drag, is_valid_mimetype, to_accept_attribute } from "./utils";
 
 describe("is_valid_mimetype", () => {
 	test("matches compound extensions", () => {
@@ -41,6 +41,33 @@ describe("is_valid_mimetype", () => {
 		expect(is_valid_mimetype([".png", ".nii.gz"], "brain.nii.gz", "")).toBe(
 			true
 		);
+	});
+});
+
+describe("to_accept_attribute", () => {
+	test("widens a compound extension so the native picker can resolve it", () => {
+		expect(to_accept_attribute([".nii.gz"])).toBe(".nii.gz, .gz");
+		expect(to_accept_attribute([".tar.gz", ".png"])).toBe(".tar.gz, .gz, .png");
+	});
+
+	test("leaves plain extensions and mime types untouched", () => {
+		expect(to_accept_attribute([".png"])).toBe(".png");
+		expect(to_accept_attribute(["image/*"])).toBe("image/*");
+		expect(to_accept_attribute("*")).toBe("*");
+	});
+
+	test("does not duplicate an extension that is already listed", () => {
+		expect(to_accept_attribute([".tar.gz", ".gz"])).toBe(".tar.gz, .gz");
+	});
+
+	test("accepts a comma-separated string", () => {
+		expect(to_accept_attribute(".tar.gz, .png")).toBe(".tar.gz, .gz, .png");
+	});
+
+	test("preserves the no-filter cases", () => {
+		expect(to_accept_attribute(null)).toBe(undefined);
+		expect(to_accept_attribute("")).toBe("");
+		expect(to_accept_attribute([])).toBe("");
 	});
 });
 

--- a/js/upload/src/utils.test.ts
+++ b/js/upload/src/utils.test.ts
@@ -23,9 +23,10 @@ describe("is_valid_mimetype", () => {
 		expect(is_valid_mimetype(".js", "my.js.txt", "")).toBe(false);
 	});
 
-	test("still accepts a bare extension in place of a filename", () => {
-		expect(is_valid_mimetype(".png", ".png", "")).toBe(true);
-		expect(is_valid_mimetype(".png", ".jpg", "")).toBe(false);
+	test("a file whose whole name is the extension does not match", () => {
+		expect(is_valid_mimetype(".png", ".png", "")).toBe(false);
+		expect(is_valid_mimetype(".nii.gz", ".nii.gz", "")).toBe(false);
+		expect(is_valid_mimetype(".nii.gz", "nii.gz", "")).toBe(false);
 	});
 
 	test("still matches mime categories and wildcards", () => {

--- a/js/upload/src/utils.ts
+++ b/js/upload/src/utils.ts
@@ -37,6 +37,26 @@ export function is_valid_mimetype(
 	);
 }
 
+export function to_accept_attribute(
+	file_accept: string | string[] | null
+): string | undefined {
+	if (file_accept == null) return undefined;
+	const types = Array.isArray(file_accept)
+		? file_accept
+		: file_accept.split(",");
+	const widened = new Set<string>();
+	for (const raw of types) {
+		const type = raw.trim();
+		if (!type) continue;
+		widened.add(type);
+		const last_dot = type.lastIndexOf(".");
+		if (type.startsWith(".") && last_dot > 0) {
+			widened.add(type.slice(last_dot));
+		}
+	}
+	return Array.from(widened).join(", ");
+}
+
 interface DragActionOptions {
 	disable_click?: boolean;
 	ignore_click_selector?: string;
@@ -74,9 +94,9 @@ export function create_drag(): {
 				hidden_input.style.display = "none";
 				hidden_input.setAttribute("aria-label", "File upload");
 				hidden_input.setAttribute("data-testid", "file-upload");
-				const accept_options = Array.isArray(_options.accepted_types)
-					? _options.accepted_types.join(",")
-					: _options.accepted_types || undefined;
+				const accept_options = to_accept_attribute(
+					_options.accepted_types ?? null
+				);
 
 				if (accept_options) {
 					hidden_input.accept = accept_options;

--- a/js/upload/src/utils.ts
+++ b/js/upload/src/utils.ts
@@ -1,5 +1,9 @@
 export function is_valid_mimetype(
 	file_accept: string | string[] | null,
+	// Either a bare extension (".gz") or the whole filename ("scan.nii.gz").
+	// Extension entries in `file_accept` are matched against the tail of this
+	// string, so passing the filename is what makes compound extensions such as
+	// ".nii.gz" or ".tar.gz" match.
 	uploaded_file_extension: string,
 	uploaded_file_type: string
 ): boolean {
@@ -21,8 +25,13 @@ export function is_valid_mimetype(
 		return false;
 	}
 
+	const name = uploaded_file_extension.toLowerCase();
 	return (
-		acceptArray.includes(uploaded_file_extension) ||
+		acceptArray.some((type) => {
+			if (!type.startsWith(".")) return false;
+			const ext = type.toLowerCase();
+			return name.length > ext.length ? name.endsWith(ext) : name === ext;
+		}) ||
 		acceptArray.some((type) => {
 			const [category] = type.split("/").map((s) => s.trim());
 			return (

--- a/js/upload/src/utils.ts
+++ b/js/upload/src/utils.ts
@@ -1,10 +1,6 @@
 export function is_valid_mimetype(
 	file_accept: string | string[] | null,
-	// Either a bare extension (".gz") or the whole filename ("scan.nii.gz").
-	// Extension entries in `file_accept` are matched against the tail of this
-	// string, so passing the filename is what makes compound extensions such as
-	// ".nii.gz" or ".tar.gz" match.
-	uploaded_file_extension: string,
+	uploaded_file_name: string,
 	uploaded_file_type: string
 ): boolean {
 	if (
@@ -25,12 +21,12 @@ export function is_valid_mimetype(
 		return false;
 	}
 
-	const name = uploaded_file_extension.toLowerCase();
+	const file_name = uploaded_file_name.toLowerCase();
 	return (
 		acceptArray.some((type) => {
 			if (!type.startsWith(".")) return false;
 			const ext = type.toLowerCase();
-			return name.length > ext.length ? name.endsWith(ext) : name === ext;
+			return file_name.length > ext.length && file_name.endsWith(ext);
 		}) ||
 		acceptArray.some((type) => {
 			const [category] = type.split("/").map((s) => s.trim());

--- a/js/uploadbutton/shared/UploadButton.svelte
+++ b/js/uploadbutton/shared/UploadButton.svelte
@@ -2,7 +2,7 @@
 	import { tick } from "svelte";
 	import { BaseButton } from "@gradio/button";
 	import { prepare_files, type FileData, type Client } from "@gradio/client";
-	import { is_valid_mimetype } from "@gradio/upload";
+	import { is_valid_mimetype, to_accept_attribute } from "@gradio/upload";
 
 	let {
 		elem_id = "",
@@ -119,7 +119,7 @@
 
 <input
 	class="hide"
-	accept={accept_file_types}
+	accept={to_accept_attribute(accept_file_types)}
 	type="file"
 	bind:this={hidden_upload}
 	onchange={load_files_from_upload}

--- a/js/uploadbutton/shared/UploadButton.svelte
+++ b/js/uploadbutton/shared/UploadButton.svelte
@@ -72,8 +72,9 @@
 
 	async function load_files(files: FileList): Promise<void> {
 		let _files: File[] = Array.from(files).filter((file) => {
-			const ext = "." + file.name.toLowerCase().split(".").pop();
-			if (is_valid_mimetype(accept_file_types, ext, file.type)) {
+			if (
+				is_valid_mimetype(accept_file_types, file.name.toLowerCase(), file.type)
+			) {
 				return true;
 			}
 			onerror?.(`Invalid file type only ${file_types?.join(", ")} allowed.`);


### PR DESCRIPTION
Closes #10022

`file_types=[".nii.gz"]` rejected every `.nii.gz` file (and the same for `.tar.gz`, `.tar.bz2`, …). Only the single-component `.gz` worked, which is what the reporter fell back to. There were two issues:

- **Server side** — `is_valid_file` (`client/python/gradio_client/utils.py`) used `Path(file_path).suffix`, which is `".gz"` for `scan.nii.gz`. A `.nii.gz` entry could therefore never equal it.
- **Client side** — `Upload.svelte` and `UploadButton.svelte` passed `"." + name.split(".").pop()` into `is_valid_mimetype`, which did an exact `acceptArray.includes(...)`. Same problem, and it bites first: the file was dropped in the browser before any request was made, so fixing only the Python half would have left the bug visible.

In this PR, we now match extension entries against the tail of the filename instead of against a single parsed suffix, both in the frontend and the backend.

I tested everything with a local demo and confirmed that it works:

```python
import os
import tempfile

import gradio as gr
from gradio.data_classes import FileData

d = tempfile.mkdtemp()
CASES = [
    ("scan.nii.gz", [".nii.gz"], True),
    ("scan.nii.gz", [".gz"], True),
    ("scan.nii", [".nii.gz"], False),
    ("src.tar.gz", [".tar.gz"], True),
    ("src.zip", [".tar.gz"], False),
]

for name, file_types, should_accept in CASES:
    path = os.path.join(d, name)
    with open(path, "wb") as f:
        f.write(b"x")
    comp = gr.File(file_types=file_types)
    try:
        comp.preprocess(FileData(path=path, orig_name=name, size=1))
        accepted = True
    except Exception:
        accepted = False
    status = "ok " if accepted is should_accept else "BAD"
    print(f"{status} {name:<14} file_types={str(file_types):<12} accepted={accepted}")

with gr.Blocks() as demo:
    gr.Markdown("Upload a `.nii.gz` (or `.tar.gz`) file — it should be accepted.")
    gr.File(file_types=[".nii.gz", ".tar.gz"], label="NIfTI / tarball")

if __name__ == "__main__":
    demo.launch()
```