### PR TITLE
Allow saving Workflow to the Space itself

### DIFF
--- a/.changeset/sweet-sloths-beam.md
+++ b/.changeset/sweet-sloths-beam.md
@@ -1,0 +1,6 @@
+---
+"@gradio/workflowcanvas": minor
+"gradio": minor
+---
+
+feat:workflow: allow exporting workflow file when on hf spaces

--- a/.changeset/sweet-sloths-beam.md
+++ b/.changeset/sweet-sloths-beam.md
@@ -3,4 +3,4 @@
 "gradio": minor
 ---
 
-feat:workflow: allow exporting workflow file when on hf spaces
+feat:Allow saving Workflow to the Space itself

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -561,6 +561,12 @@ def get_write_access(
     return "true" if has_write_access(request, token) else "false"
 
 
+def get_space_id(_data=None) -> str:
+    """Return this Space's repo id (`owner/name`) for the "Save to Space" button.
+    Empty locally — the button is hidden there anyway."""
+    return os.getenv("SPACE_ID") or ""
+
+
 def get_oauth_available(_data=None) -> str:
     """Whether OAuth sign-in is actually wired up. On a Space this requires
     `hf_oauth: true` in the README metadata, which provisions OAUTH_CLIENT_ID
@@ -1872,6 +1878,7 @@ class Workflow(Blocks):
             get_token,
             get_write_access,
             get_oauth_available,
+            get_space_id,
             call_space,
             call_model,
             fetch_dataset,

--- a/js/workflowcanvas/workflow/WorkflowCanvas.css
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.css
@@ -337,6 +337,51 @@ button.access-badge.access-readonly.open {
 	border-color: #3a3b48;
 }
 
+.toolbar-export-wrap {
+	position: relative;
+	display: flex;
+	align-items: center;
+}
+
+.toolbar-export-menu {
+	position: absolute;
+	top: calc(100% + 8px);
+	left: 0;
+	min-width: 180px;
+	background: #16171f;
+	border: 1px solid #2a2b36;
+	border-radius: 10px;
+	padding: 6px;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	box-shadow:
+		0 8px 24px rgba(0, 0, 0, 0.45),
+		0 0 0 1px rgba(255, 255, 255, 0.03);
+	z-index: 40;
+}
+
+.toolbar-export-menu-btn {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-family: "Manrope", sans-serif;
+	font-size: 12px;
+	font-weight: 600;
+	padding: 6px 10px;
+	border: none;
+	border-radius: 6px;
+	background: transparent;
+	color: #e0e1e6;
+	cursor: pointer;
+	text-align: left;
+	transition: background 0.15s;
+}
+
+.toolbar-export-menu-btn:hover {
+	background: #1e1f2a;
+}
+
 .toolbar-token-input {
 	font-family: "JetBrains Mono", monospace;
 	font-size: 11px;

--- a/js/workflowcanvas/workflow/WorkflowCanvas.css
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.css
@@ -337,51 +337,6 @@ button.access-badge.access-readonly.open {
 	border-color: #3a3b48;
 }
 
-.toolbar-export-wrap {
-	position: relative;
-	display: flex;
-	align-items: center;
-}
-
-.toolbar-export-menu {
-	position: absolute;
-	top: calc(100% + 8px);
-	left: 0;
-	min-width: 180px;
-	background: #16171f;
-	border: 1px solid #2a2b36;
-	border-radius: 10px;
-	padding: 6px;
-	display: flex;
-	flex-direction: column;
-	gap: 2px;
-	box-shadow:
-		0 8px 24px rgba(0, 0, 0, 0.45),
-		0 0 0 1px rgba(255, 255, 255, 0.03);
-	z-index: 40;
-}
-
-.toolbar-export-menu-btn {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	font-family: "Manrope", sans-serif;
-	font-size: 12px;
-	font-weight: 400;
-	padding: 6px 10px;
-	border: none;
-	border-radius: 6px;
-	background: transparent;
-	color: #e0e1e6;
-	cursor: pointer;
-	text-align: left;
-	transition: background 0.15s;
-}
-
-.toolbar-export-menu-btn:hover {
-	background: #1e1f2a;
-}
-
 .toolbar-token-input {
 	font-family: "JetBrains Mono", monospace;
 	font-size: 11px;

--- a/js/workflowcanvas/workflow/WorkflowCanvas.css
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.css
@@ -367,7 +367,7 @@ button.access-badge.access-readonly.open {
 	gap: 8px;
 	font-family: "Manrope", sans-serif;
 	font-size: 12px;
-	font-weight: 600;
+	font-weight: 400;
 	padding: 6px 10px;
 	border: none;
 	border-radius: 6px;

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -2398,7 +2398,7 @@
 					{/if}
 				</div>
 			{/if}
-			{#if saveIndicator}
+			{#if saveIndicator && !auth.isHFSpace}
 				<span
 					class="save-indicator"
 					in:fade={{ duration: 120 }}

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -127,7 +127,11 @@
 	// Serialized form of what's currently persisted on the server. Autosave
 	// compares against this so loading the workflow into the store on page load
 	// (and any no-op change) doesn't trigger a redundant save + "Saved" flash.
-	let lastSavedSerialized: string | null = null;
+	let lastSavedSerialized = $state<string | null>(null);
+	const isDirty = $derived(
+		lastSavedSerialized !== null &&
+			JSON.stringify(sanitize_for_save($workflow)) !== lastSavedSerialized
+	);
 	function flashSaved(): void {
 		saveIndicator = true;
 		if (saveIndicatorTimer) clearTimeout(saveIndicatorTimer);
@@ -2367,17 +2371,6 @@
 				<CodeIcon />
 				View API
 			</button>
-			{#if auth.isHFSpace && auth.canWrite && spaceId && auth.token}
-				<button
-					class="tool-btn"
-					disabled={savingToSpace}
-					onclick={() => (saveToSpaceConfirm = true)}
-					title="Commit workflow.json to this Space's repo (will restart the Space)"
-				>
-					<UploadIcon />
-					{savingToSpace ? "Saving…" : "Save to Space"}
-				</button>
-			{/if}
 			{#if saveIndicator && !auth.isHFSpace}
 				<span
 					class="save-indicator"
@@ -2462,6 +2455,17 @@
 			{/if}
 			{#if !readOnly}
 				<button class="tool-btn" onclick={clearWorkflow}>Clear</button>
+				{#if auth.isHFSpace && auth.canWrite && spaceId && auth.token && isDirty}
+					<button
+						class="tool-btn save-space-btn"
+						disabled={savingToSpace}
+						onclick={() => (saveToSpaceConfirm = true)}
+						title="Commit workflow.json to this Space's repo (will restart the Space)"
+					>
+						<UploadIcon />
+						{savingToSpace ? "Saving…" : "Unsaved · Save"}
+					</button>
+				{/if}
 				{#if auth.writeAccessKnown}
 					<span
 						class="access-badge access-write"
@@ -3169,6 +3173,14 @@
 		color: #0f9d76;
 		background: rgba(15, 157, 118, 0.08);
 		border-color: rgba(15, 157, 118, 0.25);
+	}
+	.save-space-btn {
+		color: #ff9350;
+		border-color: rgba(255, 147, 80, 0.4);
+	}
+	.save-space-btn:hover:not(:disabled) {
+		background: rgba(255, 147, 80, 0.12);
+		border-color: rgba(255, 147, 80, 0.6);
 	}
 	:global(body:not(.dark) button.access-badge.access-readonly:hover),
 	:global(body:not(.dark) button.access-badge.access-readonly.open) {

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -186,8 +186,11 @@
 		const wf = $workflow;
 		// Wait for the write-access answer before autosaving — the optimistic
 		// editable window would otherwise fire saves the backend rejects.
+		// On HF Spaces, saving is manual via "Save to Space"; skip autosave so
+		// the "Unsaved · Save" affordance stays visible until the user commits.
 		if (!server?.save_workflow || !auth.writeAccessKnown || !auth.canWrite)
 			return;
+		if (auth.isHFSpace) return;
 		const serialized = JSON.stringify(sanitize_for_save(wf));
 		if (lastSavedSerialized === null) {
 			// No persisted baseline yet (e.g. a brand-new workflow with no saved

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -12,6 +12,7 @@
 	import LayoutIcon from "./icons/LayoutIcon.svelte";
 	import InfoIcon from "./icons/InfoIcon.svelte";
 	import CodeIcon from "./icons/CodeIcon.svelte";
+	import DownloadIcon from "./icons/DownloadIcon.svelte";
 
 	import {
 		MODALITIES,
@@ -386,6 +387,38 @@
 
 	function dismissToast(id: number): void {
 		toasts = toasts.filter((t) => t.id !== id);
+	}
+
+	function serializedWorkflow(): string {
+		return JSON.stringify(sanitize_for_save($workflow), null, 2);
+	}
+
+	async function copyWorkflowJson(): Promise<void> {
+		try {
+			await navigator.clipboard.writeText(serializedWorkflow());
+			showToast("Copied workflow JSON to clipboard", 2000, "success");
+		} catch {
+			showToast(
+				"Couldn't copy to clipboard — use Download instead",
+				3500,
+				"warning"
+			);
+		}
+	}
+
+	function downloadWorkflowJson(): void {
+		const blob = new Blob([serializedWorkflow()], {
+			type: "application/json"
+		});
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		a.href = url;
+		const safeName = ($workflow.name || "workflow").replace(/[^\w.-]+/g, "_");
+		a.download = `${safeName}.json`;
+		document.body.appendChild(a);
+		a.click();
+		a.remove();
+		URL.revokeObjectURL(url);
 	}
 
 	// v1 shape for read paths; writes go through v2 store actions.
@@ -2322,6 +2355,24 @@
 				<CodeIcon />
 				View API
 			</button>
+			{#if auth.isHFSpace}
+				<button
+					class="tool-btn"
+					onclick={copyWorkflowJson}
+					title="Copy the workflow JSON to your clipboard"
+				>
+					<CodeIcon />
+					Copy JSON
+				</button>
+				<button
+					class="tool-btn"
+					onclick={downloadWorkflowJson}
+					title="Download the workflow as a .json file"
+				>
+					<DownloadIcon />
+					Download
+				</button>
+			{/if}
 			{#if saveIndicator}
 				<span
 					class="save-indicator"

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -2872,10 +2872,7 @@
 	{#if saveToSpaceConfirm}
 		<!-- svelte-ignore a11y_click_events_have_key_events -->
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
-		<div
-			class="wf-modal-backdrop"
-			onclick={() => (saveToSpaceConfirm = false)}
-		>
+		<div class="wf-modal-backdrop" onclick={() => (saveToSpaceConfirm = false)}>
 			<div
 				class="wf-modal"
 				role="dialog"

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -13,6 +13,7 @@
 	import InfoIcon from "./icons/InfoIcon.svelte";
 	import CodeIcon from "./icons/CodeIcon.svelte";
 	import DownloadIcon from "./icons/DownloadIcon.svelte";
+	import ChevronDownIcon from "./icons/ChevronDownIcon.svelte";
 
 	import {
 		MODALITIES,
@@ -337,6 +338,7 @@
 	);
 	let showShortcuts = $state(false);
 	let showUserMenu = $state(false);
+	let showExportMenu = $state(false);
 	let showApiPanel = $state(false);
 	// Popover shown when the "Run only" badge is clicked, explaining why editing
 	// is disabled and how to enable it.
@@ -1818,6 +1820,9 @@
 		if (showUserMenu && !target?.closest(".toolbar-user-wrap")) {
 			showUserMenu = false;
 		}
+		if (showExportMenu && !target?.closest(".toolbar-export-wrap")) {
+			showExportMenu = false;
+		}
 		if (showAccessInfo && !target?.closest(".access-info-wrap")) {
 			showAccessInfo = false;
 		}
@@ -2356,22 +2361,42 @@
 				View API
 			</button>
 			{#if auth.isHFSpace}
-				<button
-					class="tool-btn"
-					onclick={copyWorkflowJson}
-					title="Copy the workflow JSON to your clipboard"
-				>
-					<CodeIcon />
-					Copy JSON
-				</button>
-				<button
-					class="tool-btn"
-					onclick={downloadWorkflowJson}
-					title="Download the workflow as a .json file"
-				>
-					<DownloadIcon />
-					Download
-				</button>
+				<div class="toolbar-export-wrap">
+					<button
+						class="tool-btn"
+						class:open={showExportMenu}
+						onclick={() => (showExportMenu = !showExportMenu)}
+						title="Export this workflow"
+					>
+						<DownloadIcon />
+						Export
+						<ChevronDownIcon />
+					</button>
+					{#if showExportMenu}
+						<div class="toolbar-export-menu">
+							<button
+								class="toolbar-export-menu-btn"
+								onclick={() => {
+									showExportMenu = false;
+									void copyWorkflowJson();
+								}}
+							>
+								<CodeIcon />
+								Copy JSON
+							</button>
+							<button
+								class="toolbar-export-menu-btn"
+								onclick={() => {
+									showExportMenu = false;
+									downloadWorkflowJson();
+								}}
+							>
+								<DownloadIcon />
+								Download .json
+							</button>
+						</div>
+					{/if}
+				</div>
 			{/if}
 			{#if saveIndicator}
 				<span
@@ -3107,6 +3132,17 @@
 	:global(body:not(.dark) .toolbar-user-menu-btn:hover) {
 		background: #f0f1f5;
 		border-color: #d0d2dc;
+	}
+	:global(body:not(.dark) .toolbar-export-menu) {
+		background: #ffffff;
+		border-color: #e2e4ea;
+		box-shadow: 0 8px 24px rgba(20, 22, 30, 0.08);
+	}
+	:global(body:not(.dark) .toolbar-export-menu-btn) {
+		color: #1a1b25;
+	}
+	:global(body:not(.dark) .toolbar-export-menu-btn:hover) {
+		background: #f0f1f5;
 	}
 	:global(body:not(.dark) .toolbar-token-input) {
 		background: #ffffff;

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -12,8 +12,8 @@
 	import LayoutIcon from "./icons/LayoutIcon.svelte";
 	import InfoIcon from "./icons/InfoIcon.svelte";
 	import CodeIcon from "./icons/CodeIcon.svelte";
-	import DownloadIcon from "./icons/DownloadIcon.svelte";
-	import ChevronDownIcon from "./icons/ChevronDownIcon.svelte";
+	import UploadIcon from "./icons/UploadIcon.svelte";
+	import { uploadFile } from "@huggingface/hub";
 
 	import {
 		MODALITIES,
@@ -338,8 +338,19 @@
 	);
 	let showShortcuts = $state(false);
 	let showUserMenu = $state(false);
-	let showExportMenu = $state(false);
 	let showApiPanel = $state(false);
+	let saveToSpaceConfirm = $state(false);
+	let savingToSpace = $state(false);
+	let spaceId = $state("");
+	$effect(() => {
+		if (!server?.get_space_id) return;
+		void server
+			.get_space_id()
+			.then((id: string) => {
+				spaceId = id || "";
+			})
+			.catch(() => {});
+	});
 	// Popover shown when the "Run only" badge is clicked, explaining why editing
 	// is disabled and how to enable it.
 	let showAccessInfo = $state(false);
@@ -391,36 +402,35 @@
 		toasts = toasts.filter((t) => t.id !== id);
 	}
 
-	function serializedWorkflow(): string {
-		return JSON.stringify(sanitize_for_save($workflow), null, 2);
-	}
-
-	async function copyWorkflowJson(): Promise<void> {
+	async function saveToSpace(): Promise<void> {
+		saveToSpaceConfirm = false;
+		if (!spaceId || !auth.token || savingToSpace) return;
+		savingToSpace = true;
+		const serialized = JSON.stringify(sanitize_for_save($workflow), null, 2);
 		try {
-			await navigator.clipboard.writeText(serializedWorkflow());
-			showToast("Copied workflow JSON to clipboard", 2000, "success");
-		} catch {
+			await uploadFile({
+				repo: { type: "space", name: spaceId },
+				accessToken: auth.token,
+				file: {
+					path: "workflow.json",
+					content: new Blob([serialized], { type: "application/json" })
+				},
+				commitTitle: "Update workflow.json from canvas"
+			});
 			showToast(
-				"Couldn't copy to clipboard — use Download instead",
-				3500,
-				"warning"
+				`Committed workflow.json to ${spaceId} — the Space will restart.`,
+				4000,
+				"success"
 			);
+		} catch (e: any) {
+			const msg =
+				e?.message?.includes("403") || e?.statusCode === 403
+					? "Your token doesn't have write access to this Space repo."
+					: `Save failed: ${e?.message ?? e}`;
+			showToast(msg, 5000, "warning");
+		} finally {
+			savingToSpace = false;
 		}
-	}
-
-	function downloadWorkflowJson(): void {
-		const blob = new Blob([serializedWorkflow()], {
-			type: "application/json"
-		});
-		const url = URL.createObjectURL(blob);
-		const a = document.createElement("a");
-		a.href = url;
-		const safeName = ($workflow.name || "workflow").replace(/[^\w.-]+/g, "_");
-		a.download = `${safeName}.json`;
-		document.body.appendChild(a);
-		a.click();
-		a.remove();
-		URL.revokeObjectURL(url);
 	}
 
 	// v1 shape for read paths; writes go through v2 store actions.
@@ -1820,9 +1830,6 @@
 		if (showUserMenu && !target?.closest(".toolbar-user-wrap")) {
 			showUserMenu = false;
 		}
-		if (showExportMenu && !target?.closest(".toolbar-export-wrap")) {
-			showExportMenu = false;
-		}
 		if (showAccessInfo && !target?.closest(".access-info-wrap")) {
 			showAccessInfo = false;
 		}
@@ -2360,43 +2367,16 @@
 				<CodeIcon />
 				View API
 			</button>
-			{#if auth.isHFSpace}
-				<div class="toolbar-export-wrap">
-					<button
-						class="tool-btn"
-						class:open={showExportMenu}
-						onclick={() => (showExportMenu = !showExportMenu)}
-						title="Export this workflow"
-					>
-						<DownloadIcon />
-						Export
-						<ChevronDownIcon />
-					</button>
-					{#if showExportMenu}
-						<div class="toolbar-export-menu">
-							<button
-								class="toolbar-export-menu-btn"
-								onclick={() => {
-									showExportMenu = false;
-									void copyWorkflowJson();
-								}}
-							>
-								<CodeIcon />
-								Copy JSON
-							</button>
-							<button
-								class="toolbar-export-menu-btn"
-								onclick={() => {
-									showExportMenu = false;
-									downloadWorkflowJson();
-								}}
-							>
-								<DownloadIcon />
-								Download .json
-							</button>
-						</div>
-					{/if}
-				</div>
+			{#if auth.isHFSpace && auth.canWrite && spaceId && auth.token}
+				<button
+					class="tool-btn"
+					disabled={savingToSpace}
+					onclick={() => (saveToSpaceConfirm = true)}
+					title="Commit workflow.json to this Space's repo (will restart the Space)"
+				>
+					<UploadIcon />
+					{savingToSpace ? "Saving…" : "Save to Space"}
+				</button>
 			{/if}
 			{#if saveIndicator && !auth.isHFSpace}
 				<span
@@ -2889,6 +2869,41 @@
 		</div>
 	{/if}
 
+	{#if saveToSpaceConfirm}
+		<!-- svelte-ignore a11y_click_events_have_key_events -->
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div
+			class="wf-modal-backdrop"
+			onclick={() => (saveToSpaceConfirm = false)}
+		>
+			<div
+				class="wf-modal"
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="wf-save-space-title"
+				onclick={(e) => e.stopPropagation()}
+			>
+				<div class="wf-modal-title" id="wf-save-space-title">
+					Save to Space?
+				</div>
+				<div class="wf-modal-body">
+					This will commit <strong>workflow.json</strong> to
+					<strong>{spaceId}</strong>. The Space will
+					<strong>restart</strong> to pick up the change.
+				</div>
+				<div class="wf-modal-actions">
+					<button
+						class="wf-modal-btn"
+						onclick={() => (saveToSpaceConfirm = false)}>Cancel</button
+					>
+					<button class="wf-modal-btn wf-modal-btn-danger" onclick={saveToSpace}
+						>Save & restart</button
+					>
+				</div>
+			</div>
+		</div>
+	{/if}
+
 	{#if showApiPanel}
 		<WorkflowApiPanel
 			{server}
@@ -3132,17 +3147,6 @@
 	:global(body:not(.dark) .toolbar-user-menu-btn:hover) {
 		background: #f0f1f5;
 		border-color: #d0d2dc;
-	}
-	:global(body:not(.dark) .toolbar-export-menu) {
-		background: #ffffff;
-		border-color: #e2e4ea;
-		box-shadow: 0 8px 24px rgba(20, 22, 30, 0.08);
-	}
-	:global(body:not(.dark) .toolbar-export-menu-btn) {
-		color: #1a1b25;
-	}
-	:global(body:not(.dark) .toolbar-export-menu-btn:hover) {
-		background: #f0f1f5;
 	}
 	:global(body:not(.dark) .toolbar-token-input) {
 		background: #ffffff;


### PR DESCRIPTION
## Description

the saved <img width="130" height="56" alt="image" src="https://github.com/user-attachments/assets/0a465676-6811-4410-864c-3a8029d305e6" /> text is misleading when you're editing a workflow on hf spaces, and you cant actually save your changes. 

i've added a button exclusively to spaces allowing you to export the workflow as JSON via clipboard or .json download

<img width="504" height="161" alt="image" src="https://github.com/user-attachments/assets/95c542b2-8301-4df3-9dce-11d32fcf9624" />

https://huggingface.co/spaces/hmb/minimax-h3-model-2