### PR TITLE
Remux instead of re-encoding videos whose streams are already playable

### DIFF
--- a/gradio/components/video.py
+++ b/gradio/components/video.py
@@ -304,7 +304,9 @@ class Video(StreamingOutput, Component):
                 "Video does not have browser-compatible container or codec. Converting to mp4."
             )
             with trace_phase_sync("postprocess_video_convert_video_to_playable_mp4"):
-                video = processing_utils.convert_video_to_playable_mp4(video)
+                video = processing_utils.convert_video_to_playable_mp4(
+                    video, cache_dir=self.GRADIO_CACHE
+                )
         # Recalculate the format in case convert_video_to_playable_mp4 already made it the selected format
         returned_format = utils.get_extension_from_file_path_or_url(video).lower()
         if (

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -1143,13 +1143,13 @@ def _can_remux_to_mp4(video_path: str) -> bool:
     )
 
 
-def convert_video_to_playable_mp4(video_path: str) -> str:
+def convert_video_to_playable_mp4(video_path: str, cache_dir: str | None = None) -> str:
     """Convert the video to mp4. If something goes wrong return the original video."""
     from gradio._vendor.ffmpy import FFmpeg, FFRuntimeError
 
-    def to_mp4(input_path: str, output_path: Path, copy_streams: bool) -> None:
+    def to_mp4(output_path: Path, copy_streams: bool) -> None:
         ff = FFmpeg(
-            inputs={input_path: None},
+            inputs={video_path: None},
             # Only the video and audio streams are carried over when copying:
             # a Matroska file can hold subtitle or attachment streams that an
             # mp4 cannot, and those would fail the mux. `0:a?` makes audio
@@ -1169,26 +1169,29 @@ def convert_video_to_playable_mp4(video_path: str) -> str:
     # file takes minutes and degrades quality (#13527).
     can_remux = _can_remux_to_mp4(video_path)
 
+    # The result goes to a fresh directory rather than next to the source.
+    # `Path(video_path).with_suffix(".mp4")` overwrites an unrelated `clip.mp4`
+    # sitting beside `clip.mkv`, and for a non-playable `.mp4` it resolves to the
+    # input itself, rewriting the user's own file in place. Writing elsewhere
+    # also means the input no longer has to be copied aside first, which for a
+    # multi-gigabyte upload cost more than the remux it was protecting.
+    output_dir = Path(tempfile.mkdtemp(dir=cache_dir or get_upload_folder()))
+    output_path = output_dir / f"{Path(video_path).stem}.mp4"
+
     try:
-        with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
-            output_path = Path(video_path).with_suffix(".mp4")
-            shutil.copy2(video_path, tmp_file.name)
-            if can_remux:
-                try:
-                    to_mp4(tmp_file.name, output_path, copy_streams=True)
-                    return str(output_path)
-                except FFRuntimeError:
-                    # The streams turned out not to be muxable into an mp4
-                    # after all; fall back to a full re-encode.
-                    pass
-            # ffmpeg will automatically use h264 codec (playable in browser) when converting to mp4
-            to_mp4(tmp_file.name, output_path, copy_streams=False)
+        if can_remux:
+            try:
+                to_mp4(output_path, copy_streams=True)
+                return str(output_path)
+            except FFRuntimeError:
+                # The streams turned out not to be muxable into an mp4
+                # after all; fall back to a full re-encode.
+                pass
+        # ffmpeg will automatically use h264 codec (playable in browser) when converting to mp4
+        to_mp4(output_path, copy_streams=False)
     except FFRuntimeError as e:
         print(f"Error converting video to browser-playable format {str(e)}")
-        output_path = video_path
-    finally:
-        # Remove temp file
-        os.remove(tmp_file.name)  # type: ignore
+        return str(video_path)
     return str(output_path)
 
 

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -1150,12 +1150,13 @@ def convert_video_to_playable_mp4(video_path: str, cache_dir: str | None = None)
     def to_mp4(output_path: Path, copy_streams: bool) -> None:
         ff = FFmpeg(
             inputs={video_path: None},
-            # Only the video and audio streams are carried over when copying:
-            # a Matroska file can hold subtitle or attachment streams that an
-            # mp4 cannot, and those would fail the mux. `0:a?` makes audio
-            # optional so silent videos still work.
+            # Only the first video and audio stream are carried over when
+            # copying. A Matroska file can hold subtitle or attachment streams
+            # that an mp4 cannot, and those would fail the mux; it can also hold
+            # further audio tracks that `_can_remux_to_mp4` never checked. The
+            # `?` keeps audio optional so silent videos still work.
             outputs={
-                str(output_path): "-map 0:v:0 -map 0:a? -c copy"
+                str(output_path): "-map 0:v:0 -map 0:a:0? -c copy"
                 if copy_streams
                 else None
             },
@@ -1175,7 +1176,11 @@ def convert_video_to_playable_mp4(video_path: str, cache_dir: str | None = None)
     # input itself, rewriting the user's own file in place. Writing elsewhere
     # also means the input no longer has to be copied aside first, which for a
     # multi-gigabyte upload cost more than the remux it was protecting.
-    output_dir = Path(tempfile.mkdtemp(dir=cache_dir or get_upload_folder()))
+    # `get_upload_folder()` only names the cache, it does not create it, and
+    # `mkdtemp` will not create missing parents.
+    cache_root = Path(cache_dir or get_upload_folder())
+    cache_root.mkdir(parents=True, exist_ok=True)
+    output_dir = Path(tempfile.mkdtemp(dir=cache_root))
     output_path = output_dir / f"{Path(video_path).stem}.mp4"
 
     try:
@@ -1191,6 +1196,10 @@ def convert_video_to_playable_mp4(video_path: str, cache_dir: str | None = None)
         to_mp4(output_path, copy_streams=False)
     except FFRuntimeError as e:
         print(f"Error converting video to browser-playable format {str(e)}")
+        # The original is returned, so nothing will ever reference this
+        # directory or the partial file ffmpeg may have left in it, and the
+        # cache cleanup only tracks paths that were handed out.
+        shutil.rmtree(output_dir, ignore_errors=True)
         return str(video_path)
     return str(output_path)
 

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -1100,21 +1100,89 @@ def video_is_playable(video_filepath: str) -> bool:
         return True
 
 
+# Codecs that both fit in an mp4 container and are playable in browsers, so a
+# file holding them only needs remuxing rather than re-encoding. The video set
+# matches the mp4 entries in `video_is_playable`.
+MP4_COMPATIBLE_VIDEO_CODECS = frozenset({"h264", "av1"})
+MP4_COMPATIBLE_AUDIO_CODECS = frozenset({"aac", "mp3"})
+
+
+def _first_stream_codecs(video_path: str) -> tuple[str | None, str | None] | None:
+    """Return the first (video codec, audio codec) of a media file.
+
+    Either element is None when the file has no stream of that kind. Returns
+    None if the file could not be probed at all.
+    """
+    from gradio._vendor.ffmpy import FFprobe, FFRuntimeError
+
+    try:
+        probe = FFprobe(
+            global_options="-show_streams -print_format json",
+            inputs={video_path: None},
+        )
+        output = probe.run(stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        streams = json.loads(output[0])["streams"]  # type: ignore
+    except (FFRuntimeError, IndexError, KeyError, ValueError):
+        return None
+    codecs: dict[str, str] = {}
+    for stream in streams:
+        codec_type = stream.get("codec_type")
+        if codec_type in ("video", "audio") and codec_type not in codecs:
+            codecs[codec_type] = stream.get("codec_name", "")
+    return codecs.get("video"), codecs.get("audio")
+
+
+def _can_remux_to_mp4(video_path: str) -> bool:
+    """Whether the file's streams can be copied into an mp4 as-is."""
+    codecs = _first_stream_codecs(video_path)
+    if codecs is None:
+        return False
+    video_codec, audio_codec = codecs
+    return video_codec in MP4_COMPATIBLE_VIDEO_CODECS and (
+        audio_codec is None or audio_codec in MP4_COMPATIBLE_AUDIO_CODECS
+    )
+
+
 def convert_video_to_playable_mp4(video_path: str) -> str:
     """Convert the video to mp4. If something goes wrong return the original video."""
     from gradio._vendor.ffmpy import FFmpeg, FFRuntimeError
+
+    def to_mp4(input_path: str, output_path: Path, copy_streams: bool) -> None:
+        ff = FFmpeg(
+            inputs={input_path: None},
+            # Only the video and audio streams are carried over when copying:
+            # a Matroska file can hold subtitle or attachment streams that an
+            # mp4 cannot, and those would fail the mux. `0:a?` makes audio
+            # optional so silent videos still work.
+            outputs={
+                str(output_path): "-map 0:v:0 -map 0:a? -c copy"
+                if copy_streams
+                else None
+            },
+            global_options="-y -loglevel quiet",
+        )
+        ff.run()
+
+    # A container that browsers cannot play (.mkv, say) often still holds
+    # streams they can, in which case only the container has to change. Copying
+    # the streams is near-instant and lossless, where a re-encode of a large
+    # file takes minutes and degrades quality (#13527).
+    can_remux = _can_remux_to_mp4(video_path)
 
     try:
         with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
             output_path = Path(video_path).with_suffix(".mp4")
             shutil.copy2(video_path, tmp_file.name)
+            if can_remux:
+                try:
+                    to_mp4(tmp_file.name, output_path, copy_streams=True)
+                    return str(output_path)
+                except FFRuntimeError:
+                    # The streams turned out not to be muxable into an mp4
+                    # after all; fall back to a full re-encode.
+                    pass
             # ffmpeg will automatically use h264 codec (playable in browser) when converting to mp4
-            ff = FFmpeg(
-                inputs={str(tmp_file.name): None},
-                outputs={str(output_path): None},
-                global_options="-y -loglevel quiet",
-            )
-            ff.run()
+            to_mp4(tmp_file.name, output_path, copy_streams=False)
     except FFRuntimeError as e:
         print(f"Error converting video to browser-playable format {str(e)}")
         output_path = video_path

--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import shutil
+import subprocess
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -423,22 +424,15 @@ class TestVideoProcessing:
         assert not processing_utils._can_remux_to_mp4(str(unreadable))
 
     @staticmethod
-    @contextmanager
-    def _record_ffmpeg_commands():
-        """Yield the list of ffmpeg command lines run inside the block.
-
-        `FFprobe` subclasses `FFmpeg`, so probe calls are filtered out.
-        """
-        commands: list[str] = []
-        real_run = ffmpy.FFmpeg.run
-
-        def record(self, *args, **kwargs):
-            if not self.cmd.startswith("ffprobe"):
-                commands.append(self.cmd)
-            return real_run(self, *args, **kwargs)
-
-        with patch.object(ffmpy.FFmpeg, "run", record):
-            yield commands
+    def _video_stream_md5(path: str) -> str:
+        """Checksum of the encoded video stream, ignoring the container."""
+        output = subprocess.run(
+            ["ffmpeg", "-v", "quiet", "-i", path, "-map", "0:v:0", "-f", "md5", "-"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return output.stdout.strip()
 
     def test_convert_video_copies_already_compatible_streams(
         self, test_file_dir, tmp_path
@@ -447,12 +441,11 @@ class TestVideoProcessing:
         mkv = tmp_path / "h264.mkv"
         self._as_mkv(test_file_dir / "video_sample.mp4", mkv)
 
-        with self._record_ffmpeg_commands() as commands:
-            playable_vid = processing_utils.convert_video_to_playable_mp4(str(mkv))
+        playable_vid = processing_utils.convert_video_to_playable_mp4(str(mkv))
 
         assert processing_utils.video_is_playable(playable_vid)
-        assert len(commands) == 1, "should not fall back to a re-encode"
-        assert "-c copy" in commands[0]
+        # The stream came through untouched, which a re-encode could not manage
+        assert self._video_stream_md5(playable_vid) == self._video_stream_md5(str(mkv))
 
     def test_convert_video_reencodes_incompatible_streams(
         self, test_file_dir, tmp_path
@@ -460,13 +453,15 @@ class TestVideoProcessing:
         """theora/vorbis cannot be copied into an mp4, so it must be re-encoded."""
         mkv = tmp_path / "theora.mkv"
         shutil.copy(test_file_dir / "playable_but_bad_container.mkv", mkv)
+        assert processing_utils._first_stream_codecs(str(mkv)) == ("theora", "vorbis")
 
-        with self._record_ffmpeg_commands() as commands:
-            playable_vid = processing_utils.convert_video_to_playable_mp4(str(mkv))
+        playable_vid = processing_utils.convert_video_to_playable_mp4(str(mkv))
 
         assert processing_utils.video_is_playable(playable_vid)
-        assert len(commands) == 1, "should not have attempted a remux"
-        assert "-c copy" not in commands[0]
+        # theora has no place in an mp4, so the streams must have been rebuilt
+        video_codec, audio_codec = processing_utils._first_stream_codecs(playable_vid)
+        assert video_codec == "h264"
+        assert audio_codec != "vorbis"
 
     def test_convert_video_to_playable_mp4(self, test_file_dir):
         with tempfile.NamedTemporaryFile(

--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -471,7 +471,9 @@ class TestVideoProcessing:
 
         assert processing_utils.video_is_playable(playable_vid)
         # theora has no place in an mp4, so the streams must have been rebuilt
-        video_codec, audio_codec = processing_utils._first_stream_codecs(playable_vid)
+        codecs = processing_utils._first_stream_codecs(playable_vid)
+        assert codecs is not None
+        video_codec, audio_codec = codecs
         assert video_codec == "h264"
         assert audio_codec != "vorbis"
 

--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import os
 import shutil
 import subprocess
@@ -424,6 +425,17 @@ class TestVideoProcessing:
         assert not processing_utils._can_remux_to_mp4(str(unreadable))
 
     @staticmethod
+    def _streams(path: str) -> list[dict]:
+        """The stream descriptors ffprobe reports for a file."""
+        output = subprocess.run(
+            ["ffprobe", "-v", "quiet", "-show_streams", "-print_format", "json", path],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return json.loads(output.stdout)["streams"]
+
+    @staticmethod
     def _video_stream_md5(path: str) -> str:
         """Checksum of the encoded video stream, ignoring the container."""
         output = subprocess.run(
@@ -474,6 +486,62 @@ class TestVideoProcessing:
                 tmp_not_playable_vid.name
             )
             assert processing_utils.video_is_playable(playable_vid)
+
+    def test_convert_video_copies_only_the_validated_audio_track(
+        self, test_file_dir, tmp_path
+    ):
+        """Extra audio tracks are not vetted by `_can_remux_to_mp4`, so they are dropped."""
+        mkv = tmp_path / "two_audio.mkv"
+        ffmpy.FFmpeg(
+            inputs={
+                str(test_file_dir / "video_sample.mp4"): None,
+                "sine=duration=2": "-f lavfi",
+            },
+            outputs={
+                str(mkv): "-map 0:v:0 -map 0:a:0 -map 1:a:0 "
+                "-c:v copy -c:a:0 copy -c:a:1 libopus"
+            },
+            global_options="-y -loglevel quiet",
+        ).run()
+
+        playable_vid = processing_utils.convert_video_to_playable_mp4(str(mkv))
+
+        assert processing_utils.video_is_playable(playable_vid)
+        codecs = [
+            stream["codec_name"]
+            for stream in self._streams(playable_vid)
+            if stream["codec_type"] == "audio"
+        ]
+        assert codecs == ["aac"], "the unchecked opus track should not be carried over"
+
+    def test_convert_video_creates_the_cache_root(self, test_file_dir, tmp_path):
+        """The cache directory is only a name until something creates it."""
+        mkv = tmp_path / "h264.mkv"
+        self._as_mkv(test_file_dir / "video_sample.mp4", mkv)
+        missing_cache = tmp_path / "not" / "created" / "yet"
+
+        playable_vid = processing_utils.convert_video_to_playable_mp4(
+            str(mkv), cache_dir=str(missing_cache)
+        )
+
+        assert processing_utils.video_is_playable(playable_vid)
+        assert missing_cache.exists()
+
+    def test_convert_video_cleans_up_after_a_failed_conversion(
+        self, test_file_dir, tmp_path
+    ):
+        """A failed conversion must not leave a directory nothing can reach."""
+        cache = tmp_path / "cache"
+        with patch(
+            "gradio._vendor.ffmpy.FFmpeg.run",
+            side_effect=ffmpy.FFRuntimeError("", "", "", ""),  # type: ignore
+        ):
+            returned = processing_utils.convert_video_to_playable_mp4(
+                str(test_file_dir / "bad_video_sample.mp4"), cache_dir=str(cache)
+            )
+
+        assert returned == str(test_file_dir / "bad_video_sample.mp4")
+        assert list(cache.iterdir()) == []
 
     def test_convert_video_does_not_write_next_to_the_source(
         self, test_file_dir, tmp_path

--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -393,6 +393,80 @@ class TestVideoProcessing:
             )
             assert processing_utils.video_is_playable(tmp_not_playable_vid.name)
 
+    @staticmethod
+    def _as_mkv(source: Path, destination: Path) -> None:
+        """Rewrap a video into a Matroska container without touching the streams."""
+        ffmpy.FFmpeg(
+            inputs={str(source): None},
+            outputs={str(destination): "-c copy"},
+            global_options="-y -loglevel quiet",
+        ).run()
+
+    def test_can_remux_to_mp4(self, test_file_dir, tmp_path):
+        # h264 + aac, only the container is wrong
+        mkv = tmp_path / "h264.mkv"
+        self._as_mkv(test_file_dir / "video_sample.mp4", mkv)
+        assert processing_utils._can_remux_to_mp4(str(mkv))
+
+        # theora + vorbis cannot live in an mp4
+        assert not processing_utils._can_remux_to_mp4(
+            str(test_file_dir / "playable_but_bad_container.mkv")
+        )
+        # mpeg4 is not browser-playable
+        assert not processing_utils._can_remux_to_mp4(
+            str(test_file_dir / "bad_video_sample.mp4")
+        )
+        # a file ffprobe cannot read at all
+        unreadable = tmp_path / "unreadable.mkv"
+        unreadable.write_bytes(b"not a video")
+        assert not processing_utils._can_remux_to_mp4(str(unreadable))
+
+    @staticmethod
+    @contextmanager
+    def _record_ffmpeg_commands():
+        """Yield the list of ffmpeg command lines run inside the block.
+
+        `FFprobe` subclasses `FFmpeg`, so probe calls are filtered out.
+        """
+        commands: list[str] = []
+        real_run = ffmpy.FFmpeg.run
+
+        def record(self, *args, **kwargs):
+            if not self.cmd.startswith("ffprobe"):
+                commands.append(self.cmd)
+            return real_run(self, *args, **kwargs)
+
+        with patch.object(ffmpy.FFmpeg, "run", record):
+            yield commands
+
+    def test_convert_video_copies_already_compatible_streams(
+        self, test_file_dir, tmp_path
+    ):
+        """A browser-playable codec in a bad container only needs remuxing (#13527)."""
+        mkv = tmp_path / "h264.mkv"
+        self._as_mkv(test_file_dir / "video_sample.mp4", mkv)
+
+        with self._record_ffmpeg_commands() as commands:
+            playable_vid = processing_utils.convert_video_to_playable_mp4(str(mkv))
+
+        assert processing_utils.video_is_playable(playable_vid)
+        assert len(commands) == 1, "should not fall back to a re-encode"
+        assert "-c copy" in commands[0]
+
+    def test_convert_video_reencodes_incompatible_streams(
+        self, test_file_dir, tmp_path
+    ):
+        """theora/vorbis cannot be copied into an mp4, so it must be re-encoded."""
+        mkv = tmp_path / "theora.mkv"
+        shutil.copy(test_file_dir / "playable_but_bad_container.mkv", mkv)
+
+        with self._record_ffmpeg_commands() as commands:
+            playable_vid = processing_utils.convert_video_to_playable_mp4(str(mkv))
+
+        assert processing_utils.video_is_playable(playable_vid)
+        assert len(commands) == 1, "should not have attempted a remux"
+        assert "-c copy" not in commands[0]
+
     def test_convert_video_to_playable_mp4(self, test_file_dir):
         with tempfile.NamedTemporaryFile(
             suffix="out.avi", delete=False

--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import shutil
 import tempfile
@@ -474,13 +475,41 @@ class TestVideoProcessing:
             shutil.copy(
                 str(test_file_dir / "bad_video_sample.mp4"), tmp_not_playable_vid.name
             )
-            with patch("os.remove", wraps=os.remove) as mock_remove:
-                playable_vid = processing_utils.convert_video_to_playable_mp4(
-                    tmp_not_playable_vid.name
-                )
-            # check tempfile got deleted
-            assert not Path(mock_remove.call_args[0][0]).exists()
+            playable_vid = processing_utils.convert_video_to_playable_mp4(
+                tmp_not_playable_vid.name
+            )
             assert processing_utils.video_is_playable(playable_vid)
+
+    def test_convert_video_does_not_write_next_to_the_source(
+        self, test_file_dir, tmp_path
+    ):
+        """The conversion must not touch anything in the source directory.
+
+        `Path(video_path).with_suffix(".mp4")` overwrote an unrelated file of the
+        same stem, and for a non-playable `.mp4` it resolved to the input itself.
+        """
+        mkv = tmp_path / "clip.mkv"
+        self._as_mkv(test_file_dir / "video_sample.mp4", mkv)
+        neighbour = tmp_path / "clip.mp4"
+        neighbour.write_bytes(b"an unrelated file that happens to share a stem")
+
+        playable_vid = processing_utils.convert_video_to_playable_mp4(str(mkv))
+
+        assert processing_utils.video_is_playable(playable_vid)
+        assert Path(playable_vid).parent != tmp_path
+        assert (
+            neighbour.read_bytes() == b"an unrelated file that happens to share a stem"
+        )
+
+        # A `.mp4` that is not playable would otherwise be rewritten in place.
+        source = tmp_path / "user_video.mp4"
+        shutil.copy(test_file_dir / "bad_video_sample.mp4", source)
+        digest = hashlib.md5(source.read_bytes()).hexdigest()
+
+        playable_vid = processing_utils.convert_video_to_playable_mp4(str(source))
+
+        assert processing_utils.video_is_playable(playable_vid)
+        assert hashlib.md5(source.read_bytes()).hexdigest() == digest
 
     @patch(
         "gradio._vendor.ffmpy.FFmpeg.run",


### PR DESCRIPTION
Closes #13527

Uploading a large `.mkv` to `gr.Video` took minutes before the video appeared, even when the streams inside it were already h264/aac. Now, we probe the first video and audio stream. When both are already mp4- **and** browser-compatible, copy the streams instead of re-encoding; otherwise transcode exactly as before, saving us lots of time. Also fixed an issue with original video files that could be overwritten.

Before (`main`):



https://github.com/user-attachments/assets/d57cc0a5-7b6a-4fdf-88ab-c1c91a5683da


After (this PR):

https://github.com/user-attachments/assets/c7af10b6-e077-454a-be37-d9aa0b22973d


