### PR TITLE
Unblock releases: fix the mixed changeset and pin core metadata to 2.4

### DIFF
--- a/.changeset/soft-bags-type.md
+++ b/.changeset/soft-bags-type.md
@@ -57,7 +57,6 @@
 "@self/app": minor
 "@self/component-test": minor
 "@self/spa": minor
-"@self/spaces-test": minor
 "gradio": minor
 "gradio_test": minor
 "website": minor

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-requirements-txt", "hatch-fancy-pypi-readme>=22.5.0"]
+requires = ["hatchling>=1.27", "hatch-requirements-txt", "hatch-fancy-pypi-readme>=22.5.0"]
 build-backend = "hatchling.build"
 
 [project]
@@ -50,7 +50,11 @@ fragments = [
   { path = "README.md" },
 ]
 
+[tool.hatch.build.targets.wheel]
+core-metadata-version = "2.4"
+
 [tool.hatch.build.targets.sdist]
+core-metadata-version = "2.4"
 include = [
   "/gradio_client",
   "/README.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "hatchling",
+  "hatchling>=1.27",
   "hatch-requirements-txt",
   "hatch-fancy-pypi-readme>=22.5.0",
 ]
@@ -78,7 +78,11 @@ artifacts = [
   "/gradio/py.typed",
 ]
 
+[tool.hatch.build.targets.wheel]
+core-metadata-version = "2.4"
+
 [tool.hatch.build.targets.sdist]
+core-metadata-version = "2.4"
 include = [
   "/gradio",
   "/test",


### PR DESCRIPTION
Releases are blocked by two independent problems. This fixes both.

## 1. `changeset version` fails on a mixed changeset

Every `publish` run since 2026-08-06 has failed at `create and publish versions`, before the PyPI step ever runs — the last PyPI release was `gradio` 6.22.0 on 2026-07-31:

```
🦋  error Error: Found mixed changeset soft-bags-type
🦋  error Found ignored packages: @self/spaces-test
🦋  error Mixed changesets that contain both ignored and not ignored packages are not allowed
```

`.changeset/soft-bags-type.md` (from #13700) listed `"@self/spaces-test": minor` alongside ~60 non-ignored packages, and `@self/spaces-test` is in the `ignore` list in `.changeset/config.json`. That one line is removed.

Verified with the changesets CLI against this working tree: `changeset status` reproduces the error above before the change and completes normally after it. No other changeset mixes ignored with non-ignored packages.

## 2. PyPI upload would then fail on metadata version 2.5

`hatchling` 1.32.0 (released 2026-08-11 05:03 UTC) bumped its `DEFAULT_METADATA_VERSION` from 2.4 to 2.5. Both `gradio` and `gradio_client` declare `hatchling` unpinned and build in isolation, so they now emit `Metadata-Version: 2.5`.

`gradio-app/github/actions/publish-pypi` installs `twine==6` under a vendored constraints file that pins `packaging==25.0` via `PIP_CONSTRAINT`, and `packaging` is what validates the metadata — 2.4 is the newest version it knows. So every upload from that action fails:

```
ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

This already happened for real on trackio ([failing run](https://github.com/gradio-app/trackio/actions/runs/31496585592/job/93795716701), fixed by gradio-app/trackio#665). gradio hasn't hit it yet only because of problem 1.

The fix is `core-metadata-version = "2.4"` on the `wheel` and `sdist` targets of both packages. hatchling reads this per-target with no global fallback, and `build_pypi.sh` builds both an sdist and a wheel for each package, so all four targets need it. `hatchling>=1.27` is added because 2.4 is the first metadata version hatchling can construct. Pinning the emitted metadata rather than `hatchling<1.32` leaves hatchling free to upgrade.

### Verification

Built both packages from a clean checkout with hatchling 1.32.0, before and after, and checked against `twine 6.2.0` + `packaging 25.0` — the exact combination the action uses:

| | before | after |
|---|---|---|
| `gradio` wheel | `Metadata-Version: 2.5`, `twine check` **ERROR** | `2.4`, **PASSED** |
| `gradio_client` wheel + sdist | `2.5`, **ERROR** | `2.4`, **PASSED** |

Archive file lists are identical before and after in every case (247 entries for the `gradio` wheel), so `Metadata-Version` is the only thing that changes — adding the `[tool.hatch.build.targets.wheel]` section did not disturb the default file selection.

---

Note that the durable fix for problem 2 belongs in `gradio-app/github`: bumping `twine` **and** the pinned `packaging` so 2.5 is accepted. This PR is the repo-side unblock, and it will keep working either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)