### PR TITLE
Fix dataframe header alignment

### DIFF
--- a/js/dataframe/Dataframe.test.ts
+++ b/js/dataframe/Dataframe.test.ts
@@ -96,6 +96,34 @@ describe("Dataframe rendering", () => {
 		expect(rows.length).toBe(3);
 	});
 
+	test("resets inherited table padding so headers align with body cells", async () => {
+		const global_style = document.createElement("style");
+		global_style.textContent = "table { padding: 10px; }";
+		document.head.appendChild(global_style);
+
+		try {
+			const { container } = await render(Dataframe, default_props);
+			await wait();
+
+			const header_table = container.querySelector(
+				".header-table"
+			) as HTMLTableElement;
+			const first_header = get_header_cells(container)[0];
+			const first_body_cell = get_cell(container, 0, 0)!;
+			const header_rect = first_header.getBoundingClientRect();
+			const body_rect = first_body_cell.getBoundingClientRect();
+
+			expect(getComputedStyle(header_table).padding).toBe("0px");
+			expect(header_table.getBoundingClientRect().height).toBe(
+				header_rect.height
+			);
+			expect(header_rect.left).toBeCloseTo(body_rect.left);
+			expect(header_rect.right).toBeCloseTo(body_rect.right);
+		} finally {
+			global_style.remove();
+		}
+	});
+
 	test("renders label when show_label is true", async () => {
 		const { container } = await render(Dataframe, {
 			...default_props,

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -1338,6 +1338,7 @@
 	/* Header table: auto-sizes columns by content, sticky */
 	.header-table {
 		width: 100%;
+		padding: 0;
 		color: var(--body-text-color);
 		font-size: var(--input-text-size);
 		line-height: var(--line-md);


### PR DESCRIPTION
## Description

Reset inherited padding on the Dataframe header table so its height and column separators align with the flex-rendered body cells. Add regression coverage for inherited table padding, header height, and column-edge alignment.

Closes: #13733

## Preview Spaces

Both Spaces use the same Dataframe reproduction and wheels built from the exact commits shown below.

| Preview | Commit | Space |
| --- | --- | --- |
| Before (`main`) | [`1a939bfad`](https://github.com/gradio-app/gradio/commit/1a939bfad3148bdcb0c2105540589305d8a49cc3) | [Open before Space](https://huggingface.co/spaces/gradio-pr-deploys/pr-13732-dataframe-before) |
| After (this PR) | [`109e8032b`](https://github.com/gradio-app/gradio/commit/109e8032b5e78ffac2e8e72b4b0a4aa8c118bc81) | [Open after Space](https://huggingface.co/spaces/gradio-pr-deploys/pr-13732-dataframe-after) |

To compare, inspect the header height and the vertical separators between the headers and body cells. The main preview shows the inherited table padding; the PR preview resets it.

## AI Disclosure

- [x] I used AI to investigate the layout regression, implement the CSS fix, draft regression coverage, and prepare the preview deployments. I reviewed every changed line and verified the result locally.
- [ ] I did not use AI

## Testing and Formatting Your Code

- Focused Dataframe browser suite: 46 passed, 2 existing todos.
- Frontend formatting completed successfully.
- Repository-wide type checking reports 16 pre-existing errors in unrelated files.
- Public visual verification: the baseline has 10px header-table padding and a 57px header container; the fix has 0px padding, a 37px header container, and exact alignment across all four header/body column edges.
