### PR TITLE
Fix publish workflow authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
           title: "chore: update versions"
           publish: pnpm ci:publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GRADIO_PAT }}
+          GITHUB_TOKEN: ${{ secrets.COMMENT_TOKEN }}
       - name: Upload npm logs
         if: always()
         uses: actions/upload-artifact@v4
@@ -64,19 +64,19 @@ jobs:
         run: gh pr edit "$PR_NUMBER" --add-label "no-visual-update"
         env:
           PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
-          GITHUB_TOKEN: ${{ secrets.GRADIO_PAT }}
+          GITHUB_TOKEN: ${{ secrets.COMMENT_TOKEN }}
       - name: add label to run flaky tests
         if: ${{ steps.changesets.outputs.pullRequestNumber != '' && steps.changesets.outputs.pullRequestNumber != 'undefined' }}
         run: gh pr edit "$PR_NUMBER" --add-label "flaky-tests"
         env:
           PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
-          GITHUB_TOKEN: ${{ secrets.GRADIO_PAT }}
+          GITHUB_TOKEN: ${{ secrets.COMMENT_TOKEN }}
       - name: add label to run backend tests on Windows
         if: ${{ steps.changesets.outputs.pullRequestNumber != '' && steps.changesets.outputs.pullRequestNumber != 'undefined' }}
         run: gh pr edit "$PR_NUMBER" --add-label "windows-tests"
         env:
           PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
-          GITHUB_TOKEN: ${{ secrets.GRADIO_PAT }}
+          GITHUB_TOKEN: ${{ secrets.COMMENT_TOKEN }}
       - name: publish to pypi
         if: steps.changesets.outputs.hasChangesets != 'true'
         uses: "gradio-app/github/actions/publish-pypi@main"


### PR DESCRIPTION
## Summary

- replace the expired `GRADIO_PAT` used by the publish workflow with the recently rotated repository automation token
- use the same token for release PR labeling so the workflow has one consistent GitHub credential

## Root cause

The publish environment `GRADIO_PAT` was last updated on August 5, 2025. Every publish run since August 5, 2026 has failed while `changeset version` fetches changelog metadata from GitHub with `401 Bad credentials`. The latest failure was run 31531032009.

## Validation

- parsed `.github/workflows/publish.yml` as YAML
- Prettier check
- `git diff --check`
- confirmed the replacement repository secret exists and was rotated August 10, 2026