### PR TITLE
Fix changeset workflow checkout authentication

### DIFF
--- a/.github/workflows/generate-changeset.yml
+++ b/.github/workflows/generate-changeset.yml
@@ -60,7 +60,7 @@ jobs:
           repository: ${{ needs.get-pr.outputs.source_repo }}
           ref: ${{ needs.get-pr.outputs.source_branch }}
           fetch-depth: 0
-          token: ${{ secrets.COMMENT_TOKEN }}
+          token: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
       - name: generate changeset
         id: version
         uses: "gradio-app/github/actions/generate-changeset@main"


### PR DESCRIPTION
## Summary

- use the dedicated `CHANGESET_GITHUB_TOKEN` for checkout in the changeset job
- unblock generated changesets after the repository-level `COMMENT_TOKEN` expired

## Validation

- parsed workflow YAML
- ran Prettier check
- ran `git diff --check`