### PR TITLE
Resolve relative `/gradio_api/file=` requests against `allowed_paths`, not just the CWD

### DIFF
--- a/.changeset/lucky-paths-serve.md
+++ b/.changeset/lucky-paths-serve.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Make `allowed_paths` work for relative file requests regardless of the server's working directory

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -1386,23 +1386,47 @@ def file_fetch(
     if starts_with_protocol(path_or_url):
         raise HTTPException(403, f"File not allowed: {path_or_url}.")
 
-    abs_path = utils.abspath(path_or_url)
-    try:
-        if abs_path.is_dir() or not abs_path.exists():
-            raise HTTPException(403, f"File not allowed: {path_or_url}.")
-    except Exception as e:
-        raise HTTPException(403, f"File not allowed: {path_or_url}.") from e
-
     from gradio.data_classes import _StaticFiles
 
-    allowed, reason = utils.is_allowed_file(
-        abs_path,
-        blocked_paths=blocks_or_config.blocked_paths,
-        allowed_paths=blocks_or_config.allowed_paths + _StaticFiles.all_paths,
-        created_paths=[upload_dir, str(utils.get_cache_folder())],
-    )
-    if not allowed:
-        raise HTTPException(403, f"File not allowed: {path_or_url}.")
+    allowed_paths = blocks_or_config.allowed_paths + _StaticFiles.all_paths
+
+    # A relative request path is resolved against the server's working directory,
+    # which is not necessarily the directory the path was written against. A Docker
+    # WORKDIR with the data volume mounted somewhere else is the common case: the
+    # app works when started from inside the data directory and 403s otherwise
+    # (#10180). So if the working directory does not yield a servable file, fall
+    # back to resolving the path against each allowed root. `is_allowed_file()`
+    # still has the final say for every candidate, so this cannot widen what is
+    # servable, only stop it from depending on the working directory.
+    candidates = [utils.abspath(path_or_url)]
+    if not os.path.isabs(str(path_or_url)):
+        candidates += [
+            utils.abspath(Path(allowed_path) / str(path_or_url))
+            for allowed_path in allowed_paths
+        ]
+
+    abs_path: Path | None = None
+    reason = None
+    error: Exception | None = None
+    for candidate in candidates:
+        try:
+            if candidate.is_dir() or not candidate.exists():
+                continue
+        except Exception as e:  # noqa: PERF203
+            error = error or e
+            continue
+        candidate_allowed, candidate_reason = utils.is_allowed_file(
+            candidate,
+            blocked_paths=blocks_or_config.blocked_paths,
+            allowed_paths=allowed_paths,
+            created_paths=[upload_dir, str(utils.get_cache_folder())],
+        )
+        if candidate_allowed:
+            abs_path, reason = candidate, candidate_reason
+            break
+
+    if abs_path is None:
+        raise HTTPException(403, f"File not allowed: {path_or_url}.") from error
 
     mime_type, _ = mimetypes.guess_type(abs_path)
     if mime_type in XSS_SAFE_MIMETYPES or reason == "allowed":

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -307,6 +307,39 @@ class TestRoutes:
         assert len(file_response.text) == len(media_data.BASE64_IMAGE)
         io.close()
 
+    def test_get_allowed_paths_relative_to_allowed_root(self):
+        # A relative request path used to be resolved only against the server's
+        # working directory, so `allowed_paths` silently stopped working whenever the
+        # app was not started from the directory the path was written against -- a
+        # Docker WORKDIR with the data volume mounted elsewhere being the common
+        # case. See https://github.com/gradio-app/gradio/issues/10180.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            allowed_file = Path(temp_dir) / "images" / "0.jpg"
+            allowed_file.parent.mkdir(parents=True, exist_ok=True)
+            allowed_file.write_text("hello")
+            # the working directory of the test process is not the allowed root
+            assert not (Path.cwd() / "images" / "0.jpg").exists()
+
+            outside_file = Path(temp_dir).parent / "outside_10180.txt"
+            outside_file.write_text("secret")
+
+            io = gr.Interface(lambda s: s.name, gr.File(), gr.File())
+            app, _, _ = io.launch(prevent_thread_lock=True, allowed_paths=[temp_dir])
+            try:
+                client = TestClient(app)
+                file_response = client.get(f"{API_PREFIX}/file=images/0.jpg")
+                assert file_response.status_code == 200
+                assert file_response.text == "hello"
+
+                # ...but a relative path that escapes the allowed root is not served
+                escaping_response = client.get(
+                    f"{API_PREFIX}/file=../{outside_file.name}"
+                )
+                assert escaping_response.status_code == 403
+            finally:
+                io.close()
+                outside_file.unlink()
+
     def test_response_attachment_format(self, media_data):
         image_file = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".png")
         image_file.write(media_data.BASE64_IMAGE)


### PR DESCRIPTION
Fixes #10180

## Root cause

`/gradio_api/file=<path>` resolved the requested path with `utils.abspath()` only, i.e. against the **working directory of the server process**. Docker is incidental to the report: with a `WORKDIR` of `/app` and the data volume mounted at `/root_path`, `images/0.jpg` resolves to `/app/images/0.jpg`, which is outside `allowed_paths=["/root_path/"]` — hence `{"detail":"File not allowed: images/0.jpg."}`. The identical app started from inside the data directory works, which is why it reproduced only in the container.

## Fix

`file_fetch()` now also tries resolving a *relative* request path against each allowed root, and uses the first candidate that exists and passes `is_allowed_file()`. The CWD candidate is still tried first, so nothing that is served today changes.

`is_allowed_file()` remains the only authority on what is servable, so this cannot widen access: `blocked_paths` still wins, and a relative path that escapes the allowed root (`../secret.txt`) is still a 403.

## Verification

```
$ python -m pytest test/test_routes.py -k "allowed_paths or blocked_path or attachment_format" -q
6 passed
```

`test_get_allowed_paths_relative_to_allowed_root` is new and fails on `main` (`assert 403 == 200`). The full `test/test_routes.py` has the same 7 pre-existing failures before and after this change (background-task/lifespan and deep-link tests, plus `test_header_size_limit`, all failing on `main` in the same env).

Manual check with the demo below, started from a CWD that is *not* the data root:

```
$ curl -sS -w '%{http_code}' "http://127.0.0.1:7885/gradio_api/file=images/0.jpg"
before: 403 {"detail":"File not allowed: images/0.jpg."}      after: 200
$ curl -sS --path-as-is "http://127.0.0.1:7885/gradio_api/file=../secret.txt"          -> 403 (both)
$ curl -sS --path-as-is ".../file=images/../../../../../../etc/passwd"                  -> 403 (both)
```

## Minimal demo (not committed)

```python
import sys
from pathlib import Path
import gradio as gr

DATA_ROOT = Path("/tmp/rootpath")
(DATA_ROOT / "images").mkdir(parents=True, exist_ok=True)
(DATA_ROOT / "images" / "0.jpg").write_bytes(b"not-really-a-jpeg")

with gr.Blocks() as demo:
    gr.Markdown('<img src="/gradio_api/file=images/0.jpg" width="80">')

if __name__ == "__main__":
    demo.launch(allowed_paths=[str(DATA_ROOT)], server_port=7885)
```

Run it from a different directory (`cd /tmp && python demo.py`) — that is what reproduces the report. The demo file was kept untracked and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)