### PR TITLE
Replay text-encoded files in `gr.load_chat` history as text, not as images

### DIFF
--- a/.changeset/eager-files-speak.md
+++ b/.changeset/eager-files-speak.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Keep text-encoded files as text when replaying `gr.load_chat` history

--- a/gradio/external.py
+++ b/gradio/external.py
@@ -748,6 +748,14 @@ TEXT_FILE_EXTENSIONS = (
 IMAGE_FILE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".gif", ".webp")
 
 
+def _is_text_encoded_file(path: str) -> bool:
+    return not is_http_url_like(path) and path.lower().endswith(TEXT_FILE_EXTENSIONS)
+
+
+def _text_encoded_file_as_prompt(path: str) -> str:
+    return f"\n## {Path(path).name}\n{Path(path).read_text()}"
+
+
 def format_conversation(
     history: list[NormalizedMessageDict], new_message: str | MultimodalValue
 ) -> list[dict]:
@@ -760,14 +768,22 @@ def format_conversation(
                     f"Invalid message format: {message['content']}. Each element must have a type key."
                 )
             elif content["type"] == "file":
-                new_content.append(
-                    {
-                        "type": "image_url",
-                        "image_url": {
-                            "url": encode_url_or_file_to_base64(content["file"]["path"])  # type: ignore
-                        },
-                    }
-                )
+                path = content["file"]["path"]  # type: ignore
+                if _is_text_encoded_file(path):
+                    # Appended to the prompt as text, the same as when the message was
+                    # first sent. Base64-encoding a text file as `image_url` (which is
+                    # what used to happen once the turn was in the history) makes a
+                    # non-multimodal model reject every subsequent request. See #11331.
+                    new_content.append(
+                        {"type": "text", "text": _text_encoded_file_as_prompt(path)}
+                    )
+                else:
+                    new_content.append(
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": encode_url_or_file_to_base64(path)},
+                        }
+                    )
             else:
                 new_content.append(content)
         message["content"] = new_content
@@ -780,7 +796,7 @@ def format_conversation(
         files = new_message.get("files", [])
     image_files, text_encoded = [], []
     for file in files:
-        if file.lower().endswith(TEXT_FILE_EXTENSIONS):
+        if _is_text_encoded_file(file):
             text_encoded.append(file)
         else:
             image_files.append(file)
@@ -799,12 +815,7 @@ def format_conversation(
         )
     if text or text_encoded:
         text = text or ""
-        text += "\n".join(
-            [
-                f"\n## {Path(file).name}\n{Path(file).read_text()}"
-                for file in text_encoded
-            ]
-        )
+        text += "\n".join([_text_encoded_file_as_prompt(file) for file in text_encoded])
         conversation.append(
             {"role": "user", "content": [{"type": "text", "text": text}]}
         )

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -413,6 +413,48 @@ def test_load_chat_with_streaming(mock_openai):
     assert responses == ["Hello", "Hello World", "Hello World!"]
 
 
+def test_format_conversation_replays_text_files_as_text(tmp_path):
+    # A pasted long prompt arrives as a text file, which is inlined into the prompt on
+    # the turn it is sent. Once that turn was in the history it used to be re-sent as
+    # `image_url`, so every later message made a non-multimodal model reject the
+    # request. See https://github.com/gradio-app/gradio/issues/11331.
+    from gradio.external import format_conversation
+
+    text_file = tmp_path / "pasted_text.txt"
+    text_file.write_text("a very long pasted prompt")
+    image_file = tmp_path / "photo.png"
+    image_file.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    history = [
+        {
+            "role": "user",
+            "content": [{"type": "file", "file": {"path": str(text_file)}}],
+        },
+        {"role": "assistant", "content": [{"type": "text", "text": "ok"}]},
+        {
+            "role": "user",
+            "content": [{"type": "file", "file": {"path": str(image_file)}}],
+        },
+        {"role": "assistant", "content": [{"type": "text", "text": "ok"}]},
+    ]
+
+    conversation = format_conversation(history, "and now a short one")  # type: ignore
+
+    # the text file is inlined as text, the same as when it was first sent...
+    assert conversation[0]["content"] == [
+        {"type": "text", "text": "\n## pasted_text.txt\na very long pasted prompt"}
+    ]
+    # ...while an image is still sent as an image
+    image_content = conversation[2]["content"][0]
+    assert image_content["type"] == "image_url"
+    assert image_content["image_url"]["url"].startswith("data:image/png;base64,")
+
+    assert conversation[-1] == {
+        "role": "user",
+        "content": [{"type": "text", "text": "and now a short one"}],
+    }
+
+
 def test_load_chat_textbox_override():
     from gradio import ChatInterface
 


### PR DESCRIPTION
Fixes #11331

## Root cause

With the default `gr.load_chat(..., file_types="text_encoded")`, pasting a large prompt turns it into a text-file attachment. `format_conversation()` handles that correctly **on the turn it is sent** — it reads text-encoded files and appends their contents to the prompt as text.

But when it walks the *history*, it turned every `file` content part into an image regardless of type:

```python
elif content["type"] == "file":
    new_content.append({"type": "image_url", "image_url": {"url": encode_url_or_file_to_base64(...)}})
```

So the pasted-text turn goes out fine, and then every message after it re-sends that `.txt` base64-encoded as an image — the payload literally contains `"url": "data:text/plain;base64,..."`. That is the request `vllm serve` rejects with *"model is not multimodal"*, which matches the reported sequence exactly: paste long text (works) → type something short (fails).

It also explains why `file_types=[]` made the error go away: no attachment, so nothing to replay.

## Fix

Text-encoded files in the history are inlined as text, the same as when they were first sent. Images still go out as `image_url`. The extension check and the `## filename\ncontents` formatting are now shared between the two paths so they cannot drift again, and the check also excludes http(s) URLs, which `Path(...).read_text()` could not have handled anyway.

## Verification

```
$ python -m pytest test/test_external.py -k format_conversation -q
1 passed
```

`test_format_conversation_replays_text_files_as_text` is new and fails on `main`:

```
E  AssertionError: assert [{'type': 'im...Byb21wdA=='}}] == [{'type': 'te...sted prompt'}]
```

It also pins that a `.png` in the history is still sent as `image_url`. Full `test/test_external.py`: the 3 pre-existing failures are unchanged (`test_load_chat_*`, which need `openai`, not installed in my env). `TestLoadInterface::test_multiple_spaces_one_private` flaked in one batch run and passes on its own — it hits real Spaces over the network.

End-to-end, with the demo below (a local stand-in for `vllm serve` that rejects image content the way a non-multimodal model does):

```
before:  payload content types: ['image_url', 'text', 'text']
         BadRequestError: Error code: 400 - ... 'Model Qwen/Qwen3-8B is not multimodal, but multimodal input was provided.'
after:   payload content types: ['text', 'text', 'text']
         response: ok
```

## Minimal demo (not committed)

```python
from pathlib import Path
from gradio.external import format_conversation

pasted = Path("pasted_text.txt")
pasted.write_text("a very long pasted prompt\n" * 50)

# what the Chatbot holds after a turn where a long prompt was pasted
history = [
    {"role": "user", "content": [{"type": "file", "file": {"path": str(pasted)}}]},
    {"role": "assistant", "content": [{"type": "text", "text": "ok"}]},
]

conversation = format_conversation(history, "and now a short one")
print([part["type"] for m in conversation for part in m["content"]])
```

The full demo file (which also starts a fake OpenAI-compatible server and drives a real `gr.load_chat`) was kept untracked and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)