### PR TITLE
Render the PLY and OBJ files `gr.Model3D` showed as a blank canvas

### DIFF
--- a/.changeset/few-shoes-like.md
+++ b/.changeset/few-shoes-like.md
@@ -1,0 +1,7 @@
+---
+"@gradio/model3d": patch
+"@self/tootils": patch
+"gradio": patch
+---
+
+fix:Render mesh and point-cloud PLY files in `gr.Model3D`

--- a/.changeset/few-shoes-like.md
+++ b/.changeset/few-shoes-like.md
@@ -4,4 +4,4 @@
 "gradio": patch
 ---
 
-fix:Render mesh and point-cloud PLY files in `gr.Model3D`
+fix:Render the PLY and OBJ files `gr.Model3D` showed as a blank canvas

--- a/gradio/components/model3d.py
+++ b/gradio/components/model3d.py
@@ -67,7 +67,7 @@ class Model3D(Component):
         """
         Parameters:
             value: path to (.obj, .glb, .stl, .gltf, .splat, or .ply) file to show in model3D viewer. If a function is provided, the function will be called each time the app loads to set the initial value of this component.
-            display_mode: the display mode of the 3D model in the scene. Can be "solid" (which renders the model as a solid object), "point_cloud", or "wireframe". For .splat, or .ply files, this parameter is ignored, as those files can only be rendered as solid objects.
+            display_mode: the display mode of the 3D model in the scene. Can be "solid" (which renders the model as a solid object), "point_cloud", or "wireframe". For .splat files, and for .ply files holding a Gaussian splat, this parameter is ignored, as those can only be rendered as solid objects.
             clear_color: background color of scene, should be a tuple of 4 floats between 0 and 1 representing RGBA values.
             camera_position: initial camera position of scene, provided as a tuple of `(alpha, beta, radius)`. Each value is optional. If provided, `alpha` and `beta` should be in degrees reflecting the angular position along the longitudinal and latitudinal axes, respectively. Radius corresponds to the distance from the center of the object to the camera.
             zoom_speed: the speed of zooming in and out of the scene when the cursor wheel is rotated or when screen is pinched on a mobile device. Should be a positive float, increase this value to make zooming faster, decrease to make it slower. Affects the wheelPrecision property of the camera.

--- a/js/model3D/Model3D.test.ts
+++ b/js/model3D/Model3D.test.ts
@@ -17,6 +17,7 @@ import {
 	download_file,
 	TEST_GLTF,
 	TEST_PLY,
+	TEST_PLY_MESH,
 	TEST_SPLAT
 } from "@self/tootils/render";
 import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
@@ -199,6 +200,19 @@ describe("Static mode", () => {
 			expect(getByTestId("model3d")).toBeInTheDocument();
 		});
 		expect(queryByLabelText("Undo")).not.toBeInTheDocument();
+	});
+
+	test(".ply mesh value shows undo button (Canvas3D branch)", async () => {
+		const { getByLabelText } = await render(Model3D, {
+			...base_props,
+			value: TEST_PLY_MESH
+		});
+
+		// A .ply is only a Gaussian splat if its header says so; a triangle mesh
+		// has to go to Babylon, which gsplat cannot render.
+		await waitFor(() => {
+			expect(getByLabelText("Undo")).toBeInTheDocument();
+		});
 	});
 
 	test(".gltf value shows undo button (Canvas3D branch)", async () => {

--- a/js/model3D/Model3D.test.ts
+++ b/js/model3D/Model3D.test.ts
@@ -190,6 +190,20 @@ describe("Static mode", () => {
 		expect(queryByLabelText("Undo")).not.toBeInTheDocument();
 	});
 
+	test("an upper-case .PLY has its header read too", async () => {
+		// Babylon lowercases the extension when it picks a loader, so a `.PLY`
+		// that skipped the header read here would reach the splat loader anyway.
+		const { queryByLabelText, getByTestId } = await render(Model3D, {
+			...base_props,
+			value: { ...TEST_PLY, path: TEST_PLY.path.replace(".ply", ".PLY") }
+		});
+
+		await waitFor(() => {
+			expect(getByTestId("model3d")).toBeInTheDocument();
+		});
+		expect(queryByLabelText("Undo")).not.toBeInTheDocument();
+	});
+
 	test(".splat value skips undo button (Canvas3DGS branch)", async () => {
 		const { queryByLabelText, getByTestId } = await render(Model3D, {
 			...base_props,

--- a/js/model3D/shared/Canvas3D.svelte
+++ b/js/model3D/shared/Canvas3D.svelte
@@ -2,8 +2,17 @@
 	import { onMount } from "svelte";
 	import type { FileData } from "@gradio/client";
 	import type { Viewer, ViewerDetails } from "@babylonjs/viewer";
+	import { has_drawable_geometry, resolve_obj_point_cloud } from "./obj.js";
 
 	let BABYLON_VIEWER: typeof import("@babylonjs/viewer");
+
+	const LOAD_OPTIONS = {
+		pluginOptions: {
+			obj: {
+				importVertexColors: true
+			}
+		}
+	};
 
 	let {
 		value,
@@ -85,13 +94,10 @@
 
 		if (source) {
 			try {
-				await currentViewer.loadModel(source, {
-					pluginOptions: {
-						obj: {
-							importVertexColors: true
-						}
-					}
-				});
+				await currentViewer.loadModel(source, LOAD_OPTIONS);
+				if (mounted && currentViewer === viewer) {
+					await load_as_point_cloud(currentViewer, source);
+				}
 			} catch (error) {
 				if (mounted && currentViewer === viewer) {
 					console.error(error);
@@ -111,6 +117,26 @@
 		} else {
 			currentViewer.resetModel();
 		}
+	}
+
+	/**
+	 * A face-less OBJ can load without error and leave nothing to draw, so it is
+	 * reloaded as a point cloud. See obj.ts.
+	 */
+	async function load_as_point_cloud(
+		currentViewer: Viewer,
+		source: string | File
+	): Promise<void> {
+		if (typeof source !== "string" || !value.path.endsWith(".obj")) return;
+		const meshes = viewerDetails?.model?.assetContainer.meshes ?? [];
+		if (has_drawable_geometry(meshes)) return;
+
+		const points = await resolve_obj_point_cloud(source);
+		if (!points || !mounted || currentViewer !== viewer) return;
+		await currentViewer.loadModel(
+			new File([points], "model.ply"),
+			LOAD_OPTIONS
+		);
 	}
 
 	export function update_camera(

--- a/js/model3D/shared/Canvas3D.svelte
+++ b/js/model3D/shared/Canvas3D.svelte
@@ -127,12 +127,18 @@
 		currentViewer: Viewer,
 		source: string | File
 	): Promise<void> {
-		if (typeof source !== "string" || !value.path.endsWith(".obj")) return;
+		if (typeof source !== "string") return;
+		if (!value.path.toLowerCase().endsWith(".obj")) return;
+
 		const meshes = viewerDetails?.model?.assetContainer.meshes ?? [];
 		if (has_drawable_geometry(meshes)) return;
 
 		const points = await resolve_obj_point_cloud(source);
-		if (!points || !mounted || currentViewer !== viewer) return;
+		// `value` can change while the file is in flight. Babylon aborts an
+		// in-flight load on the next one, so loading here would undo the newer
+		// model rather than the other way round.
+		if (!points || !mounted || currentViewer !== viewer || source !== url)
+			return;
 		await currentViewer.loadModel(
 			new File([points], "model.ply"),
 			LOAD_OPTIONS

--- a/js/model3D/shared/Canvas3D.svelte
+++ b/js/model3D/shared/Canvas3D.svelte
@@ -11,7 +11,8 @@
 		clear_color,
 		camera_position,
 		zoom_speed,
-		pan_speed
+		pan_speed,
+		data
 	}: {
 		value: FileData;
 		display_mode: "solid" | "point_cloud" | "wireframe";
@@ -19,6 +20,8 @@
 		camera_position: [number | null, number | null, number | null];
 		zoom_speed: number;
 		pan_speed: number;
+		/** Already-decoded bytes to load instead of fetching `value.url`. */
+		data?: Uint8Array<ArrayBuffer>;
 	} = $props();
 
 	let url = $derived(value.url);
@@ -64,7 +67,9 @@
 
 	$effect(() => {
 		if (mounted) {
-			void load_model(url);
+			// Babylon picks its loader from the filename, so decoded bytes are
+			// handed over as a named file rather than a bare buffer.
+			void load_model(data ? new File([data], "model.ply") : url);
 		}
 	});
 
@@ -74,13 +79,13 @@
 		viewerDetails.scene.forceWireframe = wireframe;
 	}
 
-	async function load_model(url: string | undefined): Promise<void> {
+	async function load_model(source: string | File | undefined): Promise<void> {
 		const currentViewer = viewer;
 		if (!currentViewer) return;
 
-		if (url) {
+		if (source) {
 			try {
-				await currentViewer.loadModel(url, {
+				await currentViewer.loadModel(source, {
 					pluginOptions: {
 						obj: {
 							importVertexColors: true

--- a/js/model3D/shared/Model3D.svelte
+++ b/js/model3D/shared/Model3D.svelte
@@ -4,9 +4,8 @@
 	import { File, Download, Undo } from "@gradio/icons";
 	import type { I18nFormatter } from "@gradio/utils";
 	import { dequal } from "dequal";
-	import type Canvas3DGS from "./Canvas3DGS.svelte";
 	import type Canvas3D from "./Canvas3D.svelte";
-	import { resolve_ply_source, type PlySource } from "./ply";
+	import { create_renderer } from "./renderer.svelte";
 
 	let {
 		value,
@@ -33,57 +32,11 @@
 	} = $props();
 
 	let current_settings = $state({ camera_position, zoom_speed, pan_speed });
-	let use_3dgs = $state(false);
-	let ply_data = $state<Uint8Array<ArrayBuffer>>();
-	let Canvas3DGSComponent = $state<typeof Canvas3DGS>();
-	let Canvas3DComponent = $state<typeof Canvas3D>();
 	let canvas3d = $state<Canvas3D | undefined>();
 
-	async function loadCanvas3D(): Promise<typeof Canvas3D> {
-		const module = await import("./Canvas3D.svelte");
-		return module.default;
-	}
-	async function loadCanvas3DGS(): Promise<typeof Canvas3DGS> {
-		const module = await import("./Canvas3DGS.svelte");
-		return module.default;
-	}
-
-	$effect(() => {
-		const file = value;
-		if (!file) return;
-
-		const is_splat = file.path.endsWith(".splat");
-		const is_ply = file.path.endsWith(".ply");
-		// Assume a .ply is a splat until its header says otherwise, so the
-		// toolbar doesn't change once the header has been read.
-		use_3dgs = is_splat || is_ply;
-
-		let stale = false;
-		const use = (source: PlySource): void => {
-			if (stale) return;
-			use_3dgs = source.renderer === "gsplat";
-			ply_data = source.renderer === "babylon" ? source.data : undefined;
-			if (use_3dgs) {
-				loadCanvas3DGS().then((component) => {
-					Canvas3DGSComponent = component;
-				});
-			} else {
-				loadCanvas3D().then((component) => {
-					Canvas3DComponent = component;
-				});
-			}
-		};
-
-		if (is_ply && file.url) {
-			resolve_ply_source(file.url).then(use);
-		} else {
-			use({ renderer: is_splat || is_ply ? "gsplat" : "babylon" });
-		}
-
-		return () => {
-			stale = true;
-		};
-	});
+	const model = create_renderer(() => value);
+	const GaussianCanvas = $derived(model.gsplat_component);
+	const BabylonCanvas = $derived(model.babylon_component);
 
 	function handle_undo(): void {
 		canvas3d?.reset_camera_position();
@@ -109,7 +62,7 @@
 {#if value}
 	<div class="model3D" data-testid="model3d">
 		<IconButtonWrapper>
-			{#if !use_3dgs}
+			{#if model.renderer === "babylon"}
 				<!-- Canvas3DGS doesn't implement the undo method (reset_camera_position) -->
 				<IconButton
 					Icon={Undo}
@@ -128,10 +81,10 @@
 			</a>
 		</IconButtonWrapper>
 
-		{#if use_3dgs}
-			<Canvas3DGSComponent {value} {zoom_speed} {pan_speed} />
-		{:else}
-			<Canvas3DComponent
+		{#if model.renderer === "gsplat" && GaussianCanvas}
+			<GaussianCanvas {value} {zoom_speed} {pan_speed} />
+		{:else if model.renderer === "babylon" && BabylonCanvas}
+			<BabylonCanvas
 				bind:this={canvas3d}
 				{value}
 				{display_mode}
@@ -139,7 +92,7 @@
 				{camera_position}
 				{zoom_speed}
 				{pan_speed}
-				data={ply_data}
+				data={model.data}
 			/>
 		{/if}
 	</div>

--- a/js/model3D/shared/Model3D.svelte
+++ b/js/model3D/shared/Model3D.svelte
@@ -5,7 +5,7 @@
 	import type { I18nFormatter } from "@gradio/utils";
 	import { dequal } from "dequal";
 	import type Canvas3D from "./Canvas3D.svelte";
-	import { create_renderer } from "./renderer.svelte";
+	import { create_renderer } from "./renderer.svelte.js";
 
 	let {
 		value,

--- a/js/model3D/shared/Model3D.svelte
+++ b/js/model3D/shared/Model3D.svelte
@@ -6,6 +6,7 @@
 	import { dequal } from "dequal";
 	import type Canvas3DGS from "./Canvas3DGS.svelte";
 	import type Canvas3D from "./Canvas3D.svelte";
+	import { resolve_ply_source, type PlySource } from "./ply";
 
 	let {
 		value,
@@ -33,6 +34,7 @@
 
 	let current_settings = $state({ camera_position, zoom_speed, pan_speed });
 	let use_3dgs = $state(false);
+	let ply_data = $state<Uint8Array<ArrayBuffer>>();
 	let Canvas3DGSComponent = $state<typeof Canvas3DGS>();
 	let Canvas3DComponent = $state<typeof Canvas3D>();
 	let canvas3d = $state<Canvas3D | undefined>();
@@ -47,8 +49,20 @@
 	}
 
 	$effect(() => {
-		if (value) {
-			use_3dgs = value.path.endsWith(".splat") || value.path.endsWith(".ply");
+		const file = value;
+		if (!file) return;
+
+		const is_splat = file.path.endsWith(".splat");
+		const is_ply = file.path.endsWith(".ply");
+		// Assume a .ply is a splat until its header says otherwise, so the
+		// toolbar doesn't change once the header has been read.
+		use_3dgs = is_splat || is_ply;
+
+		let stale = false;
+		const use = (source: PlySource): void => {
+			if (stale) return;
+			use_3dgs = source.renderer === "gsplat";
+			ply_data = source.renderer === "babylon" ? source.data : undefined;
 			if (use_3dgs) {
 				loadCanvas3DGS().then((component) => {
 					Canvas3DGSComponent = component;
@@ -58,7 +72,17 @@
 					Canvas3DComponent = component;
 				});
 			}
+		};
+
+		if (is_ply && file.url) {
+			resolve_ply_source(file.url).then(use);
+		} else {
+			use({ renderer: is_splat || is_ply ? "gsplat" : "babylon" });
 		}
+
+		return () => {
+			stale = true;
+		};
 	});
 
 	function handle_undo(): void {
@@ -115,6 +139,7 @@
 				{camera_position}
 				{zoom_speed}
 				{pan_speed}
+				data={ply_data}
 			/>
 		{/if}
 	</div>

--- a/js/model3D/shared/Model3DUpload.svelte
+++ b/js/model3D/shared/Model3DUpload.svelte
@@ -7,6 +7,7 @@
 	import type { I18nFormatter } from "@gradio/utils";
 	import type Canvas3DGS from "./Canvas3DGS.svelte";
 	import type Canvas3D from "./Canvas3D.svelte";
+	import { resolve_ply_source, type PlySource } from "./ply";
 
 	let {
 		value = $bindable(),
@@ -55,6 +56,7 @@
 	} = $props();
 
 	let use_3dgs = $state(false);
+	let ply_data = $state<Uint8Array<ArrayBuffer>>();
 	let Canvas3DGSComponent = $state<typeof Canvas3DGS>();
 	let Canvas3DComponent = $state<typeof Canvas3D>();
 	let canvas3d = $state<Canvas3D | undefined>();
@@ -70,8 +72,20 @@
 	}
 
 	$effect(() => {
-		if (value) {
-			use_3dgs = value.path.endsWith(".splat") || value.path.endsWith(".ply");
+		const file = value;
+		if (!file) return;
+
+		const is_splat = file.path.endsWith(".splat");
+		const is_ply = file.path.endsWith(".ply");
+		// Assume a .ply is a splat until its header says otherwise, so the
+		// toolbar doesn't change once the header has been read.
+		use_3dgs = is_splat || is_ply;
+
+		let stale = false;
+		const use = (source: PlySource): void => {
+			if (stale) return;
+			use_3dgs = source.renderer === "gsplat";
+			ply_data = source.renderer === "babylon" ? source.data : undefined;
 			if (use_3dgs) {
 				loadCanvas3DGS().then((component) => {
 					Canvas3DGSComponent = component;
@@ -81,7 +95,17 @@
 					Canvas3DComponent = component;
 				});
 			}
+		};
+
+		if (is_ply && file.url) {
+			resolve_ply_source(file.url).then(use);
+		} else {
+			use({ renderer: is_splat || is_ply ? "gsplat" : "babylon" });
 		}
+
+		return () => {
+			stale = true;
+		};
 	});
 
 	$effect(() => {
@@ -149,6 +173,7 @@
 				{camera_position}
 				{zoom_speed}
 				{pan_speed}
+				data={ply_data}
 			/>
 		{/if}
 	</div>

--- a/js/model3D/shared/Model3DUpload.svelte
+++ b/js/model3D/shared/Model3DUpload.svelte
@@ -6,7 +6,7 @@
 	import { File } from "@gradio/icons";
 	import type { I18nFormatter } from "@gradio/utils";
 	import type Canvas3D from "./Canvas3D.svelte";
-	import { create_renderer } from "./renderer.svelte";
+	import { create_renderer } from "./renderer.svelte.js";
 
 	let {
 		value = $bindable(),

--- a/js/model3D/shared/Model3DUpload.svelte
+++ b/js/model3D/shared/Model3DUpload.svelte
@@ -5,9 +5,8 @@
 	import { BlockLabel } from "@gradio/atoms";
 	import { File } from "@gradio/icons";
 	import type { I18nFormatter } from "@gradio/utils";
-	import type Canvas3DGS from "./Canvas3DGS.svelte";
 	import type Canvas3D from "./Canvas3D.svelte";
-	import { resolve_ply_source, type PlySource } from "./ply";
+	import { create_renderer } from "./renderer.svelte";
 
 	let {
 		value = $bindable(),
@@ -55,58 +54,12 @@
 		children?: Snippet;
 	} = $props();
 
-	let use_3dgs = $state(false);
-	let ply_data = $state<Uint8Array<ArrayBuffer>>();
-	let Canvas3DGSComponent = $state<typeof Canvas3DGS>();
-	let Canvas3DComponent = $state<typeof Canvas3D>();
 	let canvas3d = $state<Canvas3D | undefined>();
 	let dragging = $state(false);
 
-	async function loadCanvas3D(): Promise<typeof Canvas3D> {
-		const module = await import("./Canvas3D.svelte");
-		return module.default;
-	}
-	async function loadCanvas3DGS(): Promise<typeof Canvas3DGS> {
-		const module = await import("./Canvas3DGS.svelte");
-		return module.default;
-	}
-
-	$effect(() => {
-		const file = value;
-		if (!file) return;
-
-		const is_splat = file.path.endsWith(".splat");
-		const is_ply = file.path.endsWith(".ply");
-		// Assume a .ply is a splat until its header says otherwise, so the
-		// toolbar doesn't change once the header has been read.
-		use_3dgs = is_splat || is_ply;
-
-		let stale = false;
-		const use = (source: PlySource): void => {
-			if (stale) return;
-			use_3dgs = source.renderer === "gsplat";
-			ply_data = source.renderer === "babylon" ? source.data : undefined;
-			if (use_3dgs) {
-				loadCanvas3DGS().then((component) => {
-					Canvas3DGSComponent = component;
-				});
-			} else {
-				loadCanvas3D().then((component) => {
-					Canvas3DComponent = component;
-				});
-			}
-		};
-
-		if (is_ply && file.url) {
-			resolve_ply_source(file.url).then(use);
-		} else {
-			use({ renderer: is_splat || is_ply ? "gsplat" : "babylon" });
-		}
-
-		return () => {
-			stale = true;
-		};
-	});
+	const model = create_renderer(() => value);
+	const GaussianCanvas = $derived(model.gsplat_component);
+	const BabylonCanvas = $derived(model.babylon_component);
 
 	$effect(() => {
 		ondrag?.(dragging);
@@ -156,16 +109,16 @@
 {:else}
 	<div class="input-model">
 		<ModifyUpload
-			undoable={!use_3dgs}
+			undoable={model.renderer === "babylon"}
 			onclear={handle_clear}
 			{i18n}
 			onundo={handle_undo}
 		/>
 
-		{#if use_3dgs}
-			<Canvas3DGSComponent {value} {zoom_speed} {pan_speed} />
-		{:else}
-			<Canvas3DComponent
+		{#if model.renderer === "gsplat" && GaussianCanvas}
+			<GaussianCanvas {value} {zoom_speed} {pan_speed} />
+		{:else if model.renderer === "babylon" && BabylonCanvas}
+			<BabylonCanvas
 				bind:this={canvas3d}
 				{value}
 				{display_mode}
@@ -173,7 +126,7 @@
 				{camera_position}
 				{zoom_speed}
 				{pan_speed}
-				data={ply_data}
+				data={model.data}
 			/>
 		{/if}
 	</div>

--- a/js/model3D/shared/obj.test.ts
+++ b/js/model3D/shared/obj.test.ts
@@ -78,6 +78,16 @@ describe("obj_point_cloud_to_ply", () => {
 		]);
 	});
 
+	test("does not read the `w` of `v x y z w` as a colour", () => {
+		// A fourth coordinate is legal, and Babylon takes a colour only from a line
+		// carrying all three components, so this has to stay grey to match it.
+		const body = body_of(obj_point_cloud_to_ply("v 1 2 3 1.0\n")!);
+
+		expect([body.getUint8(12), body.getUint8(13), body.getUint8(14)]).toEqual([
+			128, 128, 128
+		]);
+	});
+
 	test("returns null for a file that has faces", () => {
 		// Points would paper over a mesh that failed to load for some other
 		// reason, so only a face-less file is converted.

--- a/js/model3D/shared/obj.test.ts
+++ b/js/model3D/shared/obj.test.ts
@@ -1,0 +1,139 @@
+import { test, describe, expect } from "vitest";
+import { GaussianSplattingMesh } from "@babylonjs/core/Meshes/GaussianSplatting/gaussianSplattingMesh";
+
+import {
+	has_drawable_geometry,
+	obj_point_cloud_to_ply,
+	resolve_obj_point_cloud
+} from "./obj";
+import { parse_ply_header } from "./ply";
+
+const POINT_CLOUD_OBJ = `# Created by Open3D
+o output_mesh
+v -1 -1 0 1 0 0
+v 1 -1 0 0 1 0
+v 0 1 0 0 0 1
+`;
+
+const FACED_OBJ = `v -1 -1 0
+v 1 -1 0
+v 0 1 0
+f 1 2 3
+`;
+
+const body_of = (ply: Uint8Array): DataView =>
+	new DataView(ply.buffer, ply.byteOffset + parse_ply_header(ply)!.byte_length);
+
+describe("obj_point_cloud_to_ply", () => {
+	test("writes the vertices as a binary point-cloud PLY", () => {
+		const ply = obj_point_cloud_to_ply(POINT_CLOUD_OBJ)!;
+		const header = parse_ply_header(ply)!;
+
+		expect(header.format).toBe("binary_little_endian");
+		expect(header.elements).toEqual([
+			{
+				name: "vertex",
+				count: 3,
+				properties: [
+					{ kind: "scalar", name: "x", type: "float" },
+					{ kind: "scalar", name: "y", type: "float" },
+					{ kind: "scalar", name: "z", type: "float" },
+					{ kind: "scalar", name: "red", type: "uchar" },
+					{ kind: "scalar", name: "green", type: "uchar" },
+					{ kind: "scalar", name: "blue", type: "uchar" }
+				]
+			}
+		]);
+
+		const body = body_of(ply);
+		expect(body.getFloat32(0, true)).toBe(-1);
+		expect(body.getFloat32(4, true)).toBe(-1);
+		expect(body.getFloat32(8, true)).toBe(0);
+		expect(ply.byteLength).toBe(header.byte_length + 3 * 15);
+
+		// Third vertex, to show the rows advance by the full stride.
+		expect(body.getFloat32(30, true)).toBe(0);
+		expect(body.getFloat32(34, true)).toBe(1);
+	});
+
+	test("scales colours the way Babylon's OBJ parser does", () => {
+		// Anything above 1 is read as 0-255 and the rest as 0-1, since an OBJ
+		// vertex colour has no declared range and files are written both ways.
+		const ply = obj_point_cloud_to_ply("v 0 0 0 1 0.5 0\nv 1 1 1 255 128 0\n")!;
+		const body = body_of(ply);
+
+		expect([body.getUint8(12), body.getUint8(13), body.getUint8(14)]).toEqual([
+			255, 128, 0
+		]);
+		expect([body.getUint8(27), body.getUint8(28), body.getUint8(29)]).toEqual([
+			255, 128, 0
+		]);
+	});
+
+	test("gives a vertex with no colour the grey Babylon would use", () => {
+		const body = body_of(obj_point_cloud_to_ply("v 0 0 0\n")!);
+
+		expect([body.getUint8(12), body.getUint8(13), body.getUint8(14)]).toEqual([
+			128, 128, 128
+		]);
+	});
+
+	test("returns null for a file that has faces", () => {
+		// Points would paper over a mesh that failed to load for some other
+		// reason, so only a face-less file is converted.
+		expect(obj_point_cloud_to_ply(FACED_OBJ)).toBe(null);
+	});
+
+	test("returns null when there are no vertices", () => {
+		expect(obj_point_cloud_to_ply("# Created by Open3D\no output_mesh\n")).toBe(
+			null
+		);
+	});
+
+	test("returns null when a vertex line has no usable coordinates", () => {
+		expect(obj_point_cloud_to_ply("v 0 0 0\nv nan nan nan\n")).toBe(null);
+	});
+});
+
+describe("what Babylon makes of the converted output", () => {
+	test("reads the point cloud", () => {
+		// Babylon's PLY reader takes one narrow dialect, so the bytes being right
+		// on their own says nothing about it accepting them.
+		const ply = obj_point_cloud_to_ply(POINT_CLOUD_OBJ)!;
+
+		expect(GaussianSplattingMesh.ParseHeader(ply.buffer)?.rowVertexLength).toBe(
+			3 * 4 + 3
+		);
+	});
+});
+
+describe("has_drawable_geometry", () => {
+	const mesh = (vertices: number): { getTotalVertices(): number } => ({
+		getTotalVertices: () => vertices
+	});
+
+	test("is false for the empty mesh a face-less OBJ leaves behind", () => {
+		expect(has_drawable_geometry([mesh(0)])).toBe(false);
+	});
+
+	test("is false when nothing loaded at all", () => {
+		expect(has_drawable_geometry([])).toBe(false);
+	});
+
+	test("is true when any mesh carries vertices", () => {
+		expect(has_drawable_geometry([mesh(0), mesh(3)])).toBe(true);
+	});
+});
+
+describe("resolve_obj_point_cloud", () => {
+	test("converts a served OBJ", async () => {
+		const url = URL.createObjectURL(new Blob([POINT_CLOUD_OBJ]));
+		const ply = await resolve_obj_point_cloud(url);
+
+		expect(parse_ply_header(ply!)!.elements[0].count).toBe(3);
+	});
+
+	test("returns null instead of rejecting when the file can't be read", async () => {
+		expect(await resolve_obj_point_cloud("blob:nothing-here")).toBe(null);
+	});
+});

--- a/js/model3D/shared/obj.ts
+++ b/js/model3D/shared/obj.ts
@@ -43,8 +43,8 @@ export function obj_point_cloud_to_ply(
 		}
 
 		positions.push(x, y, z);
-		// Babylon takes a colour only from a line carrying all three components,
-		// so the `w` of a legal `v x y z w` line must not become red.
+		// Babylon needs all three components before it reads a colour, so the `w`
+		// of a legal `v x y z w` line does not become red.
 		if (parts.length >= 7) {
 			colors.push(
 				color_byte(parts[4]),
@@ -73,10 +73,7 @@ export async function resolve_obj_point_cloud(
 	}
 }
 
-/**
- * An OBJ vertex colour has no declared range, so Babylon reads a component above
- * 1 as 0-255 and the rest as 0-1. Both paths have to agree on that.
- */
+/** No declared range, so Babylon reads above 1 as 0-255 and the rest as 0-1. */
 function color_byte(token: string): number {
 	const value = Number(token);
 	if (!Number.isFinite(value)) return DEFAULT_COLOR;

--- a/js/model3D/shared/obj.ts
+++ b/js/model3D/shared/obj.ts
@@ -43,11 +43,17 @@ export function obj_point_cloud_to_ply(
 		}
 
 		positions.push(x, y, z);
-		colors.push(
-			color_byte(parts[4]),
-			color_byte(parts[5]),
-			color_byte(parts[6])
-		);
+		// Babylon takes a colour only from a line carrying all three components,
+		// so the `w` of a legal `v x y z w` line must not become red.
+		if (parts.length >= 7) {
+			colors.push(
+				color_byte(parts[4]),
+				color_byte(parts[5]),
+				color_byte(parts[6])
+			);
+		} else {
+			colors.push(DEFAULT_COLOR, DEFAULT_COLOR, DEFAULT_COLOR);
+		}
 	}
 
 	if (positions.length === 0) return null;
@@ -71,9 +77,9 @@ export async function resolve_obj_point_cloud(
  * An OBJ vertex colour has no declared range, so Babylon reads a component above
  * 1 as 0-255 and the rest as 0-1. Both paths have to agree on that.
  */
-function color_byte(token: string | undefined): number {
+function color_byte(token: string): number {
 	const value = Number(token);
-	if (token === undefined || !Number.isFinite(value)) return DEFAULT_COLOR;
+	if (!Number.isFinite(value)) return DEFAULT_COLOR;
 	return Math.max(
 		0,
 		Math.min(255, Math.round(value > 1 ? value : value * 255))

--- a/js/model3D/shared/obj.ts
+++ b/js/model3D/shared/obj.ts
@@ -1,0 +1,119 @@
+/**
+ * Babylon reads an OBJ carrying vertices and no faces only when the file
+ * declares no `o`, no `g` and no `usemtl`; otherwise it drops the vertices
+ * before the viewer sees them and draws nothing. Such a file is rewritten here
+ * as a binary point-cloud PLY, which it reads either way. The rewrite is driven
+ * by the loaded model turning out to be empty rather than by reading every OBJ
+ * up front: handing Babylon bytes in place of a URL breaks `mtllib` and texture
+ * references, which resolve against it.
+ */
+
+const ROW_LENGTH = 3 * 4 + 3;
+
+/** The grey Babylon gives a vertex whose line carries no colour. */
+const DEFAULT_COLOR = 128;
+
+export function has_drawable_geometry(
+	meshes: readonly { getTotalVertices(): number }[]
+): boolean {
+	return meshes.some((mesh) => mesh.getTotalVertices() > 0);
+}
+
+/**
+ * Rewrites the vertices of a face-less OBJ as a binary point-cloud PLY. A file
+ * with faces returns null: geometry missing from one of those is a different
+ * failure, and drawing its vertices would hide it.
+ */
+export function obj_point_cloud_to_ply(
+	text: string
+): Uint8Array<ArrayBuffer> | null {
+	const positions: number[] = [];
+	const colors: number[] = [];
+
+	for (const line of text.split("\n")) {
+		const parts = line.trim().split(/\s+/);
+		if (parts[0] === "f") return null;
+		if (parts[0] !== "v") continue;
+
+		const x = Number(parts[1]);
+		const y = Number(parts[2]);
+		const z = Number(parts[3]);
+		if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+			return null;
+		}
+
+		positions.push(x, y, z);
+		colors.push(
+			color_byte(parts[4]),
+			color_byte(parts[5]),
+			color_byte(parts[6])
+		);
+	}
+
+	if (positions.length === 0) return null;
+	return write_point_cloud_ply(positions, colors);
+}
+
+/** Reads and converts `url`. Never rejects, as `resolve_ply_source` doesn't. */
+export async function resolve_obj_point_cloud(
+	url: string
+): Promise<Uint8Array<ArrayBuffer> | null> {
+	try {
+		const response = await fetch(url);
+		if (!response.ok) return null;
+		return obj_point_cloud_to_ply(await response.text());
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * An OBJ vertex colour has no declared range, so Babylon reads a component above
+ * 1 as 0-255 and the rest as 0-1. Both paths have to agree on that.
+ */
+function color_byte(token: string | undefined): number {
+	const value = Number(token);
+	if (token === undefined || !Number.isFinite(value)) return DEFAULT_COLOR;
+	return Math.max(
+		0,
+		Math.min(255, Math.round(value > 1 ? value : value * 255))
+	);
+}
+
+function write_point_cloud_ply(
+	positions: number[],
+	colors: number[]
+): Uint8Array<ArrayBuffer> {
+	const count = positions.length / 3;
+	const header = new TextEncoder().encode(
+		[
+			"ply",
+			"format binary_little_endian 1.0",
+			`element vertex ${count}`,
+			"property float x",
+			"property float y",
+			"property float z",
+			"property uchar red",
+			"property uchar green",
+			"property uchar blue",
+			"end_header",
+			""
+		].join("\n")
+	);
+
+	const result = new Uint8Array(header.length + count * ROW_LENGTH);
+	result.set(header);
+	const view = new DataView(result.buffer, header.length);
+
+	for (let i = 0; i < count; i++) {
+		const offset = i * ROW_LENGTH;
+		view.setFloat32(offset, positions[i * 3], true);
+		view.setFloat32(offset + 4, positions[i * 3 + 1], true);
+		view.setFloat32(offset + 8, positions[i * 3 + 2], true);
+		view.setUint8(offset + 12, colors[i * 3]);
+		view.setUint8(offset + 13, colors[i * 3 + 1]);
+		view.setUint8(offset + 14, colors[i * 3 + 2]);
+	}
+
+	return result;
+}

--- a/js/model3D/shared/ply.test.ts
+++ b/js/model3D/shared/ply.test.ts
@@ -1,4 +1,5 @@
 import { test, describe, expect } from "vitest";
+import { GaussianSplattingMesh } from "@babylonjs/core/Meshes/GaussianSplatting/gaussianSplattingMesh";
 
 import {
 	ascii_ply_to_binary,
@@ -130,12 +131,24 @@ describe("ascii_ply_to_binary", () => {
 		expect(result.byteLength).toBe(new_header.byte_length + face + 13);
 	});
 
-	test("stops at the end of the body, not at the declared count", () => {
+	test("rejects a list length that cannot describe a face", () => {
 		const malicious = MESH_PLY.replace("3 0 1 2", "9999999999 0 1 2");
 		const bytes = encode(malicious);
 		expect(() =>
 			ascii_ply_to_binary(bytes, parse_ply_header(bytes)!)
-		).toThrowError(/Truncated/);
+		).toThrowError(/Unsupported PLY list length/);
+	});
+
+	test("does not walk the rows of an element with no properties", () => {
+		// Nothing is read per row here, so the row loop consumes no tokens and
+		// cannot be stopped by the body running out. Without the skip this spins
+		// for hours on a 61 byte file.
+		const bytes = encode(
+			"ply\nformat ascii 1.0\nelement vertex 900000000000\nend_header\n"
+		);
+		const result = ascii_ply_to_binary(bytes, parse_ply_header(bytes)!);
+
+		expect(result.byteLength).toBe(parse_ply_header(result)!.byte_length);
 	});
 
 	test("throws when the body has fewer rows than the header promises", () => {
@@ -144,6 +157,48 @@ describe("ascii_ply_to_binary", () => {
 		expect(() =>
 			ascii_ply_to_binary(bytes, parse_ply_header(bytes)!)
 		).toThrowError(/Truncated/);
+	});
+});
+
+describe("what Babylon makes of the transcoded output", () => {
+	// Asserting on our own bytes only covers half the job: Babylon's PLY reader
+	// accepts one narrow dialect, and the gap between "we wrote it correctly" and
+	// "it can read it" is where every case below used to fail.
+	const parse = (text: string): { rowVertexLength: number } | null => {
+		const bytes = encode(text);
+		const binary = ascii_ply_to_binary(bytes, parse_ply_header(bytes)!);
+		return GaussianSplattingMesh.ParseHeader(binary.buffer);
+	};
+
+	test("reads a mesh", () => {
+		expect(parse(MESH_PLY)?.rowVertexLength).toBe(3 * 4 + 3);
+	});
+
+	test("reads a source written with CRLF line endings", () => {
+		// Babylon looks for a literal "end_header\n", so a copied CRLF header
+		// makes it give up and treat the file as a raw splat.
+		expect(parse(MESH_PLY.replace(/\n/g, "\r\n"))?.rowVertexLength).toBe(
+			3 * 4 + 3
+		);
+	});
+
+	test("reads a source written with alias type names", () => {
+		// Babylon's size table has no `float32` or `uint8`, so copying those
+		// spellings through leaves it computing NaN offsets.
+		const aliased = MESH_PLY.replace(
+			/property float /g,
+			"property float32 "
+		).replace(/property uchar /g, "property uint8 ");
+
+		expect(parse(aliased)?.rowVertexLength).toBe(3 * 4 + 3);
+	});
+
+	test("reads a source using a type Babylon has no size for", () => {
+		// `char` is a normal PLY type that Babylon's table simply omits, so it
+		// has to be widened to one that is in there.
+		const chars = MESH_PLY.replace(/property float /g, "property char ");
+
+		expect(parse(chars)?.rowVertexLength).toBe(3 * 4 + 3);
 	});
 });
 

--- a/js/model3D/shared/ply.test.ts
+++ b/js/model3D/shared/ply.test.ts
@@ -1,0 +1,139 @@
+import { test, describe, expect } from "vitest";
+
+import {
+	ascii_ply_to_binary,
+	is_gaussian_splat_ply,
+	parse_ply_header
+} from "./ply";
+
+const encode = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+const MESH_PLY = `ply
+format ascii 1.0
+element vertex 3
+property float x
+property float y
+property float z
+property uchar red
+property uchar green
+property uchar blue
+element face 1
+property list uchar int vertex_indices
+end_header
+-1 -1 0 255 0 0
+1 -1 0 0 255 0
+0 1 0 0 0 255
+3 0 1 2
+`;
+
+const SPLAT_PLY = `ply
+format binary_little_endian 1.0
+element vertex 1
+property float x
+property float y
+property float z
+property float f_dc_0
+property float f_dc_1
+property float f_dc_2
+property float opacity
+property float scale_0
+property float scale_1
+property float scale_2
+property float rot_0
+property float rot_1
+property float rot_2
+property float rot_3
+end_header
+`;
+
+const POINT_CLOUD_PLY = `ply
+format ascii 1.0
+element vertex 2
+property float x
+property float y
+property float z
+end_header
+0 0 0
+1 2 3
+`;
+
+describe("parse_ply_header", () => {
+	test("reads the format, element counts and property layout", () => {
+		const header = parse_ply_header(encode(MESH_PLY))!;
+
+		expect(header.format).toBe("ascii");
+		expect(header.elements.map((e) => [e.name, e.count])).toEqual([
+			["vertex", 3],
+			["face", 1]
+		]);
+		expect(header.byte_length).toBe(MESH_PLY.indexOf("end_header") + 11);
+	});
+
+	test("returns null for data that is not PLY", () => {
+		expect(parse_ply_header(encode("not a ply file"))).toBeNull();
+	});
+
+	test("returns null when the header is truncated", () => {
+		expect(parse_ply_header(encode("ply\nformat ascii 1.0\n"))).toBeNull();
+	});
+});
+
+describe("is_gaussian_splat_ply", () => {
+	test("is true for a file carrying the splat properties", () => {
+		expect(is_gaussian_splat_ply(parse_ply_header(encode(SPLAT_PLY))!)).toBe(
+			true
+		);
+	});
+
+	test("is false for a triangle mesh", () => {
+		expect(is_gaussian_splat_ply(parse_ply_header(encode(MESH_PLY))!)).toBe(
+			false
+		);
+	});
+
+	test("is false for a plain point cloud", () => {
+		expect(
+			is_gaussian_splat_ply(parse_ply_header(encode(POINT_CLOUD_PLY))!)
+		).toBe(false);
+	});
+});
+
+describe("ascii_ply_to_binary", () => {
+	test("writes the same values as little-endian binary", () => {
+		const bytes = encode(MESH_PLY);
+		const header = parse_ply_header(bytes)!;
+		const result = ascii_ply_to_binary(bytes, header);
+
+		const new_header = parse_ply_header(result)!;
+		expect(new_header.format).toBe("binary_little_endian");
+		expect(new_header.elements).toEqual(header.elements);
+
+		const view = new DataView(
+			result.buffer,
+			result.byteOffset + new_header.byte_length
+		);
+		// First vertex: three floats then three colour bytes.
+		expect(view.getFloat32(0, true)).toBe(-1);
+		expect(view.getFloat32(4, true)).toBe(-1);
+		expect(view.getFloat32(8, true)).toBe(0);
+		expect([view.getUint8(12), view.getUint8(13), view.getUint8(14)]).toEqual([
+			255, 0, 0
+		]);
+
+		// The single face: a uchar count followed by three int indices.
+		const face = 3 * 15;
+		expect(view.getUint8(face)).toBe(3);
+		expect(view.getInt32(face + 1, true)).toBe(0);
+		expect(view.getInt32(face + 5, true)).toBe(1);
+		expect(view.getInt32(face + 9, true)).toBe(2);
+		expect(result.byteLength).toBe(new_header.byte_length + face + 13);
+	});
+
+	test("throws when the body has fewer rows than the header promises", () => {
+		const truncated = MESH_PLY.replace("element vertex 3", "element vertex 4");
+		const bytes = encode(truncated);
+		expect(() =>
+			ascii_ply_to_binary(bytes, parse_ply_header(bytes)!)
+		).toThrowError(/Truncated/);
+	});
+});

--- a/js/model3D/shared/ply.test.ts
+++ b/js/model3D/shared/ply.test.ts
@@ -130,6 +130,14 @@ describe("ascii_ply_to_binary", () => {
 		expect(result.byteLength).toBe(new_header.byte_length + face + 13);
 	});
 
+	test("stops at the end of the body, not at the declared count", () => {
+		const malicious = MESH_PLY.replace("3 0 1 2", "9999999999 0 1 2");
+		const bytes = encode(malicious);
+		expect(() =>
+			ascii_ply_to_binary(bytes, parse_ply_header(bytes)!)
+		).toThrowError(/Truncated/);
+	});
+
 	test("throws when the body has fewer rows than the header promises", () => {
 		const truncated = MESH_PLY.replace("element vertex 3", "element vertex 4");
 		const bytes = encode(truncated);

--- a/js/model3D/shared/ply.test.ts
+++ b/js/model3D/shared/ply.test.ts
@@ -75,6 +75,19 @@ describe("parse_ply_header", () => {
 		expect(parse_ply_header(encode("not a ply file"))).toBeNull();
 	});
 
+	test("does not end the header at `end_header` inside a comment", () => {
+		const commented = MESH_PLY.replace(
+			"element vertex 3",
+			"comment end_header comes later\nelement vertex 3"
+		);
+		const header = parse_ply_header(encode(commented))!;
+
+		expect(header.elements.map((element) => element.name)).toEqual([
+			"vertex",
+			"face"
+		]);
+	});
+
 	test("returns null when the header is truncated", () => {
 		expect(parse_ply_header(encode("ply\nformat ascii 1.0\n"))).toBeNull();
 	});

--- a/js/model3D/shared/ply.test.ts
+++ b/js/model3D/shared/ply.test.ts
@@ -3,7 +3,8 @@ import { test, describe, expect } from "vitest";
 import {
 	ascii_ply_to_binary,
 	is_gaussian_splat_ply,
-	parse_ply_header
+	parse_ply_header,
+	resolve_ply_source
 } from "./ply";
 
 const encode = (text: string): Uint8Array => new TextEncoder().encode(text);
@@ -135,5 +136,34 @@ describe("ascii_ply_to_binary", () => {
 		expect(() =>
 			ascii_ply_to_binary(bytes, parse_ply_header(bytes)!)
 		).toThrowError(/Truncated/);
+	});
+});
+
+describe("resolve_ply_source", () => {
+	const serve = (text: string): string =>
+		URL.createObjectURL(new Blob([encode(text)]));
+
+	test("routes an ASCII mesh to Babylon with transcoded bytes", async () => {
+		const source = await resolve_ply_source(serve(MESH_PLY));
+
+		expect(source.renderer).toBe("babylon");
+		const data = source.renderer === "babylon" ? source.data : undefined;
+		expect(parse_ply_header(data!)!.format).toBe("binary_little_endian");
+	});
+
+	test("routes a splat to gsplat without transcoding", async () => {
+		expect(await resolve_ply_source(serve(SPLAT_PLY))).toEqual({
+			renderer: "gsplat"
+		});
+	});
+
+	test("falls back to gsplat when the body can't be transcoded", async () => {
+		const truncated = MESH_PLY.replace("element vertex 3", "element vertex 4");
+
+		// A throw here used to reach the caller as an unhandled rejection, which
+		// left the canvas blank: the same failure this module exists to prevent.
+		expect(await resolve_ply_source(serve(truncated))).toEqual({
+			renderer: "gsplat"
+		});
 	});
 });

--- a/js/model3D/shared/ply.ts
+++ b/js/model3D/shared/ply.ts
@@ -1,0 +1,359 @@
+/**
+ * PLY is used for two unrelated things: Gaussian splats, which the gsplat
+ * renderer handles, and ordinary meshes and point clouds, which Babylon
+ * handles. The extension alone doesn't say which one a file is, so the header
+ * has to be read before a renderer can be picked.
+ *
+ * Babylon's PLY support is also little-endian binary only, so ASCII files are
+ * transcoded here before being handed over.
+ */
+
+type ScalarType =
+	| "char"
+	| "uchar"
+	| "short"
+	| "ushort"
+	| "int"
+	| "uint"
+	| "float"
+	| "double";
+
+const TYPE_ALIASES: Record<string, ScalarType> = {
+	char: "char",
+	int8: "char",
+	uchar: "uchar",
+	uint8: "uchar",
+	short: "short",
+	int16: "short",
+	ushort: "ushort",
+	uint16: "ushort",
+	int: "int",
+	int32: "int",
+	uint: "uint",
+	uint32: "uint",
+	float: "float",
+	float32: "float",
+	double: "double",
+	float64: "double"
+};
+
+const TYPE_SIZES: Record<ScalarType, number> = {
+	char: 1,
+	uchar: 1,
+	short: 2,
+	ushort: 2,
+	int: 4,
+	uint: 4,
+	float: 4,
+	double: 8
+};
+
+const SPLAT_PROPERTIES = [
+	"x",
+	"y",
+	"z",
+	"scale_0",
+	"scale_1",
+	"scale_2",
+	"opacity",
+	"rot_0",
+	"rot_1",
+	"rot_2",
+	"rot_3"
+];
+
+const SPLAT_COLOR_PROPERTIES = [
+	"red",
+	"green",
+	"blue",
+	"f_dc_0",
+	"f_dc_1",
+	"f_dc_2"
+];
+
+/** How far into a file to look for `end_header` before giving up. */
+const HEADER_SCAN_LIMIT = 64 * 1024;
+
+export type PlyFormat = "ascii" | "binary_little_endian" | "binary_big_endian";
+
+type PlyProperty =
+	| { kind: "scalar"; name: string; type: ScalarType }
+	| {
+			kind: "list";
+			name: string;
+			count_type: ScalarType;
+			entry_type: ScalarType;
+	  };
+
+interface PlyElement {
+	name: string;
+	count: number;
+	properties: PlyProperty[];
+}
+
+export interface PlyHeader {
+	format: PlyFormat;
+	/** Size of the header in bytes, including the `end_header` line. */
+	byte_length: number;
+	text: string;
+	elements: PlyElement[];
+}
+
+export type PlySource =
+	/** A Gaussian splat: render with gsplat, which fetches the URL itself. */
+	| { renderer: "gsplat" }
+	/**
+	 * A mesh or point cloud: render with Babylon. `data` is set only when the
+	 * file had to be transcoded, otherwise Babylon fetches the URL itself.
+	 */
+	| { renderer: "babylon"; data?: Uint8Array<ArrayBuffer> };
+
+export function parse_ply_header(bytes: Uint8Array): PlyHeader | null {
+	const text = new TextDecoder().decode(bytes);
+	if (!text.startsWith("ply")) return null;
+
+	const end = text.indexOf("end_header");
+	if (end < 0) return null;
+	const line_end = text.indexOf("\n", end);
+	if (line_end < 0) return null;
+
+	const header_text = text.slice(0, line_end + 1);
+	const elements: PlyElement[] = [];
+	let format: PlyFormat | null = null;
+
+	for (const line of header_text.split(/\r?\n/)) {
+		const parts = line.trim().split(/\s+/);
+		if (parts[0] === "format") {
+			if (
+				parts[1] !== "ascii" &&
+				parts[1] !== "binary_little_endian" &&
+				parts[1] !== "binary_big_endian"
+			) {
+				return null;
+			}
+			format = parts[1];
+		} else if (parts[0] === "element") {
+			elements.push({
+				name: parts[1],
+				count: parseInt(parts[2], 10),
+				properties: []
+			});
+		} else if (parts[0] === "property") {
+			const element = elements[elements.length - 1];
+			if (!element) return null;
+			if (parts[1] === "list") {
+				const count_type = TYPE_ALIASES[parts[2]];
+				const entry_type = TYPE_ALIASES[parts[3]];
+				if (!count_type || !entry_type) return null;
+				element.properties.push({
+					kind: "list",
+					name: parts[4],
+					count_type,
+					entry_type
+				});
+			} else {
+				const type = TYPE_ALIASES[parts[1]];
+				if (!type) return null;
+				element.properties.push({ kind: "scalar", name: parts[2], type });
+			}
+		}
+	}
+
+	if (!format || elements.some((element) => !Number.isFinite(element.count))) {
+		return null;
+	}
+
+	return {
+		format,
+		byte_length: new TextEncoder().encode(header_text).length,
+		text: header_text,
+		elements
+	};
+}
+
+export function is_gaussian_splat_ply(header: PlyHeader): boolean {
+	// Faces make it a mesh regardless of what the vertex properties look like.
+	const face = header.elements.find((element) => element.name === "face");
+	if (face && face.count > 0) return false;
+
+	// Quantised splats (`element chunk`) don't carry the plain splat properties.
+	if (header.elements.some((element) => element.name === "chunk")) return true;
+
+	const vertex = header.elements.find((element) => element.name === "vertex");
+	if (!vertex) return false;
+
+	const names = new Set(vertex.properties.map((property) => property.name));
+	return (
+		SPLAT_PROPERTIES.every((name) => names.has(name)) &&
+		SPLAT_COLOR_PROPERTIES.filter((name) => names.has(name)).length >= 3
+	);
+}
+
+/** Rewrites an ASCII PLY as little-endian binary, keeping the same layout. */
+export function ascii_ply_to_binary(
+	bytes: Uint8Array,
+	header: PlyHeader
+): Uint8Array<ArrayBuffer> {
+	const body = new TextDecoder().decode(bytes.subarray(header.byte_length));
+	const next = token_reader(body);
+	const out = new ByteWriter();
+
+	for (const element of header.elements) {
+		for (let row = 0; row < element.count; row++) {
+			for (const property of element.properties) {
+				if (property.kind === "scalar") {
+					out.write(property.type, next());
+				} else {
+					const count = next();
+					out.write(property.count_type, count);
+					for (let i = 0; i < count; i++)
+						out.write(property.entry_type, next());
+				}
+			}
+		}
+	}
+
+	const new_header = new TextEncoder().encode(
+		header.text.replace(/^format\s+ascii\s+/m, "format binary_little_endian ")
+	);
+	const result = new Uint8Array(new_header.length + out.length);
+	result.set(new_header);
+	result.set(out.bytes(), new_header.length);
+	return result;
+}
+
+/**
+ * Reads enough of `url` to work out how the file should be rendered. Falls back
+ * to gsplat, the historical behaviour for `.ply`, when the header can't be read.
+ */
+export async function resolve_ply_source(url: string): Promise<PlySource> {
+	let response: Response;
+	try {
+		response = await fetch(url);
+	} catch {
+		return { renderer: "gsplat" };
+	}
+	if (!response.ok) return { renderer: "gsplat" };
+
+	const reader = response.body?.getReader();
+	if (!reader) {
+		return classify(new Uint8Array(await response.arrayBuffer()));
+	}
+
+	const chunks: Uint8Array[] = [];
+	let size = 0;
+	let header: PlyHeader | null = null;
+	let done = false;
+
+	while (!done && size < HEADER_SCAN_LIMIT) {
+		const result = await reader.read();
+		done = !!result.done;
+		if (result.value) {
+			chunks.push(result.value);
+			size += result.value.length;
+			header = parse_ply_header(concat(chunks, size));
+			if (header) break;
+		}
+	}
+
+	if (!header || is_gaussian_splat_ply(header)) {
+		void reader.cancel().catch(() => {});
+		return { renderer: "gsplat" };
+	}
+	if (header.format !== "ascii") {
+		void reader.cancel().catch(() => {});
+		return { renderer: "babylon" };
+	}
+
+	while (!done) {
+		const result = await reader.read();
+		done = !!result.done;
+		if (result.value) {
+			chunks.push(result.value);
+			size += result.value.length;
+		}
+	}
+
+	return {
+		renderer: "babylon",
+		data: ascii_ply_to_binary(concat(chunks, size), header)
+	};
+}
+
+function classify(bytes: Uint8Array): PlySource {
+	const header = parse_ply_header(bytes);
+	if (!header || is_gaussian_splat_ply(header)) return { renderer: "gsplat" };
+	if (header.format !== "ascii") return { renderer: "babylon" };
+	return { renderer: "babylon", data: ascii_ply_to_binary(bytes, header) };
+}
+
+function concat(chunks: Uint8Array[], size: number): Uint8Array {
+	if (chunks.length === 1) return chunks[0];
+	const merged = new Uint8Array(size);
+	let offset = 0;
+	for (const chunk of chunks) {
+		merged.set(chunk, offset);
+		offset += chunk.length;
+	}
+	return merged;
+}
+
+function token_reader(body: string): () => number {
+	let position = 0;
+	const is_space = (character: string): boolean =>
+		character === " " ||
+		character === "\n" ||
+		character === "\r" ||
+		character === "\t";
+
+	return () => {
+		while (position < body.length && is_space(body[position])) position++;
+		const start = position;
+		while (position < body.length && !is_space(body[position])) position++;
+		if (start === position) {
+			throw new Error("Truncated ASCII PLY body");
+		}
+		const value = Number(body.slice(start, position));
+		if (!Number.isFinite(value)) {
+			throw new Error(
+				`Invalid number in ASCII PLY: ${body.slice(start, position)}`
+			);
+		}
+		return value;
+	};
+}
+
+class ByteWriter {
+	private buffer = new ArrayBuffer(1024);
+	private view = new DataView(this.buffer);
+	length = 0;
+
+	write(type: ScalarType, value: number): void {
+		const size = TYPE_SIZES[type];
+		this.reserve(size);
+		const offset = this.length;
+		if (type === "char") this.view.setInt8(offset, value);
+		else if (type === "uchar") this.view.setUint8(offset, value);
+		else if (type === "short") this.view.setInt16(offset, value, true);
+		else if (type === "ushort") this.view.setUint16(offset, value, true);
+		else if (type === "int") this.view.setInt32(offset, value, true);
+		else if (type === "uint") this.view.setUint32(offset, value, true);
+		else if (type === "float") this.view.setFloat32(offset, value, true);
+		else this.view.setFloat64(offset, value, true);
+		this.length += size;
+	}
+
+	bytes(): Uint8Array {
+		return new Uint8Array(this.buffer, 0, this.length);
+	}
+
+	private reserve(size: number): void {
+		if (this.length + size <= this.buffer.byteLength) return;
+		let capacity = this.buffer.byteLength * 2;
+		while (capacity < this.length + size) capacity *= 2;
+		const grown = new ArrayBuffer(capacity);
+		new Uint8Array(grown).set(new Uint8Array(this.buffer, 0, this.length));
+		this.buffer = grown;
+		this.view = new DataView(this.buffer);
+	}
+}

--- a/js/model3D/shared/ply.ts
+++ b/js/model3D/shared/ply.ts
@@ -87,7 +87,10 @@ const EMIT_TYPE: Record<ScalarType, ScalarType> = {
 };
 
 // Babylon reads a face as a uchar length followed by three 32-bit indices and
-// ignores what the header declares, so lists are written to match that.
+// ignores what the header declares, so lists are written to match that. Its
+// header parser never looks at faces, so unlike the vertex layout this pairing
+// has no test holding it in place; it was checked by eye against a rendered
+// mesh.
 const LIST_COUNT_TYPE: ScalarType = "uchar";
 const LIST_ENTRY_TYPE: ScalarType = "int";
 
@@ -205,6 +208,10 @@ export function is_gaussian_splat_ply(header: PlyHeader): boolean {
 function binary_header_text(header: PlyHeader): string {
 	const lines = ["ply", "format binary_little_endian 1.0"];
 	for (const element of header.elements) {
+		// Skipped in the body as well, so declaring it would describe rows that
+		// aren't there.
+		if (element.properties.length === 0) continue;
+
 		lines.push(`element ${element.name} ${element.count}`);
 		for (const property of element.properties) {
 			lines.push(

--- a/js/model3D/shared/ply.ts
+++ b/js/model3D/shared/ply.ts
@@ -3,9 +3,6 @@
  * renderer handles, and ordinary meshes and point clouds, which Babylon
  * handles. The extension alone doesn't say which one a file is, so the header
  * has to be read before a renderer can be picked.
- *
- * Babylon's PLY support is also little-endian binary only, so ASCII files are
- * transcoded here before being handed over.
  */
 
 type ScalarType =
@@ -94,7 +91,6 @@ const EMIT_TYPE: Record<ScalarType, ScalarType> = {
 const LIST_COUNT_TYPE: ScalarType = "uchar";
 const LIST_ENTRY_TYPE: ScalarType = "int";
 
-/** How far into a file to look for `end_header` before giving up. */
 const HEADER_SCAN_LIMIT = 64 * 1024;
 
 export type PlyFormat = "ascii" | "binary_little_endian" | "binary_big_endian";
@@ -122,12 +118,8 @@ export interface PlyHeader {
 }
 
 export type PlySource =
-	/** A Gaussian splat: render with gsplat, which fetches the URL itself. */
 	| { renderer: "gsplat" }
-	/**
-	 * A mesh or point cloud: render with Babylon. `data` is set only when the
-	 * file had to be transcoded, otherwise Babylon fetches the URL itself.
-	 */
+	/** `data` is set only when the file had to be transcoded. */
 	| { renderer: "babylon"; data?: Uint8Array<ArrayBuffer> };
 
 export function parse_ply_header(bytes: Uint8Array): PlyHeader | null {
@@ -227,11 +219,9 @@ function binary_header_text(header: PlyHeader): string {
 }
 
 /**
- * Rewrites an ASCII PLY as little-endian binary. The header is rebuilt from the
- * parsed elements rather than copied from the source, so the line endings, type
- * spellings and list layout all come out in the one dialect Babylon reads. A
- * copied header keeps whatever the writing tool used, and CRLF alone is enough
- * for Babylon to miss `end_header` and treat the whole file as a raw splat.
+ * Rewrites an ASCII PLY as little-endian binary. The header is rebuilt rather
+ * than copied because Babylon reads one narrow dialect: a copied CRLF header is
+ * enough for it to miss `end_header` and treat the file as a raw splat.
  */
 export function ascii_ply_to_binary(
 	bytes: Uint8Array,

--- a/js/model3D/shared/ply.ts
+++ b/js/model3D/shared/ply.ts
@@ -88,9 +88,7 @@ const EMIT_TYPE: Record<ScalarType, ScalarType> = {
 
 // Babylon reads a face as a uchar length followed by three 32-bit indices and
 // ignores what the header declares, so lists are written to match that. Its
-// header parser never looks at faces, so unlike the vertex layout this pairing
-// has no test holding it in place; it was checked by eye against a rendered
-// mesh.
+// header parser never looks at faces, so no test covers this pairing.
 const LIST_COUNT_TYPE: ScalarType = "uchar";
 const LIST_ENTRY_TYPE: ScalarType = "int";
 
@@ -208,8 +206,6 @@ export function is_gaussian_splat_ply(header: PlyHeader): boolean {
 function binary_header_text(header: PlyHeader): string {
 	const lines = ["ply", "format binary_little_endian 1.0"];
 	for (const element of header.elements) {
-		// Skipped in the body as well, so declaring it would describe rows that
-		// aren't there.
 		if (element.properties.length === 0) continue;
 
 		lines.push(`element ${element.name} ${element.count}`);

--- a/js/model3D/shared/ply.ts
+++ b/js/model3D/shared/ply.ts
@@ -88,7 +88,8 @@ const EMIT_TYPE: Record<ScalarType, ScalarType> = {
 
 // Babylon reads a face as a uchar length followed by three 32-bit indices and
 // ignores what the header declares, so lists are written to match that. Its
-// header parser never looks at faces, so no test covers this pairing.
+// header parser never looks at faces, so no test covers Babylon's side of this
+// pairing.
 const LIST_COUNT_TYPE: ScalarType = "uchar";
 const LIST_ENTRY_TYPE: ScalarType = "int";
 
@@ -127,12 +128,12 @@ export function parse_ply_header(bytes: Uint8Array): PlyHeader | null {
 	const text = new TextDecoder().decode(bytes);
 	if (!text.startsWith("ply")) return null;
 
-	const end = text.indexOf("end_header");
-	if (end < 0) return null;
-	const line_end = text.indexOf("\n", end);
-	if (line_end < 0) return null;
+	// Matched as a line of its own: `end_header` is also legal inside a comment,
+	// and taking that as the end would put `byte_length` inside the header.
+	const end = /(?:^|\n)end_header[ \t]*\r?\n/.exec(text);
+	if (!end) return null;
 
-	const header_text = text.slice(0, line_end + 1);
+	const header_text = text.slice(0, end.index + end[0].length);
 	const elements: PlyElement[] = [];
 	let format: PlyFormat | null = null;
 

--- a/js/model3D/shared/ply.ts
+++ b/js/model3D/shared/ply.ts
@@ -223,16 +223,20 @@ export function ascii_ply_to_binary(
 }
 
 /**
- * Reads enough of `url` to work out how the file should be rendered. Falls back
- * to gsplat, the historical behaviour for `.ply`, when the header can't be read.
+ * Reads enough of `url` to work out how the file should be rendered. Never
+ * rejects: a failed request, an interrupted stream or a body that can't be
+ * transcoded all fall back to gsplat, the historical behaviour for `.ply`.
  */
 export async function resolve_ply_source(url: string): Promise<PlySource> {
-	let response: Response;
 	try {
-		response = await fetch(url);
+		return await read_ply_source(url);
 	} catch {
 		return { renderer: "gsplat" };
 	}
+}
+
+async function read_ply_source(url: string): Promise<PlySource> {
+	const response = await fetch(url);
 	if (!response.ok) return { renderer: "gsplat" };
 
 	const reader = response.body?.getReader();
@@ -281,7 +285,7 @@ export async function resolve_ply_source(url: string): Promise<PlySource> {
 }
 
 function classify(bytes: Uint8Array): PlySource {
-	const header = parse_ply_header(bytes);
+	const header = parse_ply_header(bytes.subarray(0, HEADER_SCAN_LIMIT));
 	if (!header || is_gaussian_splat_ply(header)) return { renderer: "gsplat" };
 	if (header.format !== "ascii") return { renderer: "babylon" };
 	return { renderer: "babylon", data: ascii_ply_to_binary(bytes, header) };

--- a/js/model3D/shared/ply.ts
+++ b/js/model3D/shared/ply.ts
@@ -71,6 +71,29 @@ const SPLAT_COLOR_PROPERTIES = [
 	"f_dc_2"
 ];
 
+/**
+ * Babylon's PLY reader has byte sizes and value getters for these types only,
+ * so the rest are widened to one that holds the same values. `short` is not the
+ * missing 2-byte case it looks like: it has a size but no getter, so a file
+ * using it loses its coordinates rather than failing outright. The body is
+ * written here as well, so widening keeps the file consistent.
+ */
+const EMIT_TYPE: Record<ScalarType, ScalarType> = {
+	char: "int",
+	short: "int",
+	ushort: "uint",
+	uchar: "uchar",
+	int: "int",
+	uint: "uint",
+	float: "float",
+	double: "double"
+};
+
+// Babylon reads a face as a uchar length followed by three 32-bit indices and
+// ignores what the header declares, so lists are written to match that.
+const LIST_COUNT_TYPE: ScalarType = "uchar";
+const LIST_ENTRY_TYPE: ScalarType = "int";
+
 /** How far into a file to look for `end_header` before giving up. */
 const HEADER_SCAN_LIMIT = 64 * 1024;
 
@@ -95,7 +118,6 @@ export interface PlyHeader {
 	format: PlyFormat;
 	/** Size of the header in bytes, including the `end_header` line. */
 	byte_length: number;
-	text: string;
 	elements: PlyElement[];
 }
 
@@ -159,14 +181,13 @@ export function parse_ply_header(bytes: Uint8Array): PlyHeader | null {
 		}
 	}
 
-	if (!format || elements.some((element) => !Number.isFinite(element.count))) {
-		return null;
-	}
+	const bad_count = (element: PlyElement): boolean =>
+		!Number.isSafeInteger(element.count) || element.count < 0;
+	if (!format || elements.some(bad_count)) return null;
 
 	return {
 		format,
 		byte_length: new TextEncoder().encode(header_text).length,
-		text: header_text,
 		elements
 	};
 }
@@ -189,7 +210,29 @@ export function is_gaussian_splat_ply(header: PlyHeader): boolean {
 	);
 }
 
-/** Rewrites an ASCII PLY as little-endian binary, keeping the same layout. */
+function binary_header_text(header: PlyHeader): string {
+	const lines = ["ply", "format binary_little_endian 1.0"];
+	for (const element of header.elements) {
+		lines.push(`element ${element.name} ${element.count}`);
+		for (const property of element.properties) {
+			lines.push(
+				property.kind === "list"
+					? `property list ${LIST_COUNT_TYPE} ${LIST_ENTRY_TYPE} ${property.name}`
+					: `property ${EMIT_TYPE[property.type]} ${property.name}`
+			);
+		}
+	}
+	lines.push("end_header");
+	return lines.join("\n") + "\n";
+}
+
+/**
+ * Rewrites an ASCII PLY as little-endian binary. The header is rebuilt from the
+ * parsed elements rather than copied from the source, so the line endings, type
+ * spellings and list layout all come out in the one dialect Babylon reads. A
+ * copied header keeps whatever the writing tool used, and CRLF alone is enough
+ * for Babylon to miss `end_header` and treat the whole file as a raw splat.
+ */
 export function ascii_ply_to_binary(
 	bytes: Uint8Array,
 	header: PlyHeader
@@ -199,23 +242,27 @@ export function ascii_ply_to_binary(
 	const out = new ByteWriter();
 
 	for (const element of header.elements) {
+		// An element with no properties reads and writes nothing, so iterating its
+		// rows would consume no tokens and a large count would only spin.
+		if (element.properties.length === 0) continue;
+
 		for (let row = 0; row < element.count; row++) {
 			for (const property of element.properties) {
 				if (property.kind === "scalar") {
-					out.write(property.type, next());
-				} else {
-					const count = next();
-					out.write(property.count_type, count);
-					for (let i = 0; i < count; i++)
-						out.write(property.entry_type, next());
+					out.write(EMIT_TYPE[property.type], next());
+					continue;
 				}
+				const count = next();
+				if (!Number.isInteger(count) || count < 0 || count > 255) {
+					throw new Error(`Unsupported PLY list length: ${count}`);
+				}
+				out.write(LIST_COUNT_TYPE, count);
+				for (let i = 0; i < count; i++) out.write(LIST_ENTRY_TYPE, next());
 			}
 		}
 	}
 
-	const new_header = new TextEncoder().encode(
-		header.text.replace(/^format\s+ascii\s+/m, "format binary_little_endian ")
-	);
+	const new_header = new TextEncoder().encode(binary_header_text(header));
 	const result = new Uint8Array(new_header.length + out.length);
 	result.set(new_header);
 	result.set(out.bytes(), new_header.length);

--- a/js/model3D/shared/renderer.svelte.ts
+++ b/js/model3D/shared/renderer.svelte.ts
@@ -32,8 +32,12 @@ export function create_renderer(get_value: () => FileData | null | undefined) {
 		data = undefined;
 		if (!file) return;
 
-		const is_splat = file.path.endsWith(".splat");
-		const is_ply = file.path.endsWith(".ply");
+		// Babylon lowercases the extension before it picks a loader, so an
+		// upper-case one has to be recognised here too or it reaches the splat
+		// loader without its header ever being read.
+		const path = file.path.toLowerCase();
+		const is_splat = path.endsWith(".splat");
+		const is_ply = path.endsWith(".ply");
 
 		let stale = false;
 		const use = (source: PlySource): void => {

--- a/js/model3D/shared/renderer.svelte.ts
+++ b/js/model3D/shared/renderer.svelte.ts
@@ -16,9 +16,19 @@ export function create_renderer(get_value: () => FileData | null | undefined) {
 	let data = $state<Uint8Array<ArrayBuffer>>();
 	let gsplat_component = $state<typeof Canvas3DGS>();
 	let babylon_component = $state<typeof Canvas3D>();
+	// Deliberately not reactive: the effect reads it to recognise a value it has
+	// already resolved, and tracking it would make the effect re-run itself.
+	let resolved: string | undefined;
 
 	$effect(() => {
 		const file = get_value();
+		const key = file ? `${file.path}\n${file.url ?? ""}` : "";
+		// The same file arriving again would otherwise tear the canvas down and
+		// fetch the header a second time, which for Babylon means discarding an
+		// engine and building a new one.
+		if (key === resolved) return;
+
+		resolved = undefined;
 		renderer = undefined;
 		data = undefined;
 		if (!file) return;
@@ -29,6 +39,9 @@ export function create_renderer(get_value: () => FileData | null | undefined) {
 		let stale = false;
 		const use = (source: PlySource): void => {
 			if (stale) return;
+			// Only now, so an effect re-run while the header is still in flight
+			// starts over rather than settling on nothing.
+			resolved = key;
 			renderer = source.renderer;
 			data = source.renderer === "babylon" ? source.data : undefined;
 			if (source.renderer === "gsplat") {

--- a/js/model3D/shared/renderer.svelte.ts
+++ b/js/model3D/shared/renderer.svelte.ts
@@ -1,0 +1,70 @@
+import type { FileData } from "@gradio/client";
+import type Canvas3DGS from "./Canvas3DGS.svelte";
+import type Canvas3D from "./Canvas3D.svelte";
+import { resolve_ply_source, type PlySource } from "./ply";
+
+/**
+ * Picks the renderer for a value and lazily loads the matching canvas.
+ *
+ * `renderer` stays `undefined` while a `.ply` header is being read. Guessing
+ * gsplat for that round trip would hand a mesh to gsplat on any instance that
+ * had already shown a splat, which downloads the whole file and throws the
+ * unhandled rejection this module exists to remove.
+ */
+export function create_renderer(get_value: () => FileData | null | undefined) {
+	let renderer = $state<"gsplat" | "babylon">();
+	let data = $state<Uint8Array<ArrayBuffer>>();
+	let gsplat_component = $state<typeof Canvas3DGS>();
+	let babylon_component = $state<typeof Canvas3D>();
+
+	$effect(() => {
+		const file = get_value();
+		renderer = undefined;
+		data = undefined;
+		if (!file) return;
+
+		const is_splat = file.path.endsWith(".splat");
+		const is_ply = file.path.endsWith(".ply");
+
+		let stale = false;
+		const use = (source: PlySource): void => {
+			if (stale) return;
+			renderer = source.renderer;
+			data = source.renderer === "babylon" ? source.data : undefined;
+			if (source.renderer === "gsplat") {
+				void import("./Canvas3DGS.svelte").then((module) => {
+					if (!stale) gsplat_component = module.default;
+				});
+			} else {
+				void import("./Canvas3D.svelte").then((module) => {
+					if (!stale) babylon_component = module.default;
+				});
+			}
+		};
+
+		if (is_ply && file.url) {
+			void resolve_ply_source(file.url).then(use);
+		} else {
+			use({ renderer: is_splat || is_ply ? "gsplat" : "babylon" });
+		}
+
+		return () => {
+			stale = true;
+		};
+	});
+
+	return {
+		get renderer() {
+			return renderer;
+		},
+		get data() {
+			return data;
+		},
+		get gsplat_component() {
+			return gsplat_component;
+		},
+		get babylon_component() {
+			return babylon_component;
+		}
+	};
+}

--- a/js/model3D/shared/renderer.svelte.ts
+++ b/js/model3D/shared/renderer.svelte.ts
@@ -32,9 +32,8 @@ export function create_renderer(get_value: () => FileData | null | undefined) {
 		data = undefined;
 		if (!file) return;
 
-		// Babylon lowercases the extension before it picks a loader, so an
-		// upper-case one has to be recognised here too or it reaches the splat
-		// loader without its header ever being read.
+		// Babylon lowercases the extension to pick a loader, so an upper-case one
+		// left unmatched here reaches the splat loader with its header unread.
 		const path = file.path.toLowerCase();
 		const is_splat = path.endsWith(".splat");
 		const is_ply = path.endsWith(".ply");

--- a/js/model3D/shared/renderer.svelte.ts
+++ b/js/model3D/shared/renderer.svelte.ts
@@ -23,9 +23,8 @@ export function create_renderer(get_value: () => FileData | null | undefined) {
 	$effect(() => {
 		const file = get_value();
 		const key = file ? `${file.path}\n${file.url ?? ""}` : "";
-		// The same file arriving again would otherwise tear the canvas down and
-		// fetch the header a second time, which for Babylon means discarding an
-		// engine and building a new one.
+		// Re-resolving a value already on screen would tear the canvas down and
+		// cost Babylon an engine.
 		if (key === resolved) return;
 
 		resolved = undefined;

--- a/js/tootils/src/fixtures.ts
+++ b/js/tootils/src/fixtures.ts
@@ -21,6 +21,12 @@ export const TEST_WAV = fixture("audio_sample.wav", "audio/wav", 16136);
 export const TEST_PDF = fixture("sample_file.pdf", "application/pdf", 10558);
 export const TEST_GLTF = fixture("Box.gltf", "model/gltf+json", 5249);
 export const TEST_PLY = fixture("model.ply", "application/octet-stream", 413);
+/** A plain triangle mesh, as opposed to the Gaussian splat in `TEST_PLY`. */
+export const TEST_PLY_MESH = fixture(
+	"mesh.ply",
+	"application/octet-stream",
+	292
+);
 export const TEST_SPLAT = fixture(
 	"model.splat",
 	"application/octet-stream",

--- a/js/tootils/src/render.ts
+++ b/js/tootils/src/render.ts
@@ -302,6 +302,7 @@ export {
 	TEST_PDF,
 	TEST_GLTF,
 	TEST_PLY,
+	TEST_PLY_MESH,
 	TEST_SPLAT
 } from "./fixtures.js";
 export * from "@testing-library/dom";

--- a/test/test_files/mesh.ply
+++ b/test/test_files/mesh.ply
@@ -1,0 +1,18 @@
+ply
+format ascii 1.0
+element vertex 4
+property float x
+property float y
+property float z
+property uchar red
+property uchar green
+property uchar blue
+element face 2
+property list uchar int vertex_indices
+end_header
+-1 -1 0 255 0 0
+1 -1 0 0 255 0
+1 1 0 0 0 255
+-1 1 0 255 255 0
+3 0 1 2
+3 0 2 3


### PR DESCRIPTION
## Description

`gr.Model3D` showed a blank canvas for any `.ply` file that isn't a Gaussian splat, and for an OBJ that carries vertices and no faces. A triangle-mesh PLY exported from Blender, MeshLab or Open3D rendered nothing at all, with no error in the UI, and neither did a point cloud in either container. The two have separate causes, so they are described in turn below.

`Model3D.svelte` and `Model3DUpload.svelte` picked the renderer from the file extension alone:

```js
use_3dgs = value.path.endsWith(".splat") || value.path.endsWith(".ply");
```

That sent every `.ply` to `Canvas3DGS`, which uses gsplat. gsplat only understands PLY files whose vertex element carries the Gaussian-splat properties, so on a mesh PLY its loader throws `Unsupported property type: list` (the `property list uchar int vertex_indices` line that declares faces). `Canvas3DGS.reset_scene()` calls `load()` without a `.catch`, so the rejection went unhandled, the render loop kept drawing an empty scene, and the user saw an empty canvas. `clear_color` had no effect either, because `Canvas3DGS` doesn't take that prop.

PLY is really two unrelated formats sharing an extension, so the renderer can't be chosen without looking inside the file. This PR adds `js/model3D/shared/ply.ts`, which reads the header and routes on what it finds:

- Gaussian splats keep going to gsplat, unchanged. That includes quantised splats (`element chunk`), whose vertex properties don't look like a plain splat's.
- Meshes and point clouds go to the Babylon viewer, which has handled all three PLY flavours since its SPLAT loader gained mesh and point-cloud modes.

Babylon's PLY support is little-endian binary only: it walks the body by computed byte offsets and never checks whether the file says `format ascii`. Since ASCII is what most tools write by default (and what the issue reports), `ply.ts` also transcodes ASCII PLY to `binary_little_endian` in the browser and hands the result to `Canvas3D` as a named `File`, so Babylon resolves its loader the usual way.

The header of that transcoded file is rebuilt from the parsed elements rather than copied from the source, because Babylon reads one narrow dialect and a copied header carries whatever the writing tool happened to use. It searches for a literal `end_header\n`, so a CRLF header is enough for it to give up and treat the whole file as a raw splat, and a script writing a PLY through Python's text-mode `open` produces exactly that on Windows. Its type table also has no entry for alias spellings such as `float32`, nor for `char`, and an unknown type leaves it adding `undefined` to its running offset. Rebuilding the header means the line endings, type names and list layout are all chosen here, and since the body is written here too, widening a type to one Babylon can read keeps the file consistent.

Only the header is downloaded to make the routing decision. The response body is read in chunks until `end_header` and then cancelled, so a splat that will be fetched by gsplat anyway isn't downloaded twice. Anything that goes wrong along the way, a failed request, an unreadable header, an interrupted stream or a body that can't be transcoded, falls back to gsplat, which is what `.ply` did before.

#8826 asks for the same thing about a file that carries vertices and no faces, and the routing above already answers the PLY half of it: a point cloud loads and renders where it used to show nothing. The OBJ half needed its own fix. Babylon's OBJ parser does have a fallback that switches to point-cloud rendering for a file with no faces, but it sits on the branch taken when the file declares no object or group name. As soon as an `o`, a `g` or a `usemtl` appears, the parser unwraps vertices through the faces that referenced them, so a face-less file arrives at the viewer with no geometry and draws nothing. Six variants of the same 20k-point sphere confirmed the split: only the one declaring none of the three renders.

`js/model3D/shared/obj.ts` rewrites the vertices of such a file as a binary point-cloud PLY, which Babylon reads whatever the file declares. `Canvas3D` reaches for it only after a load has left the model with no vertices anywhere, rather than reading every OBJ up front to look for a face. That ordering matters: handing Babylon bytes in place of a URL breaks `mtllib` and texture references, which resolve against the file's own URL, so checking before the load would trade this bug for broken materials on every textured OBJ. Detecting the empty model instead costs nothing on files that already work, needs no second download except in the broken case, and stops firing by itself if Babylon ever fixes its fallback.

A few notes on what this does not change. GLB, glTF and STL are unaffected, as is an OBJ that has faces; the parts of #12158 and #12120 about those formats no longer reproduce on `main`, presumably fixed by a later Babylon bump. A `binary_big_endian` PLY is no better off than before: the routing sends it to Babylon, whose reader is little-endian throughout, so it stays as blank as it was when gsplat had it. Transcoding it would mean a byte-swapping pass over the body, and the format is rare enough that it is left for whoever turns up with one. A mesh whose faces are not all triangles still renders incompletely: Babylon skips a face whose vertex count is not three without advancing its read offset, so the first quad costs every face after it. Triangulating in the transcoder would only help ASCII files, since binary ones are handed over untouched, so that asymmetry is left alone here.

Closes: #12158
Closes: #8826

## Testing

`js/model3D/shared/ply.test.ts` covers the new module: header parsing, splat vs mesh vs point-cloud classification, the ASCII-to-binary transcode (checking the emitted floats, colour bytes and face indices), and the routing `resolve_ply_source` picks for each of those, including its fallback to gsplat when a file can't be transcoded.

`Model3D.test.ts` gains one test that renders a mesh PLY and asserts the Babylon canvas is used. It fails on `main` and passes with this change.

A further group of tests runs Babylon's own `GaussianSplattingMesh.ParseHeader` over the transcoded output. Asserting on the bytes we emit says nothing about whether the reader on the other side accepts them, and that gap is exactly where the CRLF and type-name problems were sitting.

`js/model3D/shared/obj.test.ts` covers the OBJ side: the conversion itself, the colour scaling Babylon's parser applies, the grey it gives a vertex with no colour and the `w` of a `v x y z w` line that must not be read as one, the cases that return null instead of converting, the empty-geometry check that triggers the whole thing, and `resolve_obj_point_cloud` returning null rather than rejecting on a file it can't read. `ParseHeader` reads the converted output here too.

There is no component test for the OBJ fallback. An OBJ still routes to Babylon exactly as it did, so there is no branch to assert, and whether the fallback fired shows up only inside the canvas.

To check by hand, point a `gr.Model3D` at an ASCII mesh PLY:

```python
import gradio as gr

with gr.Blocks() as demo:
    gr.Model3D(value="cube.ply", height=400)

demo.launch()
```

Before, the viewer is empty. After, the cube renders, and a Gaussian-splat PLY such as [luigi.ply](https://huggingface.co/datasets/dylanebert/3dgs/resolve/main/luigi/luigi.ply) still renders as before.

One thing to expect if you try the exact cube from the issue: 6 of its 12 triangles are wound inward, so those faces are back-face culled and the cube still looks half transparent once it renders. That is a property of the file rather than of the renderer, and reversing those six triangles gives a solid cube.

For the OBJ half, point the same component at a file of `v x y z r g b` lines with an `o` or `usemtl` line and no `f` lines, which is what an exporter writes for a point cloud. Before, the viewer is empty; after, the points render. Dropping the `o` and `usemtl` lines from that same file makes it render on `main` too, which is the difference the fix removes.

## Before / after Spaces

The same app on released 6.23.1 and on the preview wheel for this PR, if you would rather not check it out:

- [Before fix](https://huggingface.co/spaces/hysts-debug/gradio-12158-before)
- [After fix](https://huggingface.co/spaces/hysts-debug/gradio-12158-after)

The first row is the cube from #12158 next to the same cube with its winding corrected, so the blank canvas this PR fixes is separated from the half-culled cube it does not. The second row is the same 20k-point sphere as two face-less OBJ files that differ only in an `o output_mesh` line: on the released build the named one is empty and the bare one renders, which is the whole of the OBJ half of #8826, and with the fix both render.

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`




