### PR TITLE
workflow: forward x-ip-token so zerogpu spaces bill the caller

### DIFF
--- a/.changeset/fresh-lizards-knock.md
+++ b/.changeset/fresh-lizards-knock.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:workflow: forward x-ip-token so zerogpu spaces bill the caller

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -71,7 +71,7 @@ from gradio import (
     utils,
 )
 from gradio.brotli_middleware import BrotliMiddleware
-from gradio.context import Context
+from gradio.context import Context, LocalContext
 from gradio.data_classes import (
     CancelBody,
     ComponentServerBlobBody,
@@ -1718,12 +1718,18 @@ class App(FastAPI):
                 request,  # type: ignore
                 None,
             )
-            if inspect.iscoroutinefunction(fn):
-                return await fn(*processed_input)
-            else:
+            # So `gradio_client.Client` in a server fn can forward `x-ip-token`
+            # (ZeroGPU quota) — regular event handlers get this via
+            # `get_function_with_locals`, this path bypasses that wrapping.
+            LocalContext.request.set(request)  # type: ignore
+            try:
+                if inspect.iscoroutinefunction(fn):
+                    return await fn(*processed_input)
                 return await anyio.to_thread.run_sync(
                     fn, *processed_input, limiter=app.get_blocks().limiter
                 )
+            finally:
+                LocalContext.request.set(None)
 
         @router.get(
             "/queue/status",

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -71,7 +71,7 @@ from gradio import (
     utils,
 )
 from gradio.brotli_middleware import BrotliMiddleware
-from gradio.context import Context, LocalContext
+from gradio.context import Context
 from gradio.data_classes import (
     CancelBody,
     ComponentServerBlobBody,
@@ -1718,18 +1718,19 @@ class App(FastAPI):
                 request,  # type: ignore
                 None,
             )
-            # So `gradio_client.Client` in a server fn can forward `x-ip-token`
-            # (ZeroGPU quota) — regular event handlers get this via
-            # `get_function_with_locals`, this path bypasses that wrapping.
-            LocalContext.request.set(request)  # type: ignore
-            try:
-                if inspect.iscoroutinefunction(fn):
-                    return await fn(*processed_input)
-                return await anyio.to_thread.run_sync(
-                    fn, *processed_input, limiter=app.get_blocks().limiter
-                )
-            finally:
-                LocalContext.request.set(None)
+            fn = utils.get_function_with_locals(
+                fn,
+                app.get_blocks(),
+                event_id=None,
+                in_event_listener=False,
+                request=request,  # type: ignore
+                state=state,
+            )
+            if inspect.iscoroutinefunction(fn):
+                return await fn(*processed_input)
+            return await anyio.to_thread.run_sync(
+                fn, *processed_input, limiter=app.get_blocks().limiter
+            )
 
         @router.get(
             "/queue/status",

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -2553,6 +2553,39 @@ def test_server_fn_passes_request():
     assert response.json()["_url"].endswith("/gradio_api/component_server")
 
 
+def test_server_fn_forwards_x_ip_token_via_local_context():
+    """/component_server must set LocalContext.request so gradio_client.Client
+    can forward the caller's x-ip-token to downstream ZeroGPU Spaces."""
+    import requests
+
+    from gradio.components.base import server
+    from gradio.context import LocalContext
+
+    def get_ip_token(self, _data):
+        req = LocalContext.request.get(None)
+        return req.headers.get("x-ip-token") if req else None
+
+    tb = gr.Textbox()
+    tb.get_ip_token = server(get_ip_token)  # type: ignore
+    iface = gr.Interface(lambda x: x, inputs=tb, outputs="text")
+    component_id = next(
+        c["id"] for c in iface.config["components"] if c["type"] == "textbox"  # type: ignore
+    )
+    _, local_url, _ = iface.launch(prevent_thread_lock=True)
+    response = requests.post(
+        f"{local_url}/gradio_api/component_server",
+        json={
+            "session_hash": "foo",
+            "component_id": component_id,
+            "fn_name": "get_ip_token",
+            "data": json.dumps({}),
+        },
+        headers={"x-ip-token": "test-token"},
+    )
+    assert response.status_code == 200
+    assert response.json() == "test-token"
+
+
 def test_slugify():
     items = (
         ("Hello, World!", "hello-world"),

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -2569,7 +2569,9 @@ def test_server_fn_forwards_x_ip_token_via_local_context():
     tb.get_ip_token = server(get_ip_token)  # type: ignore
     iface = gr.Interface(lambda x: x, inputs=tb, outputs="text")
     component_id = next(
-        c["id"] for c in iface.config["components"] if c["type"] == "textbox"  # type: ignore
+        c["id"]
+        for c in iface.config["components"]
+        if c["type"] == "textbox"  # type: ignore
     )
     _, local_url, _ = iface.launch(prevent_thread_lock=True)
     response = requests.post(


### PR DESCRIPTION
## Description

@AK391's issue around busy zerogpu spaces was caused because the `x-ip-token` header wasn't reaching the target spaces, so ZeroGPU couldn't identify the caller and fell back to the workflow Space's shared IP quota, which was exhausted almost instantly.

the fix is to set `LocalContext.request` around the fn call in `/component_server`, matching what `get_function_with_locals` already does for normal event listeners. only `/component_server` was broken. every other user func dispatch already goes through `get_function_with_locals`.