### PR TITLE
Await `auth_dependency` and apply it when routes are built on an existing app

### DIFF
--- a/.changeset/wicked-trees-knock.md
+++ b/.changeset/wicked-trees-knock.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:Await `auth_dependency` and apply it when routes are built on an existing app

--- a/.changeset/wicked-trees-knock.md
+++ b/.changeset/wicked-trees-knock.md
@@ -1,5 +1,5 @@
 ---
-"gradio": minor
+"gradio": patch
 ---
 
 feat:Await `auth_dependency` and apply it when routes are built on an existing app

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -17,7 +17,7 @@ import warnings
 import weakref
 import webbrowser
 from collections import defaultdict
-from collections.abc import AsyncIterator, Callable, Coroutine, Sequence, Set
+from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Sequence, Set
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import TYPE_CHECKING, Any, Literal, Union, cast
@@ -2678,7 +2678,8 @@ Received inputs:
         share_server_address: str | None = None,
         share_server_protocol: Literal["http", "https"] | None = None,
         share_server_tls_certificate: str | None = None,
-        auth_dependency: Callable[[fastapi.Request], str | None] | None = None,
+        auth_dependency: Callable[[fastapi.Request], str | None | Awaitable[str | None]]
+        | None = None,
         max_file_size: str | int | None = None,
         enable_monitoring: bool | None = None,
         strict_cors: bool = True,

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -17,7 +17,7 @@ import sys
 import time
 import traceback
 import warnings
-from collections.abc import AsyncIterator, Callable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -230,7 +230,8 @@ class App(FastAPI):
 
     def __init__(
         self,
-        auth_dependency: Callable[[fastapi.Request], str | None] | None = None,
+        auth_dependency: Callable[[fastapi.Request], str | None | Awaitable[str | None]]
+        | None = None,
         **kwargs,
     ):
         self.tokens = {}
@@ -365,7 +366,8 @@ class App(FastAPI):
         blocks: gradio.Blocks,
         app: App | None = None,
         app_kwargs: dict[str, Any] | None = None,
-        auth_dependency: Callable[[fastapi.Request], str | None] | None = None,
+        auth_dependency: Callable[[fastapi.Request], str | None | Awaitable[str | None]]
+        | None = None,
         strict_cors: bool = True,
         mcp_server: bool | None = None,
         debug: bool = False,
@@ -384,6 +386,8 @@ class App(FastAPI):
             app.router.lifespan_context = create_lifespan_handler(
                 app_kwargs.get("lifespan", None), *delete_cache
             )
+            if auth_dependency is not None:
+                app.auth_dependency = auth_dependency
         if blocks.mcp_server_obj:
             blocks.mcp_server_obj.launch_mcp_on_sse(app, mcp_subpath, blocks.root_path)
         router = APIRouter(prefix=API_PREFIX)
@@ -403,9 +407,12 @@ class App(FastAPI):
 
         @router.get("/user")
         @router.get("/user/")
-        def get_current_user(request: fastapi.Request) -> str | None:
+        async def get_current_user(request: fastapi.Request) -> str | None:
             if app.auth_dependency is not None:
-                return app.auth_dependency(request)
+                user = app.auth_dependency(request)
+                if inspect.isawaitable(user):
+                    user = await user
+                return user
             token = request.cookies.get(
                 f"access-token-{app.cookie_id}"
             ) or request.cookies.get(f"access-token-unsecure-{app.cookie_id}")
@@ -2504,7 +2511,8 @@ def mount_gradio_app(
     *,
     auth: Callable | tuple[str, str] | list[tuple[str, str]] | None = None,
     auth_message: str | None = None,
-    auth_dependency: Callable[[fastapi.Request], str | None] | None = None,
+    auth_dependency: Callable[[fastapi.Request], str | None | Awaitable[str | None]]
+    | None = None,
     root_path: str | None = None,
     allowed_paths: list[str] | None = None,
     blocked_paths: list[str] | None = None,

--- a/gradio/server.py
+++ b/gradio/server.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path
 from typing import Any, Literal
 
@@ -255,7 +255,8 @@ class Server(App):
         share_server_address: str | None = None,
         share_server_protocol: Literal["http", "https"] | None = None,
         share_server_tls_certificate: str | None = None,
-        auth_dependency: Callable[[fastapi.Request], str | None] | None = None,
+        auth_dependency: Callable[[fastapi.Request], str | None | Awaitable[str | None]]
+        | None = None,
         max_file_size: str | int | None = None,
         enable_monitoring: bool | None = None,
         strict_cors: bool = True,

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -607,6 +607,35 @@ class TestRoutes:
             assert not client.get("/", headers={}).is_success
             assert client.get("/", headers={"user": "abubakar"}).is_success
 
+    def test_gradio_app_with_async_auth_dependency(self):
+        async def block_anonymous(request: Request):
+            return request.headers.get("user")
+
+        demo = gr.Interface(lambda s: s, "textbox", "textbox")
+        app, _, _ = demo.launch(
+            auth_dependency=block_anonymous, prevent_thread_lock=True
+        )
+
+        with TestClient(app) as client:
+            assert not client.get("/", headers={}).is_success
+            assert client.get("/", headers={"user": "abubakar"}).is_success
+        demo.close()
+
+    def test_server_mode_with_auth_dependency(self):
+        def block_anonymous(request: Request):
+            return request.headers.get("user")
+
+        server = gr.Server()
+        demo = gr.Interface(lambda s: s, "textbox", "textbox")
+        app, _, _ = server.launch(
+            demo, auth_dependency=block_anonymous, prevent_thread_lock=True
+        )
+
+        with TestClient(app) as client:
+            assert not client.get("/", headers={}).is_success
+            assert client.get("/", headers={"user": "abubakar"}).is_success
+        demo.close()
+
     def test_mount_gradio_app_with_auth_dependency(self):
         app = FastAPI()
 

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -626,15 +626,22 @@ class TestRoutes:
             return request.headers.get("user")
 
         server = gr.Server()
-        demo = gr.Interface(lambda s: s, "textbox", "textbox")
+
+        @server.api(name="echo")
+        def echo(x: str) -> str:
+            return x
+
         app, _, _ = server.launch(
-            demo, auth_dependency=block_anonymous, prevent_thread_lock=True
+            auth_dependency=block_anonymous, prevent_thread_lock=True
         )
 
         with TestClient(app) as client:
-            assert not client.get("/", headers={}).is_success
-            assert client.get("/", headers={"user": "abubakar"}).is_success
-        demo.close()
+            assert (
+                client.get(f"{API_PREFIX}/login_check", headers={}).status_code == 401
+            )
+            assert client.get(
+                f"{API_PREFIX}/login_check", headers={"user": "abubakar"}
+            ).is_success
 
     def test_mount_gradio_app_with_auth_dependency(self):
         app = FastAPI()


### PR DESCRIPTION
Reported by an internal security audit — see the [audit thread](https://huggingface.slack.com/archives/C02SPHC1KD1/p1786538990857159) (findings GR-AUD-03 and GR-AUD-09). No public issue.

Two independent defects in how `auth_dependency` is dispatched. Both fail **open**: an app that looks correctly configured serves protected routes to anonymous callers.

## 1. An async `auth_dependency` was never awaited

`get_current_user` was a synchronous function that returned `app.auth_dependency(request)` directly. For an `async def` dependency that return value is a coroutine object, which is truthy, so `login_check` accepted it as a user ID. Python even emits `RuntimeWarning: coroutine 'block_anonymous' was never awaited` while the request succeeds.

It now awaits any awaitable result. The public annotations advertised only `str | None`, so returning an awaitable was arguably outside the contract — they now include `Awaitable[str | None]`, since awaiting it is the more useful behaviour.

## 2. `gr.Server` dropped the dependency entirely

`App.create_app()` passed `auth_dependency` only to the `App(...)` constructor, inside the branch that creates a new app:

```python
if app is None:
    app = App(auth_dependency=auth_dependency, ...)
else:
    app.router.lifespan_context = ...   # auth_dependency silently discarded
```

`gr.Server.launch()` reaches the `else` branch, because the `Server` *is* the app and is passed through as `_app`. So `app.auth_dependency` stayed `None` and every route was unprotected — with an ordinary, documented, synchronous dependency. It is now assigned in that branch as well.

## Verification

Both dependencies in the reproducer deny every request (they return `None`), so a correct app must answer 401 to an anonymous request:

```
                                             before          after
async dependency, Blocks.launch              200 (open)      401
sync dependency, Blocks.launch (control)      401            401
sync dependency, Server.launch               200 (open)      401
```

The middle row is the control: the already-working path, unchanged.

```
$ python -m pytest test/test_routes.py -k auth -q
14 passed
```

`test_gradio_app_with_async_auth_dependency` and `test_server_mode_with_auth_dependency` are new; both fail on `main` with `assert not True` — the anonymous request succeeding. Full `test/test_routes.py` has the same 7 pre-existing failures before and after (background-task/lifespan, deep-link, and `test_server_fn_passes_request`, all failing on `main` in this environment), with 153 passing versus 151.

## Note on scope

The audit lists a third, related finding (GR-AUD-10, a callable object whose `__call__` is async being treated as a truthy built-in `auth` result). That is the `auth` parameter rather than `auth_dependency` and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)