### PR TITLE
Fix initial Spaces iframe resize after app render

### DIFF
--- a/.changeset/upset-vans-judge.md
+++ b/.changeset/upset-vans-judge.md
@@ -1,6 +1,6 @@
 ---
-"@gradio/core": minor
-"gradio": minor
+"@gradio/core": patch
+"gradio": patch
 ---
 
 feat:Fix initial Spaces iframe resize after app render

--- a/.changeset/upset-vans-judge.md
+++ b/.changeset/upset-vans-judge.md
@@ -1,0 +1,6 @@
+---
+"@gradio/core": minor
+"gradio": minor
+---
+
+feat:Fix initial Spaces iframe resize after app render

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -488,6 +488,8 @@
 
 		app_tree.ready.then(() => {
 			ready = true;
+			reset_resize_growth(resize_state);
+			void tick().then(handle_resize);
 			dep_manager.dispatch_load_events();
 		});
 

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -480,7 +480,7 @@
 			subtree: true,
 			attributes: true
 		});
-		res.observe(root_container);
+		res.observe(root_container.parentElement ?? root_container);
 		const disconnect_iframe_resizer = setup_iframe_resizer(
 			window,
 			() => window.parentIFrame,

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -471,7 +471,12 @@
 		refresh_run_count();
 		const unsubscribe_run_history = on_run_history_change(refresh_run_count);
 
-		mutation_observer = new MutationObserver(handle_resize);
+		mutation_observer = new MutationObserver((records) => {
+			if (records.some((record) => record.type === "childList")) {
+				reset_resize_growth(resize_state);
+			}
+			handle_resize();
+		});
 		const res = new ResizeObserver(handle_resize);
 
 		mutation_observer.observe(root_container, {
@@ -488,8 +493,6 @@
 
 		app_tree.ready.then(() => {
 			ready = true;
-			reset_resize_growth(resize_state);
-			void tick().then(handle_resize);
 			dep_manager.dispatch_load_events();
 		});
 

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -448,6 +448,7 @@
 			stretched_bottom: el.getBoundingClientRect().bottom,
 			measure_unstretched_bottom: () => measure_unstretched_bottom(el),
 			footer_height,
+			document_height: document.documentElement.scrollHeight,
 			viewport: window.innerHeight
 		});
 
@@ -471,12 +472,7 @@
 		refresh_run_count();
 		const unsubscribe_run_history = on_run_history_change(refresh_run_count);
 
-		mutation_observer = new MutationObserver((records) => {
-			if (records.some((record) => record.type === "childList")) {
-				reset_resize_growth(resize_state);
-			}
-			handle_resize();
-		});
+		mutation_observer = new MutationObserver(handle_resize);
 		const res = new ResizeObserver(handle_resize);
 
 		mutation_observer.observe(root_container, {
@@ -493,6 +489,8 @@
 
 		app_tree.ready.then(() => {
 			ready = true;
+			reset_resize_growth(resize_state);
+			void settled().then(handle_resize);
 			dep_manager.dispatch_load_events();
 		});
 

--- a/js/core/src/resize.test.ts
+++ b/js/core/src/resize.test.ts
@@ -10,7 +10,11 @@ import {
 import type { ResizeState } from "./resize";
 
 interface Content {
-	(viewport: number): { stretched_bottom: number; unstretched_bottom: number };
+	(viewport: number): {
+		stretched_bottom: number;
+		unstretched_bottom: number;
+		document_height?: number;
+	};
 }
 
 /** `fill_height` content: fills the frame when it fits, overflows when it does not. */
@@ -51,6 +55,8 @@ class Frame {
 			stretched_bottom: m.stretched_bottom,
 			measure_unstretched_bottom: () => m.unstretched_bottom,
 			footer_height: this.footer,
+			document_height:
+				m.document_height ?? m.stretched_bottom + this.footer + FRAME_SLACK,
 			viewport: this.viewport
 		});
 		if (next !== null) {
@@ -172,17 +178,18 @@ describe("next_frame_height", () => {
 			stretched_bottom: 108,
 			measure_unstretched_bottom: measure,
 			footer_height: 21,
+			document_height: 161,
 			viewport: 800
 		});
 		expect(measure).not.toHaveBeenCalled();
 	});
 
 	// gradio-app/gradio#12089
-	test("does not grow for content sized in viewport units", () => {
+	test("grows only once for viewport-sized content with a footer", () => {
 		const frame = new Frame(800);
 		frame.settle(viewport_sized);
-		expect(frame.viewport).toBe(800);
-		expect(frame.reports).toEqual([]);
+		expect(frame.viewport).toBe(853);
+		expect(frame.reports).toEqual([853]);
 	});
 
 	// gradio-app/gradio#12992 (`fill_height` with `footer_links=[]`)
@@ -226,24 +233,20 @@ describe("next_frame_height", () => {
 		expect(frame.tick(revealed)).toBeGreaterThan(frame.viewport);
 	});
 
-	test("reports the settled layout after initial rendering trips the limiter", () => {
+	test("exposes the footer below viewport-filling initial content", () => {
 		const frame = new Frame(670);
-		let needs = 700;
-		const rendering: Content = () => {
-			needs += 100;
-			return { stretched_bottom: needs, unstretched_bottom: needs };
-		};
-
-		for (let i = 0; i < 20; i++) {
-			frame.tick(rendering);
-			frame.apply();
-		}
-
-		const settled = rigid(frame.viewport + 300);
-		expect(frame.tick(settled)).toBe(null);
-
-		reset_resize_growth(frame.state);
-		expect(frame.tick(settled)).toBeGreaterThan(frame.viewport);
+		frame.state.consecutive_grows = 5;
+		expect(
+			frame.tick(() => ({
+				stretched_bottom: 654,
+				unstretched_bottom: 654,
+				document_height: 723
+			}))
+		).toBe(723);
+		frame.apply();
+		expect(frame.tick(viewport_sized)).toBe(null);
+		expect(frame.viewport).toBe(723);
+		expect(frame.reports).toEqual([723]);
 	});
 });
 

--- a/js/core/src/resize.test.ts
+++ b/js/core/src/resize.test.ts
@@ -225,6 +225,26 @@ describe("next_frame_height", () => {
 		reset_resize_growth(frame.state);
 		expect(frame.tick(revealed)).toBeGreaterThan(frame.viewport);
 	});
+
+	test("reports the settled layout after initial rendering trips the limiter", () => {
+		const frame = new Frame(670);
+		let needs = 700;
+		const rendering: Content = () => {
+			needs += 100;
+			return { stretched_bottom: needs, unstretched_bottom: needs };
+		};
+
+		for (let i = 0; i < 20; i++) {
+			frame.tick(rendering);
+			frame.apply();
+		}
+
+		const settled = rigid(frame.viewport + 300);
+		expect(frame.tick(settled)).toBe(null);
+
+		reset_resize_growth(frame.state);
+		expect(frame.tick(settled)).toBeGreaterThan(frame.viewport);
+	});
 });
 
 describe("setup_iframe_resizer", () => {

--- a/js/core/src/resize.test.ts
+++ b/js/core/src/resize.test.ts
@@ -294,4 +294,29 @@ describe("setup_iframe_resizer", () => {
 		expect(autoResize).toHaveBeenCalledWith(false);
 		expect(handle_resize).toHaveBeenCalledOnce();
 	});
+
+	test("retries when readiness is not yet readable", () => {
+		let retry: FrameRequestCallback | undefined;
+		vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+			retry = callback;
+			return 1;
+		});
+		vi.stubGlobal("cancelAnimationFrame", vi.fn());
+		const autoResize = vi.fn();
+		const handle_resize = vi.fn();
+		let parent_iframe: Window["parentIFrame"];
+
+		setup_iframe_resizer(new EventTarget(), () => parent_iframe, handle_resize);
+		parent_iframe = {
+			autoResize,
+			size: vi.fn(),
+			scrollTo: vi.fn(),
+			getPageInfo: vi.fn()
+		};
+		retry?.(0);
+
+		expect(autoResize).toHaveBeenCalledWith(false);
+		expect(handle_resize).toHaveBeenCalledOnce();
+		vi.unstubAllGlobals();
+	});
 });

--- a/js/core/src/resize.ts
+++ b/js/core/src/resize.ts
@@ -49,16 +49,27 @@ export function setup_iframe_resizer(
 	get_parent_iframe: () => Window["parentIFrame"],
 	handle_resize: () => void
 ): () => void {
+	let retry_frame: number | null = null;
+	let retry_count = 0;
+	let connected = false;
 	const connect = (): void => {
+		if (connected) return;
 		const parent_iframe = get_parent_iframe();
-		if (!parent_iframe) return;
+		if (!parent_iframe) {
+			if (retry_count++ < 60) retry_frame = requestAnimationFrame(connect);
+			return;
+		}
+		connected = true;
 		parent_iframe.autoResize(false);
 		handle_resize();
 	};
 
 	target.addEventListener(IFRAME_RESIZER_READY_EVENT, connect);
 	connect();
-	return () => target.removeEventListener(IFRAME_RESIZER_READY_EVENT, connect);
+	return () => {
+		target.removeEventListener(IFRAME_RESIZER_READY_EVENT, connect);
+		if (retry_frame !== null) cancelAnimationFrame(retry_frame);
+	};
 }
 
 /** The height to ask the parent frame for, or `null` to leave it alone. */

--- a/js/core/src/resize.ts
+++ b/js/core/src/resize.ts
@@ -7,6 +7,8 @@ export const IFRAME_RESIZER_READY_EVENT = "gradio:iframe-resizer-ready";
 export interface ResizeState {
 	last_reported_height: number;
 	consecutive_grows: number;
+	/** Whether viewport-filling content already received one bounded footer growth. */
+	has_grown_to_fit_footer: boolean;
 	/** The height the parent frame gave us of its own accord. */
 	base_height: number;
 	/** A size we asked for that the parent has not applied yet. */
@@ -20,6 +22,7 @@ export interface Measurement {
 	/** Forces a reflow, so it is only called when it can change the outcome. */
 	measure_unstretched_bottom: () => number;
 	footer_height: number;
+	document_height: number;
 	viewport: number;
 }
 
@@ -27,6 +30,7 @@ export function create_resize_state(): ResizeState {
 	return {
 		last_reported_height: 0,
 		consecutive_grows: 0,
+		has_grown_to_fit_footer: false,
 		base_height: 0,
 		awaiting_height: null,
 		viewport_at_request: 0
@@ -36,6 +40,7 @@ export function create_resize_state(): ResizeState {
 /** Start a new growth burst after UI explicitly reveals previously hidden content. */
 export function reset_resize_growth(state: ResizeState): void {
 	state.consecutive_grows = 0;
+	state.has_grown_to_fit_footer = false;
 }
 
 /** Connect manual sizing whether iframe-resizer initializes before or after us. */
@@ -93,7 +98,8 @@ export function next_frame_height(
 		}
 	}
 
-	const next = bottom + m.footer_height + FRAME_SLACK;
+	let next = bottom + m.footer_height + FRAME_SLACK;
+	let grows_to_fit_footer = false;
 
 	// Ignore sub-pixel echoes from our own resize.
 	if (Math.abs(next - state.last_reported_height) < 2) {
@@ -106,19 +112,28 @@ export function next_frame_height(
 		// `fill_height` grows to fill whatever height the iframe is given, so its
 		// measured bottom just tracks the viewport. Requesting a larger size in
 		// that case feeds back into an unbounded growth loop (#12089, #12992).
-		// (a) If the content merely fills the viewport (no real overflow), don't grow.
-		if (next > m.viewport && bottom <= m.viewport + 2) return null;
+		// (a) Viewport-filling content may grow once to expose its footer, but must
+		// not keep tracking the larger viewport. With no footer, there is no reason
+		// to grow at all.
+		if (next > m.viewport && bottom <= m.viewport + 2) {
+			if (m.footer_height === 0 || state.has_grown_to_fit_footer) return null;
+			grows_to_fit_footer = true;
+			next = Math.max(next, m.document_height);
+		}
 		// (b) Circuit breaker: if we keep growing tick after tick, the content is
 		// tracking the iframe we just grew (a feedback loop), not genuinely taller
 		// content. Stop growing so the height stays bounded. Legitimate content
 		// (late-loading images, revealed blocks) settles within a few grows.
-		state.consecutive_grows += 1;
-		if (state.consecutive_grows > 4) return null;
+		if (!grows_to_fit_footer) {
+			state.consecutive_grows += 1;
+			if (state.consecutive_grows > 4) return null;
+		}
 	} else {
 		// Shrinking to fit shorter content is always safe and breaks any loop.
 		state.consecutive_grows = 0;
 	}
 
+	if (grows_to_fit_footer) state.has_grown_to_fit_footer = true;
 	state.last_reported_height = next;
 	state.awaiting_height = next;
 	state.viewport_at_request = m.viewport;


### PR DESCRIPTION
## Description

Fixes the intermittent initial iframe height on Hugging Face Spaces, where the Space wrapper cannot scroll until hidden content such as an accordion is revealed.

The failure has two parts:

- startup can exhaust the existing growth limiter before the full app document and footer settle;
- iframe-resizer readiness can race app mounting, leaving a one-shot connection attempt with no retry when `window.parentIFrame` is not readable yet.

This change performs a final measurement after Svelte settles, observes the complete app wrapper, permits one bounded growth to expose a footer beneath viewport-filling content, and retries iframe-resizer setup for at most 60 animation frames. Footerless `fill_height` apps remain covered by the no-growth guard.

Fixed here:
https://huggingface.co/spaces/dawood/spotsound-temporal-grounding

## AI Disclosure

- [x] I used AI to reproduce and diagnose the intermittent iframe lifecycle, draft the implementation and tests, build and deploy the paired Spaces, run repeated browser verification, and draft this description. I reviewed every changed line and the live results.
- [ ] I did not use AI

## Testing and Formatting

- `CI=1 npx vitest run --config .config/vitest.config.ts js/core/src/resize.test.ts` (15/15 passed)
- `pnpm --filter @self/spa build --emptyOutDir` (passed)
- `bash scripts/format_frontend.sh` formatting completed; its repository-wide type-check reports pre-existing unrelated errors in Prism declarations, Rollup types, and Colorpicker.
- SpotSound UI parity checked against the original Space using rendered component structure and visual comparison; page title, visible Markdown heading/copy, and four generated fake examples were verified in the deployed apps.
- 10/10 fresh-load checks after app settlement: Before remained non-scrollable at 670px; After exposed 74px of scroll at 744px before opening the accordion.
