### PR TITLE
workflow: fix oauth logic check

### DIFF
--- a/.changeset/good-roses-write.md
+++ b/.changeset/good-roses-write.md
@@ -1,4 +1,5 @@
 ---
+"@gradio/workflowcanvas": minor
 "gradio": minor
 ---
 

--- a/.changeset/good-roses-write.md
+++ b/.changeset/good-roses-write.md
@@ -2,4 +2,4 @@
 "gradio": minor
 ---
 
-feat:workflow: 
+feat:workflow: fix oauth logic check

--- a/.changeset/good-roses-write.md
+++ b/.changeset/good-roses-write.md
@@ -1,0 +1,5 @@
+---
+"gradio": minor
+---
+
+feat:workflow: 

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -567,15 +567,12 @@ def get_write_access(
 
 
 def get_oauth_available(_data=None) -> str:
-    """Whether `hf_oauth: true` is set in the Space's README."""
-    if get_space() is None:
-        return "false"
-    try:
-        with open("README.md", encoding="utf-8") as f:
-            head = f.read(4096)
-    except OSError:
-        return "false"
-    return "true" if re.search(r"^hf_oauth:\s*true\b", head, re.MULTILINE) else "false"
+    """True on a Space with `hf_oauth: true` (i.e. OAUTH_CLIENT_ID is set)."""
+    return (
+        "true"
+        if get_space() is not None and bool(os.getenv("OAUTH_CLIENT_ID"))
+        else "false"
+    )
 
 
 def call_space(

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -567,17 +567,15 @@ def get_write_access(
 
 
 def get_oauth_available(_data=None) -> str:
-    """Whether OAuth sign-in is actually wired up. On a Space this requires
-    `hf_oauth: true` in the README metadata, which provisions OAUTH_CLIENT_ID
-    and causes the `/login/huggingface` route to be mounted (mirrors the gate
-    that adds the LoginButton in `__init__`). Without it, sign-in would 404, so
-    the frontend hides the login button and explains the fix on the read-only
-    badge. OAuth is not used locally (the write-token model is used instead)."""
-    return (
-        "true"
-        if get_space() is not None and bool(os.getenv("OAUTH_CLIENT_ID"))
-        else "false"
-    )
+    """Whether `hf_oauth: true` is set in the Space's README."""
+    if get_space() is None:
+        return "false"
+    try:
+        with open("README.md", encoding="utf-8") as f:
+            head = f.read(4096)
+    except OSError:
+        return "false"
+    return "true" if re.search(r"^hf_oauth:\s*true\b", head, re.MULTILINE) else "false"
 
 
 def call_space(

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -138,25 +138,7 @@
 		void auth.init();
 	});
 
-	let oauthHintShown = false;
-	$effect(() => {
-		if (
-			!oauthHintShown &&
-			auth.isHFSpace &&
-			auth.writeAccessKnown &&
-			!auth.canWrite &&
-			!auth.oauthAvailable
-		) {
-			oauthHintShown = true;
-			showToast(
-				"Sign-in has not been enabled on this Space. The author should add `hf_oauth: true` to the README so users can run workflows on their own inference quota, and authors can edit.",
-				0,
-				"warning"
-			);
-		}
-	});
-
-	$effect(() => {
+$effect(() => {
 		if (!initialValue) return;
 		try {
 			const parsed = JSON.parse(initialValue);

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -138,6 +138,12 @@
 		void auth.init();
 	});
 
+	$effect(() => {
+		if (server?.get_oauth_available && !auth.oauthAvailableKnown) {
+			void auth.refreshOAuthAvailable();
+		}
+	});
+
 	let oauthHintShown = false;
 	$effect(() => {
 		if (
@@ -145,6 +151,7 @@
 			auth.isHFSpace &&
 			auth.writeAccessKnown &&
 			!auth.canWrite &&
+			auth.oauthAvailableKnown &&
 			!auth.oauthAvailable
 		) {
 			oauthHintShown = true;

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -138,7 +138,25 @@
 		void auth.init();
 	});
 
-$effect(() => {
+	let oauthHintShown = false;
+	$effect(() => {
+		if (
+			!oauthHintShown &&
+			auth.isHFSpace &&
+			auth.writeAccessKnown &&
+			!auth.canWrite &&
+			!auth.oauthAvailable
+		) {
+			oauthHintShown = true;
+			showToast(
+				"Sign-in has not been enabled on this Space. The author should add `hf_oauth: true` to the README so users can run workflows on their own inference quota, and authors can edit.",
+				0,
+				"warning"
+			);
+		}
+	});
+
+	$effect(() => {
 		if (!initialValue) return;
 		try {
 			const parsed = JSON.parse(initialValue);

--- a/js/workflowcanvas/workflow/hf-auth.svelte.ts
+++ b/js/workflowcanvas/workflow/hf-auth.svelte.ts
@@ -106,6 +106,7 @@ export function createHFAuth(getServer: () => Record<string, any>) {
 	// Defaults to false so a broken "Sign in" button never flashes before the
 	// server confirms it — only shown once known to work.
 	let oauthAvailable = $state(false);
+	let oauthAvailableKnown = $state(false);
 
 	function clearIdentity(): void {
 		user = "";
@@ -144,14 +145,13 @@ export function createHFAuth(getServer: () => Record<string, any>) {
 
 	async function refreshOAuthAvailable(): Promise<void> {
 		const s = getServer();
-		if (!s?.get_oauth_available) {
-			oauthAvailable = false;
-			return;
-		}
+		if (!s?.get_oauth_available) return;
 		try {
 			oauthAvailable = (await s.get_oauth_available()) === "true";
+			oauthAvailableKnown = true;
 		} catch {
 			oauthAvailable = false;
+			oauthAvailableKnown = true;
 		}
 	}
 
@@ -301,6 +301,10 @@ export function createHFAuth(getServer: () => Record<string, any>) {
 		get oauthAvailable() {
 			return oauthAvailable;
 		},
+		get oauthAvailableKnown() {
+			return oauthAvailableKnown;
+		},
+		refreshOAuthAvailable,
 		init,
 		setPAT,
 		signIn,


### PR DESCRIPTION
## Description

The oauth error was showing unnecessarily because we were checking for the space-set `OAUTH_CLIENT_ID` env var instead of just reading hf_oauth: true from the Space README

