### PR TITLE
Stop the server from accumulating per-request and per-session state

### DIFF
--- a/.changeset/open-goats-build.md
+++ b/.changeset/open-goats-build.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Stop the server from accumulating per-request and per-session state

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -2141,7 +2141,14 @@ Received inputs:
                 and not utils.is_prop_update(data[i])
             ):
                 if final:
-                    stream_run[output_id].end_stream()
+                    # Nothing to finalize if this output never opened a stream —
+                    # the session may have been dropped on disconnect, or every
+                    # chunk before this one may have been a prop update. Falling
+                    # through would leave `first_chunk` true and build a fresh
+                    # stream that nothing ever ends.
+                    if (existing := stream_run.get(output_id)) is None:
+                        continue
+                    existing.end_stream()
                 first_chunk = output_id not in stream_run
                 binary_data, output_data = await block.stream_output(
                     data[i],

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -145,7 +145,9 @@ class Queue:
         )
         self.max_size = max_size
         self.blocks = blocks
-        self._asyncio_tasks: list[asyncio.Task] = []
+        # A set so a finished task can drop itself; the list this replaced held every
+        # task the queue had ever started until shutdown.
+        self._asyncio_tasks: set[asyncio.Task] = set()
         self.default_concurrency_limit = self._resolve_concurrency_limit(
             default_concurrency_limit
         )
@@ -490,9 +492,9 @@ class Queue:
                     pass
 
     def _cancel_asyncio_tasks(self):
-        for task in self._asyncio_tasks:
+        for task in list(self._asyncio_tasks):
             task.cancel()
-        self._asyncio_tasks = []
+        self._asyncio_tasks.clear()
 
     def set_server_app(self, app: routes.App):
         self.server_app = app
@@ -566,7 +568,8 @@ class Queue:
                         batch,
                     )
 
-                    self._asyncio_tasks.append(process_event_task)
+                    self._asyncio_tasks.add(process_event_task)
+                    process_event_task.add_done_callback(self._asyncio_tasks.discard)
                     if self.live_updates:
                         self.broadcast_estimations(concurrency_id)
                 else:
@@ -1125,7 +1128,12 @@ class Queue:
             except Exception:
                 pass
             del app.iterators[event_id]
-            app.iterators_to_reset.add(event_id)
+            # Deliberately not added to `app.iterators_to_reset` here. That set exists so
+            # that a job which is being cancelled does not restore its iterator and
+            # overwrite the state, and it is the `/reset` route -- which runs while the
+            # job is still going -- that has to record it. This is the only caller, and
+            # it runs once the event is already over, so an entry added here can never be
+            # read, and the set grew once per request for the life of the process.
         return
 
 

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -1099,11 +1099,9 @@ class Queue:
                 await run_sync(self.compute_analytics_summary, self.event_analytics)
 
                 self.event_ids_to_events.pop(event._id, None)
-                pending = self.pending_event_ids_session.get(event.session_hash)
-                if pending is not None:
-                    pending.discard(event._id)
-                    if not pending:
-                        self.pending_event_ids_session.pop(event.session_hash, None)
+                self.pending_event_ids_session.get(event.session_hash, set()).discard(
+                    event._id
+                )
 
     async def reset_iterators(self, event_id: str):
         # Do the same thing as the /reset route

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -23,6 +23,13 @@ from gradio.data_classes import (
 )
 from gradio.exceptions import Error
 from gradio.helpers import TrackedIterable
+from gradio.profiling import (
+    PROFILING_ENABLED,
+    RequestTrace,
+    collector,
+    get_current_trace,
+    set_current_trace,
+)
 from gradio.server_messages import (
     EstimationMessage,
     EventMessage,
@@ -145,15 +152,10 @@ class Queue:
         )
         self.max_size = max_size
         self.blocks = blocks
-        # A set so a finished task can drop itself; the list this replaced held every
-        # task the queue had ever started until shutdown.
         self._asyncio_tasks: set[asyncio.Task] = set()
         self.default_concurrency_limit = self._resolve_concurrency_limit(
             default_concurrency_limit
         )
-        # Kept in insertion order and trimmed to the most recent
-        # `ANALYTICS_MAX_EVENTS`. The monitoring dashboard holds a reference to this
-        # exact dict, so entries are evicted in place rather than by rebinding it.
         self.event_analytics: dict[str, dict[str, float | str | None]] = {}
         self.ANALYTICS_MAX_EVENTS = int(
             os.getenv("GRADIO_ANALYTICS_MAX_EVENTS", "10000")
@@ -186,8 +188,6 @@ class Queue:
             raise e
 
     def compute_analytics_summary(self, event_analytics):
-        # Counted against events seen rather than `len(event_analytics)`, which stops
-        # rising once the history is full and would freeze the summary.
         if (
             self.events_recorded - self.event_count_at_last_cache
             >= self.ANAYLTICS_CACHE_FREQUENCY
@@ -864,12 +864,6 @@ class Queue:
             )
             first_iteration = 0
 
-            from gradio.profiling import (
-                PROFILING_ENABLED,
-                RequestTrace,
-                set_current_trace,
-            )
-
             if PROFILING_ENABLED:
                 trace = RequestTrace(
                     event_id=events[0]._id,
@@ -1069,8 +1063,6 @@ class Queue:
             if not isinstance(e, Error) or e.print_exception:
                 traceback.print_exc()
         finally:
-            from gradio.profiling import PROFILING_ENABLED, collector, get_current_trace
-
             if PROFILING_ENABLED:
                 trace = get_current_trace()
                 if trace is not None:
@@ -1106,13 +1098,12 @@ class Queue:
                     )
                 await run_sync(self.compute_analytics_summary, self.event_analytics)
 
-                # The event is over, and nothing looks one up by id afterwards: the
-                # `/stream/{event_id}` routes only feed an event that is still running,
-                # and `/queue/data/{event_id}` falls back to the id as the session hash,
-                # which is what it is for a client that sent no session hash. Holding on
-                # would pin this event's `fastapi.Request` and its request payload for
-                # the life of the process.
                 self.event_ids_to_events.pop(event._id, None)
+                pending = self.pending_event_ids_session.get(event.session_hash)
+                if pending is not None:
+                    pending.discard(event._id)
+                    if not pending:
+                        self.pending_event_ids_session.pop(event.session_hash, None)
 
     async def reset_iterators(self, event_id: str):
         # Do the same thing as the /reset route
@@ -1128,12 +1119,6 @@ class Queue:
             except Exception:
                 pass
             del app.iterators[event_id]
-            # Deliberately not added to `app.iterators_to_reset` here. That set exists so
-            # that a job which is being cancelled does not restore its iterator and
-            # overwrite the state, and it is the `/reset` route -- which runs while the
-            # job is still going -- that has to record it. This is the only caller, and
-            # it runs once the event is already over, so an entry added here can never be
-            # read, and the set grew once per request for the life of the process.
         return
 
 

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -157,9 +157,10 @@ class Queue:
             default_concurrency_limit
         )
         self.event_analytics: dict[str, dict[str, float | str | None]] = {}
-        self.ANALYTICS_MAX_EVENTS = int(
-            os.getenv("GRADIO_ANALYTICS_MAX_EVENTS", "10000")
+        self.ANALYTICS_MAX_EVENTS = max(
+            1, int(os.getenv("GRADIO_ANALYTICS_MAX_EVENTS", "10000"))
         )
+        self.events_recorded_per_fn: defaultdict[str | None, int] = defaultdict(int)
         self.cached_event_analytics_summary = {"functions": {}}
         self.events_recorded = 0
         self.event_count_at_last_cache = 0
@@ -168,31 +169,29 @@ class Queue:
         )
 
     @staticmethod
-    def _get_df(event_analytics):
+    def _get_df(records):
         import pandas as pd
 
         try:
             with pd.option_context("future.no_silent_downcasting", True):
                 return (
-                    pd.DataFrame(list(event_analytics.values()))
-                    .fillna(value=np.nan)
-                    .infer_objects(copy=False)  # type: ignore
+                    pd.DataFrame(records).fillna(value=np.nan).infer_objects(copy=False)  # type: ignore
                 )
         except Exception as e:
             if "No such keys(s)" in str(e):
                 return (
-                    pd.DataFrame(list(event_analytics.values()))
-                    .fillna(value=np.nan)
-                    .infer_objects(copy=False)  # type: ignore
+                    pd.DataFrame(records).fillna(value=np.nan).infer_objects(copy=False)  # type: ignore
                 )
             raise e
 
-    def compute_analytics_summary(self, event_analytics):
+    def compute_analytics_summary(self, records):
+        if not records:
+            return self.cached_event_analytics_summary
         if (
             self.events_recorded - self.event_count_at_last_cache
             >= self.ANAYLTICS_CACHE_FREQUENCY
         ):
-            df = self._get_df(event_analytics)
+            df = self._get_df(records)
             self.event_count_at_last_cache = self.events_recorded
             grouped = df.groupby("function")
             metrics = {"functions": {}}
@@ -210,7 +209,9 @@ class Queue:
                         "90th": percentiles[1],  # type: ignore
                         "99th": percentiles[2],  # type: ignore
                     },
-                    "total_requests": fn_df.shape[0],
+                    "total_requests": self.events_recorded_per_fn.get(
+                        fn_name, fn_df.shape[0]
+                    ),
                 }
             self.cached_event_analytics_summary = metrics
         return self.cached_event_analytics_summary
@@ -474,6 +475,7 @@ class Queue:
             "session_hash": body.session_hash,
         }
         self.events_recorded += 1
+        self.events_recorded_per_fn[fn.api_name] += 1
         while len(self.event_analytics) > self.ANALYTICS_MAX_EVENTS:
             self.event_analytics.pop(next(iter(self.event_analytics)))
 
@@ -907,7 +909,10 @@ class Queue:
                             success=False,
                         ),
                     )
-                    await run_sync(self.compute_analytics_summary, self.event_analytics)
+                    await run_sync(
+                        self.compute_analytics_summary,
+                        list(self.event_analytics.values()),
+                    )
             if response and response.get("is_generating", False):
                 old_response = response
                 old_err = err
@@ -1096,7 +1101,10 @@ class Queue:
                         if event in awake_events
                         else "cancelled"
                     )
-                await run_sync(self.compute_analytics_summary, self.event_analytics)
+                await run_sync(
+                    self.compute_analytics_summary,
+                    list(self.event_analytics.values()),
+                )
 
                 self.event_ids_to_events.pop(event._id, None)
                 self.pending_event_ids_session.get(event.session_hash, set()).discard(

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -149,8 +149,15 @@ class Queue:
         self.default_concurrency_limit = self._resolve_concurrency_limit(
             default_concurrency_limit
         )
+        # Kept in insertion order and trimmed to the most recent
+        # `ANALYTICS_MAX_EVENTS`. The monitoring dashboard holds a reference to this
+        # exact dict, so entries are evicted in place rather than by rebinding it.
         self.event_analytics: dict[str, dict[str, float | str | None]] = {}
+        self.ANALYTICS_MAX_EVENTS = int(
+            os.getenv("GRADIO_ANALYTICS_MAX_EVENTS", "10000")
+        )
         self.cached_event_analytics_summary = {"functions": {}}
+        self.events_recorded = 0
         self.event_count_at_last_cache = 0
         self.ANAYLTICS_CACHE_FREQUENCY = int(
             os.getenv("GRADIO_ANALYTICS_CACHE_FREQUENCY", "1")
@@ -177,12 +184,14 @@ class Queue:
             raise e
 
     def compute_analytics_summary(self, event_analytics):
+        # Counted against events seen rather than `len(event_analytics)`, which stops
+        # rising once the history is full and would freeze the summary.
         if (
-            len(event_analytics) - self.event_count_at_last_cache
+            self.events_recorded - self.event_count_at_last_cache
             >= self.ANAYLTICS_CACHE_FREQUENCY
         ):
             df = self._get_df(event_analytics)
-            self.event_count_at_last_cache = len(event_analytics)
+            self.event_count_at_last_cache = self.events_recorded
             grouped = df.groupby("function")
             metrics = {"functions": {}}
             for fn_name, fn_df in grouped:
@@ -462,6 +471,9 @@ class Queue:
             "function": fn.api_name,
             "session_hash": body.session_hash,
         }
+        self.events_recorded += 1
+        while len(self.event_analytics) > self.ANALYTICS_MAX_EVENTS:
+            self.event_analytics.pop(next(iter(self.event_analytics)))
 
         self.broadcast_estimations(event.concurrency_id, len(event_queue.queue) - 1)
         return True, event._id, "success"
@@ -541,7 +553,8 @@ class Queue:
                     fn = events[0].fn
                     event_queue.start_times_per_fn[fn].add(start_time)
                     for event in events:
-                        self.event_analytics[event._id]["status"] = "processing"
+                        if (a := self.event_analytics.get(event._id)) is not None:
+                            a["status"] = "processing"
                     process_event_task = run_coro_in_background(
                         self.process_events, events, batch, start_time, fn
                     )
@@ -1047,7 +1060,8 @@ class Queue:
                 if not response.get("used_cache"):
                     self.process_time_per_fn[events[0].fn].add(duration)
                 for event in events:
-                    self.event_analytics[event._id]["process_time"] = duration
+                    if (a := self.event_analytics.get(event._id)) is not None:
+                        a["process_time"] = duration
         except Exception as e:
             if not isinstance(e, Error) or e.print_exception:
                 traceback.print_exc()
@@ -1081,13 +1095,21 @@ class Queue:
                 # to start "from scratch"
                 await self.reset_iterators(event._id)
 
-                if event in awake_events:
-                    self.event_analytics[event._id]["status"] = (
-                        "success" if success else "failed"
+                if (a := self.event_analytics.get(event._id)) is not None:
+                    a["status"] = (
+                        ("success" if success else "failed")
+                        if event in awake_events
+                        else "cancelled"
                     )
-                else:
-                    self.event_analytics[event._id]["status"] = "cancelled"
                 await run_sync(self.compute_analytics_summary, self.event_analytics)
+
+                # The event is over, and nothing looks one up by id afterwards: the
+                # `/stream/{event_id}` routes only feed an event that is still running,
+                # and `/queue/data/{event_id}` falls back to the id as the session hash,
+                # which is what it is for a client that sent no session hash. Holding on
+                # would pin this event's `fastapi.Request` and its request payload for
+                # the life of the process.
+                self.event_ids_to_events.pop(event._id, None)
 
     async def reset_iterators(self, event_id: str):
         # Do the same thing as the /reset route

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -1107,9 +1107,6 @@ class Queue:
                 )
 
                 self.event_ids_to_events.pop(event._id, None)
-                self.pending_event_ids_session.get(event.session_hash, set()).discard(
-                    event._id
-                )
 
     async def reset_iterators(self, event_id: str):
         # Do the same thing as the /reset route

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -430,7 +430,7 @@ async def call_process_api(
         if iterator is not None:  # close off any streams that are still open
             run_id = id(iterator)
             pending_streams: dict[int, MediaStream] = (
-                app.get_blocks().pending_streams[session_hash].get(run_id, {})
+                app.get_blocks().pending_streams.get(session_hash, {}).get(run_id, {})
             )
             for stream in pending_streams.values():
                 stream.end_stream()

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1123,7 +1123,9 @@ class App(FastAPI):
 
         @router.post("/stream/{event_id}")
         async def _(event_id: str, body: PredictBody, request: fastapi.Request):
-            event = app.get_blocks()._queue.event_ids_to_events[event_id]
+            event = app.get_blocks()._queue.event_ids_to_events.get(event_id)
+            if event is None:
+                return Response(status_code=404)
             body = PredictBodyInternal(**body.model_dump(), request=request)  # type: ignore
             event.data = body
             event.signal.set()
@@ -1131,7 +1133,9 @@ class App(FastAPI):
 
         @router.post("/stream/{event_id}/close")
         async def _(event_id: str):
-            event = app.get_blocks()._queue.event_ids_to_events[event_id]
+            event = app.get_blocks()._queue.event_ids_to_events.get(event_id)
+            if event is None:
+                return Response(status_code=404)
             event.run_time = math.inf
             event.closed = True
             event.signal.set()
@@ -1287,7 +1291,6 @@ class App(FastAPI):
                         if session_hash in app.state_holder.session_data:
                             app.state_holder.session_data[session_hash].is_closed = True
                         caching.clear_session_caches(session_hash)
-                        # The tab is gone, so no one will read these streams again.
                         for run in (
                             app.get_blocks()
                             .pending_streams.pop(session_hash, {})
@@ -1300,9 +1303,11 @@ class App(FastAPI):
                         ) in app.get_blocks()._queue.pending_event_ids_session.get(
                             session_hash, []
                         ):
-                            event = app.get_blocks()._queue.event_ids_to_events[
+                            event = app.get_blocks()._queue.event_ids_to_events.get(
                                 event_id
-                            ]
+                            )
+                            if event is None:
+                                continue
                             event.run_time = math.inf
                             event.signal.set()
                         return

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1529,8 +1529,25 @@ class App(FastAPI):
                     return None
                 return f"event: {event}\ndata: {json.dumps(data)}\n\n"
 
-            event = app.get_blocks()._queue.event_ids_to_events.get(event_id)
-            session_hash = event.session_hash if event else event_id
+            queue = app.get_blocks()._queue
+            event = queue.event_ids_to_events.get(event_id)
+            if event is not None:
+                session_hash = event.session_hash
+            else:
+                # A finished event is no longer held, but this route is normally
+                # called after it finishes. `pending_event_ids_session` keeps the
+                # id until the completion message is delivered, which is exactly
+                # this window. Falling back to the event id only works for a
+                # caller who sent no session hash of their own, since `Event`
+                # defaults `session_hash` to its own id.
+                session_hash = next(
+                    (
+                        s
+                        for s, ids in queue.pending_event_ids_session.items()
+                        if event_id in ids
+                    ),
+                    event_id,
+                )
             return await queue_data_helper(request, session_hash, process_msg)
 
         @router.get("/queue/data", dependencies=[Depends(login_check)])

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1141,7 +1141,7 @@ class App(FastAPI):
         async def _(session_hash: str, run: int, component_id: int):
             stream: route_utils.MediaStream | None = (
                 app.get_blocks()
-                .pending_streams[session_hash]
+                .pending_streams.get(session_hash, {})
                 .get(run, {})
                 .get(component_id, None)
             )
@@ -1174,7 +1174,7 @@ class App(FastAPI):
                 return Response(status_code=400, content="Unsupported file extension")
             stream: route_utils.MediaStream | None = (
                 app.get_blocks()
-                .pending_streams[session_hash]
+                .pending_streams.get(session_hash, {})
                 .get(run, {})
                 .get(component_id, None)
             )
@@ -1196,7 +1196,7 @@ class App(FastAPI):
         async def _(session_hash: str, run: int, component_id: int):
             stream: route_utils.MediaStream | None = (
                 app.get_blocks()
-                .pending_streams[session_hash]
+                .pending_streams.get(session_hash, {})
                 .get(run, {})
                 .get(component_id, None)
             )
@@ -1287,6 +1287,14 @@ class App(FastAPI):
                         if session_hash in app.state_holder.session_data:
                             app.state_holder.session_data[session_hash].is_closed = True
                         caching.clear_session_caches(session_hash)
+                        # The tab is gone, so no one will read these streams again.
+                        for run in (
+                            app.get_blocks()
+                            .pending_streams.pop(session_hash, {})
+                            .values()
+                        ):
+                            for stream in run.values():
+                                stream.end_stream()
                         for (
                             event_id
                         ) in app.get_blocks()._queue.pending_event_ids_session.get(

--- a/gradio/state_holder.py
+++ b/gradio/state_holder.py
@@ -46,19 +46,11 @@ class StateHolder:
     def delete_all_expired_state(
         self,
     ):
-        # Over a copy: dropping a finished session below mutates `session_data`.
         for session_id in list(self.session_data):
             self.delete_state(session_id, expired_only=True)
             self._drop_if_finished(session_id)
 
     def _drop_if_finished(self, session_id: str):
-        """Forget a closed session once its state has outlived `STATE_TTL_WHEN_CLOSED`.
-
-        Deleting the state values is not enough on its own: the `SessionState` also
-        holds a copy of the blocks config and a config dict for every component in the
-        app, and `time_last_used` holds an entry per session id ever seen. Neither was
-        ever removed, so both grew for the life of the process.
-        """
         session_state = self.session_data.get(session_id)
         if session_state is None or not session_state.is_closed:
             return

--- a/gradio/state_holder.py
+++ b/gradio/state_holder.py
@@ -40,13 +40,38 @@ class StateHolder:
             if session_id in self.session_data:
                 self.session_data.move_to_end(session_id)
             if len(self.session_data) > self.capacity:
-                self.session_data.popitem(last=False)
+                evicted, _ = self.session_data.popitem(last=False)
+                self.time_last_used.pop(evicted, None)
 
     def delete_all_expired_state(
         self,
     ):
-        for session_id in self.session_data:
+        # Over a copy: dropping a finished session below mutates `session_data`.
+        for session_id in list(self.session_data):
             self.delete_state(session_id, expired_only=True)
+            self._drop_if_finished(session_id)
+
+    def _drop_if_finished(self, session_id: str):
+        """Forget a closed session once its state has outlived `STATE_TTL_WHEN_CLOSED`.
+
+        Deleting the state values is not enough on its own: the `SessionState` also
+        holds a copy of the blocks config and a config dict for every component in the
+        app, and `time_last_used` holds an entry per session id ever seen. Neither was
+        ever removed, so both grew for the life of the process.
+        """
+        session_state = self.session_data.get(session_id)
+        if session_state is None or not session_state.is_closed:
+            return
+        last_used = self.time_last_used.get(session_id)
+        if (
+            last_used is not None
+            and (datetime.datetime.now() - last_used).total_seconds()
+            <= session_state.STATE_TTL_WHEN_CLOSED
+        ):
+            return
+        with self.lock:
+            self.session_data.pop(session_id, None)
+            self.time_last_used.pop(session_id, None)
 
     def delete_state(self, session_id: str, expired_only: bool = False):
         if session_id not in self.session_data:

--- a/gradio/state_holder.py
+++ b/gradio/state_holder.py
@@ -48,22 +48,6 @@ class StateHolder:
     ):
         for session_id in list(self.session_data):
             self.delete_state(session_id, expired_only=True)
-            self._drop_if_finished(session_id)
-
-    def _drop_if_finished(self, session_id: str):
-        session_state = self.session_data.get(session_id)
-        if session_state is None or not session_state.is_closed:
-            return
-        last_used = self.time_last_used.get(session_id)
-        if (
-            last_used is not None
-            and (datetime.datetime.now() - last_used).total_seconds()
-            <= session_state.STATE_TTL_WHEN_CLOSED
-        ):
-            return
-        with self.lock:
-            self.session_data.pop(session_id, None)
-            self.time_last_used.pop(session_id, None)
 
     def delete_state(self, session_id: str, expired_only: bool = False):
         if session_id not in self.session_data:

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -1660,6 +1660,26 @@ class TestCancel:
         assert event_id in app.iterators_to_reset
 
 
+class TestHandleStreamingOutputs:
+    @pytest.mark.asyncio
+    async def test_final_chunk_with_no_open_stream_is_a_no_op(self):
+        # The session's streams may be gone by the time the final chunk lands —
+        # a disconnect drops them — and a generator that sends only prop updates
+        # never opens one at all. Neither should cost the caller their output.
+        with gr.Blocks() as demo:
+            box = gr.Textbox()
+            audio = gr.Audio(streaming=True, autoplay=True)
+            box.submit(lambda x: x, box, audio)
+
+        block_fn = next(iter(demo.fns.values()))
+        data = await demo.handle_streaming_outputs(
+            block_fn, [b"final"], session_hash="s", run=0, final=True
+        )
+
+        assert data == [b"final"]
+        assert demo.pending_streams["s"][0] == {}
+
+
 class TestGetAPIInfo:
     def test_many_endpoints(self):
         with gr.Blocks() as demo:

--- a/test/test_no_growth.py
+++ b/test/test_no_growth.py
@@ -1,0 +1,72 @@
+import gc
+
+import gradio as gr
+
+CONTAINERS_ALLOWED_TO_GROW = {
+    "Queue.process_time_per_fn",
+    "Queue.event_queue_per_concurrency_id",
+    "Queue.active_jobs",
+}
+
+
+def census(owners: dict[str, object]) -> dict[str, int]:
+    sizes: dict[str, int] = {}
+    for owner_name, owner in owners.items():
+        for attr in dir(owner):
+            if attr.startswith("__"):
+                continue
+            try:
+                value = getattr(owner, attr)
+            except Exception:
+                continue
+            key = f"{owner_name}.{attr}"
+            if (
+                isinstance(value, (dict, set, list, frozenset, tuple))
+                and key not in CONTAINERS_ALLOWED_TO_GROW
+            ):
+                sizes[key] = len(value)
+    return sizes
+
+
+class TestServerDoesNotGrowPerRequest:
+    """Nothing the server keeps may be larger after a second identical batch of
+    requests on the same session. See https://github.com/gradio-app/gradio/issues/11602."""
+
+    def test_no_container_grows_across_identical_batches(self, connect):
+        with gr.Blocks() as demo:
+            box = gr.Textbox()
+            out = gr.Textbox()
+            state = gr.State()
+            gr.Button("go").click(
+                lambda text, _s: (text.upper(), None), [box, state], [out, state]
+            )
+
+        with connect(demo) as client:
+            demo._queue.ANALYTICS_MAX_EVENTS = 5
+
+            def batch():
+                for _ in range(8):
+                    client.predict("hello", api_name="/lambda")
+                gc.collect()
+
+            owners = {
+                "Queue": demo._queue,
+                "Blocks": demo,
+                "StateHolder": demo.state_holder,
+                "App": demo._queue.server_app,
+            }
+
+            batch()
+            before = census(owners)
+            batch()
+            after = census(owners)
+
+        grew = {
+            key: (before[key], after.get(key, 0))
+            for key in before
+            if after.get(key, 0) > before[key]
+        }
+        assert not grew, (
+            "these grew over an identical batch of requests on the same session: "
+            + ", ".join(f"{key} {b} -> {a}" for key, (b, a) in sorted(grew.items()))
+        )

--- a/test/test_no_growth.py
+++ b/test/test_no_growth.py
@@ -62,9 +62,9 @@ class TestServerDoesNotGrowPerRequest:
             after = census(owners)
 
         grew = {
-            key: (before[key], after.get(key, 0))
-            for key in before
-            if after.get(key, 0) > before[key]
+            key: (before.get(key, 0), after.get(key, 0))
+            for key in before.keys() | after.keys()
+            if after.get(key, 0) > before.get(key, 0)
         }
         assert not grew, (
             "these grew over an identical batch of requests on the same session: "

--- a/test/test_queueing.py
+++ b/test/test_queueing.py
@@ -363,6 +363,34 @@ class TestQueueDoesNotAccumulate:
 
         assert demo._queue.event_ids_to_events == {}
 
+    def test_finished_tasks_are_not_retained(self, connect):
+        with gr.Blocks() as demo:
+            box = gr.Textbox()
+            out = gr.Textbox()
+            box.submit(lambda x: x, box, out)
+
+        with connect(demo) as client:
+            for _ in range(5):
+                client.predict("a", api_name="/lambda")
+
+        # The queue keeps a reference to the task it starts so it can cancel it on
+        # shutdown; a task that has finished is not a task it needs to cancel.
+        assert demo._queue._asyncio_tasks == set()
+
+    def test_completing_an_event_does_not_mark_its_iterator_for_reset(self, connect):
+        with gr.Blocks() as demo:
+            box = gr.Textbox()
+            out = gr.Textbox()
+            box.submit(lambda x: x, box, out)
+
+        with connect(demo) as client:
+            for _ in range(5):
+                client.predict("a", api_name="/lambda")
+
+        # Only the /reset route, which runs while a job is still going, has a reason to
+        # record an id here.
+        assert demo._queue.server_app.iterators_to_reset == set()
+
     def test_event_analytics_is_bounded(self, connect):
         with gr.Blocks() as demo:
             box = gr.Textbox()

--- a/test/test_queueing.py
+++ b/test/test_queueing.py
@@ -345,3 +345,38 @@ def test_analytics_summary(monkeypatch):
         event_analytics = tc.get("/monitoring/summary").json()
         assert "predict" in event_analytics["functions"]
         assert event_analytics["functions"]["predict"]["total_requests"] == 4
+
+
+class TestQueueDoesNotAccumulate:
+    def test_finished_events_are_not_retained(self, connect):
+        # Every `Event` pins the `fastapi.Request` it came from and the request payload,
+        # so keeping them after the event is over grows the process once per call.
+        # See https://github.com/gradio-app/gradio/issues/11602.
+        with gr.Blocks() as demo:
+            box = gr.Textbox()
+            out = gr.Textbox()
+            box.submit(lambda x: x, box, out)
+
+        with connect(demo) as client:
+            for _ in range(5):
+                client.predict("a", api_name="/lambda")
+
+        assert demo._queue.event_ids_to_events == {}
+
+    def test_event_analytics_is_bounded(self, connect):
+        with gr.Blocks() as demo:
+            box = gr.Textbox()
+            out = gr.Textbox()
+            box.submit(lambda x: x, box, out)
+
+        demo._queue.ANALYTICS_MAX_EVENTS = 3
+        with connect(demo) as client:
+            for _ in range(8):
+                client.predict("a", api_name="/lambda")
+
+        assert len(demo._queue.event_analytics) == 3
+        # The summary is driven off events seen, not the size of the history, so it
+        # keeps updating after the history stops growing.
+        assert demo._queue.cached_event_analytics_summary["functions"]["lambda"][
+            "total_requests"
+        ]

--- a/test/test_queueing.py
+++ b/test/test_queueing.py
@@ -349,9 +349,6 @@ def test_analytics_summary(monkeypatch):
 
 class TestQueueDoesNotAccumulate:
     def test_finished_events_are_not_retained(self, connect):
-        # Every `Event` pins the `fastapi.Request` it came from and the request payload,
-        # so keeping them after the event is over grows the process once per call.
-        # See https://github.com/gradio-app/gradio/issues/11602.
         with gr.Blocks() as demo:
             box = gr.Textbox()
             out = gr.Textbox()
@@ -373,8 +370,6 @@ class TestQueueDoesNotAccumulate:
             for _ in range(5):
                 client.predict("a", api_name="/lambda")
 
-        # The queue keeps a reference to the task it starts so it can cancel it on
-        # shutdown; a task that has finished is not a task it needs to cancel.
         assert demo._queue._asyncio_tasks == set()
 
     def test_completing_an_event_does_not_mark_its_iterator_for_reset(self, connect):
@@ -387,8 +382,6 @@ class TestQueueDoesNotAccumulate:
             for _ in range(5):
                 client.predict("a", api_name="/lambda")
 
-        # Only the /reset route, which runs while a job is still going, has a reason to
-        # record an id here.
         assert demo._queue.server_app.iterators_to_reset == set()
 
     def test_event_analytics_is_bounded(self, connect):
@@ -403,8 +396,6 @@ class TestQueueDoesNotAccumulate:
                 client.predict("a", api_name="/lambda")
 
         assert len(demo._queue.event_analytics) == 3
-        # The summary is driven off events seen, not the size of the history, so it
-        # keeps updating after the history stops growing.
         assert demo._queue.cached_event_analytics_summary["functions"]["lambda"][
             "total_requests"
         ]

--- a/test/test_queueing.py
+++ b/test/test_queueing.py
@@ -396,6 +396,10 @@ class TestQueueDoesNotAccumulate:
                 client.predict("a", api_name="/lambda")
 
         assert len(demo._queue.event_analytics) == 3
-        assert demo._queue.cached_event_analytics_summary["functions"]["lambda"][
-            "total_requests"
-        ]
+        assert demo._queue.events_recorded == 8
+        assert (
+            demo._queue.cached_event_analytics_summary["functions"]["lambda"][
+                "total_requests"
+            ]
+            == 8
+        )

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1740,6 +1740,31 @@ class TestSimpleAPIRoutes:
             btn3.click(fn_3, None, [output, output2], api_name="fn3")
         return demo
 
+    def test_simple_route_collects_a_result_under_the_callers_session_hash(self):
+        # `/call` accepts a session hash of the caller's choosing, and the GET
+        # that collects the result routinely arrives after the event has
+        # finished. The route has to recover that hash from somewhere the
+        # finished event no longer is.
+        demo = self.get_demo()
+        demo.launch(prevent_thread_lock=True)
+
+        response = requests.post(
+            f"{demo.local_api_url}call/fn1",
+            json={"data": ["world"], "session_hash": "a-session-of-my-own"},
+        )
+        assert response.status_code == 200, "Failed to call fn1"
+        event_id = response.json()["event_id"]
+
+        time.sleep(2)  # fn1 is fast, so it is done well before the GET
+
+        output = []
+        response = requests.get(f"{demo.local_api_url}call/fn1/{event_id}", stream=True)
+        for line in response.iter_lines():
+            if line:
+                output.append(line.decode("utf-8"))
+
+        assert output == ["event: complete", 'data: ["Hello, world!"]']
+
     def test_successful_simple_route(self):
         demo = self.get_demo()
         demo.launch(prevent_thread_lock=True)

--- a/test/test_state_holder.py
+++ b/test/test_state_holder.py
@@ -18,9 +18,7 @@ def _demo() -> gr.Blocks:
 
 
 class TestStateHolderDoesNotAccumulate:
-    """A `SessionState` holds a copy of the blocks config and a config dict for every
-    component, so keeping one per session ever seen grows the process for its lifetime.
-    See https://github.com/gradio-app/gradio/issues/11602."""
+    """See https://github.com/gradio-app/gradio/issues/11602."""
 
     def test_open_session_is_kept(self):
         holder = _holder(_demo())

--- a/test/test_state_holder.py
+++ b/test/test_state_holder.py
@@ -1,5 +1,3 @@
-import datetime
-
 import gradio as gr
 from gradio.state_holder import StateHolder
 
@@ -20,35 +18,14 @@ def _demo() -> gr.Blocks:
 class TestStateHolderDoesNotAccumulate:
     """See https://github.com/gradio-app/gradio/issues/11602."""
 
-    def test_open_session_is_kept(self):
-        holder = _holder(_demo())
-        holder["abc"]
-
-        holder.delete_all_expired_state()
-
-        assert "abc" in holder.session_data
-        assert "abc" in holder.time_last_used
-
-    def test_closed_session_is_kept_during_its_grace_period(self):
+    def test_expiring_state_keeps_the_session(self):
         holder = _holder(_demo())
         holder["abc"].is_closed = True
 
         holder.delete_all_expired_state()
 
         assert "abc" in holder.session_data
-
-    def test_closed_session_is_forgotten_once_it_expires(self):
-        holder = _holder(_demo())
-        session = holder["abc"]
-        session.is_closed = True
-        holder.time_last_used["abc"] = datetime.datetime.now() - datetime.timedelta(
-            seconds=session.STATE_TTL_WHEN_CLOSED + 10
-        )
-
-        holder.delete_all_expired_state()
-
-        assert "abc" not in holder.session_data
-        assert "abc" not in holder.time_last_used
+        assert "abc" in holder.time_last_used
 
     def test_evicting_over_capacity_forgets_the_last_used_time(self):
         holder = _holder(_demo())

--- a/test/test_state_holder.py
+++ b/test/test_state_holder.py
@@ -1,0 +1,63 @@
+import datetime
+
+import gradio as gr
+from gradio.state_holder import StateHolder
+
+
+def _holder(demo: gr.Blocks) -> StateHolder:
+    holder = StateHolder()
+    holder.set_blocks(demo)
+    return holder
+
+
+def _demo() -> gr.Blocks:
+    with gr.Blocks() as demo:
+        gr.State(0)
+        gr.Textbox()
+    return demo
+
+
+class TestStateHolderDoesNotAccumulate:
+    """A `SessionState` holds a copy of the blocks config and a config dict for every
+    component, so keeping one per session ever seen grows the process for its lifetime.
+    See https://github.com/gradio-app/gradio/issues/11602."""
+
+    def test_open_session_is_kept(self):
+        holder = _holder(_demo())
+        holder["abc"]
+
+        holder.delete_all_expired_state()
+
+        assert "abc" in holder.session_data
+        assert "abc" in holder.time_last_used
+
+    def test_closed_session_is_kept_during_its_grace_period(self):
+        holder = _holder(_demo())
+        holder["abc"].is_closed = True
+
+        holder.delete_all_expired_state()
+
+        assert "abc" in holder.session_data
+
+    def test_closed_session_is_forgotten_once_it_expires(self):
+        holder = _holder(_demo())
+        session = holder["abc"]
+        session.is_closed = True
+        holder.time_last_used["abc"] = datetime.datetime.now() - datetime.timedelta(
+            seconds=session.STATE_TTL_WHEN_CLOSED + 10
+        )
+
+        holder.delete_all_expired_state()
+
+        assert "abc" not in holder.session_data
+        assert "abc" not in holder.time_last_used
+
+    def test_evicting_over_capacity_forgets_the_last_used_time(self):
+        holder = _holder(_demo())
+        holder.capacity = 2
+
+        for i in range(5):
+            holder[f"s{i}"]
+
+        assert len(holder.session_data) == 2
+        assert set(holder.time_last_used) == set(holder.session_data)


### PR DESCRIPTION
Fixes #11602.

## What was leaking

Four server-side structures grew for the life of the process. The first is the one behind #11602 — memory that rises with every interaction and never comes back down.

| structure | grew by | what each entry pins |
|---|---|---|
| `Queue.event_ids_to_events` | one per request served | the `fastapi.Request` **and** the request payload |
| `Queue.event_analytics` | one per request served | a small dict, but also drives an O(total) DataFrame build |
| `StateHolder.time_last_used` | one per session opened | a float, but never pruned when its session is evicted |
| `Blocks.pending_streams` | one per session hash *named in a URL* | a dict of `MediaStream`s |

Measured on a 5-component app driven over its own API, 200 KB per call, one fresh session per 25 calls:

| calls | events retained (before → after) | RSS (before → after) |
|---|---|---|
| 25 | 25 → **0** | 163 MB → 155 MB |
| 50 | 50 → **0** | 175 MB → 157 MB |
| 75 | 75 → **0** | 188 MB → 158 MB |
| 100 | 100 → **0** | 199 MB → 159 MB |

## What is deliberately not here

`StateHolder.session_data` is not on the list, though an earlier revision of this PR tried to prune it. It is already bounded by `state_session_capacity`, so it is not one of the structures that grows without limit; the one that did was `time_last_used`, which kept an entry for every session ever opened because capacity eviction dropped the session but not its timestamp. Pruning it on eviction is the whole fix.

Dropping a *closed* session's `SessionState` earlier is a real improvement, but a separate one: it happens after `STATE_TTL_WHEN_CLOSED`, which `GRADIO_IS_E2E_TEST` sets to one second, so a second after any unload beacon the session's `config_values` were gone and eleven `state_change` e2e tests failed. Reducing what a closed session holds needs its own change, with its own thought about that TTL.

`Queue.pending_event_ids_session` is also left alone. Draining a finished event's id from it looked like the same kind of cleanup, but that set is how the `/queue/data` loop counts the completion messages it still owes — when it empties, the loop closes the stream — so pruning it from the event's `finally` risks closing a stream while another event's output is still queued behind it. It is bounded by uncollected requests, not by requests served, and `clean_events` clears it on disconnect.

## Keeping a finished event collectable

Not retaining a finished event costs something the routes were quietly relying on. `GET /call/{api_name}/{event_id}` reads the event to find which session's message stream to follow, and normally runs *after* the event has finished:

```python
event = app.get_blocks()._queue.event_ids_to_events.get(event_id)
session_hash = event.session_hash if event else event_id
```

That fallback is only right for a caller who sent no session hash, since `Event.session_hash` defaults to `self._id` in that case. `POST /call/{api_name}` takes a `SimplePredictBody`, which has a `session_hash` field, so a caller can send their own — and then the fallback names a session that never existed and the stream raises its 404. The status is **200**, because the raise happens after the `StreamingResponse` headers went out, so a caller branching on the status code reads it as success.

`pending_event_ids_session` holds the id until the completion message is actually delivered, which is exactly this window, so the route now recovers the hash from there. `test_simple_route_collects_a_result_under_the_callers_session_hash` covers it: explicit session hash, fast function, delay before the GET. No existing test sent a session hash to `/call`, which is why CI was green.

## Guarding the final stream chunk

Ending a session's streams on disconnect can leave `handle_streaming_outputs` with an empty run while a generator is still producing (`run_time = math.inf` only ends `connection == "stream"` events), and `stream_run[output_id].end_stream()` then raises `KeyError` on the final chunk — a failed event instead of the user's output. That line can already raise on `main` when a generator sends only prop updates to an output until the end, so the guard is worth having either way. It has to `continue` rather than just skip `end_stream()`: falling through leaves `first_chunk` true, so the final chunk builds a fresh `MediaStream` that nothing ends, in an entry the loop has already passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
