### PR TITLE
Resolve the `/config` username through the auth dependency

### DIFF
--- a/.changeset/tiny-signs-sneeze.md
+++ b/.changeset/tiny-signs-sneeze.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Resolve the `/config` username through the auth dependency

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -987,7 +987,11 @@ class App(FastAPI):
 
         @app.get("/config/", dependencies=[Depends(login_check)])
         @app.get("/config", dependencies=[Depends(login_check)])
-        def get_config(request: fastapi.Request, deep_link: str = ""):
+        def get_config(
+            request: fastapi.Request,
+            user: str = Depends(get_current_user),
+            deep_link: str = "",
+        ):
             config = utils.safe_deepcopy(app.get_blocks().config)
             root = route_utils.get_root_url(
                 request=request,
@@ -996,7 +1000,7 @@ class App(FastAPI):
                 or request.scope.get("root_path")
                 or blocks.custom_mount_path,
             )
-            config["username"] = get_current_user(request)
+            config["username"] = user
             if deep_link:
                 components, deep_link_state = load_deep_link(deep_link, config, page="")  # type: ignore
                 config["components"] = components  # type: ignore

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1132,6 +1132,39 @@ class TestAuthenticatedRoutes:
         assert response.status_code == 401
 
 
+class TestConfigUsername:
+    """`/config` reports who is logged in. Resolving the user is async, so a
+    caller that does not await it gets a coroutine, which `ORJSONResponse`
+    stringifies rather than rejects. See
+    https://github.com/gradio-app/gradio/issues/13758."""
+
+    def test_username_is_none_without_auth(self):
+        io = Interface(lambda x: x, "text", "text")
+        app, _, _ = io.launch(prevent_thread_lock=True)
+
+        with TestClient(app) as client:
+            assert client.get("/config").json()["username"] is None
+
+    def test_username_is_the_logged_in_user(self):
+        io = Interface(lambda x: x, "text", "text")
+        app, _, _ = io.launch(auth=("admin", "password"), prevent_thread_lock=True)
+
+        with TestClient(app) as client:
+            client.post("/login", data={"username": "admin", "password": "password"})
+            assert client.get("/config").json()["username"] == "admin"
+
+    def test_username_comes_from_an_async_auth_dependency(self):
+        async def whoever_asked(request: Request):
+            return request.headers.get("user")
+
+        io = Interface(lambda x: x, "text", "text")
+        app, _, _ = io.launch(auth_dependency=whoever_asked, prevent_thread_lock=True)
+
+        with TestClient(app) as client:
+            response = client.get("/config", headers={"user": "abubakar"})
+            assert response.json()["username"] == "abubakar"
+
+
 class TestQueueRoutes:
     @pytest.mark.asyncio
     async def test_queue_join_routes_sets_app_if_none_set(self):


### PR DESCRIPTION
Fixes #13758. Thanks @kausmeows — the diagnosis in the issue is exactly right, down to the regressing PR.

## Root cause

#13749 made `get_current_user` `async def` so it could await an awaitable `auth_dependency`. `get_config` is a sync endpoint and still called it directly:

```python
config["username"] = get_current_user(request)
```

So `config["username"]` held a coroutine. It did not crash because `ORJSONResponse.default` falls back to `str()` for objects it cannot serialize, so `/config` reported a `<coroutine object ...>` string where a consumer expected `null` or the logged-in user — and the server logged `RuntimeWarning: coroutine 'get_current_user' was never awaited` on the first request.

## The fix

Take the user through the dependency instead:

```python
def get_config(
    request: fastapi.Request,
    user: str = Depends(get_current_user),
    deep_link: str = "",
):
    ...
    config["username"] = user
```

The issue suggests making `get_config` `async def` and awaiting the call, which also works. I went with `Depends` for two reasons. It is how `main` — 350 lines up in the same file — and every other call site already resolves the user, so this call site becomes the same shape as its neighbours rather than a second shape. And it keeps `get_config` sync: FastAPI resolves the async dependency before calling the endpoint, so the per-request `safe_deepcopy` of the config stays on the threadpool instead of moving onto the event loop. That deepcopy measures ~1.6 ms on a 240-component app, and `/config` is hit on every page load, so it is worth not moving.

`login_check` already depends on `get_current_user` for this route, and FastAPI caches dependency results within a request, so the user is still resolved once.

## Verification

`curl -s http://127.0.0.1:7860/config | python -c "import json,sys; print(repr(json.load(sys.stdin)['username']))"` against the demo below:

| | before | after |
|---|---|---|
| `username` | `'<coroutine object App.create_app.<locals>.get_current_user at 0x11a6797b0>'` | `None` |
| `RuntimeWarning` in server log | 2 | 0 |

```
$ python -m pytest test/test_routes.py -q
167 passed
```

`TestConfigUsername` is new. `None` alone is a weak assertion — it is also what you would get if the value were simply dropped — so it covers all three paths: no auth, basic auth (expects `"admin"`), and an **async** `auth_dependency` (expects the resolved user), that last one being the case #13749 introduced. All three fail on the parent commit and pass here.

## Demo (not committed)

```python
import gradio as gr

def echo(message, history):
    return message

demo = gr.ChatInterface(fn=echo)
demo.launch()
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
