### PR TITLE
Keep queued work when the connection drops, and collect its result by job id

### DIFF
--- a/.changeset/mean-llamas-doubt.md
+++ b/.changeset/mean-llamas-doubt.md
@@ -1,5 +1,6 @@
 ---
 "@gradio/client": minor
+"@gradio/core": minor
 "@self/app": minor
 "@self/spa": minor
 "gradio": minor

--- a/.changeset/mean-llamas-doubt.md
+++ b/.changeset/mean-llamas-doubt.md
@@ -5,4 +5,4 @@
 "gradio": minor
 ---
 
-feat:Detect when someone deliberately leaves the page
+feat:Keep queued work when the connection drops, and collect its result by job id

--- a/.changeset/mean-llamas-doubt.md
+++ b/.changeset/mean-llamas-doubt.md
@@ -1,0 +1,8 @@
+---
+"@gradio/client": minor
+"@self/app": minor
+"@self/spa": minor
+"gradio": minor
+---
+
+feat:Detect when someone deliberately leaves the page

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -38,6 +38,7 @@ import { clear_run_history } from "./utils/run_history";
 import {
 	API_INFO_ERROR_MSG,
 	APP_ID_URL,
+	CLOSE_URL,
 	CONFIG_ERROR_MSG,
 	HEARTBEAT_URL,
 	COMPONENT_SERVER_URL
@@ -322,8 +323,39 @@ export class Client {
 	}
 
 	close(): void {
+		if (!this.closed) {
+			this.report_departure();
+		}
 		this.closed = true;
 		close_stream(this.stream_status, this.abort_controller);
+	}
+
+	/**
+	 * Tells the server that this client is deliberately leaving, so that the work it
+	 * submitted is stopped rather than kept for a reconnection. Sent with `keepalive`
+	 * so that it survives the page being torn down, which also rules out
+	 * `navigator.sendBeacon`, since that cannot carry an `Authorization` header.
+	 *
+	 * Best effort by design: the request is dropped on a crash or a force quit, and
+	 * the server falls back to stopping the work once its own deadline passes.
+	 */
+	private report_departure(): void {
+		if (!this.config || typeof window === "undefined") return;
+
+		const headers: Record<string, string> = {
+			"Content-Type": "application/json"
+		};
+		if (this.options.token) {
+			headers.Authorization = `Bearer ${this.options.token}`;
+		}
+
+		void this.fetch(`${this.config.root}${this.api_prefix}/${CLOSE_URL}`, {
+			method: "POST",
+			headers,
+			body: JSON.stringify({ session_hash: this.session_hash }),
+			credentials: this.options.credentials ?? "same-origin",
+			keepalive: true
+		}).catch(() => {});
 	}
 
 	/**

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -33,7 +33,13 @@ import {
 } from "./helpers/init_helpers";
 import { check_and_wake_space, check_space_status } from "./helpers/spaces";
 import { initialize_zerogpu_handshake } from "./helpers/zerogpu";
-import { open_stream, readable_stream, close_stream } from "./utils/stream";
+import {
+	open_stream,
+	readable_stream,
+	close_stream,
+	MAX_RECONNECT_DELAY,
+	RECONNECT_DELAY
+} from "./utils/stream";
 import { clear_run_history } from "./utils/run_history";
 import {
 	API_INFO_ERROR_MSG,
@@ -67,6 +73,9 @@ export class Client {
 	pending_diff_streams: Record<string, any[][]> = {};
 	event_callbacks: Record<string, (data?: unknown) => Promise<void>> = {};
 	unclosed_events: Set<string> = new Set();
+	/** Attempts made so far to reopen a stream that broke, for the backoff. */
+	reconnect_attempts = 0;
+	private reconnect_timer: ReturnType<typeof setTimeout> | null = null;
 	heartbeat_event: EventSource | null = null;
 	abort_controller: AbortController | null = null;
 	stream_instance: EventSource | null = null;
@@ -322,11 +331,54 @@ export class Client {
 		return "connected";
 	}
 
+	/**
+	 * Reopens the stream after a backoff, unless the client has been closed or has
+	 * nothing outstanding to hear about.
+	 */
+	reopen_stream_later(): void {
+		if (this.closed || this.reconnect_timer || !this.unclosed_events.size) {
+			return;
+		}
+		const delay = Math.min(
+			RECONNECT_DELAY * 2 ** this.reconnect_attempts,
+			MAX_RECONNECT_DELAY
+		);
+		this.reconnect_attempts += 1;
+		this.reconnect_timer = setTimeout(() => {
+			this.reconnect_timer = null;
+			if (this.closed || !this.unclosed_events.size) return;
+			void this.open_stream().catch(() => this.reopen_stream_later());
+		}, delay);
+	}
+
+	clear_reconnect(): void {
+		if (this.reconnect_timer) {
+			clearTimeout(this.reconnect_timer);
+			this.reconnect_timer = null;
+		}
+	}
+
+	/**
+	 * Reopens the stream if it is not running while jobs are still outstanding. A
+	 * page restored from the back/forward cache, or a phone returning to a
+	 * backgrounded tab, comes back with its connections already closed and no error
+	 * ever delivered, so nothing else would notice.
+	 */
+	resume_stream(): void {
+		if (this.closed || this.stream_status.open || !this.unclosed_events.size) {
+			return;
+		}
+		this.reconnect_attempts = 0;
+		this.clear_reconnect();
+		void this.open_stream().catch(() => this.reopen_stream_later());
+	}
+
 	close(): void {
 		if (!this.closed) {
 			this.report_departure();
 		}
 		this.closed = true;
+		this.clear_reconnect();
 		close_stream(this.stream_status, this.abort_controller);
 	}
 

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -22,6 +22,7 @@ import { post_data } from "./utils/post_data";
 import { predict } from "./utils/predict";
 import { duplicate } from "./utils/duplicate";
 import { submit } from "./utils/submit";
+import { read_pending_jobs, type PendingJob } from "./utils/jobs";
 import { RE_SPACE_NAME, process_endpoint } from "./helpers/api_info";
 import {
 	map_names_to_ids,
@@ -329,6 +330,35 @@ export class Client {
 			return "changed";
 		}
 		return "connected";
+	}
+
+	/** Jobs submitted before this page loaded whose result never arrived. */
+	pending_jobs(): PendingJob[] {
+		if (!this.config) return [];
+		return read_pending_jobs(this.config);
+	}
+
+	/**
+	 * Picks previously submitted jobs back up, one stream each. The jobs keep running
+	 * under the session they were submitted from — that is where their `gr.State`
+	 * lives — while this page keeps the new session, and cleared state, that reloading
+	 * gave it. Only the output crosses over.
+	 */
+	reattach_jobs(
+		jobs: PendingJob[] = this.pending_jobs()
+	): SubmitIterable<GradioEvent>[] {
+		return jobs.map(({ fn_index, event_id }) =>
+			submit.call(
+				this,
+				fn_index,
+				{},
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				event_id
+			)
+		);
 	}
 
 	/**

--- a/client/js/src/constants.ts
+++ b/client/js/src/constants.ts
@@ -15,6 +15,7 @@ export const HEARTBEAT_URL = `heartbeat`;
 export const COMPONENT_SERVER_URL = `component_server`;
 export const RESET_URL = `reset`;
 export const CANCEL_URL = `cancel`;
+export const CLOSE_URL = `queue/close`;
 export const APP_ID_URL = `app_id`;
 
 export const RAW_API_INFO_URL = `info?serialize=False`;

--- a/client/js/src/constants.ts
+++ b/client/js/src/constants.ts
@@ -16,6 +16,7 @@ export const COMPONENT_SERVER_URL = `component_server`;
 export const RESET_URL = `reset`;
 export const CANCEL_URL = `cancel`;
 export const CLOSE_URL = `queue/close`;
+export const EVENT_URL = `queue/event`;
 export const APP_ID_URL = `app_id`;
 
 export const RAW_API_INFO_URL = `info?serialize=False`;

--- a/client/js/src/index.ts
+++ b/client/js/src/index.ts
@@ -5,6 +5,7 @@ export { submit } from "./utils/submit";
 export { upload_files } from "./utils/upload_files";
 export { FileData, upload, prepare_files } from "./upload";
 export { handle_file } from "./helpers/data";
+export { is_deliberate_exit, on_deliberate_exit } from "./utils/lifecycle";
 export {
 	clear_run_history,
 	consume_run_history_replay,

--- a/client/js/src/index.ts
+++ b/client/js/src/index.ts
@@ -5,7 +5,11 @@ export { submit } from "./utils/submit";
 export { upload_files } from "./utils/upload_files";
 export { FileData, upload, prepare_files } from "./upload";
 export { handle_file } from "./helpers/data";
-export { is_deliberate_exit, on_deliberate_exit } from "./utils/lifecycle";
+export {
+	is_deliberate_exit,
+	on_deliberate_exit,
+	on_page_return
+} from "./utils/lifecycle";
 export {
 	clear_run_history,
 	consume_run_history_replay,

--- a/client/js/src/index.ts
+++ b/client/js/src/index.ts
@@ -10,6 +10,7 @@ export {
 	on_deliberate_exit,
 	on_page_return
 } from "./utils/lifecycle";
+export type { PendingJob } from "./utils/jobs";
 export {
 	clear_run_history,
 	consume_run_history_replay,

--- a/client/js/src/test/init.test.ts
+++ b/client/js/src/test/init.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./test_data";
 import { initialise_server } from "./server";
 import { SPACE_NOT_FOUND_MSG } from "../constants";
+import { http, HttpResponse } from "msw";
 
 const app_reference = "hmb/hello_world";
 const broken_app_reference = "hmb/bye_world";
@@ -120,6 +121,61 @@ describe("Client class", () => {
 			const app = Client.connect(broken_app_reference);
 			await expect(app).rejects.toThrowError();
 		});
+	});
+
+	describe("close", () => {
+		test.skipIf(typeof window === "undefined")(
+			"reports a deliberate departure to the server",
+			async () => {
+				const app = await Client.connect(secret_direct_app_reference, {
+					token: "hf_123"
+				});
+				let received_session_hash: string | undefined;
+				let received_authorization: string | null = null;
+				let resolve_request: () => void = () => {};
+				const request_received = new Promise<void>((resolve) => {
+					resolve_request = resolve;
+				});
+				server.resetHandlers(
+					http.post(
+						`${secret_direct_app_reference}/queue/close`,
+						async ({ request }) => {
+							const body = (await request.json()) as { session_hash: string };
+							received_session_hash = body.session_hash;
+							received_authorization = request.headers.get("Authorization");
+							resolve_request();
+							return HttpResponse.json({ success: true });
+						}
+					)
+				);
+
+				app.close();
+				await request_received;
+
+				expect(received_session_hash).toBe(app.session_hash);
+				expect(received_authorization).toBe("Bearer hf_123");
+			}
+		);
+
+		test.skipIf(typeof window === "undefined")(
+			"only reports the departure once",
+			async () => {
+				const app = await Client.connect(direct_app_reference);
+				let requests = 0;
+				server.resetHandlers(
+					http.post(`${direct_app_reference}/queue/close`, () => {
+						requests += 1;
+						return HttpResponse.json({ success: true });
+					})
+				);
+
+				app.close();
+				app.close();
+				await new Promise((resolve) => setTimeout(resolve, 50));
+
+				expect(requests).toBe(1);
+			}
+		);
 	});
 
 	describe("duplicate", () => {

--- a/client/js/src/test/init.test.ts
+++ b/client/js/src/test/init.test.ts
@@ -178,6 +178,54 @@ describe("Client class", () => {
 		);
 	});
 
+	describe("reattach_jobs", () => {
+		// Reattaching is a browser affair: the jobs to come back for are remembered in
+		// `sessionStorage`, which does not exist outside one.
+		test.skipIf(typeof window === "undefined")(
+			"collects a job's output from the job's own stream",
+			async () => {
+				const app = await Client.connect(direct_app_reference, {
+					events: ["data", "status"]
+				});
+				let requested_url = "";
+				// Reattaching asks for the job by id, never by session hash: the session it
+				// was submitted from keeps its own `gr.State`, and this page has started a
+				// new one.
+				server.resetHandlers(
+					http.get(
+						`${direct_app_reference}/queue/event/:event_id`,
+						({ request }) => {
+							requested_url = new URL(request.url).pathname;
+							return new HttpResponse(
+								'data: {"msg":"process_completed","event_id":"event-1",' +
+									'"output":{"data":["done"]},"success":true}\n\n' +
+									'data: {"msg":"close_stream"}\n\n',
+								{ headers: { "Content-Type": "text/event-stream" } }
+							);
+						}
+					)
+				);
+
+				const submission = app.reattach_jobs([
+					{ event_id: "event-1", fn_index: 0 }
+				])[0];
+
+				const seen: string[] = [];
+				for await (const event of submission) {
+					seen.push(event.type);
+					if (event.type === "data") {
+						expect(event.data).toEqual(["done"]);
+					}
+					if (event.type === "status" && event.stage === "complete") break;
+				}
+
+				expect(requested_url).toBe("/queue/event/event-1");
+				expect(seen).toContain("data");
+				await submission.return();
+			}
+		);
+	});
+
 	describe("duplicate", () => {
 		test("backwards compatibility of duplicate using deprecated syntax", async () => {
 			const app = await duplicate("gradio/hello_world", {

--- a/client/js/src/test/jobs.test.ts
+++ b/client/js/src/test/jobs.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "../types";
+import {
+	clear_pending_job,
+	read_pending_jobs,
+	track_pending_job
+} from "../utils/jobs";
+
+class MemoryStorage implements Storage {
+	values = new Map<string, string>();
+
+	get length(): number {
+		return this.values.size;
+	}
+	clear(): void {
+		this.values.clear();
+	}
+	getItem(key: string): string | null {
+		return this.values.get(key) ?? null;
+	}
+	key(index: number): string | null {
+		return [...this.values.keys()][index] ?? null;
+	}
+	removeItem(key: string): void {
+		this.values.delete(key);
+	}
+	setItem(key: string, value: string): void {
+		this.values.set(key, value);
+	}
+}
+
+const config = { app_id: "app-1", root: "https://example.com" } as Config;
+
+describe("pending jobs", () => {
+	beforeEach(() => {
+		if (typeof sessionStorage === "undefined") {
+			vi.stubGlobal("sessionStorage", new MemoryStorage());
+		}
+		sessionStorage.clear();
+	});
+
+	it("remembers a job until it is cleared", () => {
+		track_pending_job(config, { event_id: "event-1", fn_index: 3 });
+
+		expect(read_pending_jobs(config)).toEqual([
+			{ event_id: "event-1", fn_index: 3 }
+		]);
+
+		clear_pending_job("event-1");
+		expect(read_pending_jobs(config)).toEqual([]);
+	});
+
+	it("keeps several jobs and clears them one at a time", () => {
+		track_pending_job(config, { event_id: "event-1", fn_index: 1 });
+		track_pending_job(config, { event_id: "event-2", fn_index: 2 });
+
+		clear_pending_job("event-1");
+
+		expect(read_pending_jobs(config)).toEqual([
+			{ event_id: "event-2", fn_index: 2 }
+		]);
+	});
+
+	it("does not record the same job twice", () => {
+		track_pending_job(config, { event_id: "event-1", fn_index: 1 });
+		track_pending_job(config, { event_id: "event-1", fn_index: 1 });
+
+		expect(read_pending_jobs(config)).toHaveLength(1);
+	});
+
+	it("forgets jobs belonging to another app", () => {
+		track_pending_job(config, { event_id: "event-1", fn_index: 1 });
+
+		// Easily done on localhost, where a different app answers on the same origin.
+		expect(read_pending_jobs({ ...config, app_id: "app-2" } as Config)).toEqual(
+			[]
+		);
+		expect(read_pending_jobs(config)).toEqual([]);
+	});
+
+	it("keeps jobs for as long as the tab lives", () => {
+		vi.useFakeTimers();
+		try {
+			track_pending_job(config, { event_id: "event-1", fn_index: 1 });
+			vi.advanceTimersByTime(6 * 60 * 60 * 1000);
+
+			// The server decides when a job is past saving, not the client.
+			expect(read_pending_jobs(config)).toHaveLength(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("stores no session hash, so a reload starts a new session", () => {
+		track_pending_job(config, { event_id: "event-1", fn_index: 1 });
+
+		const stored = sessionStorage.getItem("gradio_pending_jobs") ?? "";
+		expect(stored).not.toContain("session_hash");
+	});
+});

--- a/client/js/src/test/lifecycle.test.ts
+++ b/client/js/src/test/lifecycle.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { is_deliberate_exit, on_deliberate_exit } from "../utils/lifecycle";
+
+const in_browser =
+	typeof window !== "undefined" && typeof document !== "undefined";
+
+function set_visibility(state: DocumentVisibilityState): void {
+	Object.defineProperty(document, "visibilityState", {
+		value: state,
+		configurable: true
+	});
+}
+
+function fire_pagehide(persisted: boolean): void {
+	const event = new Event("pagehide");
+	Object.defineProperty(event, "persisted", { value: persisted });
+	window.dispatchEvent(event);
+}
+
+describe.skipIf(!in_browser)("on_deliberate_exit", () => {
+	afterEach(() => {
+		// Hand `visibilityState` back to the real getter on Document.prototype.
+		Reflect.deleteProperty(document, "visibilityState");
+	});
+
+	it("fires when a visible page is torn down", () => {
+		const callback = vi.fn();
+		const stop = on_deliberate_exit(callback);
+		set_visibility("visible");
+
+		fire_pagehide(false);
+
+		expect(callback).toHaveBeenCalledTimes(1);
+		stop();
+	});
+
+	it("does not fire when the page is put in the back/forward cache", () => {
+		const callback = vi.fn();
+		const stop = on_deliberate_exit(callback);
+		set_visibility("visible");
+
+		fire_pagehide(true);
+
+		expect(callback).not.toHaveBeenCalled();
+		stop();
+	});
+
+	it("does not fire when an already hidden page is torn down", () => {
+		const callback = vi.fn();
+		const stop = on_deliberate_exit(callback);
+		// A backgrounded tab that the browser or OS is reclaiming: the person
+		// switched away and expects to come back to their work.
+		set_visibility("hidden");
+
+		fire_pagehide(false);
+
+		expect(callback).not.toHaveBeenCalled();
+		stop();
+	});
+
+	it("stops listening once released", () => {
+		const callback = vi.fn();
+		const stop = on_deliberate_exit(callback);
+		set_visibility("visible");
+
+		stop();
+		fire_pagehide(false);
+
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it("reports intent without needing a listener", () => {
+		set_visibility("visible");
+		expect(
+			is_deliberate_exit({ persisted: false } as PageTransitionEvent)
+		).toBe(true);
+		expect(is_deliberate_exit({ persisted: true } as PageTransitionEvent)).toBe(
+			false
+		);
+
+		set_visibility("hidden");
+		expect(
+			is_deliberate_exit({ persisted: false } as PageTransitionEvent)
+		).toBe(false);
+	});
+});
+
+describe.skipIf(in_browser)("on_deliberate_exit without a DOM", () => {
+	it("does nothing when server rendered", () => {
+		const callback = vi.fn();
+
+		const stop = on_deliberate_exit(callback);
+		stop();
+
+		expect(callback).not.toHaveBeenCalled();
+	});
+});

--- a/client/js/src/test/lifecycle.test.ts
+++ b/client/js/src/test/lifecycle.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { is_deliberate_exit, on_deliberate_exit } from "../utils/lifecycle";
+import {
+	is_deliberate_exit,
+	on_deliberate_exit,
+	on_page_return
+} from "../utils/lifecycle";
 
 const in_browser =
 	typeof window !== "undefined" && typeof document !== "undefined";
@@ -82,6 +86,50 @@ describe.skipIf(!in_browser)("on_deliberate_exit", () => {
 		expect(
 			is_deliberate_exit({ persisted: false } as PageTransitionEvent)
 		).toBe(false);
+	});
+});
+
+describe.skipIf(!in_browser)("on_page_return", () => {
+	afterEach(() => {
+		Reflect.deleteProperty(document, "visibilityState");
+	});
+
+	it("fires when a page is restored from the back/forward cache", () => {
+		const callback = vi.fn();
+		const stop = on_page_return(callback);
+
+		const event = new Event("pageshow");
+		Object.defineProperty(event, "persisted", { value: true });
+		window.dispatchEvent(event);
+
+		expect(callback).toHaveBeenCalledTimes(1);
+		stop();
+	});
+
+	it("ignores an ordinary page load", () => {
+		const callback = vi.fn();
+		const stop = on_page_return(callback);
+
+		const event = new Event("pageshow");
+		Object.defineProperty(event, "persisted", { value: false });
+		window.dispatchEvent(event);
+
+		expect(callback).not.toHaveBeenCalled();
+		stop();
+	});
+
+	it("fires when a backgrounded page is brought forward", () => {
+		const callback = vi.fn();
+		const stop = on_page_return(callback);
+
+		set_visibility("hidden");
+		document.dispatchEvent(new Event("visibilitychange"));
+		expect(callback).not.toHaveBeenCalled();
+
+		set_visibility("visible");
+		document.dispatchEvent(new Event("visibilitychange"));
+		expect(callback).toHaveBeenCalledTimes(1);
+		stop();
 	});
 });
 

--- a/client/js/src/test/stream.test.ts
+++ b/client/js/src/test/stream.test.ts
@@ -62,10 +62,11 @@ describe("open_stream", () => {
 		if (!app.stream_instance?.onmessage || !app.stream_instance?.onerror) {
 			throw new Error("stream instance is not defined");
 		}
+		const stream = app.stream_instance;
 
 		const message = { msg: "hello jerry" };
 
-		app.stream_instance.onmessage({
+		stream.onmessage({
 			data: JSON.stringify(message)
 		} as MessageEvent);
 		expect(app.stream_status.open).toBe(true);
@@ -74,14 +75,73 @@ describe("open_stream", () => {
 		expect(app.pending_stream_messages).toEqual({});
 
 		const close_stream_message = { msg: "close_stream" };
-		app.stream_instance.onmessage({
+		stream.onmessage({
 			data: JSON.stringify(close_stream_message)
 		} as MessageEvent);
 		expect(app.stream_status.open).toBe(false);
+		expect(app.stream_instance).toBeNull();
 
-		app.stream_instance.onerror({
+		// A stream that has already been closed no longer speaks for the client, so
+		// an error arriving late on it must not reopen anything.
+		stream.onerror?.({
 			data: JSON.stringify("404")
 		} as MessageEvent);
 		expect(app.stream_status.open).toBe(false);
+		expect(app.stream).toHaveBeenCalledTimes(1);
+	});
+
+	it("reopens the stream when a job is still outstanding", async () => {
+		vi.useFakeTimers();
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		app.event_callbacks["event-1"] = vi.fn().mockResolvedValue(undefined);
+		app.unclosed_events.add("event-1");
+
+		await app.open_stream();
+		const stream = app.stream_instance;
+		if (!stream?.onerror) {
+			throw new Error("stream instance is not defined");
+		}
+
+		stream.onerror({ data: JSON.stringify("network error") } as MessageEvent);
+
+		// The job is not lost with the connection, so nothing is told it broke.
+		expect(app.stream_status.open).toBe(false);
+		expect(app.event_callbacks["event-1"]).not.toHaveBeenCalled();
+		expect(app.stream).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(500);
+		expect(app.stream).toHaveBeenCalledTimes(2);
+		expect(app.stream_status.open).toBe(true);
+	});
+
+	it("tells listeners the connection broke when nothing is outstanding", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		const callback = vi.fn().mockResolvedValue(undefined);
+		app.event_callbacks["event-1"] = callback;
+
+		await app.open_stream();
+		const stream = app.stream_instance;
+		if (!stream?.onerror) {
+			throw new Error("stream instance is not defined");
+		}
+
+		await stream.onerror({ data: JSON.stringify("boom") } as MessageEvent);
+
+		expect(callback).toHaveBeenCalledWith(
+			expect.objectContaining({ msg: "broken_connection" })
+		);
+		expect(app.stream).toHaveBeenCalledTimes(1);
+	});
+
+	it("reopens a stale stream when the page comes back", async () => {
+		app.event_callbacks["event-1"] = vi.fn().mockResolvedValue(undefined);
+		app.unclosed_events.add("event-1");
+
+		await app.open_stream();
+		app.stream_status.open = false;
+		app.stream_instance = null;
+
+		app.resume_stream();
+		await vi.waitFor(() => expect(app.stream).toHaveBeenCalledTimes(2));
 	});
 });

--- a/client/js/src/utils/jobs.ts
+++ b/client/js/src/utils/jobs.ts
@@ -1,0 +1,89 @@
+import type { Config } from "../types";
+
+export interface PendingJob {
+	event_id: string;
+	fn_index: number;
+}
+
+interface PendingJobs {
+	app_id?: string;
+	root: string;
+	jobs: PendingJob[];
+}
+
+const STORAGE_KEY = "gradio_pending_jobs";
+
+/**
+ * Jobs that were submitted but whose result has not arrived yet, remembered so that
+ * a page which reloads can pick them back up.
+ *
+ * Kept in `sessionStorage`, which is scoped to the tab and cleared when it closes —
+ * the same lifetime a Gradio session has. A cookie or `localStorage` would be shared
+ * across tabs, and two tabs of one app are meant to be independent.
+ *
+ * Only the job ids are stored, never the session hash. Reattaching by job id lets the
+ * work carry on under the session it was submitted from, where its `gr.State` lives,
+ * while the reloaded page starts a new session and so keeps the cleared state a reload
+ * is supposed to give. Storage may be unavailable — a private window, or an embedded
+ * page whose storage is blocked — so every access degrades to remembering nothing.
+ */
+function read(): PendingJobs | null {
+	if (typeof sessionStorage === "undefined") return null;
+
+	try {
+		const value = sessionStorage.getItem(STORAGE_KEY);
+		return value ? (JSON.parse(value) as PendingJobs) : null;
+	} catch {
+		return null;
+	}
+}
+
+function write(pending: PendingJobs | null): void {
+	if (typeof sessionStorage === "undefined") return;
+
+	try {
+		if (pending === null || pending.jobs.length === 0) {
+			sessionStorage.removeItem(STORAGE_KEY);
+		} else {
+			sessionStorage.setItem(STORAGE_KEY, JSON.stringify(pending));
+		}
+	} catch {
+		return;
+	}
+}
+
+/** The jobs still outstanding for this app, forgetting any belonging to another. */
+export function read_pending_jobs(config: Config): PendingJob[] {
+	const pending = read();
+	if (!pending) return [];
+	if (
+		pending.root !== config.root ||
+		(pending.app_id && config.app_id && pending.app_id !== config.app_id)
+	) {
+		// Left behind by a different app on the same origin, which is easily done on
+		// localhost, and its ids mean nothing here.
+		write(null);
+		return [];
+	}
+	return pending.jobs;
+}
+
+export function track_pending_job(config: Config, job: PendingJob): void {
+	const pending = read();
+	const jobs =
+		pending && pending.root === config.root
+			? pending.jobs.filter(({ event_id }) => event_id !== job.event_id)
+			: [];
+
+	write({ app_id: config.app_id, root: config.root, jobs: [...jobs, job] });
+}
+
+export function clear_pending_job(event_id: string): void {
+	const pending = read();
+	if (!pending) return;
+
+	write({
+		...pending,
+		jobs: pending.jobs.filter((job) => job.event_id !== event_id)
+	});
+}

--- a/client/js/src/utils/lifecycle.ts
+++ b/client/js/src/utils/lifecycle.ts
@@ -1,0 +1,59 @@
+/**
+ * Browsers do not expose "the user closed this tab". What they do expose is:
+ *
+ * - `pagehide`, which fires when the document is being taken away, carrying a
+ *   `persisted` flag that says whether it was parked in the back/forward cache
+ *   and can be restored later.
+ * - `visibilitychange`, which fires whenever the page is backgrounded or
+ *   foregrounded, and is the only one of the two that mobile browsers deliver
+ *   dependably.
+ *
+ * While unloading, the spec fires `pagehide` *before* the visibility state flips
+ * to hidden. So a page that is still `visible` when `pagehide` arrives is being
+ * destroyed by something happening in the foreground — a closed tab, a reload,
+ * or a navigation. A page that is already `hidden` was backgrounded earlier, so
+ * whatever is destroying it now is the browser or the operating system
+ * reclaiming memory rather than a person.
+ *
+ * The distinction is deliberately one-sided. Reading "deliberate" into someone
+ * merely switching tabs would throw away work they expect to find waiting, while
+ * reading "not deliberate" into a real exit only delays cleanup, so every
+ * ambiguous case is treated as not deliberate. Two consequences follow, and
+ * callers have to be built for them:
+ *
+ * - Closing a tab that is not in the foreground (⌘W on an inactive tab, or the
+ *   iOS tab switcher, which hides the page before you can tap the X) is
+ *   indistinguishable from the system reclaiming a background tab, and is
+ *   reported as not deliberate.
+ * - Nothing here is guaranteed to run at all. A crash, a force quit, an
+ *   out-of-memory kill, or a dead battery destroys the page silently. This is an
+ *   optimisation for the common case, never a signal to depend on.
+ */
+
+/**
+ * Whether a `pagehide` event represents someone deliberately leaving the page.
+ */
+export function is_deliberate_exit(event: PageTransitionEvent): boolean {
+	// Headed for the back/forward cache, so the page may yet be restored.
+	if (event.persisted) return false;
+	return document.visibilityState === "visible";
+}
+
+/**
+ * Calls `callback` when someone deliberately leaves the page. Returns a function
+ * that stops listening.
+ */
+export function on_deliberate_exit(callback: () => void): () => void {
+	if (typeof window === "undefined" || typeof document === "undefined") {
+		return () => {};
+	}
+
+	const handle_pagehide = (event: Event): void => {
+		if (is_deliberate_exit(event as PageTransitionEvent)) {
+			callback();
+		}
+	};
+
+	window.addEventListener("pagehide", handle_pagehide);
+	return () => window.removeEventListener("pagehide", handle_pagehide);
+}

--- a/client/js/src/utils/lifecycle.ts
+++ b/client/js/src/utils/lifecycle.ts
@@ -31,6 +31,34 @@
  */
 
 /**
+ * Calls `callback` when the page comes back into use, either restored from the
+ * back/forward cache or brought to the foreground again.
+ *
+ * A page that was frozen or cached has had its connections closed underneath it
+ * without any error being delivered, so anything that was streaming has to be
+ * checked rather than trusted. Returns a function that stops listening.
+ */
+export function on_page_return(callback: () => void): () => void {
+	if (typeof window === "undefined" || typeof document === "undefined") {
+		return () => {};
+	}
+
+	const handle_pageshow = (event: Event): void => {
+		if ((event as PageTransitionEvent).persisted) callback();
+	};
+	const handle_visibility = (): void => {
+		if (document.visibilityState === "visible") callback();
+	};
+
+	window.addEventListener("pageshow", handle_pageshow);
+	document.addEventListener("visibilitychange", handle_visibility);
+	return () => {
+		window.removeEventListener("pageshow", handle_pageshow);
+		document.removeEventListener("visibilitychange", handle_visibility);
+	};
+}
+
+/**
  * Whether a `pagehide` event represents someone deliberately leaving the page.
  */
 export function is_deliberate_exit(event: PageTransitionEvent): boolean {

--- a/client/js/src/utils/stream.ts
+++ b/client/js/src/utils/stream.ts
@@ -1,4 +1,4 @@
-import { BROKEN_CONNECTION_MSG, SSE_URL } from "../constants";
+import { BROKEN_CONNECTION_MSG, EVENT_URL, SSE_URL } from "../constants";
 import type { Client } from "../client";
 import { stream } from "fetch-event-stream";
 
@@ -124,6 +124,52 @@ export async function open_stream(this: Client): Promise<void> {
 
 		that.reopen_stream_later();
 	};
+}
+
+/**
+ * Follows a single job on its own stream, feeding its messages to `on_message`.
+ *
+ * Used by a page that reloaded: the session it submitted from is gone, so the job is
+ * reached by its own id instead. Returns a function that stops following it.
+ */
+export function follow_event(
+	client: Client,
+	event_id: string,
+	on_message: (data: any) => void | Promise<void>
+): () => void {
+	const { config } = client;
+	if (!config) {
+		throw new Error("Could not resolve app config");
+	}
+
+	const url = new URL(
+		`${config.root}${client.api_prefix}/${EVENT_URL}/${event_id}`
+	);
+	if (client.jwt) {
+		url.searchParams.set("__sign", client.jwt);
+	}
+
+	// Its own controller, so that closing this stream leaves the session's alone.
+	const controller = new AbortController();
+	const stream = readable_stream(url.toString(), { signal: controller.signal });
+
+	stream.onmessage = async function (event: MessageEvent) {
+		const data = JSON.parse(event.data);
+		if (data.msg === "close_stream") {
+			controller.abort();
+			return;
+		}
+		await on_message(data);
+	};
+	stream.onerror = async function (e) {
+		console.error(e);
+		await on_message({
+			msg: "broken_connection",
+			message: BROKEN_CONNECTION_MSG
+		});
+	};
+
+	return () => controller.abort();
 }
 
 export function close_stream(

--- a/client/js/src/utils/stream.ts
+++ b/client/js/src/utils/stream.ts
@@ -2,6 +2,10 @@ import { BROKEN_CONNECTION_MSG, SSE_URL } from "../constants";
 import type { Client } from "../client";
 import { stream } from "fetch-event-stream";
 
+/** Backoff between attempts to reopen a broken stream, and its ceiling. */
+export const RECONNECT_DELAY = 500;
+export const MAX_RECONNECT_DELAY = 5000;
+
 export async function open_stream(this: Client): Promise<void> {
 	let {
 		event_callbacks,
@@ -18,6 +22,11 @@ export async function open_stream(this: Client): Promise<void> {
 		throw new Error("Could not resolve app config");
 	}
 
+	if (stream_status.open) {
+		return;
+	}
+
+	this.clear_reconnect();
 	stream_status.open = true;
 
 	let stream: EventSource | null = null;
@@ -38,10 +47,19 @@ export async function open_stream(this: Client): Promise<void> {
 		return;
 	}
 
+	const abort_controller = this.abort_controller;
+	that.stream_instance = stream;
+
 	stream.onmessage = async function (event: MessageEvent) {
+		// A stream that has already been replaced must not speak for the client.
+		if (that.stream_instance !== stream) {
+			return;
+		}
+		that.reconnect_attempts = 0;
 		let _data = JSON.parse(event.data);
 		if (_data.msg === "close_stream") {
-			close_stream(stream_status, that.abort_controller);
+			that.stream_instance = null;
+			close_stream(stream_status, abort_controller);
 			return;
 		}
 		const event_id = _data.event_id;
@@ -82,15 +100,29 @@ export async function open_stream(this: Client): Promise<void> {
 		}
 	};
 	stream.onerror = async function (e) {
+		if (that.stream_instance !== stream) {
+			return;
+		}
 		console.error(e);
-		await Promise.all(
-			Object.keys(event_callbacks).map((event_id) =>
-				event_callbacks[event_id]({
-					msg: "broken_connection",
-					message: BROKEN_CONNECTION_MSG
-				})
-			)
-		);
+		that.stream_instance = null;
+		close_stream(stream_status, abort_controller);
+
+		// A broken connection is not the end of the jobs behind it. The server keeps
+		// them, and keeps their output, for long enough to come back for, so the
+		// stream is reopened rather than every listener being told it is over.
+		if (that.closed || unclosed_events.size === 0) {
+			await Promise.all(
+				Object.keys(event_callbacks).map((event_id) =>
+					event_callbacks[event_id]({
+						msg: "broken_connection",
+						message: BROKEN_CONNECTION_MSG
+					})
+				)
+			);
+			return;
+		}
+
+		that.reopen_stream_later();
 	};
 }
 

--- a/client/js/src/utils/submit.ts
+++ b/client/js/src/utils/submit.ts
@@ -27,7 +27,8 @@ import {
 	CANCEL_URL,
 	WS_PROTOCOL_MSG
 } from "../constants";
-import { apply_diff_stream, close_stream } from "./stream";
+import { apply_diff_stream, close_stream, follow_event } from "./stream";
+import { clear_pending_job, track_pending_job } from "./jobs";
 import { Client } from "../client";
 import {
 	start_run_history,
@@ -42,7 +43,13 @@ export function submit(
 	event_data?: unknown,
 	trigger_id?: number | null,
 	all_events?: boolean,
-	additional_headers?: Record<string, string>
+	additional_headers?: Record<string, string>,
+	/**
+	 * Picks an existing job back up instead of submitting a new one, for a page that
+	 * reloaded while it was running. Nothing is sent: the job is already queued, and
+	 * its output is followed on its own stream.
+	 */
+	reattach_event_id?: string
 ): SubmitIterable<GradioEvent> {
 	try {
 		const { token } = this.options;
@@ -77,7 +84,9 @@ export function submit(
 			config
 		);
 
-		let resolved_data = map_data_to_params(data, endpoint_info);
+		let resolved_data = reattach_event_id
+			? []
+			: map_data_to_params(data, endpoint_info);
 		let protocol = config.protocol ?? "ws";
 		if (protocol === "ws") {
 			throw new Error(WS_PROTOCOL_MSG);
@@ -115,7 +124,7 @@ export function submit(
 			config.run_history !== false && this.options.record_history !== false;
 		const history_scope = { app_id: config.app_id, username: config.username };
 		const history_run_id =
-			!history_enabled || !is_documented_endpoint
+			reattach_event_id || !history_enabled || !is_documented_endpoint
 				? null
 				: start_run_history({
 						...history_scope,
@@ -227,11 +236,184 @@ export function submit(
 			});
 		}
 
+		let stop_following: (() => void) | undefined;
+
+		/**
+		 * Wires up everything that turns queue messages for one event into the events
+		 * this iterator publishes. Used both for an event just submitted and for one
+		 * being picked back up after the page that submitted it went away.
+		 */
+		async function register_queue_event(queue_event_id: string): Promise<void> {
+			event_id = queue_event_id;
+			event_id_final = queue_event_id;
+			let callback = async function (_data: object): Promise<void> {
+				try {
+					const { type, status, data, original_msg } = handle_message(
+						_data,
+						last_status[fn_index]
+					);
+
+					if (type == "heartbeat") {
+						return;
+					}
+
+					if (type === "update" && status && !complete) {
+						// call 'status' listeners
+						fire_event({
+							type: "status",
+							endpoint: _endpoint,
+							fn_index,
+							time: new Date(),
+							original_msg: original_msg,
+							...status
+						});
+					} else if (type === "complete") {
+						complete = status;
+					} else if (
+						type == "unexpected_error" ||
+						type == "broken_connection"
+					) {
+						if (type === "unexpected_error") {
+							// The server no longer knows about this job, so there is
+							// nothing to come back for.
+							unclosed_events.delete(queue_event_id);
+							clear_pending_job(queue_event_id);
+						}
+						console.error("Unexpected error", status?.message);
+						const broken = type === "broken_connection";
+						fire_event({
+							type: "status",
+							stage: "error",
+							message: status?.message || "An Unexpected Error Occurred!",
+							queue: true,
+							endpoint: _endpoint,
+							broken,
+							session_not_found: status?.session_not_found,
+							fn_index,
+							time: new Date()
+						});
+					} else if (type === "log") {
+						fire_event({
+							type: "log",
+							title: data.title,
+							log: data.log,
+							level: data.level,
+							endpoint: _endpoint,
+							duration: data.duration,
+							visible: data.visible,
+							fn_index
+						});
+						return;
+					} else if (type === "generating" || type === "streaming") {
+						fire_event({
+							type: "status",
+							time: new Date(),
+							...status,
+							stage: status?.stage!,
+							queue: true,
+							endpoint: _endpoint,
+							fn_index
+						});
+						if (
+							data &&
+							dependency.connection !== "stream" &&
+							["sse_v2", "sse_v2.1", "sse_v3"].includes(protocol)
+						) {
+							apply_diff_stream(pending_diff_streams, event_id!, data);
+						}
+					}
+					if (data) {
+						fire_event({
+							type: "data",
+							time: new Date(),
+							data: handle_payload(
+								data.data,
+								dependency,
+								config!.components,
+								"output",
+								options.with_null_state
+							),
+							endpoint: _endpoint,
+							fn_index
+						});
+						if (data.render_config) {
+							await handle_render_config(data.render_config);
+						}
+
+						if (complete) {
+							fire_event({
+								type: "status",
+								time: new Date(),
+								...complete,
+								stage: status?.stage!,
+								queue: true,
+								endpoint: _endpoint,
+								fn_index
+							});
+							close();
+						}
+					}
+
+					if (status?.stage === "complete" || status?.stage === "error") {
+						clear_pending_job(queue_event_id);
+						if (event_callbacks[event_id!]) {
+							delete event_callbacks[event_id!];
+						}
+						if (event_id! in pending_diff_streams) {
+							delete pending_diff_streams[event_id!];
+						}
+						close();
+					}
+				} catch (e) {
+					console.error("Unexpected client exception", e);
+					fire_event({
+						type: "status",
+						stage: "error",
+						message: "An Unexpected Error Occurred!",
+						queue: true,
+						endpoint: _endpoint,
+						fn_index,
+						time: new Date()
+					});
+					if (["sse_v2", "sse_v2.1", "sse_v3"].includes(protocol)) {
+						close_stream(stream_status, that.abort_controller);
+						stream_status.open = false;
+						close();
+					}
+				}
+			};
+
+			if (queue_event_id in pending_stream_messages) {
+				pending_stream_messages[queue_event_id].forEach((msg) => callback(msg));
+				delete pending_stream_messages[queue_event_id];
+			}
+			// @ts-ignore
+			event_callbacks[queue_event_id] = callback;
+			unclosed_events.add(queue_event_id);
+			if (reattach_event_id) {
+				stop_following = follow_event(that, queue_event_id, callback);
+			} else if (!stream_status.open) {
+				await that.open_stream();
+			}
+		}
+
 		const job = this.handle_blob(
 			config.root,
 			resolved_data,
 			endpoint_info
 		).then(async (_payload) => {
+			if (reattach_event_id) {
+				fire_event({
+					type: "status",
+					stage: "pending",
+					queue: true,
+					endpoint: _endpoint,
+					fn_index,
+					time: new Date()
+				});
+				await register_queue_event(reattach_event_id);
+				return;
+			}
 			let input_data = handle_payload(
 				_payload,
 				dependency,
@@ -548,148 +730,16 @@ export function submit(
 						});
 						close();
 					} else {
-						event_id = response.event_id as string;
-						event_id_final = event_id;
-						let callback = async function (_data: object): Promise<void> {
-							try {
-								const { type, status, data, original_msg } = handle_message(
-									_data,
-									last_status[fn_index]
-								);
-
-								if (type == "heartbeat") {
-									return;
-								}
-
-								if (type === "update" && status && !complete) {
-									// call 'status' listeners
-									fire_event({
-										type: "status",
-										endpoint: _endpoint,
-										fn_index,
-										time: new Date(),
-										original_msg: original_msg,
-										...status
-									});
-								} else if (type === "complete") {
-									complete = status;
-								} else if (
-									type == "unexpected_error" ||
-									type == "broken_connection"
-								) {
-									console.error("Unexpected error", status?.message);
-									const broken = type === "broken_connection";
-									fire_event({
-										type: "status",
-										stage: "error",
-										message: status?.message || "An Unexpected Error Occurred!",
-										queue: true,
-										endpoint: _endpoint,
-										broken,
-										session_not_found: status?.session_not_found,
-										fn_index,
-										time: new Date()
-									});
-								} else if (type === "log") {
-									fire_event({
-										type: "log",
-										title: data.title,
-										log: data.log,
-										level: data.level,
-										endpoint: _endpoint,
-										duration: data.duration,
-										visible: data.visible,
-										fn_index
-									});
-									return;
-								} else if (type === "generating" || type === "streaming") {
-									fire_event({
-										type: "status",
-										time: new Date(),
-										...status,
-										stage: status?.stage!,
-										queue: true,
-										endpoint: _endpoint,
-										fn_index
-									});
-									if (
-										data &&
-										dependency.connection !== "stream" &&
-										["sse_v2", "sse_v2.1", "sse_v3"].includes(protocol)
-									) {
-										apply_diff_stream(pending_diff_streams, event_id!, data);
-									}
-								}
-								if (data) {
-									fire_event({
-										type: "data",
-										time: new Date(),
-										data: handle_payload(
-											data.data,
-											dependency,
-											config.components,
-											"output",
-											options.with_null_state
-										),
-										endpoint: _endpoint,
-										fn_index
-									});
-									if (data.render_config) {
-										await handle_render_config(data.render_config);
-									}
-
-									if (complete) {
-										fire_event({
-											type: "status",
-											time: new Date(),
-											...complete,
-											stage: status?.stage!,
-											queue: true,
-											endpoint: _endpoint,
-											fn_index
-										});
-										close();
-									}
-								}
-
-								if (status?.stage === "complete" || status?.stage === "error") {
-									if (event_callbacks[event_id!]) {
-										delete event_callbacks[event_id!];
-									}
-									if (event_id! in pending_diff_streams) {
-										delete pending_diff_streams[event_id!];
-									}
-									close();
-								}
-							} catch (e) {
-								console.error("Unexpected client exception", e);
-								fire_event({
-									type: "status",
-									stage: "error",
-									message: "An Unexpected Error Occurred!",
-									queue: true,
-									endpoint: _endpoint,
-									fn_index,
-									time: new Date()
-								});
-								if (["sse_v2", "sse_v2.1", "sse_v3"].includes(protocol)) {
-									close_stream(stream_status, that.abort_controller);
-									stream_status.open = false;
-									close();
-								}
-							}
-						};
-
-						if (event_id in pending_stream_messages) {
-							pending_stream_messages[event_id].forEach((msg) => callback(msg));
-							delete pending_stream_messages[event_id];
+						const queued_event_id = response.event_id as string;
+						// A streamed input cannot be picked up again, since the input
+						// stream does not survive the page, so it is not remembered.
+						if (dependency.connection !== "stream") {
+							track_pending_job(config, {
+								event_id: queued_event_id,
+								fn_index
+							});
 						}
-						// @ts-ignore
-						event_callbacks[event_id] = callback;
-						unclosed_events.add(event_id);
-						if (!stream_status.open) {
-							await this.open_stream();
-						}
+						await register_queue_event(queued_event_id);
 					}
 				});
 			}
@@ -718,6 +768,9 @@ export function submit(
 		) => void)[] = [];
 
 		function close(): void {
+			// A reattached job has a stream of its own, which nothing else would close.
+			stop_following?.();
+			stop_following = undefined;
 			done = true;
 			while (resolvers.length > 0)
 				(resolvers.shift() as (typeof resolvers)[0])({

--- a/gradio/data_classes.py
+++ b/gradio/data_classes.py
@@ -53,6 +53,10 @@ class CancelBody(BaseModel):
     event_id: str
 
 
+class QueueCloseBody(BaseModel):
+    session_hash: str
+
+
 class SimplePredictBody(BaseModel):
     data: list[Any]
     session_hash: str | None = None

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -216,10 +216,12 @@ class Queue:
         self.cancel_after_disconnect = max(
             0.0, float(os.getenv("GRADIO_QUEUE_DISCONNECT_TTL", "3600"))
         )
-        # A deliberate exit is acted on at once. This becomes a short grace period
-        # once a reloading page can reattach to the work it left behind, since a
-        # reload is indistinguishable from a close at the moment the client reports it.
-        self.cancel_after_close = 0.0
+        # A reload reports itself exactly like a close — the client cannot tell them
+        # apart when the page is being torn down — so a deliberate exit is given long
+        # enough for a reloading page to come back and claim its work, and no longer.
+        self.cancel_after_close = max(
+            0.0, float(os.getenv("GRADIO_QUEUE_CLOSE_GRACE_PERIOD", "15"))
+        )
         self.last_cancellation_sweep = 0.0
         self.ANAYLTICS_CACHE_FREQUENCY = int(
             os.getenv("GRADIO_ANALYTICS_CACHE_FREQUENCY", "1")

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -84,8 +84,18 @@ class Event:
         self.signal = asyncio.Event()
         # When this event should be stopped, as a `time.monotonic()` deadline. None
         # means nobody has asked for it to stop. `/cancel` sets it to now; losing the
-        # client sets it further out, so that a reconnection can clear it again.
+        # client sets it further out, so that a reconnection can clear it again. Once
+        # the event has finished, the same deadline says when to stop keeping its
+        # output for a client that has not collected it.
         self.cancel_at: float | None = None
+        # Everything sent for this event, so that a client which reconnects part way
+        # through is not left with a hole in the middle of its output.
+        self.messages: list[EventMessage] = []
+        # Cleared if the output grows past what is worth keeping. Streamed output is
+        # sent as diffs against what came before, so a buffer missing its earliest
+        # messages cannot be replayed at all: better to admit the output is gone than
+        # to rebuild it from the middle.
+        self.replayable = True
 
     @property
     def streaming(self):
@@ -101,6 +111,12 @@ class Event:
             return False
         return self.run_time >= self.fn.time_limit
 
+
+# The most messages kept for one event, and the most finished events kept at once.
+# Both are generous enough not to be reached by ordinary use and exist so that a
+# pathological app cannot grow the queue's memory without limit.
+MAX_REPLAYED_MESSAGES = 5000
+MAX_FINISHED_EVENTS = 200
 
 # How often due cancellations are looked for. The queue loop spins far faster than
 # this when it is idle, and a deadline measured in seconds does not need millisecond
@@ -150,6 +166,15 @@ class Queue:
         # connection so that a stale stream disconnecting after a reconnect does not
         # condemn the events the new stream is watching.
         self.attached_streams: dict[str, object] = {}
+        # Events that have finished but whose output nobody has collected yet, kept
+        # so that a client which reloads mid-job can still ask for its result. Bounded
+        # like `pending_messages_per_session`, since an abandoned result is only ever
+        # released by its deadline.
+        self.finished_events: LRUCache[str, Event] = LRUCache(MAX_FINISHED_EVENTS)
+        # Streams following a single event, by event id. A client that lost its page
+        # reattaches to the work rather than to the session it was submitted from, so
+        # its output has to reach it without going through that session's queue.
+        self.event_subscribers: dict[str, list[AsyncQueue[EventMessage]]] = {}
         # Sessions whose client has gone and whose `unload` handlers still have to
         # run, once whatever they left behind has stopped. Holds the request and
         # username the handlers need, because the events are gone by then.
@@ -288,8 +313,68 @@ class Queue:
         if not event.alive:
             return
         event_message.event_id = event._id
+        self.retain_message(event, event_message)
+        self.publish(event._id, event_message)
         messages = self.pending_messages_per_session[event.session_hash]
         messages.put_nowait(event_message)
+
+    def retain_message(self, event: Event, message: EventMessage) -> None:
+        """Keeps a copy of an event's output so that it can be replayed."""
+        if not event.replayable:
+            return
+        if len(event.messages) >= MAX_REPLAYED_MESSAGES:
+            event.replayable = False
+            event.messages.clear()
+            return
+        event.messages.append(message)
+
+    def publish(self, event_id: str, message: EventMessage) -> None:
+        """Hands a message to every stream following this event on its own."""
+        for subscriber in self.event_subscribers.get(event_id, ()):
+            subscriber.put_nowait(message)
+
+    def find_event(self, event_id: str) -> Event | None:
+        """The event, whether it is still queued or running, or has finished."""
+        return self.event_ids_to_events.get(event_id) or self.finished_events.get(
+            event_id
+        )
+
+    def subscribe_to_event(
+        self, event_id: str
+    ) -> tuple[list[EventMessage], AsyncQueue[EventMessage]] | None:
+        """
+        Follows one event, wherever it was submitted from. Returns what it has already
+        sent along with a queue carrying whatever it sends next, or None if the event
+        is unknown or its output can no longer be replayed.
+
+        The snapshot and the subscription are taken together without awaiting, so a
+        message sent in between cannot fall down the gap between them.
+        """
+        event = self.find_event(event_id)
+        if event is None or not event.replayable:
+            return None
+        subscriber: AsyncQueue[EventMessage] = AsyncQueue()
+        self.event_subscribers.setdefault(event_id, []).append(subscriber)
+        # Somebody is watching this event again, so it is no longer abandoned.
+        event.cancel_at = None
+        return list(event.messages), subscriber
+
+    def unsubscribe_from_event(
+        self, event_id: str, subscriber: AsyncQueue[EventMessage]
+    ) -> None:
+        subscribers = self.event_subscribers.get(event_id)
+        if subscribers is None:
+            return
+        if subscriber in subscribers:
+            subscribers.remove(subscriber)
+        if subscribers:
+            return
+        del self.event_subscribers[event_id]
+        # The last stream following it has gone, so its output goes back to being
+        # kept only until the deadline.
+        event = self.find_event(event_id)
+        if event is not None and event.cancel_at is None:
+            event.cancel_at = time.monotonic() + self.cancel_after_disconnect
 
     def _resolve_concurrency_limit(
         self, default_concurrency_limit: int | None | Literal["not_set"]
@@ -427,6 +512,9 @@ class Queue:
                 self.pending_messages_per_session[body.session_hash] = AsyncQueue()
             if body.session_hash not in self.pending_event_ids_session:
                 self.pending_event_ids_session[body.session_hash] = set()
+        # Submitting again is proof that the client is present and past whatever it
+        # ran before, so nothing of this session's is still waiting to be collected.
+        self.discard_finished_events(body.session_hash)
         self.pending_event_ids_session[body.session_hash].add(event._id)
         self.event_ids_to_events[event._id] = event
         body.event_id = event._id if not fn.batch else None
@@ -598,7 +686,9 @@ class Queue:
         """
         if not events:
             return
-        await cancel_tasks({f"{e.session_hash}_{e.fn._id}" for e in events})
+        # Marked before anything is awaited: `cancel_tasks` waits for the tasks it
+        # cancels to unwind, and an event that still looked alive as it unwound would
+        # have its output kept for a client that is not coming back for it.
         for event in events:
             event.alive = False
             event.cancel_at = None
@@ -606,18 +696,48 @@ class Queue:
             # than leaving it to sit there until its time limit runs out.
             event.run_time = float("inf")
             event.signal.set()
+        await cancel_tasks({f"{e.session_hash}_{e.fn._id}" for e in events})
+        for event in events:
             await self.remove_from_queue(event._id)
             was_pending = event._id in self.pending_event_ids_session.get(
                 event.session_hash, set()
             )
             session_open = event.session_hash in self.pending_messages_per_session
-            if notify and was_pending and session_open:
-                # Completes the job so that the client stops waiting on it.
-                self.pending_messages_per_session[event.session_hash].put_nowait(
-                    ProcessCompletedMessage(output={}, success=True, event_id=event._id)
+            if notify:
+                # Completes the job so that anyone waiting on it stops.
+                completed = ProcessCompletedMessage(
+                    output={}, success=True, event_id=event._id
                 )
+                self.publish(event._id, completed)
+                if was_pending and session_open:
+                    self.pending_messages_per_session[event.session_hash].put_nowait(
+                        completed
+                    )
             if self.server_app is not None:
                 await self.server_app.close_iterator(event._id)
+
+    def retain_finished_event(self, event: Event) -> None:
+        """
+        Keeps a finished event's output for a client that has not received it. A
+        cancelled event is not kept: it was stopped precisely because nobody was
+        coming back for it.
+        """
+        if not event.alive or not event.replayable or not event.messages:
+            return
+        # The inputs are not replayed and an upload can be large, so they go now.
+        event.data = None
+        if event.cancel_at is None and not self.event_subscribers.get(event._id):
+            event.cancel_at = time.monotonic() + self.cancel_after_disconnect
+        self.finished_events[event._id] = event
+
+    def discard_finished_events(self, session_hash: str) -> None:
+        for event_id in [
+            event_id
+            for event_id, event in self.finished_events.items()
+            if event.session_hash == session_hash
+            and not self.event_subscribers.get(event_id)
+        ]:
+            self.finished_events.pop(event_id, None)
 
     async def close_session(
         self,
@@ -653,6 +773,14 @@ class Queue:
             ],
             notify=False,
         )
+        # For an event that has already finished there is nothing left to stop, so
+        # the same deadline simply means its output is not worth keeping any longer.
+        for event_id in [
+            event_id
+            for event_id, event in self.finished_events.items()
+            if event.cancel_at is not None and event.cancel_at <= now
+        ]:
+            self.finished_events.pop(event_id, None)
         for session_hash, (request, username) in list(
             self.sessions_awaiting_close.items()
         ):
@@ -1250,6 +1378,7 @@ class Queue:
                 )
 
                 self.event_ids_to_events.pop(event._id, None)
+                self.retain_finished_event(event)
 
     async def reset_iterators(self, event_id: str):
         # Do the same thing as the /reset route

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 import fastapi
 import numpy as np
 from anyio.to_thread import run_sync
+from fastapi import BackgroundTasks
 
 from gradio import route_utils, routes
 from gradio.caching import CacheMissError, ProbeCache
@@ -43,6 +44,7 @@ from gradio.server_messages import (
 )
 from gradio.utils import (
     LRUCache,
+    cancel_tasks,
     error_payload,
     run_coro_in_background,
     safe_aclose_iterator,
@@ -80,6 +82,10 @@ class Event:
         self.run_time: float = 0
         self.enqueue_time: float = time.monotonic()
         self.signal = asyncio.Event()
+        # When this event should be stopped, as a `time.monotonic()` deadline. None
+        # means nobody has asked for it to stop. `/cancel` sets it to now; losing the
+        # client sets it further out, so that a reconnection can clear it again.
+        self.cancel_at: float | None = None
 
     @property
     def streaming(self):
@@ -94,6 +100,12 @@ class Event:
         if self.fn.time_limit is None:
             return False
         return self.run_time >= self.fn.time_limit
+
+
+# How often due cancellations are looked for. The queue loop spins far faster than
+# this when it is idle, and a deadline measured in seconds does not need millisecond
+# resolution, so the sweep is throttled rather than run on every pass.
+CANCELLATION_SWEEP_INTERVAL = 0.05
 
 
 class EventQueue:
@@ -134,6 +146,14 @@ class Queue:
         )
         self.pending_event_ids_session: dict[str, set[str]] = {}
         self.event_ids_to_events: dict[str, Event] = {}
+        # The queue stream currently listening to each session. Identifies the
+        # connection so that a stale stream disconnecting after a reconnect does not
+        # condemn the events the new stream is watching.
+        self.attached_streams: dict[str, object] = {}
+        # Sessions whose client has gone and whose `unload` handlers still have to
+        # run, once whatever they left behind has stopped. Holds the request and
+        # username the handlers need, because the events are gone by then.
+        self.sessions_awaiting_close: dict[str, tuple[fastapi.Request, str | None]] = {}
         self.pending_message_lock = safe_get_lock()
         self.event_queue_per_concurrency_id: dict[str, EventQueue] = {}
         self.stopped = False
@@ -164,6 +184,18 @@ class Queue:
         self.cached_event_analytics_summary = {"functions": {}}
         self.events_recorded = 0
         self.event_count_at_last_cache = 0
+        # How long a job outlives the loss of its client. A dropped connection is not
+        # evidence that anybody left: a phone backgrounding the page, a lost signal,
+        # or a laptop going to sleep all look identical to a closed tab from here, so
+        # the work is kept until the client has had a fair chance to come back.
+        self.cancel_after_disconnect = max(
+            0.0, float(os.getenv("GRADIO_QUEUE_DISCONNECT_TTL", "3600"))
+        )
+        # A deliberate exit is acted on at once. This becomes a short grace period
+        # once a reloading page can reattach to the work it left behind, since a
+        # reload is indistinguishable from a close at the moment the client reports it.
+        self.cancel_after_close = 0.0
+        self.last_cancellation_sweep = 0.0
         self.ANAYLTICS_CACHE_FREQUENCY = int(
             os.getenv("GRADIO_ANALYTICS_CACHE_FREQUENCY", "1")
         )
@@ -493,6 +525,144 @@ class Queue:
                 except ValueError:
                     pass
 
+    def session_events(self, session_hash: str) -> list[Event]:
+        """Every queued or running event belonging to a session."""
+        return [
+            event
+            for event in self.event_ids_to_events.values()
+            if event.session_hash == session_hash
+        ]
+
+    def attach_stream(self, session_hash: str, stream: object) -> None:
+        """
+        A queue stream is listening to this session, so nothing of its own is
+        condemned. Called for every connection, which is what reprieves a session
+        whose events were scheduled for cancellation when an earlier one dropped.
+        """
+        self.attached_streams[session_hash] = stream
+        self.sessions_awaiting_close.pop(session_hash, None)
+        for event in self.session_events(session_hash):
+            event.cancel_at = None
+
+    async def schedule_cancel(
+        self,
+        session_hash: str,
+        *,
+        after: float,
+        request: fastapi.Request | None = None,
+        username: str | None = None,
+        stream: object | None = None,
+        background_tasks: BackgroundTasks | None = None,
+    ) -> None:
+        """
+        Stops everything a session left behind, `after` seconds from now. Keeps any
+        earlier deadline already set, so a deliberate exit is not pushed back by a
+        connection dropping afterwards.
+
+        Parameters:
+            after: Seconds to wait. Zero stops the events on the next queue pass.
+            request: When given, the session's `unload` handlers run once its events
+                have stopped. Omit to stop the events but leave the session in place.
+            stream: The connection that went away. The call is ignored if a later
+                connection has already taken the session over, which is what happens
+                when a client reconnects before the server notices the old stream.
+            background_tasks: Passed on to the `unload` handlers when the caller's own
+                task has been cancelled and cannot await them.
+        """
+        if stream is not None:
+            if self.attached_streams.get(session_hash) is not stream:
+                return
+            del self.attached_streams[session_hash]
+        events = self.session_events(session_hash)
+        if request is not None:
+            if not events:
+                await self.close_session(
+                    session_hash, request, username, background_tasks
+                )
+                return
+            self.sessions_awaiting_close[session_hash] = (request, username)
+        deadline = time.monotonic() + after
+        for event in events:
+            event.cancel_at = (
+                deadline if event.cancel_at is None else min(event.cancel_at, deadline)
+            )
+
+    async def cancel_events(self, events: list[Event], *, notify: bool) -> None:
+        """
+        Stops events, whether they are still waiting in the queue or already running.
+
+        Parameters:
+            notify: Whether to tell the client that the event has finished. True when
+                somebody pressed stop and is waiting to be released, false when the
+                event is being stopped precisely because nobody is listening.
+        """
+        if not events:
+            return
+        await cancel_tasks({f"{e.session_hash}_{e.fn._id}" for e in events})
+        for event in events:
+            event.alive = False
+            event.cancel_at = None
+            # Releases a streaming event blocked waiting for its next input rather
+            # than leaving it to sit there until its time limit runs out.
+            event.run_time = float("inf")
+            event.signal.set()
+            await self.remove_from_queue(event._id)
+            was_pending = event._id in self.pending_event_ids_session.get(
+                event.session_hash, set()
+            )
+            session_open = event.session_hash in self.pending_messages_per_session
+            if notify and was_pending and session_open:
+                # Completes the job so that the client stops waiting on it.
+                self.pending_messages_per_session[event.session_hash].put_nowait(
+                    ProcessCompletedMessage(output={}, success=True, event_id=event._id)
+                )
+            if self.server_app is not None:
+                await self.server_app.close_iterator(event._id)
+
+    async def close_session(
+        self,
+        session_hash: str,
+        request: fastapi.Request,
+        username: str | None,
+        background_tasks: BackgroundTasks | None = None,
+    ) -> None:
+        """Runs a session's `unload` handlers and drops what the queue holds for it."""
+        self.sessions_awaiting_close.pop(session_hash, None)
+        self.attached_streams.pop(session_hash, None)
+        self.pending_event_ids_session.pop(session_hash, None)
+        if self.server_app is None:
+            return
+        try:
+            await routes.close_session(
+                self.server_app, session_hash, request, username, background_tasks
+            )
+        except Exception:
+            traceback.print_exc()
+
+    async def run_due_cancellations(self) -> None:
+        """Stops events whose deadline has passed, then closes emptied sessions."""
+        now = time.monotonic()
+        if now - self.last_cancellation_sweep < CANCELLATION_SWEEP_INTERVAL:
+            return
+        self.last_cancellation_sweep = now
+        await self.cancel_events(
+            [
+                event
+                for event in self.event_ids_to_events.values()
+                if event.cancel_at is not None and event.cancel_at <= now
+            ],
+            notify=False,
+        )
+        for session_hash, (request, username) in list(
+            self.sessions_awaiting_close.items()
+        ):
+            # Cancelled events are not waited on: stopping them is all that can be
+            # done, and a blocking call cannot be interrupted, so holding the
+            # `unload` handlers until it returns on its own would only delay the
+            # cleanup that used to happen the moment the client disappeared.
+            if not any(event.alive for event in self.session_events(session_hash)):
+                await self.close_session(session_hash, request, username)
+
     def _cancel_asyncio_tasks(self):
         for task in list(self._asyncio_tasks):
             task.cancel()
@@ -536,6 +706,7 @@ class Queue:
     async def start_processing(self) -> None:
         try:
             while not self.stopped:
+                await self.run_due_cancellations()
                 if len(self) == 0:
                     await asyncio.sleep(self.sleep_when_free)
                     continue
@@ -645,34 +816,6 @@ class Queue:
                     title=title,
                 )
                 self.send_message(event, log_message)
-
-    async def clean_events(
-        self, *, session_hash: str | None = None, event_id: str | None = None
-    ) -> None:
-        for job_set in self.active_jobs:
-            if job_set:
-                for job in job_set:
-                    if job.session_hash == session_hash or job._id == event_id:
-                        job.alive = False
-
-        async with self.delete_lock:
-            events_to_remove: list[Event] = []
-            for event_queue in self.event_queue_per_concurrency_id.values():
-                for event in event_queue.queue:
-                    if event.session_hash == session_hash or event._id == event_id:
-                        events_to_remove.append(event)
-
-            for event in events_to_remove:
-                self.event_queue_per_concurrency_id[event.concurrency_id].queue.remove(
-                    event
-                )
-                self.event_ids_to_events.pop(event._id, None)
-
-            if session_hash and session_hash in self.pending_event_ids_session:
-                removed_ids = {e._id for e in events_to_remove}
-                self.pending_event_ids_session[session_hash] -= removed_ids
-                if not self.pending_event_ids_session[session_hash]:
-                    self.pending_event_ids_session.pop(session_hash, None)
 
     async def notify_clients(self) -> None:
         """

--- a/gradio/queueing.py
+++ b/gradio/queueing.py
@@ -750,6 +750,8 @@ class Queue:
         self.sessions_awaiting_close.pop(session_hash, None)
         self.attached_streams.pop(session_hash, None)
         self.pending_event_ids_session.pop(session_hash, None)
+        # Nobody is coming back to read these now.
+        self.pending_messages_per_session.pop(session_hash, None)
         if self.server_app is None:
             return
         try:

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1542,6 +1542,70 @@ class App(FastAPI):
                 )
             return await queue_data_helper(request, session_hash, process_msg)
 
+        @router.get("/queue/event/{event_id}", dependencies=[Depends(login_check)])
+        async def queue_event_data(request: fastapi.Request, event_id: str):
+            """
+            Follows a single job, wherever it was submitted from. A client that lost
+            its page reattaches here rather than to `/queue/data`, because the session
+            it submitted from is gone: reclaiming that session would carry its
+            `gr.State` into a page that has otherwise started fresh. The event id is
+            enough on its own, being server-issued and unguessable.
+            """
+            blocks = app.get_blocks()
+
+            def process_msg(message: EventMessage) -> str:
+                return f"data: {orjson.dumps(message.model_dump(), default=str).decode('utf-8')}\n\n"
+
+            def is_final(message: EventMessage) -> bool:
+                return isinstance(
+                    message, (ProcessCompletedMessage, UnexpectedErrorMessage)
+                )
+
+            subscription = blocks._queue.subscribe_to_event(event_id)
+
+            async def event_stream():
+                if subscription is None:
+                    yield process_msg(
+                        UnexpectedErrorMessage(
+                            event_id=event_id,
+                            message="Event not found.",
+                            session_not_found=True,
+                        )
+                    )
+                    yield process_msg(CloseStreamMessage())
+                    return
+
+                replayed, subscriber = subscription
+                heartbeat_rate = utils.get_heartbeat_rate()
+                try:
+                    for message in replayed:
+                        yield process_msg(message)
+                        if is_final(message):
+                            yield process_msg(CloseStreamMessage())
+                            return
+                    while True:
+                        if await request.is_disconnected():
+                            return
+                        try:
+                            message = await asyncio.wait_for(
+                                subscriber.get(), timeout=heartbeat_rate
+                            )
+                        except (TimeoutError, asyncio.TimeoutError):
+                            yield process_msg(HeartbeatMessage())
+                            continue
+                        yield process_msg(message)
+                        if is_final(message):
+                            break
+                    yield process_msg(CloseStreamMessage())
+                finally:
+                    blocks._queue.unsubscribe_from_event(event_id, subscriber)
+
+            return StreamingResponse(
+                event_stream(),
+                media_type="text/event-stream",
+                headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+            )
+
         @router.get("/queue/data", dependencies=[Depends(login_check)])
         async def queue_data(
             request: fastapi.Request,

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1722,7 +1722,8 @@ class App(FastAPI):
                     )
                     response = process_msg(message)
                     if isinstance(e, asyncio.CancelledError):
-                        del blocks._queue.pending_messages_per_session[session_hash]
+                        # The session's undelivered messages are left in place: the
+                        # client is expected to reopen this stream and drain them.
                         await stream_lost()
                     if response is not None:
                         yield response

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -81,6 +81,7 @@ from gradio.data_classes import (
     JsonData,
     PredictBody,
     PredictBodyInternal,
+    QueueCloseBody,
     ResetBody,
     SimplePredictBody,
     UserProvidedPath,
@@ -289,6 +290,21 @@ class App(FastAPI):
         if self.blocks is None:
             raise ValueError("No Blocks has been configured for this app.")
         return self.blocks
+
+    async def close_iterator(self, event_id: str) -> None:
+        """
+        Ends an event's iterator, so that the generator behind it is closed and a
+        later run of the same event starts from scratch.
+        """
+        if event_id not in self.iterators:
+            return
+        async with self.lock:
+            try:
+                await safe_aclose_iterator(self.iterators[event_id])
+            except Exception:
+                pass
+            del self.iterators[event_id]
+            self.iterators_to_reset.add(event_id)
 
     def build_proxy_request(self, url_path):
         url = httpx.URL(url_path)
@@ -1266,54 +1282,21 @@ class App(FastAPI):
                         if not stop_stream_task.done():
                             stop_stream_task.cancel()
 
-                        req = Request(request, username, session_hash=session_hash)
-                        root_path = route_utils.get_root_url(
+                        # Losing the heartbeat is not proof that anybody left, so
+                        # the session's work is given time to be reclaimed and the
+                        # `unload` handlers run once it has stopped. With nothing in
+                        # flight there is nothing to wait for, and `schedule_cancel`
+                        # closes the session straight away.
+                        queue = app.get_blocks()._queue
+                        await queue.schedule_cancel(
+                            session_hash,
+                            after=queue.cancel_after_disconnect,
                             request=request,
-                            route_path=f"{API_PREFIX}/heartbeat/{session_hash}",
-                            root_path=app.root_path,
+                            username=username,
+                            # The task running this loop has been cancelled, so
+                            # anything awaited here has to be quick.
+                            background_tasks=background_tasks,
                         )
-                        body = PredictBodyInternal(
-                            session_hash=session_hash, data=[], request=request
-                        )
-                        unload_fn_indices = [
-                            i
-                            for i, dep in app.get_blocks().fns.items()
-                            if any(t for t in dep.targets if t[1] == "unload")
-                        ]
-                        for fn_index in unload_fn_indices:
-                            # The task running this loop has been cancelled
-                            # so we add tasks in the background
-                            background_tasks.add_task(
-                                route_utils.call_process_api,
-                                app=app,
-                                body=body,
-                                gr_request=req,
-                                fn=app.get_blocks().fns[fn_index],
-                                root_path=root_path,
-                            )
-                        # This will mark the state to be deleted in an hour
-                        if session_hash in app.state_holder.session_data:
-                            app.state_holder.session_data[session_hash].is_closed = True
-                        caching.clear_session_caches(session_hash)
-                        for run in (
-                            app.get_blocks()
-                            .pending_streams.pop(session_hash, {})
-                            .values()
-                        ):
-                            for stream in run.values():
-                                stream.end_stream()
-                        for (
-                            event_id
-                        ) in app.get_blocks()._queue.pending_event_ids_session.get(
-                            session_hash, []
-                        ):
-                            event = app.get_blocks()._queue.event_ids_to_events.get(
-                                event_id
-                            )
-                            if event is None:
-                                continue
-                            event.run_time = math.inf
-                            event.signal.set()
                         return
 
             return StreamingResponse(iterator(), media_type="text/event-stream")
@@ -1475,32 +1458,37 @@ class App(FastAPI):
 
         @router.post("/cancel")
         async def cancel_event(body: CancelBody):
-            await cancel_tasks({f"{body.session_hash}_{body.fn_index}"})
-            blocks = app.get_blocks()
-            # Need to complete the job so that the client disconnects
-            session_open = (
-                body.session_hash in blocks._queue.pending_messages_per_session
+            queue = app.get_blocks()._queue
+            event = queue.event_ids_to_events.get(body.event_id)
+            if event is not None:
+                await queue.cancel_events([event], notify=True)
+            else:
+                # The event has already finished or been cancelled. Stop anything
+                # still running for it and reset its iterator, as this route has
+                # always done for a repeated or late cancellation.
+                await cancel_tasks({f"{body.session_hash}_{body.fn_index}"})
+                await app.close_iterator(body.event_id)
+            return {"success": True}
+
+        @router.post("/queue/close", dependencies=[Depends(login_check)])
+        async def close_queue_session(
+            body: QueueCloseBody,
+            request: fastapi.Request,
+            username: str = Depends(get_current_user),
+        ):
+            """
+            Reports that somebody deliberately left the page. Unlike a dropped
+            connection, which the server cannot tell apart from a backgrounded tab or
+            a lost signal, this is a statement of intent, so the session's work is
+            stopped rather than kept for them.
+            """
+            queue = app.get_blocks()._queue
+            await queue.schedule_cancel(
+                body.session_hash,
+                after=queue.cancel_after_close,
+                request=request,
+                username=username,
             )
-            event_running = (
-                body.event_id
-                in blocks._queue.pending_event_ids_session.get(body.session_hash, {})
-            )
-            await blocks._queue.remove_from_queue(body.event_id)
-            if session_open and event_running:
-                message = ProcessCompletedMessage(
-                    output={}, success=True, event_id=body.event_id
-                )
-                blocks._queue.pending_messages_per_session[
-                    body.session_hash
-                ].put_nowait(message)
-            if body.event_id in app.iterators:
-                async with app.lock:
-                    try:
-                        await safe_aclose_iterator(app.iterators[body.event_id])
-                    except Exception:
-                        pass
-                    del app.iterators[body.event_id]
-                    app.iterators_to_reset.add(body.event_id)
             return {"success": True}
 
         @router.get(
@@ -1582,11 +1570,23 @@ class App(FastAPI):
                         await queue.put(HeartbeatMessage())
 
             async def sse_stream(request: fastapi.Request):
+                # Identifies this connection so that a stale stream disconnecting
+                # after a reconnect cannot condemn the new stream's events.
+                stream_token = object()
+                blocks._queue.attach_stream(session_hash, stream_token)
                 heartbeat_task = asyncio.create_task(heartbeat())
+
+                async def stream_lost() -> None:
+                    await blocks._queue.schedule_cancel(
+                        session_hash,
+                        after=blocks._queue.cancel_after_disconnect,
+                        stream=stream_token,
+                    )
+
                 try:
                     while True:
                         if await request.is_disconnected():
-                            await blocks._queue.clean_events(session_hash=session_hash)
+                            await stream_lost()
                             heartbeat_task.cancel()
                             return
 
@@ -1659,7 +1659,7 @@ class App(FastAPI):
                     response = process_msg(message)
                     if isinstance(e, asyncio.CancelledError):
                         del blocks._queue.pending_messages_per_session[session_hash]
-                        await blocks._queue.clean_events(session_hash=session_hash)
+                        await stream_lost()
                     if response is not None:
                         yield response
                     heartbeat_task.cancel()
@@ -2448,6 +2448,66 @@ Existing code:
 ########
 # Helper functions
 ########
+
+
+async def close_session(
+    app: App,
+    session_hash: str,
+    request: fastapi.Request,
+    username: str | None,
+    background_tasks: BackgroundTasks | None = None,
+) -> None:
+    """
+    Runs a session's `unload` handlers and releases everything held for it. Called by
+    the heartbeat connection when it drops with nothing in flight, and by the queue
+    once work that outlived its client has stopped.
+
+    Parameters:
+        background_tasks: When given, the `unload` handlers are scheduled here instead
+            of awaited, which is required when the calling task has been cancelled.
+    """
+    blocks = app.get_blocks()
+    req = Request(request, username, session_hash=session_hash)
+    root_path = route_utils.get_root_url(
+        request=request,
+        route_path=f"{API_PREFIX}/heartbeat/{session_hash}",
+        root_path=app.root_path,
+    )
+    body = PredictBodyInternal(session_hash=session_hash, data=[], request=request)
+    unload_fns = [
+        fn for fn in blocks.fns.values() if any(t[1] == "unload" for t in fn.targets)
+    ]
+    if background_tasks is not None:
+        for fn in unload_fns:
+            background_tasks.add_task(
+                route_utils.call_process_api,
+                app=app,
+                body=body,
+                gr_request=req,
+                fn=fn,
+                root_path=root_path,
+            )
+    else:
+        await asyncio.gather(
+            *(
+                route_utils.call_process_api(
+                    app=app,
+                    body=body,
+                    gr_request=req,
+                    fn=fn,
+                    root_path=root_path,
+                )
+                for fn in unload_fns
+            ),
+            return_exceptions=True,
+        )
+    # This will mark the state to be deleted in an hour
+    if session_hash in app.state_holder.session_data:
+        app.state_holder.session_data[session_hash].is_closed = True
+    caching.clear_session_caches(session_hash)
+    for run in blocks.pending_streams.pop(session_hash, {}).values():
+        for stream in run.values():
+            stream.end_stream()
 
 
 def load_system_prompt(starter_queries: bool = False):

--- a/js/app/src/routes/[...catchall]/+page.svelte
+++ b/js/app/src/routes/[...catchall]/+page.svelte
@@ -81,7 +81,7 @@
 	import { Embed } from "@gradio/core";
 	import type { ThemeMode } from "@gradio/core";
 	import { _ } from "svelte-i18n";
-	import { Client } from "@gradio/client";
+	import { Client, on_deliberate_exit } from "@gradio/client";
 	import { page } from "$app/state";
 	import { init } from "@huggingface/space-header";
 	import { browser } from "$app/environment";
@@ -265,9 +265,7 @@
 	}
 
 	onMount(async () => {
-		window.addEventListener("beforeunload", () => {
-			app?.close();
-		});
+		on_deliberate_exit(() => app?.close());
 		//@ts-ignore
 		config = data.config;
 		window.gradio_config = data.config;

--- a/js/app/src/routes/[...catchall]/+page.svelte
+++ b/js/app/src/routes/[...catchall]/+page.svelte
@@ -81,7 +81,7 @@
 	import { Embed } from "@gradio/core";
 	import type { ThemeMode } from "@gradio/core";
 	import { _ } from "svelte-i18n";
-	import { Client, on_deliberate_exit } from "@gradio/client";
+	import { Client, on_deliberate_exit, on_page_return } from "@gradio/client";
 	import { page } from "$app/state";
 	import { init } from "@huggingface/space-header";
 	import { browser } from "$app/environment";
@@ -266,6 +266,7 @@
 
 	onMount(async () => {
 		on_deliberate_exit(() => app?.close());
+		on_page_return(() => app?.resume_stream());
 		//@ts-ignore
 		config = data.config;
 		window.gradio_config = data.config;

--- a/js/core/src/Blocks.svelte
+++ b/js/core/src/Blocks.svelte
@@ -491,7 +491,14 @@
 			ready = true;
 			reset_resize_growth(resize_state);
 			void settled().then(handle_resize);
-			dep_manager.dispatch_load_events();
+			// A job picked back up should not have its load handler fired underneath it.
+			const pending_jobs = dep_manager.pending_jobs();
+			dep_manager.dispatch_load_events(
+				new Set(pending_jobs.map(({ fn_index }) => fn_index))
+			);
+			if (pending_jobs.length) {
+				void dep_manager.reattach(pending_jobs);
+			}
 		});
 
 		if (vibe_mode) {

--- a/js/core/src/dependency.ts
+++ b/js/core/src/dependency.ts
@@ -6,7 +6,7 @@ import type {
 	Payload
 } from "./types.js";
 import { AsyncFunction } from "./init_utils";
-import { Client, type client_return } from "@gradio/client";
+import { Client, type client_return, type PendingJob } from "@gradio/client";
 import {
 	LoadingStatusState,
 	type LoadingStatusArgs
@@ -917,8 +917,77 @@ export class DependencyManager {
 		}
 	}
 
-	dispatch_load_events() {
+	/**
+	 * Jobs left outstanding by a page that reloaded, limited to those this app still
+	 * has a matching function for. A job belonging to a function that is no longer
+	 * part of the layout has nowhere to put its output, so it is dropped.
+	 */
+	pending_jobs(): PendingJob[] {
+		return this.client
+			.pending_jobs()
+			.filter(({ fn_index }) => this.dependencies_by_fn.has(fn_index));
+	}
+
+	/**
+	 * Picks outstanding jobs back up and shows their progress and output as if they
+	 * had been started here. Kept separate from `dispatch`, which submits new work:
+	 * there is nothing to send, no inputs to validate, and no queue to wait behind.
+	 */
+	async reattach(jobs: PendingJob[] = this.pending_jobs()): Promise<void> {
+		const submissions = this.client.reattach_jobs(jobs);
+		await Promise.all(
+			jobs.map(async ({ fn_index }, index) => {
+				const dep = this.dependencies_by_fn.get(fn_index);
+				const submission = submissions[index];
+				if (!dep || !submission) return;
+
+				this.submissions.set(fn_index, submission);
+				this.loading_stati.update({
+					status: "pending",
+					fn_index,
+					stream_state: null
+				});
+				await this.update_loading_stati_state();
+
+				try {
+					for await (const result of submission) {
+						if (result === null) continue;
+						if (result.type === "data") {
+							await this.handle_data(dep.outputs, result.data);
+						} else if (result.type === "log") {
+							this.handle_log(result);
+						} else if (result.type === "status") {
+							this.loading_stati.update({
+								status: result.stage,
+								fn_index,
+								stream_state: null,
+								queue: result.queue,
+								size: result.size,
+								position: result.position,
+								eta: result.eta,
+								progress_data: result.progress_data,
+								time_limit: result.time_limit,
+								used_cache: result.used_cache,
+								cache_duration: result.cache_duration,
+								avg_time: result.avg_time
+							});
+							await this.update_loading_stati_state();
+							if (result.stage === "complete" || result.stage === "error") {
+								this.dispatch_state_change_events(result);
+								break;
+							}
+						}
+					}
+				} finally {
+					this.clear_submission(fn_index, submission);
+				}
+			})
+		);
+	}
+
+	dispatch_load_events(skipped_fn_indices: Set<number> = new Set()) {
 		this.dependencies_by_fn.forEach((dep) => {
+			if (skipped_fn_indices.has(dep.id)) return;
 			dep.targets.forEach(([target_id, event_name]) => {
 				if (event_name === "load") {
 					this.dispatch({

--- a/js/spa/src/Index.svelte
+++ b/js/spa/src/Index.svelte
@@ -86,6 +86,7 @@
 	import { onMount, onDestroy } from "svelte";
 	import {
 		consume_run_history_replay,
+		on_deliberate_exit,
 		type SpaceStatus,
 		type StoredRun
 	} from "@gradio/client";
@@ -412,9 +413,7 @@
 			events: ["data", "log", "status", "render"],
 			query_params
 		});
-		window.addEventListener("beforeunload", () => {
-			app.close();
-		});
+		on_deliberate_exit(() => app.close());
 
 		if (!app.config && !config?.auth_required) {
 			throw new Error("Could not resolve app config");

--- a/js/spa/src/Index.svelte
+++ b/js/spa/src/Index.svelte
@@ -87,6 +87,7 @@
 	import {
 		consume_run_history_replay,
 		on_deliberate_exit,
+		on_page_return,
 		type SpaceStatus,
 		type StoredRun
 	} from "@gradio/client";
@@ -414,6 +415,7 @@
 			query_params
 		});
 		on_deliberate_exit(() => app.close());
+		on_page_return(() => app.resume_stream());
 
 		if (!app.config && !config?.auth_required) {
 			throw new Error("Could not resolve app config");

--- a/test/test_queueing.py
+++ b/test/test_queueing.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import sys
+import threading
 import time
 from unittest.mock import patch
 
@@ -403,3 +404,193 @@ class TestQueueDoesNotAccumulate:
             ]
             == 8
         )
+
+
+def join(test_client, session_hash: str, fn_index: int = 0) -> str:
+    response = test_client.post(
+        f"{API_PREFIX}/queue/join",
+        json={
+            "data": [],
+            "fn_index": fn_index,
+            "event_data": None,
+            "session_hash": session_hash,
+            "trigger_id": None,
+        },
+    )
+    assert response.status_code == 200
+    return response.json()["event_id"]
+
+
+def slow_demo(started: threading.Event | None = None):
+    with gr.Blocks() as demo:
+        start = gr.Button()
+
+        def slow():
+            if started is not None:
+                started.set()
+            time.sleep(30)
+
+        start.click(slow)
+
+    demo.queue(default_concurrency_limit=1)
+    return demo
+
+
+def test_losing_a_stream_does_not_remove_the_event():
+    """A dropped connection is not a departure: the work is kept for a reconnection."""
+    started = threading.Event()
+    demo = slow_demo(started)
+    app, _, _ = demo.launch(prevent_thread_lock=True)
+    test_client = TestClient(app)
+
+    try:
+        event_id = join(test_client, "dropped")
+        assert started.wait(timeout=2)
+
+        # The stream opens and is then lost, which is what a backgrounded phone or a
+        # few seconds without signal looks like from the server.
+        stream = object()
+        demo._queue.attach_stream("dropped", stream)
+        asyncio.run(
+            demo._queue.schedule_cancel(
+                "dropped", after=demo._queue.cancel_after_disconnect, stream=stream
+            )
+        )
+
+        event = demo._queue.event_ids_to_events[event_id]
+        assert event.cancel_at is not None
+        assert event.cancel_at > time.monotonic() + 60
+        assert event.alive is True
+
+        asyncio.run(demo._queue.run_due_cancellations())
+        assert event_id in demo._queue.event_ids_to_events
+        assert event.alive is True
+    finally:
+        demo.close()
+
+
+def test_reconnecting_clears_a_scheduled_cancellation():
+    demo = slow_demo()
+    app, _, _ = demo.launch(prevent_thread_lock=True)
+    test_client = TestClient(app)
+
+    try:
+        event_id = join(test_client, "returning")
+        first = object()
+        demo._queue.attach_stream("returning", first)
+        asyncio.run(demo._queue.schedule_cancel("returning", after=3600, stream=first))
+        assert demo._queue.event_ids_to_events[event_id].cancel_at is not None
+
+        demo._queue.attach_stream("returning", object())
+        assert demo._queue.event_ids_to_events[event_id].cancel_at is None
+    finally:
+        demo.close()
+
+
+def test_a_replaced_stream_cannot_condemn_the_new_one():
+    """A refresh reconnects before the server notices the previous stream dropped."""
+    demo = slow_demo()
+    app, _, _ = demo.launch(prevent_thread_lock=True)
+    test_client = TestClient(app)
+
+    try:
+        event_id = join(test_client, "refreshed")
+        old_stream, new_stream = object(), object()
+        demo._queue.attach_stream("refreshed", old_stream)
+        demo._queue.attach_stream("refreshed", new_stream)
+
+        asyncio.run(
+            demo._queue.schedule_cancel("refreshed", after=0, stream=old_stream)
+        )
+
+        assert demo._queue.event_ids_to_events[event_id].cancel_at is None
+        assert demo._queue.attached_streams["refreshed"] is new_stream
+    finally:
+        demo.close()
+
+
+def test_closing_the_page_stops_the_event_and_unloads():
+    started = threading.Event()
+    unloaded = threading.Event()
+
+    with gr.Blocks() as demo:
+        start = gr.Button()
+
+        def slow():
+            started.set()
+            time.sleep(30)
+
+        start.click(slow)
+        demo.unload(unloaded.set)
+
+    demo.queue(default_concurrency_limit=1)
+    app, _, _ = demo.launch(prevent_thread_lock=True)
+    test_client = TestClient(app)
+
+    try:
+        event_id = join(test_client, "departed")
+        assert started.wait(timeout=2)
+
+        response = test_client.post(
+            f"{API_PREFIX}/queue/close", json={"session_hash": "departed"}
+        )
+        assert response.status_code == 200
+        event = demo._queue.event_ids_to_events[event_id]
+        assert event.cancel_at is not None
+        assert event.cancel_at <= time.monotonic()
+
+        # The sweep is throttled, so the queue loop may not have run it yet.
+        demo._queue.last_cancellation_sweep = 0
+        asyncio.run(demo._queue.run_due_cancellations())
+
+        assert event.alive is False
+        assert event.run_time == float("inf")
+        assert event.signal.is_set()
+        assert unloaded.wait(timeout=2)
+        assert app.state_holder.session_data["departed"].is_closed is True
+    finally:
+        demo.close()
+
+
+def test_cancel_route_still_completes_a_queued_event():
+    with gr.Blocks() as demo:
+        start = gr.Button()
+        output = gr.Textbox()
+
+        def slow():
+            time.sleep(30)
+            return "done"
+
+        start.click(slow, None, output)
+
+    demo.queue(default_concurrency_limit=1)
+    app, _, _ = demo.launch(prevent_thread_lock=True)
+    test_client = TestClient(app)
+
+    try:
+        first = join(test_client, "cancels")
+        second = join(test_client, "cancels")
+        for _ in range(50):
+            if len(demo._queue) == 1:
+                break
+            time.sleep(0.1)
+        assert len(demo._queue) == 1
+
+        response = test_client.post(
+            f"{API_PREFIX}/cancel",
+            json={"session_hash": "cancels", "fn_index": 0, "event_id": second},
+        )
+        assert response.status_code == 200
+        assert second not in demo._queue.event_ids_to_events
+        assert len(demo._queue) == 0
+        assert first in demo._queue.event_ids_to_events
+
+        # The client is told the cancelled job finished so that it stops waiting.
+        messages = demo._queue.pending_messages_per_session["cancels"]
+        completed = [messages.get_nowait() for _ in range(messages.qsize())]
+        assert any(
+            message.event_id == second and message.msg == "process_completed"
+            for message in completed
+        )
+    finally:
+        demo.close()

--- a/test/test_queueing.py
+++ b/test/test_queueing.py
@@ -10,7 +10,9 @@ import pytest
 from fastapi.testclient import TestClient
 
 import gradio as gr
+from gradio import queueing
 from gradio.route_utils import API_PREFIX
+from gradio.server_messages import ProcessGeneratingMessage
 
 
 class TestQueueing:
@@ -196,7 +198,10 @@ def test_heartbeat_task_cancelled_after_stream_completes():
 
     def tracking_create_task(coro, **kwargs):
         task = original_create_task(coro, **kwargs)
-        heartbeat_tasks.append(task)
+        # `asyncio` is shared process-wide, so this patch also sees tasks created by
+        # servers that earlier tests left running. Only collect the heartbeats.
+        if getattr(coro, "__qualname__", "").endswith("heartbeat"):
+            heartbeat_tasks.append(task)
         return task
 
     with patch("gradio.routes.asyncio.create_task", side_effect=tracking_create_task):
@@ -428,7 +433,7 @@ def slow_demo(started: threading.Event | None = None):
         def slow():
             if started is not None:
                 started.set()
-            time.sleep(30)
+            time.sleep(5)
 
         start.click(slow)
 
@@ -462,7 +467,7 @@ def test_losing_a_stream_does_not_remove_the_event():
         assert event.cancel_at > time.monotonic() + 60
         assert event.alive is True
 
-        asyncio.run(demo._queue.run_due_cancellations())
+        time.sleep(0.2)
         assert event_id in demo._queue.event_ids_to_events
         assert event.alive is True
     finally:
@@ -531,19 +536,20 @@ def test_closing_the_page_stops_the_event_and_unloads():
         event_id = join(test_client, "departed")
         assert started.wait(timeout=2)
 
+        event = demo._queue.event_ids_to_events[event_id]
         response = test_client.post(
             f"{API_PREFIX}/queue/close", json={"session_hash": "departed"}
         )
         assert response.status_code == 200
-        event = demo._queue.event_ids_to_events[event_id]
         assert event.cancel_at is not None
         assert event.cancel_at <= time.monotonic()
 
-        # The sweep is throttled, so the queue loop may not have run it yet.
-        demo._queue.last_cancellation_sweep = 0
-        asyncio.run(demo._queue.run_due_cancellations())
-
-        assert event.alive is False
+        # The queue's own loop performs the cancellation. Driving it from a second
+        # event loop here would race the real one.
+        deadline = time.monotonic() + 5
+        while event.alive:
+            assert time.monotonic() < deadline, "the event was never stopped"
+            time.sleep(0.02)
         assert event.run_time == float("inf")
         assert event.signal.is_set()
         assert unloaded.wait(timeout=2)
@@ -592,5 +598,185 @@ def test_cancel_route_still_completes_a_queued_event():
             message.event_id == second and message.msg == "process_completed"
             for message in completed
         )
+    finally:
+        demo.close()
+
+
+def read_sse(response) -> list[dict]:
+    return [
+        json.loads(line[5:])
+        for line in response.iter_lines()
+        if line.startswith("data:")
+    ]
+
+
+def test_finished_output_can_be_collected_by_event_id():
+    """A page that reloads mid-job asks for the job, not for the session it left."""
+    with gr.Blocks() as demo:
+        start = gr.Button()
+        output = gr.Textbox()
+        start.click(lambda: "done", None, output)
+
+    demo.queue()
+    app, _, _ = demo.launch(prevent_thread_lock=True)
+    test_client = TestClient(app)
+
+    try:
+        event_id = join(test_client, "left_the_page")
+        deadline = time.monotonic() + 5
+        while event_id not in demo._queue.finished_events:
+            assert time.monotonic() < deadline
+            time.sleep(0.01)
+
+        # A brand new session hash, as a reloaded page would have: the result is
+        # reached through the event, so nothing of the old session is inherited.
+        messages = read_sse(test_client.get(f"{API_PREFIX}/queue/event/{event_id}"))
+        completed = [m for m in messages if m["msg"] == "process_completed"]
+        assert completed and completed[0]["output"]["data"] == ["done"]
+        assert messages[-1]["msg"] == "close_stream"
+    finally:
+        demo.close()
+
+
+def test_collecting_by_event_id_leaves_session_state_alone():
+    with gr.Blocks() as demo:
+        start = gr.Button()
+        output = gr.Textbox()
+        start.click(lambda: "done", None, output)
+
+    demo.queue()
+    app, _, _ = demo.launch(prevent_thread_lock=True)
+    test_client = TestClient(app)
+
+    try:
+        event_id = join(test_client, "old_session")
+        deadline = time.monotonic() + 5
+        while event_id not in demo._queue.finished_events:
+            assert time.monotonic() < deadline
+            time.sleep(0.01)
+
+        # A reloaded page has a new session hash, so collecting its old result must
+        # not bring the session it was submitted from back into use, nor open a new
+        # one: a reload is entitled to have its `gr.State` cleared.
+        sessions_before = set(app.state_holder.session_data)
+        read_sse(test_client.get(f"{API_PREFIX}/queue/event/{event_id}"))
+
+        assert set(app.state_holder.session_data) == sessions_before
+    finally:
+        demo.close()
+
+
+def test_an_unknown_event_is_reported_rather_than_hanging():
+    with gr.Blocks() as demo:
+        gr.Button().click(lambda: None)
+
+    demo.queue()
+    app, _, _ = demo.launch(prevent_thread_lock=True)
+    test_client = TestClient(app)
+
+    try:
+        messages = read_sse(test_client.get(f"{API_PREFIX}/queue/event/nope"))
+        assert messages[0]["session_not_found"] is True
+        assert messages[-1]["msg"] == "close_stream"
+    finally:
+        demo.close()
+
+
+def test_following_an_event_clears_its_deadline():
+    demo = slow_demo()
+    app, _, _ = demo.launch(prevent_thread_lock=True)
+    test_client = TestClient(app)
+
+    try:
+        event_id = join(test_client, "reattached")
+        stream = object()
+        demo._queue.attach_stream("reattached", stream)
+        asyncio.run(
+            demo._queue.schedule_cancel("reattached", after=3600, stream=stream)
+        )
+        assert demo._queue.event_ids_to_events[event_id].cancel_at is not None
+
+        subscription = demo._queue.subscribe_to_event(event_id)
+        assert subscription is not None
+        assert demo._queue.event_ids_to_events[event_id].cancel_at is None
+
+        # Losing the follower puts the event back on the clock.
+        demo._queue.unsubscribe_from_event(event_id, subscription[1])
+        assert demo._queue.event_ids_to_events[event_id].cancel_at is not None
+    finally:
+        demo.close()
+
+
+def test_a_cancelled_event_is_not_kept_for_collection():
+    demo = slow_demo()
+    app, _, _ = demo.launch(prevent_thread_lock=True)
+    test_client = TestClient(app)
+
+    try:
+        event_id = join(test_client, "gave_up")
+        response = test_client.post(
+            f"{API_PREFIX}/queue/close", json={"session_hash": "gave_up"}
+        )
+        assert response.status_code == 200
+
+        event = demo._queue.event_ids_to_events[event_id]
+        deadline = time.monotonic() + 5
+        while event.alive:
+            assert time.monotonic() < deadline, "the event was never stopped"
+            time.sleep(0.02)
+        # A blocking call cannot be abandoned, so the event unwinds whenever it
+        # returns. Whenever that is, its output is not kept: it was stopped because
+        # nobody was coming back for it.
+        demo._queue.retain_finished_event(event)
+        assert event_id not in demo._queue.finished_events
+    finally:
+        demo.close()
+
+
+def test_output_stops_being_replayable_once_it_grows_too_large(monkeypatch):
+    monkeypatch.setattr(queueing, "MAX_REPLAYED_MESSAGES", 2)
+    with gr.Blocks() as demo:
+        gr.Button().click(lambda: None)
+
+    demo.queue()
+    event = next(iter(demo._queue.event_ids_to_events.values()), None)
+    assert event is None
+
+    class FakeEvent:
+        replayable = True
+        messages: list = []
+
+    fake = FakeEvent()
+    fake.messages = []
+    for _ in range(3):
+        demo._queue.retain_message(
+            fake,  # type: ignore[arg-type]
+            ProcessGeneratingMessage(output={"data": ["1"]}, success=True),
+        )
+
+    # A partial buffer cannot rebuild diffed output, so it is dropped entirely.
+    assert fake.replayable is False
+    assert fake.messages == []
+
+
+def test_submitting_again_releases_the_previous_result():
+    with gr.Blocks() as demo:
+        start = gr.Button()
+        output = gr.Textbox()
+        start.click(lambda: "done", None, output)
+
+    demo.queue()
+    app, _, _ = demo.launch(prevent_thread_lock=True)
+    test_client = TestClient(app)
+
+    try:
+        first = join(test_client, "keeps_going")
+        deadline = time.monotonic() + 5
+        while first not in demo._queue.finished_events:
+            assert time.monotonic() < deadline
+            time.sleep(0.01)
+
+        join(test_client, "keeps_going")
+        assert first not in demo._queue.finished_events
     finally:
         demo.close()

--- a/test/test_queueing.py
+++ b/test/test_queueing.py
@@ -541,11 +541,13 @@ def test_closing_the_page_stops_the_event_and_unloads():
             f"{API_PREFIX}/queue/close", json={"session_hash": "departed"}
         )
         assert response.status_code == 200
+        # Long enough for a reloading page to come back and claim the job, short
+        # enough that an abandoned tab stops holding compute.
         assert event.cancel_at is not None
-        assert event.cancel_at <= time.monotonic()
+        assert 0 < event.cancel_at - time.monotonic() <= 15
 
-        # The queue's own loop performs the cancellation. Driving it from a second
-        # event loop here would race the real one.
+        # Brought forward here rather than waiting out the grace period.
+        event.cancel_at = time.monotonic()
         deadline = time.monotonic() + 5
         while event.alive:
             assert time.monotonic() < deadline, "the event was never stopped"
@@ -720,6 +722,7 @@ def test_a_cancelled_event_is_not_kept_for_collection():
         assert response.status_code == 200
 
         event = demo._queue.event_ids_to_events[event_id]
+        event.cancel_at = time.monotonic()
         deadline = time.monotonic() + 5
         while event.alive:
             assert time.monotonic() < deadline, "the event was never stopped"

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1131,6 +1131,28 @@ class TestAuthenticatedRoutes:
         response = client.get("/monitoring/summary")
         assert response.status_code == 401
 
+    def test_queue_close_route(self):
+        io = Interface(lambda x: x, "text", "text")
+        app, _, _ = io.launch(
+            auth=("test", "correct_password"),
+            prevent_thread_lock=True,
+        )
+        client = TestClient(app)
+        body = {"session_hash": "session"}
+
+        try:
+            response = client.post(f"{API_PREFIX}/queue/close", json=body)
+            assert response.status_code == 401
+
+            client.post(
+                "/login",
+                data={"username": "test", "password": "correct_password"},
+            )
+            response = client.post(f"{API_PREFIX}/queue/close", json=body)
+            assert response.status_code == 200
+        finally:
+            io.close()
+
 
 class TestConfigUsername:
     """`/config` reports who is logged in. Resolving the user is async, so a


### PR DESCRIPTION
### `31829ac4b` — detect when someone deliberately leaves the page

Browsers do not expose "the user closed this tab", so the queue currently cannot tell an abandoned tab apart from one the person switched away from. This commit adds that signal to the client, and nothing else: `on_deliberate_exit()` replaces the `beforeunload` listener in both app shells with `pagehide`, gated on two conditions — the page is not being parked in the back/forward cache (`event.persisted`), and it is still visible when the event arrives. The second condition is the useful one: the spec fires `pagehide` *before* the visibility state flips to hidden, so a page that still reads `visible` is being destroyed by a foreground action, whereas a page that already reads `hidden` was backgrounded earlier and is now being reclaimed by the browser or the OS. `beforeunload` cannot draw that line and is unreliable on mobile, where it frequently never fires.

| what the person did | events fired | reported as deliberate? |
|---|---|---|
| closed the foreground tab, reloaded, or navigated away | `pagehide`, `persisted=false`, still `visible` | **yes** |
| switched to another tab or window on desktop | `visibilitychange` only — no `pagehide` | no |
| switched apps, opened another tab, or locked the screen on mobile | `visibilitychange`, `freeze`, often `pagehide` with `persisted=true` | no |
| left the tab open and the OS reclaimed it under memory pressure | `pagehide`, `persisted=false`, already `hidden` | no |
| lost network for a few seconds | nothing — the page is alive | no |
| closed a tab that was not in the foreground (⌘W on an inactive tab, iOS tab switcher) | `pagehide`, `persisted=false`, already `hidden` | no — accepted miss |
| crashed, force quit, ran out of memory or battery | nothing | no — accepted miss |

The rule is deliberately one-sided. Reading "deliberate" into someone merely switching tabs would discard work they expect to find waiting, while reading "not deliberate" into a real exit only delays cleanup, so every ambiguous case resolves to not deliberate. The last two rows are the price of that choice and are documented on the helper: a background close is indistinguishable from a system reclaim, and a crash fires nothing at all. Any consumer therefore has to treat this as an optimisation for the common case on top of a server-side timeout, never as a signal it can depend on.

No behavior change on its own — `on_deliberate_exit(() => app.close())` does what the old listener did, just in fewer situations. Five assertions cover the matrix against real Chromium, plus one for the server-rendered case where there is no DOM to listen to.

---

### `2b555dbd9` — stop an event on a deadline instead of the moment its client vanishes

Losing a connection was read as proof that somebody left: the SSE handler called `clean_events` and the work was gone. But every row of the table above that involves a dropped socket looks identical from the server, so that reading was wrong for the two cases that matter most. Events now carry `cancel_at`, and the three things that can end an event set it rather than acting immediately.

| what happens | before | now |
|---|---|---|
| mobile backgrounds the tab, or the network drops for a few seconds | the event is removed at once | `cancel_at` = one hour out (`GRADIO_QUEUE_DISCONNECT_TTL`); the work keeps running |
| a stream attaches for the session | nothing to attach to | `cancel_at` cleared — the session is reprieved |
| a stale stream's disconnect is noticed after a reconnect | — | ignored; the connection that dropped no longer owns the session |
| the client reports a deliberate exit (`POST /queue/close`) | nothing — the server waited to notice the socket, up to 10s | `cancel_at` = now |
| `POST /cancel` | cancelled the task, closed the iterator, told the client | unchanged, via the shared path |
| the heartbeat connection drops with work in flight | ran `unload` immediately, underneath the running job | deferred until the work stops |
| the heartbeat drops with nothing in flight | ran `unload` | unchanged |

Stopping an event was three partial implementations that each did a different subset of the work — which is why closing a tab did not stop a job the way pressing stop did:

| | `/cancel` | SSE disconnect | heartbeat disconnect |
|---|---|---|---|
| cancel the awaiting asyncio task | ✅ | ❌ | ❌ |
| remove it if still queued | ✅ | ✅ | ❌ |
| mark `alive = False` | ❌ | ✅ | ❌ |
| close the iterator | ✅ | only later, in `process_events` | ❌ |
| release a streaming event waiting for input | ❌ | ❌ | ✅ |
| tell the client | ✅ | ❌ | ❌ |
| run `unload` | ❌ | ❌ | ✅ |

All three now go through `Queue.cancel_events`, which does the whole set, with `notify` separating "somebody is waiting to be released" from "nobody is listening". `clean_events` had no callers left and is deleted; iterator teardown becomes `App.close_iterator`, since the app owns `iterators` and `iterators_to_reset`. `unload` likewise had to exist in two places once the queue needed it, so it is now a single `routes.close_session` called by both the heartbeat and the queue. Cancelled events are not waited on before that runs: a blocking call cannot be interrupted, so holding the handlers until it returns on its own would only delay cleanup that used to happen at once.

Two things this deliberately does **not** do yet. The reprieve works, but nothing reaches it outside the tests — a reloaded page gets a fresh `session_hash` and the client does not reopen a broken stream, so both are still one-way trips. And a job that finishes while nobody is listening still loses its output, so "your work survived" does not yet mean "you will see it". A deliberate exit therefore stops the work immediately rather than after a grace period; the grace only becomes meaningful once a reloading page can reattach, since a reload is indistinguishable from a close at the moment the client reports it.

Tests: seven cases in `test_queueing.py` covering a dropped stream keeping its event, the reprieve, a replaced stream being unable to condemn the new one, a deliberate exit stopping the work and running `unload`, and `/cancel` still completing a queued event; `/queue/close` auth in `test_routes.py`; two client tests for the `keepalive` beacon, including that it carries `Authorization` and fires only once. Also green: `test_blocks.py`, `test_routes.py`, `test_server.py`, `test_chat_interface.py`, the JS client suite in both browser and node modes, and the full JS unit suite.

---

### `78d609055` — keep a job's output so a reloaded page can collect it by job id

Surviving the loss of a client is only half the promise: the output produced while nobody was listening still went nowhere, because delivery goes through `pending_messages_per_session` — a single queue per session whose `get()` *removes* the message, so it cannot be read by anyone but that session's own stream. Events now keep what they send, and one can be followed on its own through `GET /queue/event/{event_id}`, which replays what the event has already sent and then streams the rest.

**Reattaching by job id rather than by session hash is the point.** The job keeps running under the session it was submitted from, because its `gr.State` is bound there; a reloaded page gets a fresh session hash and therefore the cleared state it is entitled to. Only the output crosses over. Reclaiming the old session instead — the obvious shortcut — would carry that state into a page that has otherwise started from scratch, silently and only when a job happened to be running at the moment of the reload. The job id is also server-issued and unguessable (`uuid4`), unlike the client-chosen `session_hash` (`Math.random()`), so it is the better capability token as well.

| | `session_hash` | `event_id` |
|---|---|---|
| issued by | the client, `Math.random()` | the server, `uuid4` |
| identifies | identity, delivery **and** `gr.State` | one job |
| reattaching implies | inheriting the old session, so state cannot reset | nothing about state |

What is kept, and for how long:

| | |
|---|---|
| **retained until** | the same `cancel_at` deadline that governs the work. A finished event whose output nobody collected is abandoned in exactly the sense that field already describes, so the existing sweep drops it — no second mechanism |
| **never retained** | for a cancelled event: it was stopped precisely because nobody was coming for it |
| **released early** | when the session submits again, which is proof the client is present and past what it ran before. No acknowledgement request is needed to say so |
| **bounded** | `MAX_REPLAYED_MESSAGES` per event, above which the output is declared unreplayable rather than kept in part — streamed output is sent as diffs and cannot be rebuilt from the middle — and `MAX_FINISHED_EVENTS` overall |
| **stripped** | of the inputs, dropped when the event finishes: they are never replayed and an upload is not small |

One ordering detail worth calling out, because a test caught it: `cancel_tasks` *awaits* the tasks it cancels to unwind, and `process_events` retains a finished event's output in its `finally`. So events have to be marked dead **before** that await, or a cancelled event's output is kept for a client that is not coming back.

Still to come, and deliberately not in this commit: nothing stores job ids across a reload yet, and a broken stream is still not reopened, so the client cannot yet reach any of this. `gr.State` returned as an output is left alone for now rather than being specially handled, and updates whose target components do not exist in the reloaded page will simply be dropped.

Tests: eight more in `test_queueing.py` — collecting a finished result by job id, that doing so creates no session state, an unknown job id reported rather than hanging, following an event clearing and restoring its deadline, a cancelled event not being kept, the replay cap, and a later submission releasing the previous result. The cancellation tests now wait on the queue's own loop rather than driving a second event loop, which is what made one of them fail on CI.

---

### `caa012864` — reopen a broken stream instead of declaring the jobs behind it lost

A stream error told every listener `broken_connection` and stopped there, so a few seconds without signal looked identical to a failure. Now that the server keeps the work *and* its output for long enough to come back for, the client reopens the stream with a backoff, and only reports a broken connection when there is nothing outstanding to hear about.

The server had to stop discarding what it had not yet delivered. Losing a stream already left the session's undelivered messages in place — except on the path where the ASGI server cancels the handler, which deleted them — so a client that reopens the stream now finds them waiting. They are dropped when the session is closed for good, at which point nobody is left to read them.

| | before | now |
|---|---|---|
| stream errors with a job outstanding | every listener told `broken_connection`, job appears failed | stream reopened after 500ms, doubling to 5s |
| stream errors with nothing outstanding | `broken_connection` | unchanged — there is nothing to come back for |
| a superseded stream errors late | tore down whatever replaced it | ignored; only the current stream speaks for the client |
| page restored from bfcache, or a phone returning to a backgrounded tab | connections were closed underneath it with no error ever delivered, so nothing noticed | `on_page_return` checks the stream and reopens it if it is stale |

That last row is the one that would otherwise be invisible: a frozen page comes back *looking* connected, and no error is ever delivered for a connection the browser closed while it was away, so the job would run to completion with nobody receiving it.

`Client.reconnect` was already taken by the app-id check, hence `reopen_stream_later()` and `resume_stream()`.

**This completes the story for a dropped connection**: the work is kept, the output is kept, and the client comes back for both — no page reload involved, so `gr.State` never enters the picture. A reloaded page still cannot reattach, because nothing stores job ids across the reload yet; that is the last commit, and it is where the deliberate-exit grace period stops being zero and becomes a window long enough for a reload to land.

Tests: three more in `stream.test.ts` (reopen while a job is outstanding, still report a broken connection when nothing is, reopen a stale stream on return) plus the existing close-stream test extended to assert a superseded stream is inert; three in `lifecycle.test.ts` for `on_page_return` across bfcache restore, ordinary load, and foregrounding.

---

### `dcc4f116c` — let a reloaded page pick its jobs back up

The last thing standing between a reload and its result was that the page had no way to name what it had been waiting for. Queued jobs are now remembered in `sessionStorage`, and a page that finds any on load reattaches through `GET /queue/event/{event_id}` instead of submitting anything.

**Job ids are stored, and deliberately not the session hash.** `gr.State` resets on reload only because the page arrives with a session hash the server has never seen — that is the entire reset mechanism, there is no other. Restoring the hash would therefore keep the old state alive, *and only when a job happened to be running at the moment of the reload*: the UI would come back empty while the server still held the previous `gr.State`, so a chat demo storing history in state would append to a conversation nobody could see. Reattaching by job id keeps the two concerns apart — the work carries on under the session that owns its state, the reloaded page starts a fresh one, and only output crosses between them.

`sessionStorage` is also the right scope where a cookie was not:

| | scope | survives reload | survives tab close | fit |
|---|---|---|---|---|
| cookie / `localStorage` | every tab | yes | yes | ✗ two tabs of one app would share a session, and so share `gr.State` |
| **`sessionStorage`** | **one tab** | **yes** | **no** | ✓ the same lifetime a Gradio session has |

The queue callback in `submit` moves into a `register_queue_event` function so a reattached job runs through exactly the same message handling as a fresh one, rather than a parallel copy that would drift. Reattaching skips the request, the inputs and the run history, and follows the job's own stream — which is closed along with the job, since nothing else would close it.

Scope decisions, taken deliberately:

- A job whose function is no longer in the layout is **dropped** rather than reattached; its output has nowhere to go.
- Streamed inputs are never remembered — the input stream does not survive the page either way, and the server does not keep their output for the same reason.
- `gr.State` returned as an output is left to the client's existing state handling rather than being specially cased.

With a reload finally able to claim its work, the grace period for a deliberate exit stops being zero: **`GRADIO_QUEUE_CLOSE_GRACE_PERIOD`, 15 seconds by default** — long enough for a reload to land, short enough that a closed tab stops holding compute.

Tests: six in a new `jobs.test.ts` (a job remembered until cleared, several cleared one at a time, no duplicates, jobs from another app on the same origin forgotten, no expiry imposed by the client, and no session hash in what is stored); one end-to-end in `init.test.ts` driving a real SSE response through msw and asserting the reattached submission requests `/queue/event/event-1` and yields its output.

---

## Where this leaves things

| what happens to the person | before | after |
|---|---|---|
| switches tabs, or backgrounds the app on a phone | job cancelled, queue place lost | job runs on, stream reopened on return, output delivered |
| loses signal for a few seconds | job cancelled, UI shows an error | job runs on, stream reopened with backoff, buffered output replayed |
| reloads the page mid-job | job cancelled, result gone | job reattached by id, output delivered, `gr.State` still reset |
| closes the tab | cancelled up to 10s later, and not the way pressing stop cancels | cancelled after a 15s grace, through the same path as `/cancel` |
| presses stop | unchanged | unchanged |

Not addressed here, and worth naming: closing a tab that is not in the foreground (⌘W on an inactive tab, or the iOS tab switcher, which hides the page before the X can be tapped) reads as a system reclaim, so those jobs wait out the full TTL rather than stopping promptly. That is the safe direction to fail, and the tightening for it — treating a teardown shortly after the page was hidden as deliberate — is a few lines whenever it proves worth having.
