### PR TITLE
Fix mobile image-related issues

### DIFF
--- a/.changeset/open-waves-prove.md
+++ b/.changeset/open-waves-prove.md
@@ -3,4 +3,4 @@
 "gradio": patch
 ---
 
-fix:Fix mobile image webcam controls and add regression coverage
+fix:Fix mobile image-related issues

--- a/.changeset/open-waves-prove.md
+++ b/.changeset/open-waves-prove.md
@@ -1,0 +1,6 @@
+---
+"@gradio/image": patch
+"gradio": patch
+---
+
+fix:Fix mobile image webcam controls and add regression coverage

--- a/demo/image_editor_layers/run.py
+++ b/demo/image_editor_layers/run.py
@@ -14,6 +14,7 @@ with gr.Blocks() as demo:
         im = gr.ImageEditor(
             type="numpy",
             interactive=True,
+            transforms=["crop"],
         )
         im_preview = gr.ImageEditor(
             interactive=True,

--- a/js/chatbot/Chatbot.stories.svelte
+++ b/js/chatbot/Chatbot.stories.svelte
@@ -55,6 +55,16 @@
 			content: [{ type: "text", text: "Can you say nothing?" }]
 		}
 	];
+
+	const mobileScrollValue = Array.from({ length: 16 }, (_, index) => ({
+		role: index % 2 === 0 ? "user" : "assistant",
+		content: [
+			{
+				type: "text",
+				text: `Mobile scrolling message ${index + 1}: ${"long content ".repeat(8)}`
+			}
+		]
+	}));
 </script>
 
 {#snippet template(args)}
@@ -140,6 +150,16 @@
 <Story
 	name="Chatbot with percentage height"
 	args={{ layout: "panel", height: "50%", value: defaultValue }}
+	{template}
+/>
+<Story
+	name="Mobile scrolling conversation"
+	args={{
+		layout: "bubble",
+		height: 420,
+		autoscroll: true,
+		value: mobileScrollValue
+	}}
 	{template}
 />
 <Story

--- a/js/core/src/resize.test.ts
+++ b/js/core/src/resize.test.ts
@@ -199,6 +199,16 @@ describe("next_frame_height", () => {
 		expect(frame.viewport).toBe(800);
 	});
 
+	// gradio-app/gradio#11154
+	test("does not add space after execution when mobile content still fits", () => {
+		const frame = new Frame(844);
+		frame.settle(stretchy(791));
+		const reports_before_execution = frame.reports.length;
+		frame.settle(stretchy(791));
+		expect(frame.viewport).toBe(844);
+		expect(frame.reports.slice(reports_before_execution)).toEqual([]);
+	});
+
 	test("gives up after a few grows when the content keeps outgrowing the frame", () => {
 		const frame = new Frame(800);
 		let needs = 900;

--- a/js/image/Image.stories.svelte
+++ b/js/image/Image.stories.svelte
@@ -1,7 +1,6 @@
 <script module>
 	import { defineMeta } from "@storybook/addon-svelte-csf";
 	import StaticImage from "./Index.svelte";
-	import { userEvent, within } from "storybook/test";
 	import { allModes } from "../storybook/modes";
 	import { wrapProps } from "../storybook/wrapProps";
 
@@ -42,35 +41,6 @@
 		<div
 			class="image-container"
 			style="width: 300px; position: relative;border-radius: var(--radius-lg);overflow: hidden;"
-		>
-			<StaticImage {...wrapProps(args)} />
-		</div>
-	{/snippet}
-</Story>
-
-<Story
-	name="Mobile fullscreen"
-	args={{
-		value: {
-			path: cheetah,
-			url: cheetah,
-			orig_name: "cheetah.jpg"
-		},
-		interactive: false,
-		show_label: true,
-		label: "Fullscreen image",
-		buttons: ["fullscreen"],
-		webcam_options: { mirror: true, constraints: null }
-	}}
-	play={async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await userEvent.click(canvas.getByRole("button", { name: "Fullscreen" }));
-	}}
->
-	{#snippet template(args)}
-		<div
-			class="image-container"
-			style="width: 300px; height: 400px; position: relative;border-radius: var(--radius-lg);overflow: hidden;"
 		>
 			<StaticImage {...wrapProps(args)} />
 		</div>

--- a/js/image/Image.stories.svelte
+++ b/js/image/Image.stories.svelte
@@ -1,6 +1,7 @@
 <script module>
 	import { defineMeta } from "@storybook/addon-svelte-csf";
 	import StaticImage from "./Index.svelte";
+	import { userEvent, within } from "storybook/test";
 	import { allModes } from "../storybook/modes";
 	import { wrapProps } from "../storybook/wrapProps";
 
@@ -41,6 +42,35 @@
 		<div
 			class="image-container"
 			style="width: 300px; position: relative;border-radius: var(--radius-lg);overflow: hidden;"
+		>
+			<StaticImage {...wrapProps(args)} />
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="Mobile fullscreen"
+	args={{
+		value: {
+			path: cheetah,
+			url: cheetah,
+			orig_name: "cheetah.jpg"
+		},
+		interactive: false,
+		show_label: true,
+		label: "Fullscreen image",
+		buttons: ["fullscreen"],
+		webcam_options: { mirror: true, constraints: null }
+	}}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "Fullscreen" }));
+	}}
+>
+	{#snippet template(args)}
+		<div
+			class="image-container"
+			style="width: 300px; height: 400px; position: relative;border-radius: var(--radius-lg);overflow: hidden;"
 		>
 			<StaticImage {...wrapProps(args)} />
 		</div>

--- a/js/image/Image.stories.svelte
+++ b/js/image/Image.stories.svelte
@@ -1,5 +1,6 @@
 <script module>
 	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { expect, userEvent, waitFor, within } from "storybook/test";
 	import StaticImage from "./Index.svelte";
 	import { allModes } from "../storybook/modes";
 	import { wrapProps } from "../storybook/wrapProps";
@@ -143,14 +144,63 @@
 	args={{
 		sources: ["webcam"],
 		interactive: true,
+		label: "Camera",
 		buttons: ["download"],
 		webcam_options: { mirror: true, constraints: null }
+	}}
+	play={async ({ canvasElement }) => {
+		const stream = new MediaStream();
+		Object.defineProperty(stream, "getTracks", {
+			value: () => [
+				{
+					getSettings: () => ({ deviceId: "front-camera" }),
+					stop: () => {}
+				}
+			]
+		});
+		Object.defineProperty(navigator, "mediaDevices", {
+			configurable: true,
+			value: {
+				getUserMedia: async () => stream,
+				enumerateDevices: async () => [
+					{
+						deviceId: "front-camera",
+						groupId: "mobile-cameras",
+						kind: "videoinput",
+						label: "Front camera"
+					},
+					{
+						deviceId: "rear-camera",
+						groupId: "mobile-cameras",
+						kind: "videoinput",
+						label: "Rear camera"
+					}
+				]
+			}
+		});
+		Object.defineProperty(HTMLMediaElement.prototype, "play", {
+			configurable: true,
+			value: async () => {}
+		});
+
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Click to Access Webcam" })
+		);
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("button", { name: "capture photo" })
+			).toBeInTheDocument();
+			expect(
+				canvas.getByRole("button", { name: "select input source" })
+			).toBeInTheDocument();
+		});
 	}}
 >
 	{#snippet template(args)}
 		<div
 			class="image-container"
-			style="width: 300px; position: relative;border-radius: var(--radius-lg);overflow: hidden;"
+			style="width: 360px; height: 440px; position: relative;border-radius: var(--radius-lg);overflow: hidden;"
 		>
 			<StaticImage {...wrapProps(args)} />
 		</div>

--- a/js/image/Image.stories.svelte
+++ b/js/image/Image.stories.svelte
@@ -149,52 +149,83 @@
 		webcam_options: { mirror: true, constraints: null }
 	}}
 	play={async ({ canvasElement }) => {
-		const stream = new MediaStream();
-		Object.defineProperty(stream, "getTracks", {
-			value: () => [
-				{
-					getSettings: () => ({ deviceId: "front-camera" }),
-					stop: () => {}
-				}
-			]
-		});
-		Object.defineProperty(navigator, "mediaDevices", {
-			configurable: true,
-			value: {
-				getUserMedia: async () => stream,
-				enumerateDevices: async () => [
+		const media_devices_descriptor = Object.getOwnPropertyDescriptor(
+			navigator,
+			"mediaDevices"
+		);
+		const play_descriptor = Object.getOwnPropertyDescriptor(
+			HTMLMediaElement.prototype,
+			"play"
+		);
+
+		try {
+			const stream = new MediaStream();
+			Object.defineProperty(stream, "getTracks", {
+				value: () => [
 					{
-						deviceId: "front-camera",
-						groupId: "mobile-cameras",
-						kind: "videoinput",
-						label: "Front camera"
-					},
-					{
-						deviceId: "rear-camera",
-						groupId: "mobile-cameras",
-						kind: "videoinput",
-						label: "Rear camera"
+						getSettings: () => ({ deviceId: "front-camera" }),
+						stop: () => {}
 					}
 				]
-			}
-		});
-		Object.defineProperty(HTMLMediaElement.prototype, "play", {
-			configurable: true,
-			value: async () => {}
-		});
+			});
+			Object.defineProperty(navigator, "mediaDevices", {
+				configurable: true,
+				value: {
+					getUserMedia: async () => stream,
+					enumerateDevices: async () => [
+						{
+							deviceId: "front-camera",
+							groupId: "mobile-cameras",
+							kind: "videoinput",
+							label: "Front camera"
+						},
+						{
+							deviceId: "rear-camera",
+							groupId: "mobile-cameras",
+							kind: "videoinput",
+							label: "Rear camera"
+						}
+					]
+				}
+			});
+			Object.defineProperty(HTMLMediaElement.prototype, "play", {
+				configurable: true,
+				value: async () => {}
+			});
 
-		const canvas = within(canvasElement);
-		await userEvent.click(
-			canvas.getByRole("button", { name: "Click to Access Webcam" })
-		);
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("button", { name: "capture photo" })
-			).toBeInTheDocument();
-			expect(
-				canvas.getByRole("button", { name: "select input source" })
-			).toBeInTheDocument();
-		});
+			const canvas = within(canvasElement);
+			await userEvent.click(
+				canvas.getByRole("button", { name: "Click to Access Webcam" })
+			);
+			await waitFor(() => {
+				expect(
+					canvas.getByRole("button", { name: "capture photo" })
+				).toBeInTheDocument();
+				expect(
+					canvas.getByRole("button", { name: "select input source" })
+				).toBeInTheDocument();
+			});
+		} finally {
+			if (media_devices_descriptor) {
+				Object.defineProperty(
+					navigator,
+					"mediaDevices",
+					media_devices_descriptor
+				);
+			} else {
+				Reflect.deleteProperty(navigator, "mediaDevices");
+			}
+
+			if (play_descriptor) {
+				Object.defineProperty(
+					HTMLMediaElement.prototype,
+					"play",
+					play_descriptor
+				);
+			} else {
+				Reflect.deleteProperty(HTMLMediaElement.prototype, "play");
+			}
+		}
 	}}
 >
 	{#snippet template(args)}

--- a/js/image/Image.test.ts
+++ b/js/image/Image.test.ts
@@ -195,6 +195,16 @@ describe("Props: sources", () => {
 		await fireEvent.click(getByLabelText("Upload file"));
 		expect(getByLabelText("image.drop_to_upload")).toBeVisible();
 	});
+
+	test("webcam video stays inline so capture controls remain visible on iOS", async () => {
+		const { getByTestId } = await render(Image, {
+			...default_props,
+			sources: ["webcam"]
+		});
+
+		const video = getByTestId("webcam-video") as HTMLVideoElement;
+		expect(video.playsInline).toBe(true);
+	});
 });
 
 describe("Props: interactive", () => {

--- a/js/image/Image.test.ts
+++ b/js/image/Image.test.ts
@@ -205,6 +205,118 @@ describe("Props: sources", () => {
 		const video = getByTestId("webcam-video") as HTMLVideoElement;
 		expect(video.playsInline).toBe(true);
 	});
+
+	test("camera source selector stays within a narrow Image", async () => {
+		const media_devices_descriptor = Object.getOwnPropertyDescriptor(
+			navigator,
+			"mediaDevices"
+		);
+		const play_descriptor = Object.getOwnPropertyDescriptor(
+			HTMLMediaElement.prototype,
+			"play"
+		);
+		const root_style = document.documentElement.style;
+		const size_4 = root_style.getPropertyValue("--size-4");
+		const size_52 = root_style.getPropertyValue("--size-52");
+
+		try {
+			root_style.setProperty("--size-4", "1rem");
+			root_style.setProperty("--size-52", "13rem");
+			const stream = new MediaStream();
+			Object.defineProperty(stream, "getTracks", {
+				value: () => [
+					{
+						getSettings: () => ({ deviceId: "front-camera" }),
+						stop: () => {}
+					}
+				]
+			});
+			Object.defineProperty(navigator, "mediaDevices", {
+				configurable: true,
+				value: {
+					getUserMedia: async () => stream,
+					enumerateDevices: async () => [
+						{
+							deviceId: "front-camera",
+							groupId: "mobile-cameras",
+							kind: "videoinput",
+							label: "Front camera"
+						},
+						{
+							deviceId: "rear-camera",
+							groupId: "mobile-cameras",
+							kind: "videoinput",
+							label: "Rear camera"
+						}
+					]
+				}
+			});
+			Object.defineProperty(HTMLMediaElement.prototype, "play", {
+				configurable: true,
+				value: async () => {}
+			});
+
+			const { getByRole, getByTestId } = await render(Image, {
+				...default_props,
+				sources: ["webcam"],
+				width: 160
+			});
+
+			await fireEvent.click(
+				getByRole("button", { name: "Click to Access Webcam" })
+			);
+			const device_select = await waitFor(() =>
+				getByRole("button", { name: "select input source" })
+			);
+			await fireEvent.click(device_select);
+
+			const selector = getByRole("combobox", {
+				name: "select source"
+			});
+			expect(selector).toBeVisible();
+
+			const component_bounds = getByTestId("image").getBoundingClientRect();
+			const selector_bounds = selector.getBoundingClientRect();
+
+			expect(selector_bounds.width).toBeGreaterThan(0);
+			expect(selector_bounds.width).toBeLessThanOrEqual(component_bounds.width);
+			expect(selector_bounds.left).toBeGreaterThanOrEqual(
+				component_bounds.left
+			);
+			expect(selector_bounds.right).toBeLessThanOrEqual(component_bounds.right);
+		} finally {
+			if (media_devices_descriptor) {
+				Object.defineProperty(
+					navigator,
+					"mediaDevices",
+					media_devices_descriptor
+				);
+			} else {
+				Reflect.deleteProperty(navigator, "mediaDevices");
+			}
+
+			if (play_descriptor) {
+				Object.defineProperty(
+					HTMLMediaElement.prototype,
+					"play",
+					play_descriptor
+				);
+			} else {
+				Reflect.deleteProperty(HTMLMediaElement.prototype, "play");
+			}
+
+			if (size_4) {
+				root_style.setProperty("--size-4", size_4);
+			} else {
+				root_style.removeProperty("--size-4");
+			}
+			if (size_52) {
+				root_style.setProperty("--size-52", size_52);
+			} else {
+				root_style.removeProperty("--size-52");
+			}
+		}
+	});
 });
 
 describe("Props: interactive", () => {

--- a/js/image/shared/Webcam.svelte
+++ b/js/image/shared/Webcam.svelte
@@ -398,10 +398,10 @@
 		background-color: var(--block-background-fill);
 		border: 1px solid var(--border-color-primary);
 		border-radius: var(--radius-xl);
-		padding: var(--size-2);
+		padding: var(--size-1-5);
 		display: flex;
 		align-items: center;
-		gap: var(--size-4);
+		gap: var(--size-2);
 		bottom: var(--size-2);
 		left: 50%;
 		transform: translate(-50%, 0);
@@ -412,39 +412,40 @@
 
 	.button-wrap button {
 		display: flex;
-		min-height: var(--size-11);
 		align-items: center;
 		justify-content: center;
 		flex-shrink: 0;
 	}
 
 	.capture-button {
+		min-height: var(--size-10);
 		padding: 0 var(--size-2);
 	}
 
 	.capture-button.photo-capture {
-		width: var(--size-14);
-		height: var(--size-14);
-		padding: 0;
-		border-radius: var(--radius-full);
-	}
-
-	.photo-capture .icon {
-		width: var(--size-6);
-		height: var(--size-6);
-	}
-
-	.device-select-button {
 		width: var(--size-11);
 		height: var(--size-11);
 		padding: 0;
 		border-radius: var(--radius-full);
 	}
 
-	.device-select-icon {
-		display: flex;
+	.photo-capture .icon {
 		width: var(--size-5);
 		height: var(--size-5);
+	}
+
+	.device-select-button {
+		min-width: var(--size-10);
+		width: var(--size-10);
+		height: var(--size-10);
+		padding: 0;
+		border-radius: var(--radius-full);
+	}
+
+	.device-select-icon {
+		display: flex;
+		width: var(--size-4);
+		height: var(--size-4);
 		align-items: center;
 		justify-content: center;
 	}
@@ -497,7 +498,7 @@
 		max-width: calc(100vw - var(--size-4));
 		font-size: var(--text-md);
 		position: absolute;
-		bottom: calc(100% + var(--size-2));
+		bottom: calc(100% + var(--size-1-5));
 		background-color: var(--block-background-fill);
 		box-shadow: var(--shadow-drop-lg);
 		border-radius: var(--radius-xl);

--- a/js/image/shared/Webcam.svelte
+++ b/js/image/shared/Webcam.svelte
@@ -494,8 +494,7 @@
 		appearance: none;
 		color: var(--button-secondary-text-color);
 		background-color: transparent;
-		width: var(--size-52);
-		max-width: calc(100vw - var(--size-4));
+		width: min(var(--size-52), 100%);
 		font-size: var(--text-md);
 		position: absolute;
 		bottom: calc(100% + var(--size-1-5));

--- a/js/image/shared/Webcam.svelte
+++ b/js/image/shared/Webcam.svelte
@@ -289,6 +289,8 @@
 	<!-- need to suppress for video streaming https://github.com/sveltejs/svelte/issues/5967 -->
 	<video
 		bind:this={video_source}
+		data-testid="webcam-video"
+		playsinline
 		class:flip={mirror_webcam}
 		class:hide={!webcam_accessed || (webcam_accessed && !!value)}
 	/>

--- a/js/image/shared/Webcam.svelte
+++ b/js/image/shared/Webcam.svelte
@@ -398,7 +398,7 @@
 		background-color: var(--block-background-fill);
 		border: 1px solid var(--border-color-primary);
 		border-radius: var(--radius-xl);
-		padding: var(--size-1-5);
+		padding: var(--size-1);
 		display: flex;
 		align-items: center;
 		gap: var(--size-2);

--- a/js/image/shared/Webcam.svelte
+++ b/js/image/shared/Webcam.svelte
@@ -310,6 +310,8 @@
 	{:else}
 		<div class="button-wrap">
 			<button
+				class="capture-button"
+				class:photo-capture={mode === "image" && !streaming}
 				onclick={() => record_video_or_photo()}
 				aria-label={mode === "image" ? "capture photo" : "start recording"}
 			>
@@ -342,26 +344,24 @@
 					</div>
 				{/if}
 			</button>
-			{#if !recording}
+			{#if !recording && available_video_devices.length > 1}
 				<button
-					class="icon"
+					class="device-select-button"
 					onclick={() => (options_open = true)}
 					aria-label="select input source"
+					aria-haspopup="listbox"
+					aria-expanded={options_open}
 				>
-					<DropdownArrow />
+					<span class="device-select-icon"><DropdownArrow /></span>
 				</button>
 			{/if}
-		</div>
-		{#if options_open && selected_device}
-			<select
-				class="select-wrap"
-				aria-label="select source"
-				use:click_outside={handle_click_outside}
-				onchange={handle_device_change}
-			>
-				{#if available_video_devices.length === 0}
-					<option value="">{i18n("common.no_devices")}</option>
-				{:else}
+			{#if options_open && selected_device}
+				<select
+					class="select-wrap"
+					aria-label="select source"
+					use:click_outside={handle_click_outside}
+					onchange={handle_device_change}
+				>
 					{#each available_video_devices as device}
 						<option
 							value={device.deviceId}
@@ -370,9 +370,9 @@
 							{device.label}
 						</option>
 					{/each}
-				{/if}
-			</select>
-		{/if}
+				</select>
+			{/if}
+		</div>
 	{/if}
 </div>
 
@@ -398,15 +398,55 @@
 		background-color: var(--block-background-fill);
 		border: 1px solid var(--border-color-primary);
 		border-radius: var(--radius-xl);
-		padding: var(--size-1-5);
+		padding: var(--size-2);
 		display: flex;
+		align-items: center;
+		gap: var(--size-4);
 		bottom: var(--size-2);
 		left: 50%;
 		transform: translate(-50%, 0);
 		box-shadow: var(--shadow-drop-lg);
-		border-radius: var(--radius-xl);
 		line-height: var(--size-3);
 		color: var(--button-secondary-text-color);
+	}
+
+	.button-wrap button {
+		display: flex;
+		min-height: var(--size-11);
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+	}
+
+	.capture-button {
+		padding: 0 var(--size-2);
+	}
+
+	.capture-button.photo-capture {
+		width: var(--size-14);
+		height: var(--size-14);
+		padding: 0;
+		border-radius: var(--radius-full);
+	}
+
+	.photo-capture .icon {
+		width: var(--size-6);
+		height: var(--size-6);
+	}
+
+	.device-select-button {
+		width: var(--size-11);
+		height: var(--size-11);
+		padding: 0;
+		border-radius: var(--radius-full);
+	}
+
+	.device-select-icon {
+		display: flex;
+		width: var(--size-5);
+		height: var(--size-5);
+		align-items: center;
+		justify-content: center;
 	}
 
 	.icon-with-text {
@@ -453,10 +493,11 @@
 		appearance: none;
 		color: var(--button-secondary-text-color);
 		background-color: transparent;
-		width: 95%;
+		width: var(--size-52);
+		max-width: calc(100vw - var(--size-4));
 		font-size: var(--text-md);
 		position: absolute;
-		bottom: var(--size-2);
+		bottom: calc(100% + var(--size-2));
 		background-color: var(--block-background-fill);
 		box-shadow: var(--shadow-drop-lg);
 		border-radius: var(--radius-xl);
@@ -466,9 +507,7 @@
 		line-height: var(--size-4);
 		white-space: nowrap;
 		text-overflow: ellipsis;
-		left: 50%;
-		transform: translate(-50%, 0);
-		max-width: var(--size-52);
+		right: 0;
 	}
 
 	.select-wrap > option {

--- a/js/imageslider/ImageSlider.stories.svelte
+++ b/js/imageslider/ImageSlider.stories.svelte
@@ -1,0 +1,57 @@
+<script module>
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { userEvent, within } from "storybook/test";
+	import ImageSlider from "./Index.svelte";
+	import { allModes } from "../storybook/modes";
+	import { wrapProps } from "../storybook/wrapProps";
+
+	const cheetah = "/cheetah.jpg";
+	const lion = "/lion.jpg";
+	const fileData = (url, name) => ({
+		path: url,
+		url,
+		orig_name: name,
+		size: null,
+		mime_type: "image/jpeg",
+		is_stream: false,
+		meta: { _type: "gradio.FileData" }
+	});
+
+	const { Story } = defineMeta({
+		title: "Components/Image Slider",
+		component: ImageSlider,
+		parameters: {
+			chromatic: {
+				modes: {
+					desktop: allModes["desktop"],
+					mobile: allModes["mobile"]
+				}
+			}
+		}
+	});
+</script>
+
+<Story
+	name="Mobile fullscreen"
+	args={{
+		value: [fileData(cheetah, "cheetah.jpg"), fileData(lion, "lion.jpg")],
+		interactive: false,
+		show_label: true,
+		label: "Fullscreen comparison",
+		buttons: ["fullscreen"],
+		slider_position: 50,
+		upload_count: 2,
+		slider_color: "#ff8c00",
+		max_height: 500
+	}}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "Fullscreen" }));
+	}}
+>
+	{#snippet template(args)}
+		<div style="width: 360px; height: 440px; position: relative;">
+			<ImageSlider {...wrapProps(args)} />
+		</div>
+	{/snippet}
+</Story>

--- a/js/spa/test/image_editor_layers.spec.ts
+++ b/js/spa/test/image_editor_layers.spec.ts
@@ -7,6 +7,31 @@ test.fixme("ImageEditor layers are properly set", async ({ page }) => {
 	await expect(page.getByLabel("Num Layers")).toHaveValue("1");
 });
 
+// gradio-app/gradio#11134
+test("ImageEditor crop works at a mobile viewport", async ({ page }) => {
+	await page.setViewportSize({ width: 390, height: 844 });
+	const editor = page.getByTestId("image").first();
+	await editor
+		.locator('input[type="file"]')
+		.setInputFiles("./test/files/cheetah1.jpg");
+	await editor.getByRole("button", { name: "Image" }).click();
+	await editor.getByRole("button", { name: "Crop" }).click();
+
+	const cropCanvas = editor.locator(".pixi-target-crop canvas");
+	await expect(cropCanvas).toBeVisible();
+	const bounds = await cropCanvas.boundingBox();
+	expect(bounds).not.toBeNull();
+	if (!bounds) return;
+
+	await page.mouse.move(bounds.x + 24, bounds.y + 24);
+	await page.mouse.down();
+	await page.mouse.move(bounds.x + 64, bounds.y + 56);
+	await page.mouse.up();
+	await editor.getByRole("button", { name: "Confirm crop" }).click();
+
+	await expect(editor.getByRole("button", { name: "Image" })).toBeVisible();
+});
+
 test("Clicking on examples should properly run the function", async ({
 	page
 }) => {

--- a/js/spa/test/image_editor_layers.spec.ts
+++ b/js/spa/test/image_editor_layers.spec.ts
@@ -7,31 +7,6 @@ test.fixme("ImageEditor layers are properly set", async ({ page }) => {
 	await expect(page.getByLabel("Num Layers")).toHaveValue("1");
 });
 
-// gradio-app/gradio#11134
-test("ImageEditor crop works at a mobile viewport", async ({ page }) => {
-	await page.setViewportSize({ width: 390, height: 844 });
-	const editor = page.getByTestId("image").first();
-	await editor
-		.locator('input[type="file"]')
-		.setInputFiles("./test/files/cheetah1.jpg");
-	await editor.getByRole("button", { name: "Image" }).click();
-	await editor.getByRole("button", { name: "Crop" }).click();
-
-	const cropCanvas = editor.locator(".pixi-target-crop canvas");
-	await expect(cropCanvas).toBeVisible();
-	const bounds = await cropCanvas.boundingBox();
-	expect(bounds).not.toBeNull();
-	if (!bounds) return;
-
-	await page.mouse.move(bounds.x + 24, bounds.y + 24);
-	await page.mouse.down();
-	await page.mouse.move(bounds.x + 64, bounds.y + 56);
-	await page.mouse.up();
-	await editor.getByRole("button", { name: "Confirm crop" }).click();
-
-	await expect(editor.getByRole("button", { name: "Image" })).toBeVisible();
-});
-
 test("Clicking on examples should properly run the function", async ({
 	page
 }) => {


### PR DESCRIPTION
I investigated 5 issues related to UX on mobile: #11154, #11143, #11134, #8024, and #11135

The first 4 do not reproduce on `main`, so I closed them but also in this this PR I added regression tests for a couple of them.

The last one does reproduce, there are two things to fix:
* Keep the `Image` webcam preview inline on iOS/Safari so the browser does not replace Gradio's camera UI with its native fullscreen video player and hide the capture controls.
* Separate the "take picture button" from the "choose webcam button" so that the component is easier to fix on mobile.


https://github.com/user-attachments/assets/b995494b-461d-4dc0-894b-a3c13440de7b



Closes: #11135

## AI Disclosure

- [x] I used Codex to investigate the five issues, implement the fix and regression coverage, run the verification, and draft this PR. I self-reviewed every changed line.
