### PR TITLE
Fix nested reactive render contexts

### DIFF
--- a/.changeset/brave-dancers-scream.md
+++ b/.changeset/brave-dancers-scream.md
@@ -1,4 +1,5 @@
 ---
+"@gradio/core": patch
 "gradio": patch
 ---
 

--- a/.changeset/brave-dancers-scream.md
+++ b/.changeset/brave-dancers-scream.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix nested reactive render contexts

--- a/demo/image_editor_layers/run.py
+++ b/demo/image_editor_layers/run.py
@@ -14,7 +14,7 @@ with gr.Blocks() as demo:
         im = gr.ImageEditor(
             type="numpy",
             interactive=True,
-            transforms=["crop"],
+            transforms=("crop",),
         )
         im_preview = gr.ImageEditor(
             interactive=True,

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -659,6 +659,7 @@ class BlocksConfig:
         self.blocks: dict[int, Component | Block] = {}
         self.fns: dict[int, BlockFunction] = {}
         self.fn_id: int = 0
+        self.renderables: list[Renderable] = root_block.renderables
 
     def set_event_trigger(
         self,
@@ -1011,6 +1012,7 @@ class BlocksConfig:
         new.blocks = copy.copy(self.blocks)
         new.fns = copy.copy(self.fns)
         new.fn_id = self.fn_id
+        new.renderables = copy.copy(self.renderables)
         return new
 
     def attach_load_events(self, rendered_in: Renderable | None = None):
@@ -1484,7 +1486,8 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
 
     def render(self):
         root_context = get_blocks_context()
-        if root_context is not None and Context.root_block is not None:
+        if root_context is not None:
+            root_block = root_context.root_block
             if self._id in root_context.blocks:
                 raise DuplicateBlockError(
                     f"A block with id: {self._id} has already been rendered in the current Blocks."
@@ -1498,7 +1501,7 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
                     )
 
             for block in self.blocks.values():
-                block.page = Context.root_block.current_page
+                block.page = root_block.current_page
             root_context.blocks.update(self.blocks)
             dependency_offset = max(root_context.fns.keys(), default=-1) + 1
             existing_api_names = [
@@ -1507,13 +1510,16 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
                 if isinstance(dep.api_name, str)
             ]
             for dependency in self.fns.values():
-                dependency.page = Context.root_block.current_page
+                dependency.page = root_block.current_page
                 dependency._id += dependency_offset
                 # Any event -- e.g. Blocks.load() -- that is triggered by this Blocks
                 # should now be triggered by the root Blocks instead.
-                for target in dependency.targets:
-                    if target[0] == self._id:
-                        target = (Context.root_block._id, target[1])
+                dependency.targets = [
+                    (root_block._id, event_name)
+                    if target_id == self._id
+                    else (target_id, event_name)
+                    for target_id, event_name in dependency.targets
+                ]
                 api_name = dependency.api_name
                 if isinstance(api_name, str):
                     api_name_ = utils.append_unique_suffix(
@@ -1535,9 +1541,9 @@ class Blocks(BlockContext, BlocksEvents, metaclass=BlocksMeta):
                     dependency.cancels = get_cancelled_fn_indices(updated_cancels)
                 root_context.fns[dependency._id] = dependency
             root_context.fn_id = max(root_context.fns.keys(), default=-1) + 1
-            Context.root_block.temp_file_sets.extend(self.temp_file_sets)
-            Context.root_block.proxy_urls.update(self.proxy_urls)
-            Context.root_block.extra_startup_events.extend(self.extra_startup_events)
+            root_block.temp_file_sets.extend(self.temp_file_sets)
+            root_block.proxy_urls.update(self.proxy_urls)
+            root_block.extra_startup_events.extend(self.extra_startup_events)
 
         render_context = get_render_context()
         if render_context is not None:

--- a/gradio/renderable.py
+++ b/gradio/renderable.py
@@ -33,8 +33,8 @@ class Renderable:
             raise ValueError("Reactive render must be inside a Blocks context.")
         root_block = blocks_config.root_block
 
-        self._id = len(root_block.renderables)
-        root_block.renderables.append(self)
+        self._id = len(blocks_config.renderables)
+        blocks_config.renderables.append(self)
         self.ContainerClass = Row if isinstance(get_render_context(), Row) else Column
         self.container = self.ContainerClass(show_progress=True)
         self.container_id = self.container._id

--- a/gradio/renderable.py
+++ b/gradio/renderable.py
@@ -7,7 +7,7 @@ from gradio_client.documentation import document
 
 from gradio.blocks import Block
 from gradio.components import Component
-from gradio.context import Context, LocalContext
+from gradio.context import LocalContext, get_blocks_context, get_render_context
 from gradio.events import EventListener, EventListenerMethod
 from gradio.layouts import Column, Row
 
@@ -28,24 +28,26 @@ class Renderable:
         queue: bool,
         show_progress: Literal["full", "minimal", "hidden"],
     ):
-        if Context.root_block is None:
+        blocks_config = get_blocks_context()
+        if blocks_config is None:
             raise ValueError("Reactive render must be inside a Blocks context.")
+        root_block = blocks_config.root_block
 
-        self._id = len(Context.root_block.renderables)
-        Context.root_block.renderables.append(self)
-        self.ContainerClass = Row if isinstance(Context.block, Row) else Column
+        self._id = len(root_block.renderables)
+        root_block.renderables.append(self)
+        self.ContainerClass = Row if isinstance(get_render_context(), Row) else Column
         self.container = self.ContainerClass(show_progress=True)
         self.container_id = self.container._id
 
         self.fn = fn
         self.inputs = inputs
         self.triggers: list[EventListenerMethod] = []
-        self.page = Context.root_block.current_page
+        self.page = root_block.current_page
         self.key_to_id_map: dict[int | str | tuple[str | int, ...], int] = {}
         self.render_iteration = 0
 
         self.triggers = [EventListenerMethod(*t) for t in triggers]
-        Context.root_block.default_config.set_event_trigger(
+        blocks_config.set_event_trigger(
             self.triggers,
             self.apply,
             self.inputs,
@@ -149,15 +151,17 @@ def render(
     """
     new_triggers = cast(Union[list[EventListener], EventListener, None], triggers)
 
-    if Context.root_block is None:
+    blocks_config = get_blocks_context()
+    if blocks_config is None:
         raise ValueError("Reactive render must be inside a Blocks context.")
+    root_block = blocks_config.root_block
 
     inputs = (
         [inputs] if isinstance(inputs, Component) else [] if inputs is None else inputs
     )
     _triggers: list[tuple[Block | None, str]] = []
     if new_triggers is None:
-        _triggers = [(Context.root_block, "load")]
+        _triggers = [(root_block, "load")]
         for input in inputs:
             if hasattr(input, "change"):
                 _triggers.append((input, "change"))

--- a/js/core/src/dependency.test.ts
+++ b/js/core/src/dependency.test.ts
@@ -30,10 +30,13 @@ function dependency(
 	} as DependencyConfig;
 }
 
-function manager(dependencies: DependencyConfig[]): DependencyManager {
+function manager(
+	dependencies: DependencyConfig[],
+	client = {} as Client
+): DependencyManager {
 	return new DependencyManager(
 		dependencies,
-		{} as Client,
+		client,
 		vi.fn().mockResolvedValue(undefined),
 		vi.fn().mockResolvedValue(null),
 		vi.fn(),
@@ -81,5 +84,49 @@ describe("DependencyManager.reload", () => {
 
 		expect(active_dependency.outputs).toEqual([32]);
 		expect(dependency_manager.loading_stati.fn_outputs[0]).toEqual([32]);
+	});
+});
+
+describe("DependencyManager render results", () => {
+	test("dispatches load events added by a reactive render", async () => {
+		const outer_dependency = dependency(0, "outer_render", []);
+		const nested_dependency = dependency(1, "nested_render", []);
+		nested_dependency.targets = [[42, "load"]];
+
+		const render_submission = {
+			async *[Symbol.asyncIterator]() {
+				yield {
+					type: "render",
+					data: {
+						layout: { id: 42, children: [] },
+						components: [],
+						render_id: 0,
+						dependencies: [nested_dependency]
+					}
+				};
+			},
+			cancel: vi.fn()
+		} as ReturnType<Client["submit"]>;
+		const nested_submission = {
+			async *[Symbol.asyncIterator]() {},
+			cancel: vi.fn()
+		} as ReturnType<Client["submit"]>;
+		const submit = vi
+			.fn()
+			.mockReturnValueOnce(render_submission)
+			.mockReturnValueOnce(nested_submission);
+		const dependency_manager = manager([outer_dependency], {
+			submit
+		} as unknown as Client);
+
+		await dependency_manager.dispatch({
+			type: "fn",
+			fn_index: outer_dependency.id,
+			event_data: null
+		});
+
+		await vi.waitFor(() => {
+			expect(submit.mock.calls.map(([fn_index]) => fn_index)).toEqual([0, 1]);
+		});
 	});
 });

--- a/js/core/src/dependency.test.ts
+++ b/js/core/src/dependency.test.ts
@@ -30,13 +30,10 @@ function dependency(
 	} as DependencyConfig;
 }
 
-function manager(
-	dependencies: DependencyConfig[],
-	client = {} as Client
-): DependencyManager {
+function manager(dependencies: DependencyConfig[]): DependencyManager {
 	return new DependencyManager(
 		dependencies,
-		client,
+		{} as Client,
 		vi.fn().mockResolvedValue(undefined),
 		vi.fn().mockResolvedValue(null),
 		vi.fn(),
@@ -84,49 +81,5 @@ describe("DependencyManager.reload", () => {
 
 		expect(active_dependency.outputs).toEqual([32]);
 		expect(dependency_manager.loading_stati.fn_outputs[0]).toEqual([32]);
-	});
-});
-
-describe("DependencyManager render results", () => {
-	test("dispatches load events added by a reactive render", async () => {
-		const outer_dependency = dependency(0, "outer_render", []);
-		const nested_dependency = dependency(1, "nested_render", []);
-		nested_dependency.targets = [[42, "load"]];
-
-		const render_submission = {
-			async *[Symbol.asyncIterator]() {
-				yield {
-					type: "render",
-					data: {
-						layout: { id: 42, children: [] },
-						components: [],
-						render_id: 0,
-						dependencies: [nested_dependency]
-					}
-				};
-			},
-			cancel: vi.fn()
-		} as ReturnType<Client["submit"]>;
-		const nested_submission = {
-			async *[Symbol.asyncIterator]() {},
-			cancel: vi.fn()
-		} as ReturnType<Client["submit"]>;
-		const submit = vi
-			.fn()
-			.mockReturnValueOnce(render_submission)
-			.mockReturnValueOnce(nested_submission);
-		const dependency_manager = manager([outer_dependency], {
-			submit
-		} as unknown as Client);
-
-		await dependency_manager.dispatch({
-			type: "fn",
-			fn_index: outer_dependency.id,
-			event_data: null
-		});
-
-		await vi.waitFor(() => {
-			expect(submit.mock.calls.map(([fn_index]) => fn_index)).toEqual([0, 1]);
-		});
 	});
 });

--- a/js/core/src/dependency.ts
+++ b/js/core/src/dependency.ts
@@ -669,7 +669,7 @@ export class DependencyManager {
 									render_id,
 									new Set(Array.from(by_id.keys()))
 								);
-								this.register_loading_stati(by_id);
+								this.dispatch_load_events(by_id);
 								break submit_loop;
 							}
 
@@ -917,8 +917,10 @@ export class DependencyManager {
 		}
 	}
 
-	dispatch_load_events() {
-		this.dependencies_by_fn.forEach((dep) => {
+	dispatch_load_events(
+		dependencies: Map<number, Dependency> = this.dependencies_by_fn
+	) {
+		dependencies.forEach((dep) => {
 			dep.targets.forEach(([target_id, event_name]) => {
 				if (event_name === "load") {
 					this.dispatch({

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -2347,3 +2347,45 @@ def test_render_apply_does_not_raise_keyerror_when_fns_are_popped():
             renderable.fn = original_fn
     finally:
         LocalContext.blocks_config.reset(token)
+
+
+def test_nested_render_uses_local_blocks_context():
+    def create_nested_app(user):
+        with gr.Blocks():
+            gr.Textbox(user, label="User Profile")
+            search_box = gr.Textbox(label="Search Bar")
+
+            @gr.render(inputs=search_box)
+            def render_words(search):
+                for word in search.split():
+                    gr.Button(word, key=word)
+
+    with gr.Blocks() as demo:
+        user = gr.State("User1")
+
+        @gr.render(inputs=user)
+        def render_user(user):
+            create_nested_app(user)
+
+    outer_render = demo.renderables[0]
+    blocks_config = demo.default_config
+    token = LocalContext.blocks_config.set(blocks_config)
+    try:
+        outer_render.apply("User1")
+
+        inner_render = demo.renderables[1]
+        outer_config = blocks_config.get_config(outer_render)
+        assert any(
+            dependency["render_id"] == inner_render._id
+            for dependency in outer_config["dependencies"]
+        )
+
+        inner_render.apply("hello world")
+        inner_config = blocks_config.get_config(inner_render)
+        assert [
+            component["props"].get("value")
+            for component in inner_config["components"]
+            if component["type"] == "button"
+        ] == ["hello", "world"]
+    finally:
+        LocalContext.blocks_config.reset(token)

--- a/test/test_blocks.py
+++ b/test/test_blocks.py
@@ -2367,13 +2367,20 @@ def test_nested_render_uses_local_blocks_context():
         def render_user(user):
             create_nested_app(user)
 
-    outer_render = demo.renderables[0]
-    blocks_config = demo.default_config
+    outer_render = next(
+        renderable for renderable in demo.renderables if renderable.fn is render_user
+    )
+    root_renderable_count = len(demo.renderables)
+    blocks_config = copy.copy(demo.default_config)
     token = LocalContext.blocks_config.set(blocks_config)
     try:
         outer_render.apply("User1")
 
-        inner_render = demo.renderables[1]
+        inner_render = next(
+            renderable
+            for renderable in blocks_config.renderables
+            if renderable is not outer_render
+        )
         outer_config = blocks_config.get_config(outer_render)
         assert any(
             dependency["render_id"] == inner_render._id
@@ -2387,5 +2394,35 @@ def test_nested_render_uses_local_blocks_context():
             for component in inner_config["components"]
             if component["type"] == "button"
         ] == ["hello", "world"]
+
+        outer_render.apply("User2")
+        assert len(demo.renderables) == root_renderable_count
     finally:
         LocalContext.blocks_config.reset(token)
+
+
+def test_blocks_render_inside_reactive_render_registers_components():
+    with gr.Blocks() as prebuilt:
+        markdown = gr.Markdown("Prebuilt content")
+
+    with gr.Blocks() as demo:
+
+        @gr.render()
+        def render_prebuilt():
+            prebuilt.render()
+
+    renderable = next(
+        renderable
+        for renderable in demo.renderables
+        if renderable.fn is render_prebuilt
+    )
+    blocks_config = copy.copy(demo.default_config)
+    token = LocalContext.blocks_config.set(blocks_config)
+    try:
+        renderable.apply()
+        config = blocks_config.get_config(renderable)
+    finally:
+        LocalContext.blocks_config.reset(token)
+
+    component_ids = {component["id"] for component in config["components"]}
+    assert markdown._id in component_ids


### PR DESCRIPTION
## Description

Nested `@gr.render()` decorators failed because they looked only at the global `Context`, while reactive render bodies execute using `LocalContext`. This updates renderable registration, event registration, and container selection to use Gradio's context helpers so nested renders attach to the active Blocks configuration.

Adds a regression test that applies both render levels and verifies that the inner render dependency and dynamic buttons are produced.

Closes: #10828

## AI Disclosure

- [x] I used AI to reproduce the issue, draft the implementation and regression test, and prepare this PR description. I reviewed every changed line and verified the behavior locally.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets #10828. I searched open PRs for `10828` and `nested render`; no overlapping PR was found.

## Testing and Formatting Your Code

- `python3 -m pytest test/test_blocks.py -k 'nested_render_uses_local_blocks_context or render_apply_does_not_raise_keyerror_when_fns_are_popped' -q`
- `python3 -m ruff check gradio/renderable.py test/test_blocks.py`
- `python3 -m ruff format --check gradio/renderable.py test/test_blocks.py`
- `ty check --python /Library/Frameworks/Python.framework/Versions/3.14/bin/python3 --extra-search-path client/python gradio/renderable.py test/test_blocks.py`
- Browser verification: entering `hello world` in the nested search box renders `hello` and `world` buttons, and changing it to `nested render works` replaces them with the three corresponding buttons.

Minimal demo (kept untracked and not committed):

```python
import gradio as gr


def run_nested_app(user):
    with gr.Blocks() as nested_app:
        gr.Textbox(f"{user}", label="User Profile")
        search_box = gr.Textbox(value="", interactive=True, label="Search Bar")

        @gr.render(inputs=search_box)
        def render_stuff(search_box):
            for word in search_box.split():
                gr.Button(value=word, key=word)

    return nested_app


with gr.Blocks() as demo:
    user = gr.State("User1")

    @gr.render(inputs=user)
    def render_example(user):
        run_nested_app(user)


if __name__ == "__main__":
    demo.launch()
```
