### PR TITLE
workflow: warn when a Space's OAuth scopes are missing

### DIFF
--- a/.changeset/large-moons-listen.md
+++ b/.changeset/large-moons-listen.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Return 413 instead of 500 when a multipart upload's headers exceed the maximum allowed size

--- a/.changeset/olive-donkeys-shout.md
+++ b/.changeset/olive-donkeys-shout.md
@@ -1,0 +1,6 @@
+---
+"@gradio/workflowcanvas": patch
+"gradio": patch
+---
+
+fix:workflow: warn when a Space's OAuth app is missing the scopes the canvas needs

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -40,6 +40,7 @@ import gradio_client.utils as client_utils
 import httpx
 import safehttpx
 from gradio_client.documentation import document
+from python_multipart.exceptions import MultipartParseError
 from python_multipart.multipart import MultipartParser, parse_options_header
 from starlette.background import BackgroundTask
 from starlette.datastructures import (
@@ -829,11 +830,21 @@ class GradioMultiPartParser:
                     await part.file.seek(0)
                 self._file_parts_to_write.clear()
                 self._file_parts_to_finish.clear()
-        except MultiPartException as exc:
+        except (MultiPartException, MultipartParseError) as exc:
             # Close all the files if there was an error.
             for file in self._files_to_close_on_error:
                 file.close()
                 Path(file.name).unlink()
+            if isinstance(exc, MultipartParseError):
+                # python_multipart enforces its own per-part header limits and
+                # aborts the parse before our header callbacks run, so surface it
+                # as a MultiPartException like every other parse failure here.
+                message = str(exc)
+                raise MultiPartException(
+                    "Headers exceeded maximum allowed size."
+                    if "header" in message.lower()
+                    else f"Could not parse multipart request: {message}"
+                ) from exc
             raise exc
 
         parser.finalize()

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -581,6 +581,30 @@ def get_oauth_available(_data=None) -> str:
     )
 
 
+WORKFLOW_OAUTH_SCOPES: dict[str, str] = {
+    "inference-api": "run nodes on the signed-in user's own inference quota",
+    "write-repos": "save the workflow back to this Space",
+}
+
+
+def get_oauth_scopes(_data=None) -> str:
+    """Which of `WORKFLOW_OAUTH_SCOPES` the Space's OAuth app was granted, and
+    which are missing. Empty off-Spaces and when OAuth is disabled."""
+    if get_space() is None or not os.getenv("OAUTH_CLIENT_ID"):
+        return json.dumps({"granted": [], "missing": {}})
+    granted = (os.getenv("OAUTH_SCOPES") or "").split()
+    return json.dumps(
+        {
+            "granted": granted,
+            "missing": {
+                scope: why
+                for scope, why in WORKFLOW_OAUTH_SCOPES.items()
+                if scope not in granted
+            },
+        }
+    )
+
+
 def call_space(
     data, request: Optional[Request] = None, token: Optional[OAuthToken] = None
 ) -> str:
@@ -1878,6 +1902,7 @@ class Workflow(Blocks):
             get_token,
             get_write_access,
             get_oauth_available,
+            get_oauth_scopes,
             get_space_id,
             call_space,
             call_model,

--- a/js/workflowcanvas/workflow/WorkflowCanvas.svelte
+++ b/js/workflowcanvas/workflow/WorkflowCanvas.svelte
@@ -150,6 +150,12 @@
 		}
 	});
 
+	$effect(() => {
+		if (server?.get_oauth_scopes && !auth.scopesKnown) {
+			void auth.refreshOAuthScopes();
+		}
+	});
+
 	let oauthHintShown = false;
 	$effect(() => {
 		if (
@@ -167,6 +173,22 @@
 				"warning"
 			);
 		}
+	});
+
+	let scopeHintShown = false;
+	$effect(() => {
+		const missing = Object.entries(auth.missingScopes);
+		if (scopeHintShown || auth.source !== "oauth" || missing.length === 0)
+			return;
+		scopeHintShown = true;
+		const detail = missing.map(([s, why]) => `\`${s}\` (to ${why})`).join(", ");
+		showToast(
+			`This Space's sign-in is missing ${detail}. The author should add ${missing
+				.map(([s]) => s)
+				.join(" and ")} under \`hf_oauth_scopes\` in the README and redeploy.`,
+			0,
+			"warning"
+		);
 	});
 
 	$effect(() => {
@@ -2468,9 +2490,11 @@
 				{#if auth.isHFSpace && auth.canWrite && spaceId && auth.token && isDirty}
 					<button
 						class="tool-btn save-space-btn"
-						disabled={savingToSpace}
+						disabled={savingToSpace || !auth.hasScope("write-repos")}
 						onclick={() => (saveToSpaceConfirm = true)}
-						title="Commit workflow.json to this Space's repo (will restart the Space)"
+						title={auth.hasScope("write-repos")
+							? "Commit workflow.json to this Space's repo (will restart the Space)"
+							: "This Space's sign-in lacks the `write-repos` scope, so saving would be rejected. Add it under `hf_oauth_scopes` in the README and redeploy."}
 					>
 						<UploadIcon />
 						{savingToSpace ? "Saving…" : "Unsaved · Save"}

--- a/js/workflowcanvas/workflow/hf-auth.svelte.ts
+++ b/js/workflowcanvas/workflow/hf-auth.svelte.ts
@@ -107,6 +107,8 @@ export function createHFAuth(getServer: () => Record<string, any>) {
 	// server confirms it — only shown once known to work.
 	let oauthAvailable = $state(false);
 	let oauthAvailableKnown = $state(false);
+	let missingScopes = $state<Record<string, string>>({});
+	let scopesKnown = $state(false);
 
 	function clearIdentity(): void {
 		user = "";
@@ -155,12 +157,31 @@ export function createHFAuth(getServer: () => Record<string, any>) {
 		}
 	}
 
+	async function refreshOAuthScopes(): Promise<void> {
+		const s = getServer();
+		if (!s?.get_oauth_scopes) return;
+		try {
+			const parsed = JSON.parse((await s.get_oauth_scopes()) || "{}");
+			missingScopes = parsed?.missing ?? {};
+			scopesKnown = true;
+		} catch {
+			missingScopes = {};
+			scopesKnown = true;
+		}
+	}
+
+	function hasScope(scope: string): boolean {
+		if (source !== "oauth") return true;
+		return !(scope in missingScopes);
+	}
+
 	async function init(): Promise<void> {
 		isHFSpace = window.location.hostname.endsWith(".hf.space");
 
 		applyWriteTokenFromUrl();
 		void refreshWriteAccess();
 		void refreshOAuthAvailable();
+		void refreshOAuthScopes();
 
 		// The server's get_token returns the OAuth user's token on a Space, but
 		// the host's locally saved `huggingface-cli login` token when running
@@ -304,7 +325,15 @@ export function createHFAuth(getServer: () => Record<string, any>) {
 		get oauthAvailableKnown() {
 			return oauthAvailableKnown;
 		},
+		get missingScopes() {
+			return missingScopes;
+		},
+		get scopesKnown() {
+			return scopesKnown;
+		},
+		hasScope,
 		refreshOAuthAvailable,
+		refreshOAuthScopes,
 		init,
 		setPAT,
 		signIn,

--- a/test/requirements.in
+++ b/test/requirements.in
@@ -21,6 +21,7 @@ pytest-asyncio
 pytest-cov
 pytest-rerunfailures
 respx
+ruff==0.12.9
 scikit-image
 torch
 tqdm

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -260,6 +260,8 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
+ruff==0.12.9
+    # via -r test/requirements.in
 s3transfer==0.11.2
     # via boto3
 safetensors==0.5.2


### PR DESCRIPTION
A Gradio Workflow Space configured with a bare `hf_oauth: true` is granted only the `openid` and `profile` scopes. That's enough for sign-in to *succeed*, but not enough to run nodes on the visitor's inference quota (`call_model` passes the OAuth token straight into `InferenceClient`) or to commit `workflow.json` back to the repo. So the "Save to Space" button added in #13715 renders happily and then fails with an opaque 403.


<img width="1503" height="853" alt="image" src="https://github.com/user-attachments/assets/506d5d46-74f5-471c-8a6b-03075598383e" />

Test with:

https://huggingface.co/spaces/abidlabs/workflow-scopes-test-13767


---

### Unrelated CI fix in this branch (`0ca80f9`)

CI was red for reasons independent of this change — GitHub evicted the venv cache, which exposed two problems the stale cache had been hiding. Both are repo-wide (`build` also fails on #13763), so they're fixed here to get this PR green:

- **`ruff` was missing from the CI venv.** It used to arrive as a transitive dependency of `gradio` itself; 6.0 dropped it and it was never added to `test/requirements.in`, so `lint_backend.sh` only kept working off the cached environment. Now pinned explicitly at `0.12.9`, the version the formatting baseline was set with.
- **`python-multipart` 0.0.20 → 0.0.32** enforces its own per-part header limits and raises `MultipartParseError` before `GradioMultiPartParser`'s header callbacks can raise `MultiPartException`. An upload with an oversized header became an unhandled **500** instead of the intended **413** (this is a real user-facing regression, not just a test failure). The parse error is now translated so the existing handlers map it back to 413, and other parse failures to 400.

Happy to split these into their own PR if you'd rather keep this one to the OAuth change.
