### PR TITLE
Fix typecheck for optional PDF demos

### DIFF
--- a/.github/filters.json
+++ b/.github/filters.json
@@ -1,6 +1,7 @@
 {
 	"gradio": [
 		"client/python/**",
+		"demo/**",
 		"gradio/**",
 		"requirements.txt",
 		".github/**",

--- a/demo/gradio_pdf_demo/run.py
+++ b/demo/gradio_pdf_demo/run.py
@@ -1,5 +1,5 @@
 import gradio as gr
-from gradio_pdf import PDF
+from gradio_pdf import PDF  # type: ignore[unresolved-import]
 from pathlib import Path
 
 current_dir = Path(__file__).parent

--- a/demo/highlight_pdf/run.py
+++ b/demo/highlight_pdf/run.py
@@ -1,5 +1,5 @@
 import gradio as gr
-from gradio_pdf import PDF
+from gradio_pdf import PDF  # type: ignore[unresolved-import]
 import pymupdf  # type: ignore
 import os
 from pathlib import Path


### PR DESCRIPTION
## Description

Suppress `unresolved-import` type errors for `gradio_pdf` in two demos because the optional custom component is not installed in the base typecheck environment. Also include `demo/**` in the backend CI path filter so future demo changes run typechecking instead of surfacing failures later in a release PR.

This unblocks the Python build for release PR #13752 and closes the CI coverage gap that allowed the error to reach the release branch.

## AI Disclosure

- [x] I used AI to diagnose the CI failure and prepare and test this fix.
- [ ] I did not use AI

## Testing and Formatting

- `bash scripts/type_check_backend.sh`
- `./scripts/lint_backend.sh`
- Parsed `.github/filters.json` with `JSON.parse`
