### PR TITLE
Upgrade vulnerable frontend dependencies

### DIFF
--- a/.changeset/neat-badgers-cut.md
+++ b/.changeset/neat-badgers-cut.md
@@ -1,0 +1,8 @@
+---
+"@gradio/markdown-code": patch
+"@gradio/sanitize": patch
+"gradio": patch
+"website": patch
+---
+
+feat:Upgrade vulnerable frontend dependencies

--- a/js/_website/package.json
+++ b/js/_website/package.json
@@ -15,7 +15,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^7.0.1",
 		"@sveltejs/adapter-static": "^3.0.10",
-		"@sveltejs/kit": "^2.57.1",
+		"@sveltejs/kit": "^2.70.3",
 		"@tailwindcss/forms": "^0.5.10",
 		"@tailwindcss/typography": "^0.5.19",
 		"@types/prismjs": "^1.26.5",
@@ -36,10 +36,10 @@
 		"@gradio/tabitem": "workspace:^",
 		"@gradio/tabs": "workspace:^",
 		"@sindresorhus/slugify": "^3.0.0",
-		"@sveltejs/adapter-vercel": "^5.10.3",
+		"@sveltejs/adapter-vercel": "^6.3.4",
 		"hast-util-to-string": "^3.0.1",
 		"mdsvex": "^0.12.6",
-		"postcss": "^8.5.6",
+		"postcss": "^8.5.26",
 		"prism-svelte": "^0.5.0",
 		"wrangler": "^4.42.1"
 	}

--- a/js/_website/package.json
+++ b/js/_website/package.json
@@ -38,7 +38,7 @@
 		"@sindresorhus/slugify": "^3.0.0",
 		"@sveltejs/adapter-vercel": "^6.3.4",
 		"hast-util-to-string": "^3.0.1",
-		"mdsvex": "^0.12.6",
+		"mdsvex": "^0.12.8",
 		"postcss": "^8.5.26",
 		"prism-svelte": "^0.5.0",
 		"wrangler": "^4.42.1"

--- a/js/markdown-code/package.json
+++ b/js/markdown-code/package.json
@@ -25,7 +25,7 @@
 		"marked": "^12.0.0",
 		"marked-gfm-heading-id": "^3.1.2",
 		"marked-highlight": "^2.0.1",
-		"mermaid": "^11.12.0",
+		"mermaid": "^11.17.0",
 		"prismjs": "^1.30.0"
 	},
 	"devDependencies": {

--- a/js/sanitize/package.json
+++ b/js/sanitize/package.json
@@ -8,7 +8,7 @@
 	"license": "ISC",
 	"dependencies": {
 		"amuchina": "^1.0.12",
-		"sanitize-html": "^2.17.0"
+		"sanitize-html": "^2.17.7"
 	},
 	"devDependencies": {
 		"@types/sanitize-html": "^2.16.0"

--- a/package.json
+++ b/package.json
@@ -49,15 +49,15 @@
 		"@types/testing-library__jest-dom": "^6.0.0",
 		"@typescript-eslint/eslint-plugin": "^8.46.0",
 		"@typescript-eslint/parser": "^8.46.0",
-		"@vitest/browser-playwright": "^4.1.5",
+		"@vitest/browser-playwright": "^4.1.11",
 		"autoprefixer": "^10.4.21",
 		"cross-env": "^10.1.0",
-		"esbuild": "^0.25.10",
+		"esbuild": "^0.28.2",
 		"eslint": "^9.37.0",
 		"eslint-plugin-svelte": "^3.12.4",
 		"globals": "^16.4.0",
 		"handlebars": "4.7.9",
-		"happy-dom": "^19.0.2",
+		"happy-dom": "^20.11.2",
 		"jsdom": "^27.0.0",
 		"kleur": "^4.1.5",
 		"msw": "^2.11.3",
@@ -67,7 +67,7 @@
 		"plotly.js-dist-min": "^3.1.1",
 		"polka": "1.0.0-next.25",
 		"pollen-css": "^5.0.2",
-		"postcss": "8.5.6",
+		"postcss": "8.5.26",
 		"postcss-custom-media": "^11.0.6",
 		"postcss-nested": "^7.0.2",
 		"postcss-prefix-selector": "^2.1.1",
@@ -76,7 +76,7 @@
 		"prettier-plugin-svelte": "^3.4.0",
 		"sirv": "^3.0.2",
 		"sirv-cli": "^3.0.1",
-		"svelte": "^5.55.4",
+		"svelte": "^5.56.9",
 		"svelte-check": "^4.4.6",
 		"svelte-eslint-parser": "^1.3.3",
 		"svelte-i18n": "^4.0.1",
@@ -88,7 +88,7 @@
 		"vite": "^8.0.9",
 		"vite-plugin-turbosnap": "1.0.3",
 		"vitefu": "^1.1.3",
-		"vitest": "^4.1.5"
+		"vitest": "^4.1.11"
 	},
 	"devDependencies": {
 		"@chromatic-com/storybook": "^4.1.3",
@@ -152,18 +152,18 @@
 		"@gradio/vibeeditor": "workspace:^",
 		"@gradio/video": "workspace:^",
 		"@gradio/workflowcanvas": "workspace:^",
-		"@storybook/addon-a11y": "^10.1.11",
-		"@storybook/addon-docs": "^10.1.11",
-		"@storybook/addon-svelte-csf": "^5.0.10",
-		"@storybook/addon-vitest": "^10.1.11",
-		"@storybook/svelte-vite": "^10.1.11",
+		"@storybook/addon-a11y": "^10.5.9",
+		"@storybook/addon-docs": "^10.5.9",
+		"@storybook/addon-svelte-csf": "^5.1.2",
+		"@storybook/addon-vitest": "^10.5.9",
+		"@storybook/svelte-vite": "^10.5.9",
 		"@testing-library/user-event": "^14.6.1",
-		"@vitest/browser": "^4.1.5",
-		"@vitest/coverage-v8": "^3.2.4",
+		"@vitest/browser": "^4.1.11",
+		"@vitest/coverage-v8": "^4.1.11",
 		"eslint-plugin-jsdoc": "^61.0.0",
-		"eslint-plugin-storybook": "^10.1.11",
-		"storybook": "^10.1.11",
-		"vitest-browser-svelte": "^2.1.1",
+		"eslint-plugin-storybook": "^10.5.9",
+		"storybook": "^10.5.9",
+		"vitest-browser-svelte": "^3.0.0",
 		"wikidata-lang": "5.0.1"
 	},
 	"engines": {
@@ -175,10 +175,5 @@
 		"extends": [
 			"plugin:storybook/recommended"
 		]
-	},
-	"pnpm": {
-		"overrides": {
-			"svelte": "5.48.0"
-		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,8 +491,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       mdsvex:
-        specifier: ^0.12.6
-        version: 0.12.6(svelte@5.56.9(@typescript-eslint/types@8.67.0))
+        specifier: ^0.12.8
+        version: 0.12.8(svelte@5.56.9(@typescript-eslint/types@8.67.0))
       postcss:
         specifier: ^8.5.26
         version: 8.5.26
@@ -7002,8 +7002,8 @@ packages:
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
-  mdsvex@0.12.6:
-    resolution: {integrity: sha512-pupx2gzWh3hDtm/iDW4WuCpljmyHbHi34r7ktOqpPGvyiM4MyfNgdJ3qMizXdgCErmvYC9Nn/qyjePy+4ss9Wg==}
+  mdsvex@0.12.8:
+    resolution: {integrity: sha512-v2sbRA9QWf0tpYWfREI5Kq7OqqrqoUzfmMKbgdOoWGfPDLc1JYU4EgDDF0N9WFhmjFW5agKrYwo/mDVutBKWKw==}
     peerDependencies:
       svelte: ^3.56.0 || ^4.0.0 || ^5.0.0-next.120
 
@@ -11029,7 +11029,7 @@ snapshots:
 
   '@types/mdast@4.0.4':
     dependencies:
-      '@types/unist': 2.0.11
+      '@types/unist': 3.0.3
 
   '@types/mdx@2.0.13': {}
 
@@ -13146,7 +13146,7 @@ snapshots:
 
   mdn-data@2.12.2: {}
 
-  mdsvex@0.12.6(svelte@5.56.9(@typescript-eslint/types@8.67.0)):
+  mdsvex@0.12.8(svelte@5.56.9(@typescript-eslint/types@8.67.0)):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 2.0.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  svelte: 5.48.0
-
 patchedDependencies:
   '@sveltejs/package':
     hash: 4bf60d897bf9a1418645763e4338b3223b9458b10046bd6cde08601581f05183
@@ -27,7 +24,7 @@ importers:
         version: 0.6.0
       '@csstools/postcss-global-data':
         specifier: ^3.1.0
-        version: 3.1.0(postcss@8.5.6)
+        version: 3.1.0(postcss@8.5.26)
       '@gradio/client':
         specifier: workspace:^
         version: link:client/js
@@ -45,10 +42,10 @@ importers:
         version: link:js/tootils
       '@sveltejs/package':
         specifier: ^2.5.7
-        version: 2.5.7(patch_hash=4bf60d897bf9a1418645763e4338b3223b9458b10046bd6cde08601581f05183)(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
+        version: 2.5.7(patch_hash=4bf60d897bf9a1418645763e4338b3223b9458b10046bd6cde08601581f05183)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.0.0
-        version: 7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+        version: 7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
       '@tailwindcss/forms':
         specifier: ^0.5.10
         version: 0.5.11(tailwindcss@4.1.18)
@@ -71,23 +68,23 @@ importers:
         specifier: ^8.46.0
         version: 8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       '@vitest/browser-playwright':
-        specifier: ^4.1.5
-        version: 4.1.8(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.8)
+        specifier: ^4.1.11
+        version: 4.1.11(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.11)
       autoprefixer:
         specifier: ^10.4.21
-        version: 10.4.23(postcss@8.5.6)
+        version: 10.4.23(postcss@8.5.26)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
       esbuild:
-        specifier: ^0.25.10
-        version: 0.25.12
+        specifier: ^0.28.2
+        version: 0.28.2
       eslint:
         specifier: ^9.37.0
         version: 9.39.2(jiti@1.21.7)
       eslint-plugin-svelte:
         specifier: ^3.12.4
-        version: 3.14.0(eslint@9.39.2(jiti@1.21.7))(svelte@5.48.0(@typescript-eslint/types@8.53.1))
+        version: 3.14.0(eslint@9.39.2(jiti@1.21.7))(svelte@5.56.9(@typescript-eslint/types@8.67.0))
       globals:
         specifier: ^16.4.0
         version: 16.5.0
@@ -95,8 +92,8 @@ importers:
         specifier: 4.7.9
         version: 4.7.9
       happy-dom:
-        specifier: ^19.0.2
-        version: 19.0.2
+        specifier: ^20.11.2
+        version: 20.11.2(bufferutil@4.1.0)
       jsdom:
         specifier: ^27.0.0
         version: 27.4.0(bufferutil@4.1.0)
@@ -125,26 +122,26 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       postcss:
-        specifier: 8.5.6
-        version: 8.5.6
+        specifier: 8.5.26
+        version: 8.5.26
       postcss-custom-media:
         specifier: ^11.0.6
-        version: 11.0.6(postcss@8.5.6)
+        version: 11.0.6(postcss@8.5.26)
       postcss-nested:
         specifier: ^7.0.2
-        version: 7.0.2(postcss@8.5.6)
+        version: 7.0.2(postcss@8.5.26)
       postcss-prefix-selector:
         specifier: ^2.1.1
-        version: 2.1.1(postcss@8.5.6)
+        version: 2.1.1(postcss@8.5.26)
       prettier:
         specifier: ^3.6.2
         version: 3.8.0
       prettier-plugin-css-order:
         specifier: ^2.1.2
-        version: 2.2.0(postcss@8.5.6)(prettier@3.8.0)
+        version: 2.2.0(postcss@8.5.26)(prettier@3.8.0)
       prettier-plugin-svelte:
         specifier: ^3.4.0
-        version: 3.4.1(prettier@3.8.0)(svelte@5.48.0(@typescript-eslint/types@8.53.1))
+        version: 3.4.1(prettier@3.8.0)(svelte@5.56.9(@typescript-eslint/types@8.67.0))
       sirv:
         specifier: ^3.0.2
         version: 3.0.2
@@ -152,20 +149,20 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.56.9
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
       svelte-check:
         specifier: ^4.4.6
-        version: 4.5.0(picomatch@4.0.4)(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
+        version: 4.5.0(picomatch@4.0.4)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)
       svelte-eslint-parser:
         specifier: ^1.3.3
-        version: 1.4.1(svelte@5.48.0(@typescript-eslint/types@8.53.1))
+        version: 1.4.1(svelte@5.56.9(@typescript-eslint/types@8.67.0))
       svelte-i18n:
         specifier: ^4.0.1
-        version: 4.0.1(svelte@5.48.0(@typescript-eslint/types@8.53.1))
+        version: 4.0.1(svelte@5.56.9(@typescript-eslint/types@8.67.0))
       svelte-preprocess:
         specifier: ^6.0.3
-        version: 6.0.3(coffeescript@2.7.0)(postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6))(postcss@8.5.6)(pug@3.0.3)(sass@1.97.2)(stylus@0.64.0)(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
+        version: 6.0.3(coffeescript@2.7.0)(postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.26))(postcss@8.5.26)(pug@3.0.3)(sass@1.97.2)(stylus@0.64.0)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.1.14
         version: 4.1.18
@@ -177,23 +174,23 @@ importers:
         version: 5.9.3
       typescript-svelte-plugin:
         specifier: ^0.3.50
-        version: 0.3.50(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
+        version: 0.3.50(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)
       vite:
         specifier: ^8.0.9
-        version: 8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
+        version: 8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)
       vite-plugin-turbosnap:
         specifier: 1.0.3
         version: 1.0.3
       vitefu:
         specifier: ^1.1.3
-        version: 1.1.3(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+        version: 1.1.3(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
       vitest:
-        specifier: ^4.1.5
-        version: 4.1.8(@types/node@24.10.9)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@3.2.4)(happy-dom@19.0.2)(jsdom@27.4.0(bufferutil@4.1.0))(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@24.10.9)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.2(bufferutil@4.1.0))(jsdom@27.4.0(bufferutil@4.1.0))(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^4.1.3
-        version: 4.1.3(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 4.1.3(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
@@ -375,41 +372,41 @@ importers:
         specifier: workspace:^
         version: link:js/workflowcanvas
       '@storybook/addon-a11y':
-        specifier: ^10.1.11
-        version: 10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        specifier: ^10.5.9
+        version: 10.5.9(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@storybook/addon-docs':
-        specifier: ^10.1.11
-        version: 10.1.11(@types/react@19.2.9)(esbuild@0.25.12)(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+        specifier: ^10.5.9
+        version: 10.5.9(@types/react@19.2.9)(esbuild@0.28.2)(rollup@4.61.0)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
       '@storybook/addon-svelte-csf':
-        specifier: ^5.0.10
-        version: 5.0.10(@storybook/svelte@10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0(@typescript-eslint/types@8.53.1)))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+        specifier: ^5.1.2
+        version: 5.1.2(@storybook/svelte@10.5.9(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.9(@typescript-eslint/types@8.67.0)))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
       '@storybook/addon-vitest':
-        specifier: ^10.1.11
-        version: 10.1.11(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8)(@vitest/runner@4.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.1.8)
+        specifier: ^10.5.9
+        version: 10.5.9(@vitest/browser-playwright@4.1.11)(@vitest/browser@4.1.11)(@vitest/runner@4.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.1.11)
       '@storybook/svelte-vite':
-        specifier: ^10.1.11
-        version: 10.1.11(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(esbuild@0.25.12)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+        specifier: ^10.5.9
+        version: 10.5.9(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(esbuild@0.28.2)(rollup@4.61.0)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/browser':
-        specifier: ^4.1.5
-        version: 4.1.8(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.8)
+        specifier: ^4.1.11
+        version: 4.1.11(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.11)
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
-        version: 3.2.4(@vitest/browser@4.1.8)(vitest@4.1.8)
+        specifier: ^4.1.11
+        version: 4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)
       eslint-plugin-jsdoc:
         specifier: ^61.0.0
         version: 61.7.1(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-storybook:
-        specifier: ^10.1.11
-        version: 10.1.11(eslint@9.39.2(jiti@1.21.7))(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
+        specifier: ^10.5.9
+        version: 10.5.9(eslint@9.39.2(jiti@1.21.7))(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       storybook:
-        specifier: ^10.1.11
-        version: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^10.5.9
+        version: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       vitest-browser-svelte:
-        specifier: ^2.1.1
-        version: 2.1.1(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vitest@4.1.8)
+        specifier: ^3.0.0
+        version: 3.0.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vitest@4.1.11)
       wikidata-lang:
         specifier: 5.0.1
         version: 5.0.1
@@ -449,10 +446,10 @@ importers:
         version: link:../spa
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
-        version: 7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))
+        version: 7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))
       '@sveltejs/kit':
         specifier: ^2.57.1
-        version: 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))
+        version: 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
       iframe-resizer:
         specifier: ^5.5.7
         version: 5.5.7
@@ -488,17 +485,17 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       '@sveltejs/adapter-vercel':
-        specifier: ^5.10.3
-        version: 5.10.3(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(rollup@4.61.0)
+        specifier: ^6.3.4
+        version: 6.3.4(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(rollup@4.61.0)
       hast-util-to-string:
         specifier: ^3.0.1
         version: 3.0.1
       mdsvex:
         specifier: ^0.12.6
-        version: 0.12.6(svelte@5.48.0(@typescript-eslint/types@8.53.1))
+        version: 0.12.6(svelte@5.56.9(@typescript-eslint/types@8.67.0))
       postcss:
-        specifier: ^8.5.6
-        version: 8.5.6
+        specifier: ^8.5.26
+        version: 8.5.26
       prism-svelte:
         specifier: ^0.5.0
         version: 0.5.0
@@ -508,13 +505,13 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
-        version: 7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))
+        version: 7.0.1(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))
+        version: 3.0.10(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))
       '@sveltejs/kit':
-        specifier: ^2.57.1
-        version: 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0))
+        specifier: ^2.70.3
+        version: 2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
       '@tailwindcss/forms':
         specifier: ^0.5.10
         version: 0.5.11(tailwindcss@3.4.19)
@@ -549,8 +546,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -577,8 +574,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -603,38 +600,38 @@ importers:
         version: link:../build
       '@sveltejs/adapter-node':
         specifier: ^5.5.4
-        version: 5.5.4(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))
+        version: 5.5.4(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))
       http-proxy:
         specifier: ^1.18.1
         version: 1.18.1
       svelte-preprocess:
         specifier: ^6.0.3
-        version: 6.0.3(coffeescript@2.7.0)(postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15))(postcss@8.5.15)(pug@3.0.3)(sass@1.97.2)(stylus@0.64.0)(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
+        version: 6.0.3(coffeescript@2.7.0)(postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.26))(postcss@8.5.26)(pug@3.0.3)(sass@1.97.2)(stylus@0.64.0)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
-        version: 7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))
+        version: 7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))
       '@sveltejs/kit':
         specifier: ^2.57.1
-        version: 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+        version: 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.0.0
-        version: 7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+        version: 7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
       prettier:
         specifier: ^3.6.2
         version: 3.8.0
       prettier-plugin-svelte:
         specifier: ^3.4.0
-        version: 3.4.1(prettier@3.8.0)(svelte@5.48.0(@typescript-eslint/types@8.53.1))
+        version: 3.4.1(prettier@3.8.0)(svelte@5.56.9(@typescript-eslint/types@8.67.0))
       svelte-check:
         specifier: ^4.4.6
-        version: 4.5.0(picomatch@4.0.4)(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
+        version: 4.5.0(picomatch@4.0.4)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^8.0.9
-        version: 8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
+        version: 8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)
 
   js/atoms:
     dependencies:
@@ -645,8 +642,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
 
   js/audio:
     dependencies:
@@ -684,11 +681,11 @@ importers:
         specifier: 1.5.1
         version: 1.5.1
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
       svelte-range-slider-pips:
         specifier: 4.1.0
-        version: 4.1.0(svelte@5.48.0(@typescript-eslint/types@8.53.1))
+        version: 4.1.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))
       wavesurfer.js:
         specifier: 7.11.0
         version: 7.11.0
@@ -703,8 +700,8 @@ importers:
         specifier: workspace:^
         version: link:../atoms
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
 
   js/browserstate:
     dependencies:
@@ -718,8 +715,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@types/crypto-js':
         specifier: ^4.2.2
@@ -734,11 +731,11 @@ importers:
         specifier: ^0.25.10
         version: 0.25.12
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
       svelte-i18n:
         specifier: ^4.0.1
-        version: 4.0.1(svelte@5.48.0(@typescript-eslint/types@8.53.1))
+        version: 4.0.1(svelte@5.56.9(@typescript-eslint/types@8.67.0))
 
   js/button:
     dependencies:
@@ -755,8 +752,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -804,8 +801,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/audio':
         specifier: workspace:^
@@ -832,8 +829,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -854,8 +851,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -939,8 +936,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -964,8 +961,8 @@ importers:
         specifier: ^1.4.6
         version: 1.4.6
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
       tinycolor2:
         specifier: ^1.6.0
         version: 1.6.0
@@ -977,8 +974,8 @@ importers:
   js/column:
     dependencies:
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1001,10 +998,10 @@ importers:
         version: link:../build
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
-        version: 7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))
+        version: 7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))
       '@sveltejs/kit':
         specifier: ^2.57.1
-        version: 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))
+        version: 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
 
   js/core:
     dependencies:
@@ -1012,11 +1009,11 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
       svelte-i18n:
         specifier: ^4.0.1
-        version: 4.0.1(svelte@5.48.0(@typescript-eslint/types@8.53.1))
+        version: 4.0.1(svelte@5.56.9(@typescript-eslint/types@8.67.0))
     devDependencies:
       '@gradio/accordion':
         specifier: workspace:^
@@ -1247,8 +1244,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1272,8 +1269,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1294,8 +1291,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1322,8 +1319,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1341,8 +1338,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1351,8 +1348,8 @@ importers:
   js/draggable:
     dependencies:
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1379,8 +1376,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1399,10 +1396,10 @@ importers:
         version: link:../utils
       '@zerodevx/svelte-json-view':
         specifier: ^1.0.11
-        version: 1.0.11(svelte@5.48.0(@typescript-eslint/types@8.53.1))
+        version: 1.0.11(svelte@5.56.9(@typescript-eslint/types@8.67.0))
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1429,8 +1426,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1466,8 +1463,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1485,8 +1482,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1525,8 +1522,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1538,8 +1535,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1563,8 +1560,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1591,8 +1588,8 @@ importers:
         specifier: ^4.7.9
         version: 4.7.9
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1601,8 +1598,8 @@ importers:
   js/icons:
     dependencies:
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
 
   js/image:
     dependencies:
@@ -1634,8 +1631,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1674,8 +1671,8 @@ importers:
         specifier: ^8.14.0
         version: 8.15.0
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
       tinycolor2:
         specifier: ^1.6.0
         version: 1.6.0
@@ -1717,8 +1714,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1739,8 +1736,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1761,8 +1758,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1786,8 +1783,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1820,14 +1817,14 @@ importers:
         specifier: ^2.0.1
         version: 2.2.3(marked@12.0.2)
       mermaid:
-        specifier: ^11.12.0
-        version: 11.12.2
+        specifier: ^11.17.0
+        version: 11.17.0
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1872,8 +1869,8 @@ importers:
         specifier: ^1.2.9
         version: 1.2.9
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1909,8 +1906,8 @@ importers:
         specifier: workspace:^
         version: link:../video
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1934,8 +1931,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
       vega:
         specifier: ^6.2.0
         version: 6.2.0
@@ -1965,8 +1962,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -1984,8 +1981,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2006,8 +2003,8 @@ importers:
         specifier: ^1.30.0
         version: 1.30.0
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2040,8 +2037,8 @@ importers:
         specifier: ^3.1.1
         version: 3.3.1
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
       vega:
         specifier: ^5.23.0
         version: 5.33.1
@@ -2060,7 +2057,7 @@ importers:
     dependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.0.0
-        version: 7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+        version: 7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
       '@types/which':
         specifier: ^3.0.4
         version: 3.0.4
@@ -2069,13 +2066,13 @@ importers:
         version: 4.59.0
       svelte-preprocess:
         specifier: ^6.0.3
-        version: 6.0.3(coffeescript@2.7.0)(postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15))(postcss@8.5.15)(pug@3.0.3)(sass@1.97.2)(stylus@0.64.0)(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
+        version: 6.0.3(coffeescript@2.7.0)(postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.26))(postcss@8.5.26)(pug@3.0.3)(sass@1.97.2)(stylus@0.64.0)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^8.0.9
-        version: 8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
+        version: 8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)
 
   js/preview/test/test/frontend: {}
 
@@ -2091,8 +2088,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2101,8 +2098,8 @@ importers:
   js/row:
     dependencies:
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2120,8 +2117,8 @@ importers:
         specifier: ^1.0.12
         version: 1.0.12
       sanitize-html:
-        specifier: ^2.17.0
-        version: 2.17.0
+        specifier: ^2.17.7
+        version: 2.17.7
     devDependencies:
       '@types/sanitize-html':
         specifier: ^2.16.0
@@ -2142,8 +2139,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2164,8 +2161,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2201,8 +2198,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2223,8 +2220,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2242,8 +2239,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2279,8 +2276,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
 
   js/statustracker:
     dependencies:
@@ -2297,8 +2294,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2308,7 +2305,7 @@ importers:
     dependencies:
       storybook-dark-mode:
         specifier: ^4.0.2
-        version: 4.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 4.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
 
   js/tabitem:
     dependencies:
@@ -2322,8 +2319,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2335,8 +2332,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2357,8 +2354,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2367,8 +2364,8 @@ importers:
   js/theme:
     dependencies:
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
 
   js/timer:
     dependencies:
@@ -2376,8 +2373,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2386,8 +2383,8 @@ importers:
   js/tooltip:
     dependencies:
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
 
   js/tootils:
     dependencies:
@@ -2398,8 +2395,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
 
   js/upload:
     dependencies:
@@ -2416,8 +2413,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
 
   js/uploadbutton:
     dependencies:
@@ -2434,8 +2431,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2462,8 +2459,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2505,8 +2502,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2530,8 +2527,8 @@ importers:
         specifier: ^1.0.0
         version: 1.1.2
       svelte:
-        specifier: 5.48.0
-        version: 5.48.0(@typescript-eslint/types@8.53.1)
+        specifier: ^5.48.0
+        version: 5.56.9(@typescript-eslint/types@8.67.0)
     devDependencies:
       '@gradio/preview':
         specifier: workspace:^
@@ -2552,10 +2549,6 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
-
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
@@ -2572,10 +2565,6 @@ packages:
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -2588,11 +2577,6 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.6':
-    resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
@@ -2600,10 +2584,6 @@ packages:
 
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.28.6':
-    resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -2632,8 +2612,8 @@ packages:
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
-  '@braintree/sanitize-url@7.1.1':
-    resolution: {integrity: sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==}
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
   '@changesets/apply-release-plan@7.0.14':
     resolution: {integrity: sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA==}
@@ -2699,20 +2679,8 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@chevrotain/cst-dts-gen@11.0.3':
-    resolution: {integrity: sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==}
-
-  '@chevrotain/gast@11.0.3':
-    resolution: {integrity: sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==}
-
-  '@chevrotain/regexp-to-ast@11.0.3':
-    resolution: {integrity: sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==}
-
-  '@chevrotain/types@11.0.3':
-    resolution: {integrity: sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==}
-
-  '@chevrotain/utils@11.0.3':
-    resolution: {integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==}
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@chromatic-com/storybook@4.1.3':
     resolution: {integrity: sha512-hc0HO9GAV9pxqDE6fTVOV5KeLpTiCfV8Jrpk5ogKLiIgeq2C+NPjpt74YnrZTjiK8E19fYcMP+2WY9ZtX7zHmw==}
@@ -2897,20 +2865,26 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/runtime@1.8.1':
-    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
@@ -2941,8 +2915,8 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -2965,8 +2939,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -2989,8 +2963,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -3013,8 +2987,8 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -3037,8 +3011,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -3061,8 +3035,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -3085,8 +3059,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -3109,8 +3083,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -3133,8 +3107,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -3157,8 +3131,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -3181,8 +3155,8 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -3205,8 +3179,8 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -3229,8 +3203,8 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -3253,8 +3227,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -3277,8 +3251,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -3301,8 +3275,8 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -3325,8 +3299,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -3343,8 +3317,8 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -3367,8 +3341,8 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -3385,8 +3359,8 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -3409,8 +3383,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -3427,8 +3401,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -3451,8 +3425,8 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -3475,8 +3449,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -3499,8 +3473,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -3523,8 +3497,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -3836,10 +3810,6 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
-  '@istanbuljs/schema@0.1.3':
-    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
-    engines: {node: '>=8'}
-
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -3927,8 +3897,8 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
-  '@mermaid-js/parser@0.6.3':
-    resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
+  '@mermaid-js/parser@1.2.1':
+    resolution: {integrity: sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==}
 
   '@mswjs/interceptors@0.40.0':
     resolution: {integrity: sha512-EFd6cVbHsgLa6wa4RljGj6Wk75qoHxUSyc5asLyyPSyuhIcdS2Q3Phw6ImS1q+CkALthJRShiYfKANcQMuMqsQ==}
@@ -3939,6 +3909,13 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.2.3':
+    resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
 
   '@neoconfetti/react@1.0.0':
     resolution: {integrity: sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==}
@@ -4089,98 +4066,98 @@ packages:
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
-  '@oxc-resolver/binding-android-arm-eabi@11.20.0':
-    resolution: {integrity: sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==}
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    resolution: {integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==}
     cpu: [arm]
     os: [android]
 
-  '@oxc-resolver/binding-android-arm64@11.20.0':
-    resolution: {integrity: sha512-QqslZAuFQG8Q9xm7JuIn8JUbvywhSBMVhuQHtYW+auirZJloS41oxUUaBXk7uUhZJgp44c5zQLeVvmFaDQB+2Q==}
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    resolution: {integrity: sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==}
     cpu: [arm64]
     os: [android]
 
-  '@oxc-resolver/binding-darwin-arm64@11.20.0':
-    resolution: {integrity: sha512-MUcavykj2ewlR+kc5arpg4tC2RvzJkUxWtNv74pf7lcNk00GpIpN43vXMj+j6r4eMmfZhlb8hueKoIb8e9kAGQ==}
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    resolution: {integrity: sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-resolver/binding-darwin-x64@11.20.0':
-    resolution: {integrity: sha512-BGB16nRUK5Etiv//ihPyzj8Lj1px0mhh4YIfe0FDf045ywknfSm0GEbiRESpr6Q4K82AvnyaRIhhluHByvS4bg==}
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    resolution: {integrity: sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-resolver/binding-freebsd-x64@11.20.0':
-    resolution: {integrity: sha512-JZgtePaqj3qmD5XFHJaSLWzHRxQu0LaPkdoM1KJXYADvAaa83ijXHclV3ej3CueeW0wxfIAbGCZVP45J0CA7uQ==}
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    resolution: {integrity: sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
-    resolution: {integrity: sha512-hOQ/p3ry3v3SchUBXicrrnszaI/UmYzM4wtS4RGfwgVUX7a+HbyQSzJ5aOzu+o6XZkFkS3ZXN4PZAzhOb77OSg==}
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    resolution: {integrity: sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-resolver/binding-linux-arm-musleabihf@11.20.0':
-    resolution: {integrity: sha512-2ArPksaw0AqeuGBfoS715VF+JvJQAhD2niWgjE5hVO+L+nAfikVQopvngCMX9x4BD8itWoQ3dnikrQyl5Ho5Jg==}
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    resolution: {integrity: sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
-    resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
-    resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
-    resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
     cpu: [ppc64]
     os: [linux]
 
-  '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
-    resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    resolution: {integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
-    resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
-    resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
-    resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    resolution: {integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==}
     cpu: [x64]
     os: [linux]
 
-  '@oxc-resolver/binding-linux-x64-musl@11.20.0':
-    resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
     cpu: [x64]
     os: [linux]
 
-  '@oxc-resolver/binding-openharmony-arm64@11.20.0':
-    resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxc-resolver/binding-wasm32-wasi@11.20.0':
-    resolution: {integrity: sha512-Tn0y1XOFYHNfK1wp1Z5QK8Rcld/bsOwRISQXfqAZ5IBpv8Gz1IvV39fUWNprqNdRizgcvFhOzWwFun2zkJsyBg==}
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    resolution: {integrity: sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
-    resolution: {integrity: sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA==}
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    resolution: {integrity: sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
-    resolution: {integrity: sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==}
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    resolution: {integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==}
     cpu: [x64]
     os: [win32]
 
@@ -4695,32 +4672,36 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@storybook/addon-a11y@10.1.11':
-    resolution: {integrity: sha512-3sr6HmcDgW1+TQAV9QtWBE3HlGyfFXVZY3RECTNLNH6fRC+rYQCItisvQIVxQpyftLSQ8EAMN9JQzs495MjWNg==}
+  '@storybook/addon-a11y@10.5.9':
+    resolution: {integrity: sha512-MvXkoJIVRcZrqhWi+wynYAmFkvTWm5aHdJfYohhgPeEJVDRF91zejtOsN7zPRE/lQvBDY+IiomKxeRN3UhWNVw==}
     peerDependencies:
-      storybook: ^10.1.11
+      storybook: ^10.5.9
 
-  '@storybook/addon-docs@10.1.11':
-    resolution: {integrity: sha512-Jwm291Fhim2eVcZIVlkG1B2skb0ZI9oru6nqMbJxceQZlvZmcIa4oxvS1oaMTKw2DJnCv97gLm57P/YvRZ8eUg==}
+  '@storybook/addon-docs@10.5.9':
+    resolution: {integrity: sha512-8sFsMkZYrrdqCLdV+hnwTwDF7RaBsBPRwl4wfc8ve9Q/7Yhi5REe/Xjvd8x1yn6fBPPw9tnID9dx6Agdnr81fw==}
     peerDependencies:
-      storybook: ^10.1.11
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.5.9
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
-  '@storybook/addon-svelte-csf@5.0.10':
-    resolution: {integrity: sha512-poSvTS7VdaQ42ZoqW5e4+2Hv1iLO0mekH9fwn/QuBNse48R4WlTyR8XFbHRTfatl9gdc9ZYC4uWzazrmV6zGIA==}
+  '@storybook/addon-svelte-csf@5.1.2':
+    resolution: {integrity: sha512-NpImknEb48J7yr/ArTYpvhDSvGUrgm5Nuybu9PCicjSKTACsXX7cln2R19572ORtns399RTE+t20BBOKxSPm2g==}
     peerDependencies:
-      '@storybook/svelte': ^0.0.0-0 || ^8.2.0 || ^9.0.0 || ^9.1.0-0 || ^10.0.0-0
-      '@sveltejs/vite-plugin-svelte': ^4.0.0 || ^5.0.0 || ^6.0.0
-      storybook: ^0.0.0-0 || ^8.2.0 || ^9.0.0 || ^9.1.0-0 || ^10.0.0-0
-      svelte: 5.48.0
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@storybook/svelte': ^0.0.0-0 || ^8.2.0 || ^9.0.0 || ^9.1.0-0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+      '@sveltejs/vite-plugin-svelte': ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      storybook: ^0.0.0-0 || ^8.2.0 || ^9.0.0 || ^9.1.0-0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+      svelte: ^5.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@storybook/addon-vitest@10.1.11':
-    resolution: {integrity: sha512-YbZzeKO3v+Xr97/malT4DZIATkVZT5EHNYx3xzEfPVuk19dDETAVYXO+tzcqCQHsgdKQHkmd56vv8nN3J3/kvw==}
+  '@storybook/addon-vitest@10.5.9':
+    resolution: {integrity: sha512-TgHczbDANprH9bEj+Z/DZ4b2LaCHpNrBdMOWK7gd+ZRGZz0ZZnGm8H5WoIh2uW4AHYibZmYCyWDSf69Plblz2w==}
     peerDependencies:
       '@vitest/browser': ^3.0.0 || ^4.0.0
       '@vitest/browser-playwright': ^4.0.0
       '@vitest/runner': ^3.0.0 || ^4.0.0
-      storybook: ^10.1.11
+      storybook: ^10.5.9
       vitest: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -4732,11 +4713,11 @@ packages:
       vitest:
         optional: true
 
-  '@storybook/builder-vite@10.1.11':
-    resolution: {integrity: sha512-MMD09Ap7FyzDfWG961pkIMv/w684XXe1bBEi+wCEpHxvrgAd3j3A9w/Rqp9Am2uRDPCEdi1QgSzS3SGW3aGThQ==}
+  '@storybook/builder-vite@10.5.9':
+    resolution: {integrity: sha512-Zg4JbGQiHFPGlFJ9HM+XPgzKmU/RFPCymhohVRJhBBYfmgaQgz0flWWzscseCDpl638MNd8/r/H+nwuoBgSYDg==}
     peerDependencies:
-      storybook: ^10.1.11
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+      storybook: ^10.5.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@storybook/components@8.6.14':
     resolution: {integrity: sha512-HNR2mC5I4Z5ek8kTrVZlIY/B8gJGs5b3XdZPBPBopTIN6U/YHXiDyOjY3JlaS4fSG1fVhp/Qp1TpMn1w/9m1pw==}
@@ -4748,12 +4729,12 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  '@storybook/csf-plugin@10.1.11':
-    resolution: {integrity: sha512-Ant0NhgqHKzQsseeVTSetZCuDHHs0W2HRkHt51Kg/sUl0T/sDtfVA+fWZT8nGzGZqYSFkxqYPWjauPmIhPtaRw==}
+  '@storybook/csf-plugin@10.5.9':
+    resolution: {integrity: sha512-4H5QIHQVtQYCuL43GCRLGjNQhZpQg9gL03ja0DV80kO2Dn9LEt6ol87bSnSjn4VDgcAXtgTzXFvRLknfVgAAqg==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^10.1.11
+      storybook: ^10.5.9
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -4779,12 +4760,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
 
-  '@storybook/icons@2.0.1':
-    resolution: {integrity: sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   '@storybook/icons@2.0.2':
     resolution: {integrity: sha512-KZBCpXsshAIjczYNXR/rlxEtCUX/eAbpFNwKi8bcOomrLA4t/SyPz5RF+lVPO2oZBUE4sAkt43mfJUevQDSEEw==}
     peerDependencies:
@@ -4796,26 +4771,33 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
-  '@storybook/react-dom-shim@10.1.11':
-    resolution: {integrity: sha512-o8WPhRlZbORUWG9lAgDgJP0pi905VHJUFJr1Kp8980gHqtlemtnzjPxKy5vFwj6glNhAlK8SS8OOYzWP7hloTQ==}
+  '@storybook/react-dom-shim@10.5.9':
+    resolution: {integrity: sha512-7qZD6CSa64p1m/zX9tG4ALcEHlEk0Bx+5++4RL3MFlRCgCFfAomXsCHTzF0RyF8cI4vl+hS7Y0ryjQchVs6UQA==}
     peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.1.11
+      storybook: ^10.5.9
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
-  '@storybook/svelte-vite@10.1.11':
-    resolution: {integrity: sha512-UVTeDWxWZ2XRbD1p1pgDz9aWJpJFfsgJHBFl/U1A858xYU6Tgp0KjyYfapM6BYVPmGcK0RCqHHWOv6Bj6cfrRQ==}
+  '@storybook/svelte-vite@10.5.9':
+    resolution: {integrity: sha512-vssxMDdH3bChfrLQDLY0Qq5Jaze43zdcwF+Xh7EuQFomEn1yj0PEoq0QAjbtwRAea4oy7tVVBdx2L5y8aJ4X2g==}
     peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
-      storybook: ^10.1.11
-      svelte: 5.48.0
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@sveltejs/vite-plugin-svelte': ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      storybook: ^10.5.9
+      svelte: ^5.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@storybook/svelte@10.1.11':
-    resolution: {integrity: sha512-G2ASV/Q16YkJf/3+4NXX1MdxFTO5qztePwGR12U8yKyyV2NjKtgnCA3jkvSakBLhRbO1nbD8+H13FgQrRfxdbQ==}
+  '@storybook/svelte@10.5.9':
+    resolution: {integrity: sha512-mnnG0QeYtulEsJN2Z7bk46qkK43A8PIDGFPfsrxO2FMkyG7oVeU49OP0Rw8u4yMDbwXqBjadJT1k9nE1vyIiGQ==}
     peerDependencies:
-      storybook: ^10.1.11
-      svelte: 5.48.0
+      storybook: ^10.5.9
+      svelte: ^5.0.0
 
   '@storybook/theming@8.6.14':
     resolution: {integrity: sha512-r4y+LsiB37V5hzpQo+BM10PaCsp7YlZ0YcZzQP1OCkPlYXmUAFy2VvDKaFRpD8IeNPKug2u4iFm/laDEbs03dg==}
@@ -4842,8 +4824,9 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
-  '@sveltejs/adapter-vercel@5.10.3':
-    resolution: {integrity: sha512-fW2ZhMiOrUKsJJhiB4ift9sYDSFWgvH3N22cjf8ukOyWgHolb9SmSS3owr+nHQNlgTEAdy4eIr4Fnasw3nkxTw==}
+  '@sveltejs/adapter-vercel@6.3.4':
+    resolution: {integrity: sha512-MxEgTqIlmNg4qy5Rz4vwDKs2vNUrsL+DjcfegUVr/spPWSvWrSYFTUPY7tLbHsi8RxdUqpxC9UN/yzkOzZeMGA==}
+    engines: {node: '>=20.0'}
     peerDependencies:
       '@sveltejs/kit': ^2.4.0
 
@@ -4854,7 +4837,23 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
       '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0
-      svelte: 5.48.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: ^5.3.3 || ^6.0.0
+      vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      typescript:
+        optional: true
+
+  '@sveltejs/kit@2.70.3':
+    resolution: {integrity: sha512-UDvEYuZqAMbfB/oXIoqKvbKcb7YczK5zYrzmsGV1zRJk03jntwp8dXiYoIJotxAndsKvcPFtx9H1GRSKFdSHgg==}
+    engines: {node: '>=18.13'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: ^5.3.3 || ^6.0.0
       vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0
     peerDependenciesMeta:
@@ -4868,13 +4867,13 @@ packages:
     engines: {node: ^16.14 || >=18}
     hasBin: true
     peerDependencies:
-      svelte: 5.48.0
+      svelte: ^3.44.0 || ^4.0.0 || ^5.0.0-next.1
 
   '@sveltejs/vite-plugin-svelte@7.1.2':
     resolution: {integrity: sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==}
     engines: {node: ^20.19 || ^22.12 || >=24}
     peerDependencies:
-      svelte: 5.48.0
+      svelte: ^5.46.4
       vite: ^8.0.0-beta.7 || ^8.0.0
 
   '@tailwindcss/forms@0.5.11':
@@ -4902,11 +4901,11 @@ packages:
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
-  '@testing-library/svelte-core@1.0.0':
-    resolution: {integrity: sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==}
+  '@testing-library/svelte-core@1.1.3':
+    resolution: {integrity: sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g==}
     engines: {node: '>=16'}
     peerDependencies:
-      svelte: 5.48.0
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
 
   '@testing-library/user-event@14.6.1':
     resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
@@ -4916,6 +4915,9 @@ packages:
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -5077,9 +5079,6 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@20.19.30':
-    resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
-
   '@types/node@24.10.9':
     resolution: {integrity: sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==}
 
@@ -5120,6 +5119,9 @@ packages:
   '@types/which@3.0.4':
     resolution: {integrity: sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.53.1':
     resolution: {integrity: sha512-cFYYFZ+oQFi6hUnBTbLRXfTJiaQtYE3t4O692agbBl+2Zy+eqSKWtPjhPXJu1G7j4RLjKgeJPDdq3EqOwmX5Ag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5141,8 +5143,18 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/project-service@8.67.0':
+    resolution: {integrity: sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.53.1':
     resolution: {integrity: sha512-Lu23yw1uJMFY8cUeq7JlrizAgeQvWugNQzJp8C3x8Eo5Jw5Q2ykMdiiTB9vBVOOUBysMzmRRmUfwFrZuI2C4SQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.67.0':
+    resolution: {integrity: sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.53.1':
@@ -5150,6 +5162,12 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/tsconfig-utils@8.67.0':
+    resolution: {integrity: sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/type-utils@8.53.1':
     resolution: {integrity: sha512-MOrdtNvyhy0rHyv0ENzub1d4wQYKb2NmIqG7qEqPWFW7Mpy2jzFC3pQ2yKDvirZB7jypm5uGjF2Qqs6OIqu47w==}
@@ -5162,11 +5180,21 @@ packages:
     resolution: {integrity: sha512-jr/swrr2aRmUAUjW5/zQHbMaui//vQlsZcJKijZf3M26bnmLj8LyZUpj8/Rd6uzaek06OWsqdofN/Thenm5O8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.67.0':
+    resolution: {integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.53.1':
     resolution: {integrity: sha512-RGlVipGhQAG4GxV1s34O91cxQ/vWiHJTDHbXRr0li2q/BGg3RR/7NM8QDWgkEgrwQYCvmJV9ichIwyoKCQ+DTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/typescript-estree@8.67.0':
+    resolution: {integrity: sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/utils@8.53.1':
     resolution: {integrity: sha512-c4bMvGVWW4hv6JmDUEG7fSYlWOl3II2I4ylt0NM+seinYQlZMQIaKaXIIVJWt9Ofh6whrpM+EdDQXKXjNovvrg==}
@@ -5175,31 +5203,45 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/utils@8.67.0':
+    resolution: {integrity: sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.53.1':
     resolution: {integrity: sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vercel/nft@0.30.4':
-    resolution: {integrity: sha512-wE6eAGSXScra60N2l6jWvNtVK0m+sh873CpfZW4KI2v8EHuUQp+mSEi4T+IcdPCSEDgCdAS/7bizbhQlkjzrSA==}
-    engines: {node: '>=18'}
+  '@typescript-eslint/visitor-keys@8.67.0':
+    resolution: {integrity: sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vercel/nft@1.11.0':
+    resolution: {integrity: sha512-m1QFg+U+3yPOnP1xSYJ73UIRxLOXdts1JOhiOiyPYqEsALgrXFFINvgUaD6R6iNvaBFAjHllBCbkfx4FuOdpaA==}
+    engines: {node: '>=20'}
     hasBin: true
 
-  '@vitest/browser-playwright@4.1.8':
-    resolution: {integrity: sha512-SR7FqgegaexEg73xvf3ArtygXegagMdXnL0EZMpxrWvvhQxvicD/E8p0ib0J91riPRtQUViyh67Xjw3NqvyhVg==}
+  '@vitest/browser-playwright@4.1.11':
+    resolution: {integrity: sha512-riLBxPqwnJ0lWs2DN2WeUfYeKLoAjbP2Xx8cLQdSddzMi20sksIa6K2mPz79DyMZKKVKH2ksOC2yJvtNcZg8cg==}
     peerDependencies:
       playwright: '*'
-      vitest: 4.1.8
+      vitest: 4.1.11
 
-  '@vitest/browser@4.1.8':
-    resolution: {integrity: sha512-u21VzX07HzlJYpFgkxmjEXar/tG2UqWGgyGG/46SrrPc7rSdCTPw5vuowopO9CIqF8UCUQzDFdbVnNpw6N0BfQ==}
+  '@vitest/browser@4.1.11':
+    resolution: {integrity: sha512-bwMovvAeuTFOK5kIFevw4VEf+1gVEICv4SYK4k3knJOxl6b1zEWud8mYKD73e1B0odAn174h1MofURy2TPWf3w==}
     peerDependencies:
-      vitest: 4.1.8
+      vitest: 4.1.11
 
-  '@vitest/coverage-v8@3.2.4':
-    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+  '@vitest/coverage-v8@4.1.11':
+    resolution: {integrity: sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==}
     peerDependencies:
-      '@vitest/browser': 3.2.4
-      vitest: 3.2.4
+      '@vitest/browser': 4.1.11
+      vitest: 4.1.11
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
@@ -5207,22 +5249,11 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
-  '@vitest/expect@4.1.8':
-    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
-
-  '@vitest/mocker@4.1.8':
-    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -5235,26 +5266,26 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/pretty-format@4.1.8':
-    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
 
-  '@vitest/runner@4.1.8':
-    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
 
-  '@vitest/snapshot@4.1.8':
-    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  '@vitest/spy@4.1.8':
-    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  '@vitest/utils@4.1.8':
-    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
@@ -5270,7 +5301,7 @@ packages:
   '@zerodevx/svelte-json-view@1.0.11':
     resolution: {integrity: sha512-mIjj0H1al/P4FPlbeDoiey93lNEUqBEAe5LIdD5GttZfEYt3awexD2lHwKNfUeY4jHizOJkoWTPN/2iO0GBqpw==}
     peerDependencies:
-      svelte: 5.48.0
+      svelte: ^3.57.0 || ^4.0.0 || ^5.0.0
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -5358,6 +5389,10 @@ packages:
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -5380,8 +5415,8 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
-  ast-v8-to-istanbul@0.3.10:
-    resolution: {integrity: sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==}
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
@@ -5418,6 +5453,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.9.16:
     resolution: {integrity: sha512-KeUZdBuxngy825i8xvzaK1Ncnkx0tBmb3k8DkEuqjKRkmtvNTjey2ZsNeh8Dw4lfKvbCOu9oeNx2TKm2vHqcRw==}
     hasBin: true
@@ -5448,6 +5487,10 @@ packages:
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -5462,6 +5505,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
 
   bufferutil@4.1.0:
     resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
@@ -5511,14 +5558,6 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
-
-  chevrotain-allstar@0.3.1:
-    resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
-    peerDependencies:
-      chevrotain: ^11.0.0
-
-  chevrotain@11.0.3:
-    resolution: {integrity: sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -5726,8 +5765,8 @@ packages:
     peerDependencies:
       cytoscape: ^3.2.0
 
-  cytoscape@3.33.1:
-    resolution: {integrity: sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==}
+  cytoscape@3.34.1:
+    resolution: {integrity: sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==}
     engines: {node: '>=0.10'}
 
   d3-array@2.12.1:
@@ -5878,8 +5917,8 @@ packages:
     resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
     engines: {node: '>=0.12'}
 
-  dagre-d3-es@7.0.13:
-    resolution: {integrity: sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==}
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
   data-urls@6.0.1:
     resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
@@ -5890,6 +5929,9 @@ packages:
 
   dayjs@1.11.19:
     resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
+
+  dayjs@1.11.23:
+    resolution: {integrity: sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -5977,18 +6019,34 @@ packages:
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
+
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
 
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.1:
-    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
+
+  dompurify@3.4.14:
+    resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
@@ -6028,6 +6086,14 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
@@ -6046,8 +6112,8 @@ packages:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
-  es-toolkit@1.44.0:
-    resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
+  es-toolkit@1.51.0:
+    resolution: {integrity: sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==}
 
   es5-ext@0.10.64:
     resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
@@ -6078,8 +6144,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6101,18 +6167,18 @@ packages:
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
 
-  eslint-plugin-storybook@10.1.11:
-    resolution: {integrity: sha512-mbq2r2kK5+AcLl0XDJ3to91JOgzCbHOqj+J3n+FRw6drk+M1boRqMShSoMMm0HdzXPLmlr7iur+qJ5ZuhH6ayQ==}
+  eslint-plugin-storybook@10.5.9:
+    resolution: {integrity: sha512-4Hrqccy/zttV0S/32TSUbqtizzj4sbkgYvv7UzHveH58v96PhrO+fSpOFAqYvzNDzdOU6smKwObFtzX+RZqj4w==}
     peerDependencies:
       eslint: '>=8'
-      storybook: ^10.1.11
+      storybook: ^10.5.9
 
   eslint-plugin-svelte@3.14.0:
     resolution: {integrity: sha512-Isw0GvaMm0yHxAj71edAdGFh28ufYs+6rk2KlbbZphnqZAzrH3Se3t12IFh2H9+1F/jlDhBBL4oiOJmLqmYX0g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.1 || ^9.0.0
-      svelte: 5.48.0
+      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
       svelte:
         optional: true
@@ -6173,8 +6239,8 @@ packages:
   esrap@1.4.9:
     resolution: {integrity: sha512-3OMlcd0a03UGuZpPeUC1HxR3nA23l+HEyCiZw3b3FumJIN9KphoGzDJKMXI1S72jVS1dsenDyQC0kJlO1U9E1g==}
 
-  esrap@2.2.9:
-    resolution: {integrity: sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==}
+  esrap@2.3.5:
+    resolution: {integrity: sha512-KciPkeZZX8srrh6xELzLR2cBaWOzgBQ4CwggO6Dh/KMlrfOcIcfyXCVy/Vvc3/OlS5gvFOd5tcxUYuaGM8o45A==}
     peerDependencies:
       '@typescript-eslint/types': ^8.2.0
     peerDependenciesMeta:
@@ -6257,6 +6323,9 @@ packages:
   fast-unique-numbers@9.0.26:
     resolution: {integrity: sha512-3Mtq8p1zQinjGyWfKeuBunbuFoixG72AUkk4VvzbX4ykCW9Q4FzRaNyIlfQhUjnKw2ARVP+/CKnoyr6wfHftig==}
     engines: {node: '>=18.2.0'}
+
+  fastdom@1.0.12:
+    resolution: {integrity: sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -6385,6 +6454,10 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -6425,8 +6498,8 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
 
-  happy-dom@19.0.2:
-    resolution: {integrity: sha512-831CLbgDyjRbd2lApHZFsBDe56onuFcjsCBPodzWpzedTpeDr8CGZjs7iEIdNW1DVwSFRecfwzLpVyGBPamwGA==}
+  happy-dom@20.11.2:
+    resolution: {integrity: sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw==}
     engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
@@ -6474,6 +6547,10 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -6635,10 +6712,6 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
-    engines: {node: '>=10'}
-
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
@@ -6662,11 +6735,11 @@ packages:
   js-stringify@1.0.2:
     resolution: {integrity: sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
@@ -6705,6 +6778,9 @@ packages:
   json-stringify-pretty-compact@4.0.0:
     resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
@@ -6716,6 +6792,10 @@ packages:
 
   katex@0.16.27:
     resolution: {integrity: sha512-aeQoDkuRWSqQN6nSvVCEFvfXdqo1OQiCmmW1kc9xSdjutPv7BGO7pqY9sQRJpMOGrEdfDgF2TfRXe5eUAD2Waw==}
+    hasBin: true
+
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
 
   keyv@4.5.4:
@@ -6731,9 +6811,8 @@ packages:
   known-css-properties@0.37.0:
     resolution: {integrity: sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==}
 
-  langium@3.3.1:
-    resolution: {integrity: sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==}
-    engines: {node: '>=16.0.0'}
+  launder@1.7.1:
+    resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
 
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
@@ -6853,9 +6932,6 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-
   lodash-es@4.17.22:
     resolution: {integrity: sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==}
 
@@ -6885,8 +6961,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -6929,7 +7005,7 @@ packages:
   mdsvex@0.12.6:
     resolution: {integrity: sha512-pupx2gzWh3hDtm/iDW4WuCpljmyHbHi34r7ktOqpPGvyiM4MyfNgdJ3qMizXdgCErmvYC9Nn/qyjePy+4ss9Wg==}
     peerDependencies:
-      svelte: 5.48.0
+      svelte: ^3.56.0 || ^4.0.0 || ^5.0.0-next.120
 
   media-encoder-host-broker@7.1.0:
     resolution: {integrity: sha512-Emu3f45Wbf6AoRJxfvZ8e5nh8fRVviBfkABgYNvVUsVBgJ7+l137gn324g/JmNVQhhVQ89fjmGT1kHIJ9JG5Nw==}
@@ -6955,8 +7031,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid@11.12.2:
-    resolution: {integrity: sha512-n34QPDPEKmaeCG4WDMGy0OT6PSyxKCfy2pJgShP+Qow2KLrvWjclwbc3yXfSIf4BanqWEhQEpngWwNp/XhZt6w==}
+  mermaid@11.17.0:
+    resolution: {integrity: sha512-Jo9N377Wb4MSnHFPTbLi2SxFpsQl4eVHoxnW5U1Md9EazvgMp3s+4ohDxr81YNTgbn5Kj7HJ3yslrSJ52kwpbA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -6975,6 +7051,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -6987,6 +7067,10 @@ packages:
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@3.1.0:
@@ -7028,13 +7112,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7122,8 +7201,8 @@ packages:
     resolution: {integrity: sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  oxc-resolver@11.20.0:
-    resolution: {integrity: sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==}
+  oxc-resolver@11.24.2:
+    resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -7198,6 +7277,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -7385,12 +7468,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -7407,7 +7486,7 @@ packages:
     resolution: {integrity: sha512-xL49LCloMoZRvSwa6IEdN2GV6cq2IqpYGstYtMT+5wmml1/dClEoI0MZR78MiVPpu6BdQFfN0/y73yO6+br5Pg==}
     peerDependencies:
       prettier: ^3.0.0
-      svelte: 5.48.0
+      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -7619,8 +7698,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sanitize-html@2.17.0:
-    resolution: {integrity: sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==}
+  sanitize-html@2.17.7:
+    resolution: {integrity: sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==}
+    engines: {node: '>=22.12.0'}
 
   sass@1.97.2:
     resolution: {integrity: sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==}
@@ -7734,31 +7814,19 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   storybook-dark-mode@4.0.2:
     resolution: {integrity: sha512-zjcwwQ01R5t1VsakA6alc2JDIRVtavryW8J3E3eKLDIlAMcvsgtpxlelWkZs2cuNspk6Z10XzhQVrUWtYc3F0w==}
 
-  storybook@10.1.11:
-    resolution: {integrity: sha512-pKP5jXJYM4OjvNklGuHKO53wOCAwfx79KvZyOWHoi9zXUH5WVMFUe/ZfWyxXG/GTcj0maRgHGUjq/0I43r0dDQ==}
-    hasBin: true
-    peerDependencies:
-      prettier: ^2 || ^3
-    peerDependenciesMeta:
-      prettier:
-        optional: true
-
-  storybook@10.4.1:
-    resolution: {integrity: sha512-V1Zd2e+gBFufqAQVZ1JR8KLqALsEZ3JYSBnWwQbKa6zCfWWanR6AFMyuOkLt2gZOgGp3h2Riuz88pGNVTQSG0A==}
+  storybook@10.5.9:
+    resolution: {integrity: sha512-UfdMKSjEhIKr8LbqYyIE5r7vT/drL/PxN75YaouJ+UG0FssEy6cf49OdTF3kstAqVMHskc+zEqyRoiQHZXHwgA==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       prettier: ^2 || ^3
-      vite-plus: ^0.1.15
+      vite-plus: ^0.1.15 || ^0.2.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -7769,6 +7837,9 @@ packages:
 
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
+  strictdom@1.0.1:
+    resolution: {integrity: sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -7843,21 +7914,21 @@ packages:
     resolution: {integrity: sha512-hRHHufbJoArFmDYQKCpCvc0xUuIEfwYksvyLYEQyH+1xb5LD5sM/IthfooCdXZQtOIqXz6xm7NmaqdfwG4kh6w==}
     engines: {node: '>=18'}
     peerDependencies:
-      svelte: 5.48.0
+      svelte: ^5.0.0
 
   svelte-check@4.5.0:
     resolution: {integrity: sha512-9lNwPxCLWniFvQIcEv1LFqjIxcFtO3smb5+5BKbRJ3ttL4o2lXCej5rLF4DAnfLPI66oaA81vAxw6ILdIWI7kA==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
     peerDependencies:
-      svelte: 5.48.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
 
   svelte-eslint-parser@1.4.1:
     resolution: {integrity: sha512-1eqkfQ93goAhjAXxZiu1SaKI9+0/sxp4JIWQwUpsz7ybehRE5L8dNuz7Iry7K22R47p5/+s9EM+38nHV2OlgXA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0, pnpm: 10.24.0}
     peerDependencies:
-      svelte: 5.48.0
+      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
       svelte:
         optional: true
@@ -7867,7 +7938,7 @@ packages:
     engines: {node: '>= 16'}
     hasBin: true
     peerDependencies:
-      svelte: 5.48.0
+      svelte: ^3 || ^4 || ^5
 
   svelte-preprocess@6.0.3:
     resolution: {integrity: sha512-PLG2k05qHdhmRG7zR/dyo5qKvakhm8IJ+hD2eFRQmMLHp7X3eJnjeupUtvuRpbNiF31RjVw45W+abDwHEmP5OA==}
@@ -7882,7 +7953,7 @@ packages:
       sass: ^1.26.8
       stylus: '>=0.55'
       sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: 5.48.0
+      svelte: ^4.0.0 || ^5.0.0-next.100 || ^5.0.0
       typescript: ^5.0.0
     peerDependenciesMeta:
       '@babel/core':
@@ -7909,16 +7980,22 @@ packages:
   svelte-range-slider-pips@4.1.0:
     resolution: {integrity: sha512-2Zw7MngIuPeqdyJ3ueEp7jPSx0hce+Sx8r1eteCeUPxEWlNavKhBtqJyuoAdpvh5csPPFVZJ4TJ4MX9s4G70uw==}
     peerDependencies:
-      svelte: 5.48.0
+      svelte: ^4.2.7 || ^5.0.0
 
   svelte2tsx@0.7.46:
     resolution: {integrity: sha512-S++Vw3w47a8rBuhbz4JK0fcGea8tOoX1boT53Aib8+oUO2EKeOG+geXprJVTDfBlvR+IJdf3jIpR2RGwT6paQA==}
     peerDependencies:
-      svelte: 5.48.0
+      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
 
-  svelte@5.48.0:
-    resolution: {integrity: sha512-+NUe82VoFP1RQViZI/esojx70eazGF4u0O/9ucqZ4rPcOZD+n5EVp17uYsqwdzjUjZyTpGKunHbDziW6AIAVkQ==}
+  svelte2tsx@0.7.61:
+    resolution: {integrity: sha512-EpQ/+UHITBULeUojx/LLD3uTYasZXcX1BrqlrzfLUnT9vdUhaOWK59a3ryWcFU8L0sY1SP+gRhJ2Beiis98+qw==}
+    peerDependencies:
+      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
+      typescript: ^4.9.4 || ^5.0.0 || ^6.0.0
+
+  svelte@5.56.9:
+    resolution: {integrity: sha512-VT8kSnlEg8069w7AiCcAk3Yf5xvMnrGTagVOmU/OpOLHaHnNqXhWZCH/4EVga/bT/HtWhvE6/fHrXLErx7OnJA==}
     engines: {node: '>=18'}
 
   symbol-tree@3.2.4:
@@ -7949,10 +8026,6 @@ packages:
     resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
     engines: {node: '>=10'}
     hasBin: true
-
-  test-exclude@7.0.1:
-    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
-    engines: {node: '>=18'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -8056,6 +8129,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -8078,6 +8157,10 @@ packages:
     resolution: {integrity: sha512-xygQcmneDyzsEuKZrFbRMne5HDqMs++aFzefrJTgEIKjQ3rekM+RPfFCVq2Gp1VIDqddoYeppCj4Pcb+RZW0GQ==}
     engines: {node: '>=20'}
 
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
+    engines: {node: '>=20'}
+
   type@2.7.3:
     resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
 
@@ -8096,9 +8179,6 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
-
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -8454,26 +8534,26 @@ packages:
       vite:
         optional: true
 
-  vitest-browser-svelte@2.1.1:
-    resolution: {integrity: sha512-qbunYRSm+N92r9bfTkdDTpBZESLmp4QFz2SluV3n/x8U7ysosfeXYJZ4vXbJ0Y0LzoqqDnV5LHprmFgn4Eo+Ug==}
+  vitest-browser-svelte@3.0.0:
+    resolution: {integrity: sha512-BKM9iBGNsEQzigWuSZFAiw6AJDqQqMttApoD8gM8LTI6vxfd423rDMN8GqUHJyGbhH3XcOo9N9u/4hu47Nxhsw==}
     peerDependencies:
-      svelte: 5.48.0
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
       vitest: ^4.0.0
 
-  vitest@4.1.8:
-    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.8
-      '@vitest/browser-preview': 4.1.8
-      '@vitest/browser-webdriverio': 4.1.8
-      '@vitest/coverage-istanbul': 4.1.8
-      '@vitest/coverage-v8': 4.1.8
-      '@vitest/ui': 4.1.8
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -8504,26 +8584,6 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
-
-  vscode-jsonrpc@8.2.0:
-    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
-    engines: {node: '>=14.0.0'}
-
-  vscode-languageserver-protocol@3.17.5:
-    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
-
-  vscode-languageserver-textdocument@1.0.12:
-    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
-
-  vscode-languageserver-types@3.17.5:
-    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
-
-  vscode-languageserver@9.0.1:
-    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
-    hasBin: true
-
-  vscode-uri@3.0.8:
-    resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
 
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
@@ -8664,6 +8724,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
@@ -8737,11 +8809,6 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@ampproject/remapping@2.3.0':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
@@ -8771,37 +8838,22 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/helper-string-parser@7.27.1': {}
-
-  '@babel/helper-string-parser@7.29.7':
-    optional: true
+  '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/helper-validator-identifier@7.29.7':
-    optional: true
-
-  '@babel/parser@7.28.6':
-    dependencies:
-      '@babel/types': 7.28.6
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
-    optional: true
 
   '@babel/runtime@7.28.6': {}
-
-  '@babel/types@7.28.6':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-    optional: true
 
   '@babylonjs/core@8.46.2': {}
 
@@ -8820,7 +8872,7 @@ snapshots:
 
   '@blazediff/core@1.9.1': {}
 
-  '@braintree/sanitize-url@7.1.1': {}
+  '@braintree/sanitize-url@7.1.2': {}
 
   '@changesets/apply-release-plan@7.0.14':
     dependencies:
@@ -8988,30 +9040,15 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@chevrotain/cst-dts-gen@11.0.3':
-    dependencies:
-      '@chevrotain/gast': 11.0.3
-      '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+  '@chevrotain/types@11.1.2': {}
 
-  '@chevrotain/gast@11.0.3':
-    dependencies:
-      '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
-
-  '@chevrotain/regexp-to-ast@11.0.3': {}
-
-  '@chevrotain/types@11.0.3': {}
-
-  '@chevrotain/utils@11.0.3': {}
-
-  '@chromatic-com/storybook@4.1.3(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@chromatic-com/storybook@4.1.3(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
       '@neoconfetti/react': 1.0.0
       chromatic: 13.3.5
       filesize: 10.1.6
       jsonfile: 6.2.0
-      storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       strip-ansi: 7.1.2
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
@@ -9245,13 +9282,19 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
 
-  '@csstools/postcss-global-data@3.1.0(postcss@8.5.6)':
+  '@csstools/postcss-global-data@3.1.0(postcss@8.5.26)':
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
 
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
@@ -9266,7 +9309,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.8.1':
+  '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -9277,6 +9320,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -9302,7 +9350,7 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.0':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.2':
     optional: true
 
   '@esbuild/android-arm64@0.19.12':
@@ -9314,7 +9362,7 @@ snapshots:
   '@esbuild/android-arm64@0.27.0':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
   '@esbuild/android-arm@0.19.12':
@@ -9326,7 +9374,7 @@ snapshots:
   '@esbuild/android-arm@0.27.0':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.28.2':
     optional: true
 
   '@esbuild/android-x64@0.19.12':
@@ -9338,7 +9386,7 @@ snapshots:
   '@esbuild/android-x64@0.27.0':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.19.12':
@@ -9350,7 +9398,7 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.0':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.28.2':
     optional: true
 
   '@esbuild/darwin-x64@0.19.12':
@@ -9362,7 +9410,7 @@ snapshots:
   '@esbuild/darwin-x64@0.27.0':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.19.12':
@@ -9374,7 +9422,7 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.0':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.19.12':
@@ -9386,7 +9434,7 @@ snapshots:
   '@esbuild/freebsd-x64@0.27.0':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm64@0.19.12':
@@ -9398,7 +9446,7 @@ snapshots:
   '@esbuild/linux-arm64@0.27.0':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm@0.19.12':
@@ -9410,7 +9458,7 @@ snapshots:
   '@esbuild/linux-arm@0.27.0':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
   '@esbuild/linux-ia32@0.19.12':
@@ -9422,7 +9470,7 @@ snapshots:
   '@esbuild/linux-ia32@0.27.0':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.28.2':
     optional: true
 
   '@esbuild/linux-loong64@0.19.12':
@@ -9434,7 +9482,7 @@ snapshots:
   '@esbuild/linux-loong64@0.27.0':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.19.12':
@@ -9446,7 +9494,7 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.0':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.28.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.19.12':
@@ -9458,7 +9506,7 @@ snapshots:
   '@esbuild/linux-ppc64@0.27.0':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.19.12':
@@ -9470,7 +9518,7 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.0':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.2':
     optional: true
 
   '@esbuild/linux-s390x@0.19.12':
@@ -9482,7 +9530,7 @@ snapshots:
   '@esbuild/linux-s390x@0.27.0':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
   '@esbuild/linux-x64@0.19.12':
@@ -9494,7 +9542,7 @@ snapshots:
   '@esbuild/linux-x64@0.27.0':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
@@ -9503,7 +9551,7 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.0':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.19.12':
@@ -9515,7 +9563,7 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.0':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
@@ -9524,7 +9572,7 @@ snapshots:
   '@esbuild/openbsd-arm64@0.27.0':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.19.12':
@@ -9536,7 +9584,7 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.0':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.28.2':
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
@@ -9545,7 +9593,7 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.0':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
   '@esbuild/sunos-x64@0.19.12':
@@ -9557,7 +9605,7 @@ snapshots:
   '@esbuild/sunos-x64@0.27.0':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.28.2':
     optional: true
 
   '@esbuild/win32-arm64@0.19.12':
@@ -9569,7 +9617,7 @@ snapshots:
   '@esbuild/win32-arm64@0.27.0':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
   '@esbuild/win32-ia32@0.19.12':
@@ -9581,7 +9629,7 @@ snapshots:
   '@esbuild/win32-ia32@0.27.0':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.28.2':
     optional: true
 
   '@esbuild/win32-x64@0.19.12':
@@ -9593,7 +9641,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.0':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@1.21.7))':
@@ -9806,7 +9854,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.8.1
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -9861,12 +9909,11 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+    optional: true
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.2
-
-  '@istanbuljs/schema@0.1.3': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -9987,7 +10034,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       node-fetch: 2.7.0
       nopt: 8.1.0
-      semver: 7.7.3
+      semver: 7.8.1
       tar: 7.5.4
     transitivePeerDependencies:
       - encoding
@@ -10001,9 +10048,9 @@ snapshots:
       '@types/react': 19.2.9
       react: 19.2.3
 
-  '@mermaid-js/parser@0.6.3':
+  '@mermaid-js/parser@1.2.1':
     dependencies:
-      langium: 3.3.1
+      '@chevrotain/types': 11.1.2
 
   '@mswjs/interceptors@0.40.0':
     dependencies:
@@ -10026,6 +10073,13 @@ snapshots:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@neoconfetti/react@1.0.0': {}
@@ -10119,65 +10173,65 @@ snapshots:
 
   '@oxc-project/types@0.133.0': {}
 
-  '@oxc-resolver/binding-android-arm-eabi@11.20.0':
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-android-arm64@11.20.0':
+  '@oxc-resolver/binding-android-arm64@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-darwin-arm64@11.20.0':
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-darwin-x64@11.20.0':
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-freebsd-x64@11.20.0':
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-arm-musleabihf@11.20.0':
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-x64-musl@11.20.0':
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-openharmony-arm64@11.20.0':
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.20.0':
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
     optional: true
 
   '@parcel/watcher-android-arm64@2.5.6':
@@ -10519,89 +10573,89 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@storybook/addon-a11y@10.5.9(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
-      storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@storybook/addon-docs@10.1.11(@types/react@19.2.9)(esbuild@0.25.12)(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
+  '@storybook/addon-docs@10.5.9(@types/react@19.2.9)(esbuild@0.28.2)(rollup@4.61.0)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.9)(react@19.2.3)
-      '@storybook/csf-plugin': 10.1.11(esbuild@0.25.12)(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
-      '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@storybook/react-dom-shim': 10.1.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@storybook/csf-plugin': 10.5.9(esbuild@0.28.2)(rollup@4.61.0)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      '@storybook/icons': 2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@storybook/react-dom-shim': 10.5.9(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-dedent: 2.2.0
+    optionalDependencies:
+      '@types/react': 19.2.9
     transitivePeerDependencies:
-      - '@types/react'
+      - '@types/react-dom'
       - esbuild
       - rollup
       - vite
       - webpack
 
-  '@storybook/addon-svelte-csf@5.0.10(@storybook/svelte@10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0(@typescript-eslint/types@8.53.1)))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
+  '@storybook/addon-svelte-csf@5.1.2(@storybook/svelte@10.5.9(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.9(@typescript-eslint/types@8.67.0)))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
     dependencies:
       '@storybook/csf': 0.1.13
-      '@storybook/svelte': 10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0(@typescript-eslint/types@8.53.1))
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      '@storybook/svelte': 10.5.9(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.9(@typescript-eslint/types@8.67.0))
+      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
       dedent: 1.7.1
-      es-toolkit: 1.44.0
+      es-toolkit: 1.51.0
       esrap: 1.4.9
       magic-string: 0.30.21
-      storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
-      svelte-ast-print: 0.4.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
+      svelte-ast-print: 0.4.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))
+      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@storybook/addon-vitest@10.1.11(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8)(@vitest/runner@4.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.1.8)':
+  '@storybook/addon-vitest@10.5.9(@vitest/browser-playwright@4.1.11)(@vitest/browser@4.1.11)(@vitest/runner@4.1.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.1.11)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@storybook/icons': 2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     optionalDependencies:
-      '@vitest/browser': 4.1.8(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.8)
-      '@vitest/browser-playwright': 4.1.8(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.8)
-      '@vitest/runner': 4.1.8
-      vitest: 4.1.8(@types/node@24.10.9)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@3.2.4)(happy-dom@19.0.2)(jsdom@27.4.0(bufferutil@4.1.0))(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      '@vitest/browser': 4.1.11(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.11)
+      '@vitest/browser-playwright': 4.1.11(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.11)
+      '@vitest/runner': 4.1.11
+      vitest: 4.1.11(@types/node@24.10.9)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.2(bufferutil@4.1.0))(jsdom@27.4.0(bufferutil@4.1.0))(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.1.11(esbuild@0.25.12)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
+  '@storybook/builder-vite@10.5.9(esbuild@0.28.2)(rollup@4.61.0)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.1.11(esbuild@0.25.12)(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
-      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
-      storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@storybook/csf-plugin': 10.5.9(esbuild@0.28.2)(rollup@4.61.0)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-dedent: 2.2.0
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
+      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)
     transitivePeerDependencies:
       - esbuild
-      - msw
       - rollup
       - webpack
 
-  '@storybook/components@8.6.14(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@storybook/components@8.6.14(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
-      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@storybook/core-events@8.6.14(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@storybook/core-events@8.6.14(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
-      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@storybook/csf-plugin@10.1.11(esbuild@0.25.12)(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
+  '@storybook/csf-plugin@10.5.9(esbuild@0.28.2)(rollup@4.61.0)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
     dependencies:
-      storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       unplugin: 2.3.11
     optionalDependencies:
-      esbuild: 0.25.12
+      esbuild: 0.28.2
       rollup: 4.61.0
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
+      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)
 
   '@storybook/csf@0.1.13':
     dependencies:
@@ -10614,97 +10668,89 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@storybook/icons@2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-
   '@storybook/icons@2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@storybook/manager-api@8.6.14(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@storybook/manager-api@8.6.14(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
-      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@storybook/react-dom-shim@10.1.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@storybook/react-dom-shim@10.5.9(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.9
 
-  '@storybook/svelte-vite@10.1.11(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(esbuild@0.25.12)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
+  '@storybook/svelte-vite@10.5.9(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(esbuild@0.28.2)(rollup@4.61.0)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
     dependencies:
-      '@storybook/builder-vite': 10.1.11(esbuild@0.25.12)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(rollup@4.61.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
-      '@storybook/svelte': 10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0(@typescript-eslint/types@8.53.1))
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      '@storybook/builder-vite': 10.5.9(esbuild@0.28.2)(rollup@4.61.0)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      '@storybook/svelte': 10.5.9(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.9(@typescript-eslint/types@8.67.0))
+      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
       magic-string: 0.30.21
-      storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
-      svelte2tsx: 0.7.46(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
+      svelte2tsx: 0.7.61(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)
       typescript: 5.9.3
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
+      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)
     transitivePeerDependencies:
       - esbuild
-      - msw
       - rollup
       - webpack
 
-  '@storybook/svelte@10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.48.0(@typescript-eslint/types@8.53.1))':
+  '@storybook/svelte@10.5.9(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(svelte@5.56.9(@typescript-eslint/types@8.67.0))':
     dependencies:
-      storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
       ts-dedent: 2.2.0
-      type-fest: 2.19.0
+      type-fest: 5.8.0
 
-  '@storybook/theming@8.6.14(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@storybook/theming@8.6.14(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
-      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))':
+  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))':
     dependencies:
-      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))
+      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
 
-  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))':
+  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))':
     dependencies:
-      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0))
+      '@sveltejs/kit': 2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
 
-  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))':
-    dependencies:
-      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
-
-  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))':
+  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))':
     dependencies:
       '@rollup/plugin-commonjs': 29.0.3(rollup@4.61.0)
       '@rollup/plugin-json': 6.1.0(rollup@4.61.0)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.61.0)
-      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
       rollup: 4.61.0
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))':
     dependencies:
-      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0))
+      '@sveltejs/kit': 2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
 
-  '@sveltejs/adapter-vercel@5.10.3(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(rollup@4.61.0)':
+  '@sveltejs/adapter-vercel@6.3.4(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(rollup@4.61.0)':
     dependencies:
-      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0))
-      '@vercel/nft': 0.30.4(rollup@4.61.0)
-      esbuild: 0.25.12
+      '@sveltejs/kit': 2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
+      '@vercel/nft': 1.11.0(rollup@4.61.0)
+      esbuild: 0.28.2
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))':
+  '@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))
+      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -10715,16 +10761,16 @@ snapshots:
       mrmime: 2.0.1
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
+      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0))':
+  '@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)))(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0))
+      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -10735,77 +10781,30 @@ snapshots:
       mrmime: 2.0.1
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
+      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)))(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
-      '@types/cookie': 0.6.0
-      acorn: 8.16.0
-      cookie: 0.6.0
-      devalue: 5.8.1
-      esm-env: 1.2.2
-      kleur: 4.1.5
-      magic-string: 0.30.21
-      mrmime: 2.0.1
-      set-cookie-parser: 3.1.0
-      sirv: 3.0.2
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
-    optionalDependencies:
-      typescript: 5.9.3
-
-  '@sveltejs/package@2.5.7(patch_hash=4bf60d897bf9a1418645763e4338b3223b9458b10046bd6cde08601581f05183)(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)':
+  '@sveltejs/package@2.5.7(patch_hash=4bf60d897bf9a1418645763e4338b3223b9458b10046bd6cde08601581f05183)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)':
     dependencies:
       chokidar: 5.0.0
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.7.3
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
-      svelte2tsx: 0.7.46(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
+      svelte2tsx: 0.7.46(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
+  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
-      vitefu: 1.1.3(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
-
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))':
-    dependencies:
-      deepmerge: 4.3.1
-      magic-string: 0.30.21
-      obug: 2.1.1
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)
-      vitefu: 1.1.3(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0))
-
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0))':
-    dependencies:
-      deepmerge: 4.3.1
-      magic-string: 0.30.21
-      obug: 2.1.1
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
-      vitefu: 1.1.3(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0))
-
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
-    dependencies:
-      deepmerge: 4.3.1
-      magic-string: 0.30.21
-      obug: 2.1.1
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
-      vitefu: 1.1.3(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
+      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)
+      vitefu: 1.1.3(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0))
 
   '@tailwindcss/forms@0.5.11(tailwindcss@3.4.19)':
     dependencies:
@@ -10846,15 +10845,20 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/svelte-core@1.0.0(svelte@5.48.0(@typescript-eslint/types@8.53.1))':
+  '@testing-library/svelte-core@1.1.3(svelte@5.56.9(@typescript-eslint/types@8.67.0))':
     dependencies:
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
 
   '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -11031,10 +11035,6 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@20.19.30':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@24.10.9':
     dependencies:
       undici-types: 7.16.0
@@ -11068,6 +11068,10 @@ snapshots:
   '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/which@3.0.4': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.10.9
 
   '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
@@ -11106,12 +11110,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.67.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.67.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.53.1':
     dependencies:
       '@typescript-eslint/types': 8.53.1
       '@typescript-eslint/visitor-keys': 8.53.1
 
+  '@typescript-eslint/scope-manager@8.67.0':
+    dependencies:
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
+
   '@typescript-eslint/tsconfig-utils@8.53.1(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/tsconfig-utils@8.67.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
@@ -11129,6 +11151,8 @@ snapshots:
 
   '@typescript-eslint/types@8.53.1': {}
 
+  '@typescript-eslint/types@8.67.0': {}
+
   '@typescript-eslint/typescript-estree@8.53.1(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.53.1(typescript@5.9.3)
@@ -11144,6 +11168,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.67.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
+      debug: 4.4.3
+      minimatch: 10.2.6
+      semver: 7.8.1
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
@@ -11155,12 +11194,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.67.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
+      eslint: 9.39.2(jiti@1.21.7)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.53.1':
     dependencies:
       '@typescript-eslint/types': 8.53.1
       eslint-visitor-keys: 4.2.1
 
-  '@vercel/nft@0.30.4(rollup@4.61.0)':
+  '@typescript-eslint/visitor-keys@8.67.0':
+    dependencies:
+      '@typescript-eslint/types': 8.67.0
+      eslint-visitor-keys: 5.0.0
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@vercel/nft@1.11.0(rollup@4.61.0)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
       '@rollup/pluginutils': 5.3.0(rollup@4.61.0)
@@ -11169,7 +11229,7 @@ snapshots:
       async-sema: 3.1.1
       bindings: 1.5.0
       estree-walker: 2.0.2
-      glob: 10.5.0
+      glob: 13.0.6
       graceful-fs: 4.2.11
       node-gyp-build: 4.8.4
       picomatch: 4.0.4
@@ -11179,29 +11239,29 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitest/browser-playwright@4.1.8(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.8)':
+  '@vitest/browser-playwright@4.1.11(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.11)':
     dependencies:
-      '@vitest/browser': 4.1.8(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.8)
-      '@vitest/mocker': 4.1.8(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      '@vitest/browser': 4.1.11(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.11)
+      '@vitest/mocker': 4.1.11(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@24.10.9)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@3.2.4)(happy-dom@19.0.2)(jsdom@27.4.0(bufferutil@4.1.0))(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      vitest: 4.1.11(@types/node@24.10.9)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.2(bufferutil@4.1.0))(jsdom@27.4.0(bufferutil@4.1.0))(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.8(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.8)':
+  '@vitest/browser@4.1.11(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.11)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.8(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
-      '@vitest/utils': 4.1.8
+      '@vitest/mocker': 4.1.11(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@24.10.9)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@3.2.4)(happy-dom@19.0.2)(jsdom@27.4.0(bufferutil@4.1.0))(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      vitest: 4.1.11(@types/node@24.10.9)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.2(bufferutil@4.1.0))(jsdom@27.4.0(bufferutil@4.1.0))(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
       ws: 8.21.0(bufferutil@4.1.0)
     transitivePeerDependencies:
       - bufferutil
@@ -11209,26 +11269,21 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@3.2.4(@vitest/browser@4.1.8)(vitest@4.1.8)':
+  '@vitest/coverage-v8@4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)':
     dependencies:
-      '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.10
-      debug: 4.4.3
+      '@vitest/utils': 4.1.11
+      ast-v8-to-istanbul: 1.0.5
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.2.0
-      magic-string: 0.30.21
-      magicast: 0.3.5
-      std-env: 3.10.0
-      test-exclude: 7.0.1
-      tinyrainbow: 2.0.0
-      vitest: 4.1.8(@types/node@24.10.9)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@3.2.4)(happy-dom@19.0.2)(jsdom@27.4.0(bufferutil@4.1.0))(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      magicast: 0.5.4
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.11(@types/node@24.10.9)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.2(bufferutil@4.1.0))(jsdom@27.4.0(bufferutil@4.1.0))(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.8(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.8)
-    transitivePeerDependencies:
-      - supports-color
+      '@vitest/browser': 4.1.11(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.11)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -11238,50 +11293,41 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/expect@4.1.8':
+  '@vitest/expect@4.1.11':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
+  '@vitest/mocker@4.1.11(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@24.10.9)(typescript@5.9.3)
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
-
-  '@vitest/mocker@4.1.8(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))':
-    dependencies:
-      '@vitest/spy': 4.1.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.12.7(@types/node@24.10.9)(typescript@5.9.3)
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
+      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/pretty-format@4.1.8':
+  '@vitest/pretty-format@4.1.11':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.8':
+  '@vitest/runner@4.1.11':
     dependencies:
-      '@vitest/utils': 4.1.8
+      '@vitest/utils': 4.1.11
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.8':
+  '@vitest/snapshot@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pathe: 2.0.3
 
@@ -11289,7 +11335,7 @@ snapshots:
     dependencies:
       tinyspy: 4.0.4
 
-  '@vitest/spy@4.1.8': {}
+  '@vitest/spy@4.1.11': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -11297,9 +11343,9 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/utils@4.1.8':
+  '@vitest/utils@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.8
+      '@vitest/pretty-format': 4.1.11
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -11309,9 +11355,9 @@ snapshots:
 
   '@xmldom/xmldom@0.8.11': {}
 
-  '@zerodevx/svelte-json-view@1.0.11(svelte@5.48.0(@typescript-eslint/types@8.53.1))':
+  '@zerodevx/svelte-json-view@1.0.11(svelte@5.56.9(@typescript-eslint/types@8.67.0))':
     dependencies:
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
 
   abbrev@3.0.1: {}
 
@@ -11376,6 +11422,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  aria-query@5.3.1: {}
+
   aria-query@5.3.2: {}
 
   array-union@2.1.0: {}
@@ -11392,11 +11440,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ast-v8-to-istanbul@0.3.10:
+  ast-v8-to-istanbul@1.0.5:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
-      js-tokens: 9.0.1
+      js-tokens: 10.0.0
 
   async-sema@3.1.1: {}
 
@@ -11407,13 +11455,13 @@ snapshots:
       '@babel/runtime': 7.28.6
       tslib: 2.8.1
 
-  autoprefixer@10.4.23(postcss@8.5.6):
+  autoprefixer@10.4.23(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.1
       caniuse-lite: 1.0.30001765
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
   axe-core@4.11.1: {}
@@ -11428,6 +11476,8 @@ snapshots:
   babylonjs-gltf2interface@8.46.2: {}
 
   balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.9.16: {}
 
@@ -11458,6 +11508,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -11479,6 +11533,10 @@ snapshots:
 
   buffer-from@1.1.2:
     optional: true
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 24.10.9
 
   bufferutil@4.1.0:
     dependencies:
@@ -11530,20 +11588,6 @@ snapshots:
   chardet@2.1.1: {}
 
   check-error@2.1.3: {}
-
-  chevrotain-allstar@0.3.1(chevrotain@11.0.3):
-    dependencies:
-      chevrotain: 11.0.3
-      lodash-es: 4.17.22
-
-  chevrotain@11.0.3:
-    dependencies:
-      '@chevrotain/cst-dts-gen': 11.0.3
-      '@chevrotain/gast': 11.0.3
-      '@chevrotain/regexp-to-ast': 11.0.3
-      '@chevrotain/types': 11.0.3
-      '@chevrotain/utils': 11.0.3
-      lodash-es: 4.17.21
 
   chokidar@3.6.0:
     dependencies:
@@ -11690,9 +11734,9 @@ snapshots:
 
   crypto-js@4.2.0: {}
 
-  css-declaration-sorter@7.3.1(postcss@8.5.6):
+  css-declaration-sorter@7.3.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
 
   css-select@5.2.2:
     dependencies:
@@ -11727,17 +11771,17 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.1):
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.1):
     dependencies:
       cose-base: 1.0.3
-      cytoscape: 3.33.1
+      cytoscape: 3.34.1
 
-  cytoscape-fcose@2.2.0(cytoscape@3.33.1):
+  cytoscape-fcose@2.2.0(cytoscape@3.34.1):
     dependencies:
       cose-base: 2.2.0
-      cytoscape: 3.33.1
+      cytoscape: 3.34.1
 
-  cytoscape@3.33.1: {}
+  cytoscape@3.34.1: {}
 
   d3-array@2.12.1:
     dependencies:
@@ -11917,7 +11961,7 @@ snapshots:
       es5-ext: 0.10.64
       type: 2.7.3
 
-  dagre-d3-es@7.0.13:
+  dagre-d3-es@7.0.14:
     dependencies:
       d3: 7.9.0
       lodash-es: 4.17.22
@@ -11930,6 +11974,8 @@ snapshots:
   dataloader@1.4.0: {}
 
   dayjs@1.11.19: {}
+
+  dayjs@1.11.23: {}
 
   debug@4.4.3:
     dependencies:
@@ -11989,13 +12035,25 @@ snapshots:
       domhandler: 5.0.3
       entities: 4.5.0
 
+  dom-serializer@3.1.1:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
   domelementtype@2.3.0: {}
+
+  domelementtype@3.0.0: {}
 
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.1:
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
+
+  dompurify@3.4.14:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -12004,6 +12062,12 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   dotenv@8.6.0: {}
 
@@ -12016,7 +12080,8 @@ snapshots:
 
   earcut@3.0.2: {}
 
-  eastasianwidth@0.2.0: {}
+  eastasianwidth@0.2.0:
+    optional: true
 
   electron-to-chromium@1.5.267: {}
 
@@ -12024,7 +12089,8 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
-  emoji-regex@9.2.2: {}
+  emoji-regex@9.2.2:
+    optional: true
 
   enquirer@2.4.1:
     dependencies:
@@ -12034,6 +12100,10 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   error-stack-parser-es@1.0.5: {}
 
@@ -12049,7 +12119,7 @@ snapshots:
       es-errors: 1.3.0
     optional: true
 
-  es-toolkit@1.44.0: {}
+  es-toolkit@1.51.0: {}
 
   es5-ext@0.10.64:
     dependencies:
@@ -12160,35 +12230,34 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.0
       '@esbuild/win32-x64': 0.27.0
 
-  esbuild@0.27.7:
+  esbuild@0.28.2:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
-    optional: true
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -12216,16 +12285,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-storybook@10.1.11(eslint@9.39.2(jiti@1.21.7))(storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3):
+  eslint-plugin-storybook@10.5.9(eslint@9.39.2(jiti@1.21.7))(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/utils': 8.67.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       eslint: 9.39.2(jiti@1.21.7)
-      storybook: 10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-svelte@3.14.0(eslint@9.39.2(jiti@1.21.7))(svelte@5.48.0(@typescript-eslint/types@8.53.1)):
+  eslint-plugin-svelte@3.14.0(eslint@9.39.2(jiti@1.21.7))(svelte@5.56.9(@typescript-eslint/types@8.67.0)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -12233,13 +12303,13 @@ snapshots:
       esutils: 2.0.3
       globals: 16.5.0
       known-css-properties: 0.37.0
-      postcss: 8.5.6
-      postcss-load-config: 3.1.4(postcss@8.5.6)
-      postcss-safe-parser: 7.0.1(postcss@8.5.6)
+      postcss: 8.5.26
+      postcss-load-config: 3.1.4(postcss@8.5.26)
+      postcss-safe-parser: 7.0.1(postcss@8.5.26)
       semver: 7.7.3
-      svelte-eslint-parser: 1.4.1(svelte@5.48.0(@typescript-eslint/types@8.53.1))
+      svelte-eslint-parser: 1.4.1(svelte@5.56.9(@typescript-eslint/types@8.67.0))
     optionalDependencies:
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
     transitivePeerDependencies:
       - ts-node
 
@@ -12331,11 +12401,11 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  esrap@2.2.9(@typescript-eslint/types@8.53.1):
+  esrap@2.3.5(@typescript-eslint/types@8.67.0):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
     optionalDependencies:
-      '@typescript-eslint/types': 8.53.1
+      '@typescript-eslint/types': 8.67.0
 
   esrecurse@4.3.0:
     dependencies:
@@ -12425,6 +12495,10 @@ snapshots:
       '@babel/runtime': 7.28.6
       tslib: 2.8.1
 
+  fastdom@1.0.12:
+    dependencies:
+      strictdom: 1.0.1
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -12472,6 +12546,7 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+    optional: true
 
   fraction.js@5.3.4: {}
 
@@ -12542,9 +12617,16 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.5
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
+    optional: true
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.6
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   globals@14.0.0: {}
 
@@ -12583,11 +12665,18 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
-  happy-dom@19.0.2:
+  happy-dom@20.11.2(bufferutil@4.1.0):
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 24.10.9
       '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
       whatwg-mimetype: 3.0.0
+      ws: 8.21.0(bufferutil@4.1.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -12628,6 +12717,13 @@ snapshots:
   html-entities@2.6.0: {}
 
   html-escaper@2.0.2: {}
+
+  htmlparser2@12.0.0:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
 
   htmlparser2@8.0.2:
     dependencies:
@@ -12785,14 +12881,6 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
@@ -12803,6 +12891,7 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+    optional: true
 
   javascript-stringify@2.1.0: {}
 
@@ -12815,9 +12904,9 @@ snapshots:
   js-stringify@1.0.2:
     optional: true
 
-  js-tokens@4.0.0: {}
+  js-tokens@10.0.0: {}
 
-  js-tokens@9.0.1: {}
+  js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
     dependencies:
@@ -12868,6 +12957,8 @@ snapshots:
 
   json-stringify-pretty-compact@4.0.0: {}
 
+  jsonc-parser@3.3.1: {}
+
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
@@ -12888,6 +12979,10 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -12898,13 +12993,9 @@ snapshots:
 
   known-css-properties@0.37.0: {}
 
-  langium@3.3.1:
+  launder@1.7.1:
     dependencies:
-      chevrotain: 11.0.3
-      chevrotain-allstar: 0.3.1(chevrotain@11.0.3)
-      vscode-languageserver: 9.0.1
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.0.8
+      dayjs: 1.11.19
 
   layout-base@1.0.2: {}
 
@@ -13000,8 +13091,6 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.17.21: {}
-
   lodash-es@4.17.22: {}
 
   lodash.merge@4.6.2: {}
@@ -13010,7 +13099,8 @@ snapshots:
 
   loupe@3.2.1: {}
 
-  lru-cache@10.4.3: {}
+  lru-cache@10.4.3:
+    optional: true
 
   lru-cache@11.2.4: {}
 
@@ -13024,15 +13114,15 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.3.5:
+  magicast@0.5.4:
     dependencies:
-      '@babel/parser': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.1
 
   map-obj@5.0.2: {}
 
@@ -13056,13 +13146,13 @@ snapshots:
 
   mdn-data@2.12.2: {}
 
-  mdsvex@0.12.6(svelte@5.48.0(@typescript-eslint/types@8.53.1)):
+  mdsvex@0.12.6(svelte@5.56.9(@typescript-eslint/types@8.67.0)):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 2.0.11
       prism-svelte: 0.4.7
       prismjs: 1.30.0
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
       unist-util-visit: 2.0.3
       vfile-message: 2.0.4
 
@@ -13107,23 +13197,25 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.12.2:
+  mermaid@11.17.0:
     dependencies:
-      '@braintree/sanitize-url': 7.1.1
+      '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.0
-      '@mermaid-js/parser': 0.6.3
+      '@mermaid-js/parser': 1.2.1
       '@types/d3': 7.4.3
-      cytoscape: 3.33.1
-      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.1)
-      cytoscape-fcose: 2.2.0(cytoscape@3.33.1)
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.1
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.1)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.1)
       d3: 7.9.0
       d3-sankey: 0.12.3
-      dagre-d3-es: 7.0.13
-      dayjs: 1.11.19
-      dompurify: 3.3.1
-      katex: 0.16.27
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.23
+      dompurify: 3.4.14
+      es-toolkit: 1.51.0
+      fastdom: 1.0.12
+      katex: 0.16.47
       khroma: 2.1.0
-      lodash-es: 4.17.22
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.3.6
@@ -13152,6 +13244,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -13163,6 +13259,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   minizlib@3.1.0:
     dependencies:
@@ -13219,9 +13317,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11: {}
-
-  nanoid@3.3.12: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -13321,27 +13417,27 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
       '@oxc-parser/binding-win32-x64-msvc': 0.127.0
 
-  oxc-resolver@11.20.0:
+  oxc-resolver@11.24.2:
     optionalDependencies:
-      '@oxc-resolver/binding-android-arm-eabi': 11.20.0
-      '@oxc-resolver/binding-android-arm64': 11.20.0
-      '@oxc-resolver/binding-darwin-arm64': 11.20.0
-      '@oxc-resolver/binding-darwin-x64': 11.20.0
-      '@oxc-resolver/binding-freebsd-x64': 11.20.0
-      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.20.0
-      '@oxc-resolver/binding-linux-arm-musleabihf': 11.20.0
-      '@oxc-resolver/binding-linux-arm64-gnu': 11.20.0
-      '@oxc-resolver/binding-linux-arm64-musl': 11.20.0
-      '@oxc-resolver/binding-linux-ppc64-gnu': 11.20.0
-      '@oxc-resolver/binding-linux-riscv64-gnu': 11.20.0
-      '@oxc-resolver/binding-linux-riscv64-musl': 11.20.0
-      '@oxc-resolver/binding-linux-s390x-gnu': 11.20.0
-      '@oxc-resolver/binding-linux-x64-gnu': 11.20.0
-      '@oxc-resolver/binding-linux-x64-musl': 11.20.0
-      '@oxc-resolver/binding-openharmony-arm64': 11.20.0
-      '@oxc-resolver/binding-wasm32-wasi': 11.20.0
-      '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
-      '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
+      '@oxc-resolver/binding-android-arm-eabi': 11.24.2
+      '@oxc-resolver/binding-android-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-x64': 11.24.2
+      '@oxc-resolver/binding-freebsd-x64': 11.24.2
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-musl': 11.24.2
+      '@oxc-resolver/binding-openharmony-arm64': 11.24.2
+      '@oxc-resolver/binding-wasm32-wasi': 11.24.2
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
+      '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
 
   p-filter@2.1.0:
     dependencies:
@@ -13367,7 +13463,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  package-json-from-dist@1.0.1: {}
+  package-json-from-dist@1.0.1:
+    optional: true
 
   package-manager-detector@0.2.11:
     dependencies:
@@ -13404,7 +13501,13 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
+    optional: true
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.4
+      minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
 
@@ -13489,73 +13592,65 @@ snapshots:
       map-obj: 5.0.2
       prettier: 3.8.0
 
-  postcss-custom-media@11.0.6(postcss@8.5.6):
+  postcss-custom-media@11.0.6(postcss@8.5.26):
     dependencies:
       '@csstools/cascade-layer-name-parser': 2.0.5(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      postcss: 8.5.6
+      postcss: 8.5.26
 
-  postcss-import@15.1.0(postcss@8.5.6):
+  postcss-import@15.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.11
 
-  postcss-js@4.1.0(postcss@8.5.6):
+  postcss-js@4.1.0(postcss@8.5.26):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.6
+      postcss: 8.5.26
 
-  postcss-less@6.0.0(postcss@8.5.6):
+  postcss-less@6.0.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
 
-  postcss-load-config@3.1.4(postcss@8.5.6):
+  postcss-load-config@3.1.4(postcss@8.5.26):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.26):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.15
-    optional: true
+      postcss: 8.5.26
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6):
+  postcss-nested@6.2.0(postcss@8.5.26):
     dependencies:
-      lilconfig: 3.1.3
-    optionalDependencies:
-      jiti: 1.21.7
-      postcss: 8.5.6
-
-  postcss-nested@6.2.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.2
 
-  postcss-nested@7.0.2(postcss@8.5.6):
+  postcss-nested@7.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
 
-  postcss-prefix-selector@2.1.1(postcss@8.5.6):
+  postcss-prefix-selector@2.1.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
 
-  postcss-safe-parser@7.0.1(postcss@8.5.6):
+  postcss-safe-parser@7.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
 
-  postcss-scss@4.0.9(postcss@8.5.6):
+  postcss-scss@4.0.9(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
 
   postcss-selector-parser@6.0.10:
     dependencies:
@@ -13574,33 +13669,27 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.15:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.6:
-    dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-css-order@2.2.0(postcss@8.5.6)(prettier@3.8.0):
+  prettier-plugin-css-order@2.2.0(postcss@8.5.26)(prettier@3.8.0):
     dependencies:
-      css-declaration-sorter: 7.3.1(postcss@8.5.6)
-      postcss-less: 6.0.0(postcss@8.5.6)
-      postcss-scss: 4.0.9(postcss@8.5.6)
+      css-declaration-sorter: 7.3.1(postcss@8.5.26)
+      postcss-less: 6.0.0(postcss@8.5.26)
+      postcss-scss: 4.0.9(postcss@8.5.26)
       prettier: 3.8.0
     transitivePeerDependencies:
       - postcss
 
-  prettier-plugin-svelte@3.4.1(prettier@3.8.0)(svelte@5.48.0(@typescript-eslint/types@8.53.1)):
+  prettier-plugin-svelte@3.4.1(prettier@3.8.0)(svelte@5.56.9(@typescript-eslint/types@8.67.0)):
     dependencies:
       prettier: 3.8.0
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
 
   prettier@2.8.8: {}
 
@@ -13911,14 +14000,15 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanitize-html@2.17.0:
+  sanitize-html@2.17.7:
     dependencies:
       deepmerge: 4.3.1
       escape-string-regexp: 4.0.0
-      htmlparser2: 8.0.2
+      htmlparser2: 12.0.0
       is-plain-object: 5.0.0
+      launder: 1.7.1
       parse-srcset: 1.0.2
-      postcss: 8.5.6
+      postcss: 8.5.26
 
   sass@1.97.2:
     dependencies:
@@ -13952,7 +14042,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.0.0
       detect-libc: 2.1.2
-      semver: 7.7.3
+      semver: 7.8.1
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -14049,18 +14139,16 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@3.10.0: {}
-
   std-env@4.1.0: {}
 
-  storybook-dark-mode@4.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+  storybook-dark-mode@4.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
-      '@storybook/components': 8.6.14(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
-      '@storybook/core-events': 8.6.14(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@storybook/components': 8.6.14(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@storybook/core-events': 8.6.14(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@storybook/manager-api': 8.6.14(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
-      '@storybook/theming': 8.6.14(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@storybook/manager-api': 8.6.14(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@storybook/theming': 8.6.14(storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       fast-deep-equal: 3.1.3
       memoizerific: 1.11.3
     transitivePeerDependencies:
@@ -14068,57 +14156,37 @@ snapshots:
       - react-dom
       - storybook
 
-  storybook@10.1.11(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      '@storybook/global': 5.0.0
-      '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@testing-library/jest-dom': 6.9.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/expect': 3.2.4
-      '@vitest/spy': 3.2.4
-      esbuild: 0.25.12
-      open: 10.2.0
-      recast: 0.23.11
-      semver: 7.7.3
-      use-sync-external-store: 1.6.0(react@19.2.3)
-      ws: 8.19.0(bufferutil@4.1.0)
-    optionalDependencies:
-      prettier: 3.8.0
-    transitivePeerDependencies:
-      - '@testing-library/dom'
-      - bufferutil
-      - react
-      - react-dom
-      - utf-8-validate
-
-  storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  storybook@10.5.9(@types/react@19.2.9)(bufferutil@4.1.0)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/dom': 10.4.1
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
       '@webcontainer/env': 1.1.1
-      esbuild: 0.25.12
+      esbuild: 0.28.2
+      jsonc-parser: 3.3.1
       open: 10.2.0
       oxc-parser: 0.127.0
-      oxc-resolver: 11.20.0
+      oxc-resolver: 11.24.2
       recast: 0.23.11
       semver: 7.8.1
       use-sync-external-store: 1.6.0(react@19.2.3)
-      ws: 8.21.0(bufferutil@4.1.0)
+      ws: 8.21.3(bufferutil@4.1.0)
     optionalDependencies:
       '@types/react': 19.2.9
       prettier: 3.8.0
     transitivePeerDependencies:
-      - '@testing-library/dom'
       - bufferutil
       - react
       - react-dom
       - utf-8-validate
 
   strict-event-emitter@0.5.1: {}
+
+  strictdom@1.0.1: {}
 
   string-width@4.2.3:
     dependencies:
@@ -14131,6 +14199,7 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.2
+    optional: true
 
   string-width@7.2.0:
     dependencies:
@@ -14185,14 +14254,9 @@ snapshots:
       tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
-  sugarss@5.0.1(postcss@8.5.15):
+  sugarss@5.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.15
-    optional: true
-
-  sugarss@5.0.1(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     optional: true
 
   supports-color@10.2.2: {}
@@ -14203,36 +14267,36 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-ast-print@0.4.2(svelte@5.48.0(@typescript-eslint/types@8.53.1)):
+  svelte-ast-print@0.4.2(svelte@5.56.9(@typescript-eslint/types@8.67.0)):
     dependencies:
       esrap: 1.2.2
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
       zimmerframe: 1.1.2
 
-  svelte-check@4.5.0(picomatch@4.0.4)(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3):
+  svelte-check@4.5.0(picomatch@4.0.4)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.4)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@1.4.1(svelte@5.48.0(@typescript-eslint/types@8.53.1)):
+  svelte-eslint-parser@1.4.1(svelte@5.56.9(@typescript-eslint/types@8.67.0)):
     dependencies:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
-      postcss: 8.5.6
-      postcss-scss: 4.0.9(postcss@8.5.6)
+      postcss: 8.5.26
+      postcss-scss: 4.0.9(postcss@8.5.26)
       postcss-selector-parser: 7.1.1
     optionalDependencies:
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
 
-  svelte-i18n@4.0.1(svelte@5.48.0(@typescript-eslint/types@8.53.1)):
+  svelte-i18n@4.0.1(svelte@5.56.9(@typescript-eslint/types@8.67.0)):
     dependencies:
       cli-color: 2.0.4
       deepmerge: 4.3.1
@@ -14240,57 +14304,53 @@ snapshots:
       estree-walker: 2.0.2
       intl-messageformat: 10.7.18
       sade: 1.8.1
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
       tiny-glob: 0.2.9
 
-  svelte-preprocess@6.0.3(coffeescript@2.7.0)(postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15))(postcss@8.5.15)(pug@3.0.3)(sass@1.97.2)(stylus@0.64.0)(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3):
+  svelte-preprocess@6.0.3(coffeescript@2.7.0)(postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.26))(postcss@8.5.26)(pug@3.0.3)(sass@1.97.2)(stylus@0.64.0)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3):
     dependencies:
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
     optionalDependencies:
       coffeescript: 2.7.0
-      postcss: 8.5.15
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)
+      postcss: 8.5.26
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.26)
       pug: 3.0.3
       sass: 1.97.2
       stylus: 0.64.0
       typescript: 5.9.3
 
-  svelte-preprocess@6.0.3(coffeescript@2.7.0)(postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6))(postcss@8.5.6)(pug@3.0.3)(sass@1.97.2)(stylus@0.64.0)(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3):
+  svelte-range-slider-pips@4.1.0(svelte@5.56.9(@typescript-eslint/types@8.67.0)):
     dependencies:
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
-    optionalDependencies:
-      coffeescript: 2.7.0
-      postcss: 8.5.6
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)
-      pug: 3.0.3
-      sass: 1.97.2
-      stylus: 0.64.0
-      typescript: 5.9.3
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
 
-  svelte-range-slider-pips@4.1.0(svelte@5.48.0(@typescript-eslint/types@8.53.1)):
-    dependencies:
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
-
-  svelte2tsx@0.7.46(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3):
+  svelte2tsx@0.7.46(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3):
     dependencies:
       dedent-js: 1.0.1
       scule: 1.3.0
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
       typescript: 5.9.3
 
-  svelte@5.48.0(@typescript-eslint/types@8.53.1):
+  svelte2tsx@0.7.61(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3):
+    dependencies:
+      dedent-js: 1.0.1
+      scule: 1.3.0
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
+      typescript: 5.9.3
+
+  svelte@5.56.9(@typescript-eslint/types@8.67.0):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
       '@types/estree': 1.0.9
+      '@types/trusted-types': 2.0.7
       acorn: 8.16.0
-      aria-query: 5.3.2
+      aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
       devalue: 5.8.1
       esm-env: 1.2.2
-      esrap: 2.2.9(@typescript-eslint/types@8.53.1)
+      esrap: 2.3.5(@typescript-eslint/types@8.67.0)
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.21
@@ -14318,11 +14378,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)
-      postcss-nested: 6.2.0(postcss@8.5.6)
+      postcss: 8.5.26
+      postcss-import: 15.1.0(postcss@8.5.26)
+      postcss-js: 4.1.0(postcss@8.5.26)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.26)
+      postcss-nested: 6.2.0(postcss@8.5.26)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
       sucrase: 3.35.1
@@ -14349,12 +14409,6 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
     optional: true
-
-  test-exclude@7.0.1:
-    dependencies:
-      '@istanbuljs/schema': 0.1.3
-      glob: 10.5.0
-      minimatch: 9.0.5
 
   thenify-all@1.6.0:
     dependencies:
@@ -14444,6 +14498,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   ts-dedent@2.2.0: {}
 
   ts-interface-checker@0.1.13: {}
@@ -14460,12 +14518,16 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-fest@5.8.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
   type@2.7.3: {}
 
-  typescript-svelte-plugin@0.3.50(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3):
+  typescript-svelte-plugin@0.3.50(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-      svelte2tsx: 0.7.46(svelte@5.48.0(@typescript-eslint/types@8.53.1))(typescript@5.9.3)
+      svelte2tsx: 0.7.46(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - svelte
       - typescript
@@ -14476,8 +14538,6 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
-
-  undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
 
@@ -15116,103 +15176,42 @@ snapshots:
 
   vite-plugin-turbosnap@1.0.3: {}
 
-  vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0):
+  vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.26
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.10.9
-      esbuild: 0.25.12
+      esbuild: 0.28.2
       fsevents: 2.3.3
       jiti: 1.21.7
       sass: 1.97.2
       stylus: 0.64.0
+      sugarss: 5.0.1(postcss@8.5.26)
       terser: 5.46.0
 
-  vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0):
+  vitefu@1.1.3(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)):
+    optionalDependencies:
+      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)
+
+  vitest-browser-svelte@3.0.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vitest@4.1.11):
     dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 24.10.9
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      sass: 1.97.2
-      stylus: 0.64.0
-      sugarss: 5.0.1(postcss@8.5.15)
-      terser: 5.46.0
+      '@testing-library/svelte-core': 1.1.3(svelte@5.56.9(@typescript-eslint/types@8.67.0))
+      svelte: 5.56.9(@typescript-eslint/types@8.67.0)
+      vitest: 4.1.11(@types/node@24.10.9)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.2(bufferutil@4.1.0))(jsdom@27.4.0(bufferutil@4.1.0))(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
 
-  vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0):
+  vitest@4.1.11(@types/node@24.10.9)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.2(bufferutil@4.1.0))(jsdom@27.4.0(bufferutil@4.1.0))(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)):
     dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 24.10.9
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      sass: 1.97.2
-      stylus: 0.64.0
-      sugarss: 5.0.1(postcss@8.5.6)
-      terser: 5.46.0
-
-  vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 24.10.9
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      sass: 1.97.2
-      stylus: 0.64.0
-      terser: 5.46.0
-
-  vitefu@1.1.3(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)):
-    optionalDependencies:
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
-
-  vitefu@1.1.3(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)):
-    optionalDependencies:
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.46.0)
-
-  vitefu@1.1.3(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)):
-    optionalDependencies:
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
-
-  vitefu@1.1.3(vite@8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)):
-    optionalDependencies:
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.27.7)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
-
-  vitest-browser-svelte@2.1.1(svelte@5.48.0(@typescript-eslint/types@8.53.1))(vitest@4.1.8):
-    dependencies:
-      '@testing-library/svelte-core': 1.0.0(svelte@5.48.0(@typescript-eslint/types@8.53.1))
-      svelte: 5.48.0(@typescript-eslint/types@8.53.1)
-      vitest: 4.1.8(@types/node@24.10.9)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@3.2.4)(happy-dom@19.0.2)(jsdom@27.4.0(bufferutil@4.1.0))(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
-
-  vitest@4.1.8(@types/node@24.10.9)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@3.2.4)(happy-dom@19.0.2)(jsdom@27.4.0(bufferutil@4.1.0))(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)):
-    dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -15224,36 +15223,19 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0)
+      vite: 8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(sugarss@5.0.1(postcss@8.5.26))(terser@5.46.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.9
-      '@vitest/browser-playwright': 4.1.8(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.25.12)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.8)
-      '@vitest/coverage-v8': 3.2.4(@vitest/browser@4.1.8)(vitest@4.1.8)
-      happy-dom: 19.0.2
+      '@vitest/browser-playwright': 4.1.11(bufferutil@4.1.0)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(playwright@1.60.0)(vite@8.0.16(@types/node@24.10.9)(esbuild@0.28.2)(jiti@1.21.7)(sass@1.97.2)(stylus@0.64.0)(terser@5.46.0))(vitest@4.1.11)
+      '@vitest/coverage-v8': 4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)
+      happy-dom: 20.11.2(bufferutil@4.1.0)
       jsdom: 27.4.0(bufferutil@4.1.0)
     transitivePeerDependencies:
       - msw
 
   void-elements@3.1.0:
     optional: true
-
-  vscode-jsonrpc@8.2.0: {}
-
-  vscode-languageserver-protocol@3.17.5:
-    dependencies:
-      vscode-jsonrpc: 8.2.0
-      vscode-languageserver-types: 3.17.5
-
-  vscode-languageserver-textdocument@1.0.12: {}
-
-  vscode-languageserver-types@3.17.5: {}
-
-  vscode-languageserver@9.0.1:
-    dependencies:
-      vscode-languageserver-protocol: 3.17.5
-
-  vscode-uri@3.0.8: {}
 
   w3c-keyname@2.2.8: {}
 
@@ -15359,6 +15341,7 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.1.2
+    optional: true
 
   wrap-ansi@9.0.2:
     dependencies:
@@ -15375,6 +15358,10 @@ snapshots:
       bufferutil: 4.1.0
 
   ws@8.21.0(bufferutil@4.1.0):
+    optionalDependencies:
+      bufferutil: 4.1.0
+
+  ws@8.21.3(bufferutil@4.1.0):
     optionalDependencies:
       bufferutil: 4.1.0
 


### PR DESCRIPTION
## Description

Upgrade the main frontend dependency graph to current patched releases and regenerate the pnpm lockfile.

This updates happy-dom, Vitest, Storybook, PostCSS, Svelte, esbuild, Mermaid, sanitize-html, SvelteKit, and the Vercel adapter. It also removes the Svelte 5.48.0 override so the workspace resolves one current Svelte version.

The first CI run exposed an mdsvex 0.12.6 crash while compiling the generated docs with Svelte 5.56.9. Updating mdsvex to 0.12.8 fixed the incompatibility while retaining the patched Svelte release; docs, website, SSR, CSR, and reload-mode CI now pass.

Closes: #13769

## AI Disclosure

- [x] I used AI to inventory Dependabot alerts, update dependency versions, regenerate the lockfile, and run and interpret validation. I reviewed the resulting manifest and lockfile changes.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets #13769.

## Testing and Formatting Your Code

- `CI=true pnpm install --frozen-lockfile`
- `pnpm format:check`
- `pnpm test:run` — 82 files passed; 2,225 tests passed, 6 skipped, 219 todo
- `pnpm build`
- `pnpm ts:check` — reports the same 16 errors on this branch and a clean checkout of `main`
- Final CI after merging current `main`: all required checks pass, including JS tests and functional tests with SSR enabled and disabled; docs, website, frontend, Storybook, preview, npm preview, reload, hygiene, and benchmark checks also pass
