### PR TITLE
Point the flaky pipeline tests at a task that transformers 5 still has

### DIFF
--- a/test/test_pipelines.py
+++ b/test/test_pipelines.py
@@ -26,11 +26,13 @@ VisualQuestionAnsweringPipeline = getattr(
     transformers, "VisualQuestionAnsweringPipeline", None
 )
 
+PIPELINE_MODEL = "hf-internal-testing/tiny-random-DistilBertForSequenceClassification"
+
 
 @pytest.mark.flaky
 def test_interface_in_blocks():
-    pipe1 = transformers.pipeline(model="deepset/roberta-base-squad2")  # type: ignore
-    pipe2 = transformers.pipeline(model="deepset/roberta-base-squad2")  # type: ignore
+    pipe1 = transformers.pipeline("text-classification", model=PIPELINE_MODEL)
+    pipe2 = transformers.pipeline("text-classification", model=PIPELINE_MODEL)
     with gr.Blocks() as demo:
         with gr.Tab("Image Inference"):
             gr.Interface.from_pipeline(pipe1)
@@ -44,12 +46,10 @@ def test_interface_in_blocks():
 def test_transformers_load_from_pipeline():
     from transformers import pipeline
 
-    pipe = pipeline(model="deepset/roberta-base-squad2")  # type: ignore
+    pipe = pipeline("text-classification", model=PIPELINE_MODEL)
     io = gr.Interface.from_pipeline(pipe)
-    assert io.input_components[0].label == "Context"  # type: ignore
-    assert io.input_components[1].label == "Question"  # type: ignore
-    assert io.output_components[0].label == "Answer"  # type: ignore
-    assert io.output_components[1].label == "Score"  # type: ignore
+    assert io.input_components[0].label == "Input"  # type: ignore
+    assert io.output_components[0].label == "Classification"  # type: ignore
 
 
 class TestHandleTransformersPipelines(unittest.TestCase):


### PR DESCRIPTION
## Description

`test_interface_in_blocks` and `test_transformers_load_from_pipeline` both built a pipeline from `deepset/roberta-base-squad2`, which transformers infers as the `question-answering` task. Transformers 5, pinned in `test/requirements.txt` since #13772, no longer has an extractive question answering pipeline, so both tests fail with `KeyError: "Unknown task question-answering, ..."` before Gradio is involved. The two tests are marked `@pytest.mark.flaky` and the `test-*-flaky` matrix entries only run on PRs labeled `flaky-tests`, so the pin landed without them ever running, and the failure now shows up on the release PR, which gets that label by default.

Both tests now build a `text-classification` pipeline from `hf-internal-testing/tiny-random-DistilBertForSequenceClassification`, and the label assertions in `test_transformers_load_from_pipeline` follow that task's mapping. The task is passed explicitly rather than inferred, because transformers 5 infers it from the Hub's `pipeline_tag` metadata, and not depending on that is one less thing that can change under the test. The tiny model also drops the roughly 500 MB download these tests used to do.

Repointing rather than skipping, because these two tests are the only coverage of `gradio/pipelines.py::load_from_pipeline`. The mock-based tests in `TestHandleTransformersPipelines` cannot reach it: it dispatches on `str(type(pipeline).__module__).startswith("transformers.pipelines.")`, so a `MagicMock` is rejected with `ValueError: pipeline must be a transformers.pipeline or diffusers.pipeline`. Skipping the two tests under transformers 5 would leave that path untested.

This is a test-only change. `gradio/pipelines_utils.py` resolves pipeline classes by name through `is_transformers_pipeline_type`, so the branches for the classes transformers 5 dropped become unreachable instead of raising, and they still serve users on transformers 4. Gradio does not depend on transformers itself, so both major versions stay supported and no library change is needed.

Closes: #13775

## Testing

Ran the file locally against `test/requirements.txt` (transformers 5.15.0, torch 2.13.0) with the frontend built:

- before the change: `test_interface_in_blocks` and `test_transformers_load_from_pipeline` fail with the `KeyError` above
- after the change: `13 passed, 2 skipped`. The two skips are the question answering and visual question answering unit tests from #13772, whose pipeline classes do not exist in transformers 5.

`ruff check`, `ruff format --check` and `ty check` are clean on the changed file.

This PR carries the `flaky-tests` label so CI actually runs the two tests it fixes.

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to... I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
