### PR TITLE
Fix file URLs and sanitize invalid uploaded filenames

### DIFF
--- a/.changeset/red-terms-march.md
+++ b/.changeset/red-terms-march.md
@@ -1,6 +1,7 @@
 ---
 "@gradio/client": minor
 "gradio": minor
+"gradio_client": minor
 ---
 
 feat:Fix uploaded file URLs with reserved filename characters

--- a/.changeset/red-terms-march.md
+++ b/.changeset/red-terms-march.md
@@ -4,4 +4,4 @@
 "gradio_client": minor
 ---
 
-feat:Fix uploaded file URLs with reserved filename characters
+feat:Fix file URLs and sanitize invalid uploaded filenames

--- a/.changeset/red-terms-march.md
+++ b/.changeset/red-terms-march.md
@@ -1,6 +1,0 @@
----
-"@gradio/client": minor
-"gradio": minor
----
-
-feat:Fix uploaded file URLs with reserved filename characters

--- a/.changeset/red-terms-march.md
+++ b/.changeset/red-terms-march.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": minor
+"gradio": minor
+---
+
+feat:Fix uploaded file URLs with reserved filename characters

--- a/client/js/src/test/upload.test.ts
+++ b/client/js/src/test/upload.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Client } from "../client";
+import { FileData, upload } from "../upload";
+
+describe("upload", () => {
+	it("encodes uploaded file paths in file URLs", async () => {
+		const path = "/tmp/computer%20vision#Huggy.png";
+		const client = {
+			api_prefix: "/gradio_api",
+			upload_files: vi.fn().mockResolvedValue({ files: [path] })
+		} as unknown as Client;
+		const input = new FileData({
+			path,
+			blob: new File([], "computer%20vision#Huggy.png")
+		});
+
+		const result = await upload.call(client, [input], "https://example.com");
+
+		expect(result?.[0]).toMatchObject({
+			path,
+			url: "https://example.com/gradio_api/file=/tmp/computer%2520vision%23Huggy.png"
+		});
+	});
+});

--- a/client/js/src/upload.ts
+++ b/client/js/src/upload.ts
@@ -30,10 +30,14 @@ export async function upload(
 				} else {
 					if (response.files) {
 						return response.files.map((f, i) => {
+							const encoded_path = f
+								.split("/")
+								.map((segment) => encodeURIComponent(segment))
+								.join("/");
 							const file = new FileData({
 								...file_data[i],
 								path: f,
-								url: `${root_url}${this.api_prefix}/file=${f}`
+								url: `${root_url}${this.api_prefix}/file=${encoded_path}`
 							});
 							return file;
 						});

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -1412,8 +1412,13 @@ class Endpoint:
             # If the URL is relative, prepend the root URL
             if not url_path.startswith(("http://", "https://")):
                 url_path = self.root_url + url_path.lstrip("/")
+            file_name = Path(url_path).name
         else:
             url_path = self.root_url + "file=" + utils.encode_file_path(x["path"])
+            # Name the download after the server's path rather than the URL. The
+            # URL is percent-encoded, so a file called "my report.png" would
+            # otherwise land on disk as "my%20report.png".
+            file_name = Path(x["path"]).name or "file"
 
         if self.client.output_dir is not None:
             os.makedirs(self.client.output_dir, exist_ok=True)
@@ -1432,15 +1437,15 @@ class Endpoint:
             **self.client.httpx_kwargs,
         ) as response:
             response.raise_for_status()
-            with open(temp_dir / Path(url_path).name, "wb") as f:
+            with open(temp_dir / file_name, "wb") as f:
                 for chunk in response.iter_bytes(chunk_size=128 * sha.block_size):
                     sha.update(chunk)
                     f.write(chunk)
 
         directory = Path(self.client.output_dir) / sha.hexdigest()
         directory.mkdir(exist_ok=True, parents=True)
-        dest = directory / Path(url_path).name
-        shutil.move(temp_dir / Path(url_path).name, dest)
+        dest = directory / file_name
+        shutil.move(temp_dir / file_name, dest)
         return str(dest.resolve())
 
     def _sse_fn_v0(self, data: dict, hash_data: dict, helper: Communicator):

--- a/client/python/gradio_client/client.py
+++ b/client/python/gradio_client/client.py
@@ -1413,7 +1413,7 @@ class Endpoint:
             if not url_path.startswith(("http://", "https://")):
                 url_path = self.root_url + url_path.lstrip("/")
         else:
-            url_path = self.root_url + "file=" + x["path"]
+            url_path = self.root_url + "file=" + utils.encode_file_path(x["path"])
 
         if self.client.output_dir is not None:
             os.makedirs(self.client.output_dir, exist_ok=True)

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -14,6 +14,7 @@ import secrets
 import shutil
 import tempfile
 import time
+import urllib.parse
 import warnings
 from collections import deque
 from collections.abc import Callable, Coroutine
@@ -776,8 +777,8 @@ def strip_invalid_filename_characters(filename: str, max_bytes: int = 200) -> st
     Only removes characters that are truly dangerous for file systems: path separators,
     null bytes, control characters, and shell-dangerous characters. Preserves all other
     characters including parentheses, brackets, unicode characters, etc.
-    The filename may include an extension (in which case it is preserved exactly as is),
-    or could be just a name without an extension.
+    The filename may include an extension (which is preserved when it fits), or
+    could be just a name without an extension.
     """
     name, ext = os.path.splitext(filename)
     name = _FORBIDDEN_RE.sub("", name)
@@ -789,6 +790,12 @@ def strip_invalid_filename_characters(filename: str, max_bytes: int = 200) -> st
     # stem (e.g. "#.txt" → ".txt" → Path(".txt").suffix == "").
     if not name and ext:
         name = "file"
+    # Windows strips trailing spaces and dots from path segments. Remove them
+    # consistently on every platform so the returned upload path is portable.
+    filename = (name + ext).rstrip(" .")
+    if not filename:
+        filename = "file"
+    name, ext = os.path.splitext(filename)
     # Prefix Windows reserved device names so uploads remain valid on NTFS
     # (CON, PRN, AUX, NUL, COM1–COM9, LPT1–LPT9, with or without extension).
     # Windows resolves device names from the segment before the *first* dot
@@ -797,15 +804,25 @@ def strip_invalid_filename_characters(filename: str, max_bytes: int = 200) -> st
     if (name + ext).partition(".")[0].rstrip(" ").upper() in _WINDOWS_RESERVED_NAMES:
         name = "_" + name
     filename = name + ext
-    filename_len = len(filename.encode())
-    if filename_len > max_bytes:
-        while filename_len > max_bytes:
-            if len(name) == 0:
-                break
-            name = name[:-1]
-            filename = name + ext
-            filename_len = len(filename.encode())
-    return filename
+    while len(filename.encode()) > max_bytes and name:
+        name = name[:-1]
+        filename = name + ext
+    if len(filename.encode()) <= max_bytes:
+        return filename
+
+    # An extension can itself exceed the limit. Keep a usable fallback stem and
+    # truncate the extension by characters so multi-byte Unicode is never split.
+    name = "file"
+    while len(name.encode()) > max_bytes and name:
+        name = name[:-1]
+    while len((name + ext).encode()) > max_bytes and ext:
+        ext = ext[:-1]
+    return name + ext
+
+
+def encode_file_path(path: str | Path) -> str:
+    """Encode a filesystem path for use after a Gradio ``/file=`` route."""
+    return urllib.parse.quote(str(path), safe="/")
 
 
 def sanitize_parameter_names(original_name: str) -> str:

--- a/client/python/gradio_client/utils.py
+++ b/client/python/gradio_client/utils.py
@@ -790,6 +790,9 @@ def strip_invalid_filename_characters(filename: str, max_bytes: int = 200) -> st
     # stem (e.g. "#.txt" → ".txt" → Path(".txt").suffix == "").
     if not name and ext:
         name = "file"
+    # Preserve the parent-directory marker so upload path validation rejects it.
+    if name + ext == "..":
+        return ".."
     # Windows strips trailing spaces and dots from path segments. Remove them
     # consistently on every platform so the returned upload path is portable.
     filename = (name + ext).rstrip(" .")

--- a/client/python/test/test_client.py
+++ b/client/python/test/test_client.py
@@ -1120,6 +1120,42 @@ class TestEndpoints:
             client.endpoints[0]._download_file(regular_file_data)  # type: ignore
 
 
+@pytest.mark.parametrize(
+    "server_path, expected_name",
+    [
+        ("/tmp/gradio/abc/my report.png", "my report.png"),
+        ("/tmp/gradio/abc/résumé (1).pdf", "résumé (1).pdf"),
+        ("/tmp/gradio/abc/computer%20vision#Huggy.png", "computer%20vision#Huggy.png"),
+    ],
+)
+def test_download_file_names_output_after_the_server_path(
+    monkeypatch, tmp_path, server_path, expected_name
+):
+    """The request URL is percent-encoded, so the saved file has to take its name
+    from the server's path. Naming it after the URL would write "my report.png"
+    to disk as "my%20report.png"."""
+    from gradio_client.client import Endpoint
+
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.raise_for_status.return_value = None
+    response.iter_bytes.return_value = [b"data"]
+    monkeypatch.setattr(httpx, "stream", lambda *args, **kwargs: response)
+
+    endpoint = MagicMock()
+    endpoint.root_url = "http://localhost:7860/gradio_api/"
+    endpoint.client.output_dir = str(tmp_path)
+    endpoint.client.headers = {}
+    endpoint.client.cookies = None
+    endpoint.client.ssl_verify = True
+    endpoint.client.httpx_kwargs = {}
+
+    downloaded = Endpoint._download_file(endpoint, {"path": server_path})
+
+    assert Path(downloaded).name == expected_name
+    assert Path(downloaded).read_bytes() == b"data"
+
+
 cpu = huggingface_hub.SpaceHardware.CPU_BASIC
 
 

--- a/client/python/test/test_client.py
+++ b/client/python/test/test_client.py
@@ -1105,11 +1105,11 @@ class TestEndpoints:
             client.endpoints[0]._download_file(stream_file_data)  # type: ignore
 
         # Test non-stream file still uses path-based URL construction
-        regular_file_data = {"path": "regular/file.txt", "is_stream": False}
+        regular_file_data = {"path": "regular/report%20#final.txt", "is_stream": False}
 
         def mock_stream_regular(*args, **kwargs):
             called_url = args[1]
-            assert called_url.endswith("file=regular/file.txt"), (
+            assert called_url.endswith("file=regular/report%2520%23final.txt"), (
                 f"Expected path-based URL, got: {called_url}"
             )
             return mock_response

--- a/client/python/test/test_utils.py
+++ b/client/python/test/test_utils.py
@@ -179,7 +179,6 @@ def test_get_mimetype(filename, expected_mimetype):
         # Sanitization must always produce a usable cross-platform filename
         ("!!!", "file"),
         (".", "file"),
-        ("..", "file"),
         ("file.", "file"),
         ("file ", "file"),
         ("config.txt", "config.txt"),

--- a/client/python/test/test_utils.py
+++ b/client/python/test/test_utils.py
@@ -77,6 +77,17 @@ def test_decode_base64_to_file(media_data):
     assert isinstance(temp_file, tempfile._TemporaryFileWrapper)
 
 
+def test_encode_file_path():
+    assert (
+        utils.encode_file_path("/tmp/computer%20vision#Huggy.png")
+        == "/tmp/computer%2520vision%23Huggy.png"
+    )
+    assert (
+        utils.encode_file_path(r"C:\Users\me\report%20#final.txt")
+        == "C%3A%5CUsers%5Cme%5Creport%2520%23final.txt"
+    )
+
+
 @pytest.mark.parametrize(
     "path_or_url, file_types, expected_result",
     [
@@ -165,12 +176,25 @@ def test_get_mimetype(filename, expected_mimetype):
         # "$" is stripped as shell-dangerous first, which already defuses CONIN$/CONOUT$
         ("CONOUT$.txt", "CONOUT.txt"),
         ("COM\xb9.log", "_COM\xb9.log"),
+        # Sanitization must always produce a usable cross-platform filename
+        ("!!!", "file"),
+        (".", "file"),
+        ("..", "file"),
+        ("file.", "file"),
+        ("file ", "file"),
         ("config.txt", "config.txt"),
         ("console.log", "console.log"),
     ],
 )
 def test_strip_invalid_filename_characters(orig_filename, new_filename):
     assert utils.strip_invalid_filename_characters(orig_filename) == new_filename
+
+
+def test_strip_invalid_filename_characters_limits_long_extensions():
+    filename = utils.strip_invalid_filename_characters("a." + "x" * 300)
+
+    assert filename.startswith("file.")
+    assert len(filename.encode()) == 200
 
 
 class AsyncMock(MagicMock):

--- a/gradio/cli/commands/upload_mcp.py
+++ b/gradio/cli/commands/upload_mcp.py
@@ -1,6 +1,6 @@
 def main(url_or_space_id: str, source_directory: str):
     import httpx
-    from gradio_client.utils import is_http_url_like
+    from gradio_client.utils import encode_file_path, is_http_url_like
     from huggingface_hub import space_info
     from mcp.server.fastmcp import FastMCP  # type: ignore
 
@@ -33,7 +33,7 @@ def main(url_or_space_id: str, source_directory: str):
             response = httpx.post(f"{url}/gradio_api/upload", files={"files": f})
         response.raise_for_status()
         result = response.json()[0]
-        return f"{url}/gradio_api/file={result}"
+        return f"{url}/gradio_api/file={encode_file_path(result)}"
 
     mcp.run(transport="stdio")
 

--- a/gradio/mcp.py
+++ b/gradio/mcp.py
@@ -1543,7 +1543,8 @@ class GradioMCPServer:
                 svg_path = processing_utils.save_bytes_to_cache(
                     svg_bytes, f"{output['orig_name']}", DEFAULT_TEMP_DIR
                 )
-                svg_url = f"{root_url}/gradio_api/file={svg_path}"
+                encoded_path = client_utils.encode_file_path(svg_path)
+                svg_url = f"{root_url}/gradio_api/file={encoded_path}"
                 return_value = [
                     self.types.ImageContent(  # type: ignore
                         type="image", data=base64_data, mimeType=mimetype

--- a/gradio/processing_utils.py
+++ b/gradio/processing_utils.py
@@ -484,13 +484,14 @@ def move_files_to_cache(
         )
         if block.proxy_url:
             proxy_url = block.proxy_url.rstrip("/")
-            url = f"{API_PREFIX}/proxy={proxy_url}{url_prefix}{payload.path}"
+            encoded_path = client_utils.encode_file_path(payload.path)
+            url = f"{API_PREFIX}/proxy={proxy_url}{url_prefix}{encoded_path}"
         elif client_utils.is_http_url_like(payload.path) or payload.path.startswith(
             f"{url_prefix}"
         ):
             url = f"{payload.path}"
         else:
-            url = f"{url_prefix}{payload.path}"
+            url = f"{url_prefix}{client_utils.encode_file_path(payload.path)}"
         payload.url = url
         _mark_svg_as_safe(payload)
         return payload.model_dump()
@@ -606,13 +607,14 @@ async def async_move_files_to_cache(
         )
         if block.proxy_url:
             proxy_url = block.proxy_url.rstrip("/")
-            url = f"{API_PREFIX}/proxy={proxy_url}{url_prefix}{payload.path}"
+            encoded_path = client_utils.encode_file_path(payload.path)
+            url = f"{API_PREFIX}/proxy={proxy_url}{url_prefix}{encoded_path}"
         elif client_utils.is_http_url_like(payload.path) or payload.path.startswith(
             f"{url_prefix}"
         ):
             url = payload.path
         else:
-            url = f"{url_prefix}{payload.path}"
+            url = f"{url_prefix}{client_utils.encode_file_path(payload.path)}"
         payload.url = url
         _mark_svg_as_safe(payload)
         return payload.model_dump()

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -32,7 +32,7 @@ from typing import (
     Union,
     cast,
 )
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import anyio
 import fastapi
@@ -1193,6 +1193,24 @@ STATIC_ROUTE_PREFIXES = (
     "/upload",
     "/custom_component/",
 )
+
+
+def requote_proxied_url(url_path: str) -> str:
+    """Restore the encoding of a URL that reached the `/proxy=` route.
+
+    The ASGI server percent-decodes the request path once before routing, so a
+    filename that legitimately contains `%`, `#` or `?` arrives here with those
+    characters literal. Re-encoding everything after the authority hands the
+    upstream server the same path we were originally asked to proxy, instead of
+    one that decodes a level too far (or, for `#`, gets truncated as a fragment).
+    """
+    scheme, separator, rest = url_path.partition("://")
+    if not separator:
+        return url_path
+    authority, slash, path = rest.partition("/")
+    if not slash:
+        return url_path
+    return f"{scheme}://{authority}/{quote(path, safe='/=')}"
 
 
 def routes_safe_join(directory: DeveloperPath, path: UserProvidedPath) -> str:

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -291,7 +291,7 @@ class App(FastAPI):
         return self.blocks
 
     def build_proxy_request(self, url_path):
-        url = httpx.URL(url_path)
+        url = httpx.URL(route_utils.requote_proxied_url(url_path))
         assert self.blocks  # noqa: S101
         # Don't proxy a URL unless it's a URL specifically loaded by the user using
         # gr.load() to prevent SSRF or harvesting of HF tokens by malicious Spaces.

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Optional, TypedDict, Union, get_type_hints
 
 import anyio
 import httpx
+from gradio_client import utils as client_utils
 from huggingface_hub import HfApi
 from huggingface_hub import get_token as hf_get_token
 
@@ -422,7 +423,8 @@ def _save_tmp(result, ext: str) -> dict:
     else:
         with open(path, "wb") as f:
             f.write(result)
-    return {"path": path, "url": f"/gradio_api/file={path}", "is_file": True}
+    url = f"/gradio_api/file={client_utils.encode_file_path(path)}"
+    return {"path": path, "url": url, "is_file": True}
 
 
 def _img_url(a) -> str:
@@ -661,7 +663,7 @@ def call_space(
                 ):
                     return {
                         "path": path,
-                        "url": f"/gradio_api/file={path}",
+                        "url": f"/gradio_api/file={client_utils.encode_file_path(path)}",
                         "is_file": True,
                     }
                 return item
@@ -672,7 +674,7 @@ def call_space(
             ):
                 return {
                     "path": item,
-                    "url": f"/gradio_api/file={item}",
+                    "url": f"/gradio_api/file={client_utils.encode_file_path(item)}",
                     "is_file": True,
                 }
             if isinstance(item, (list, tuple)):

--- a/gradio/workflow.py
+++ b/gradio/workflow.py
@@ -438,13 +438,19 @@ def _file_ref(a) -> str:
     canvas file value carries no `path` at all (`FileValue` in
     `js/workflowcanvas/workflow/workflow-types.ts`), so the prefix comes off
     here and callers get the local path either way.
+
+    The URL branch is percent-encoded, so it is unquoted on the way out. That
+    unquoting stays inside the branch: a `path` that wins can itself hold a
+    literal `%20`, which must survive as part of the filename.
     """
     src = (a.get("path") or a.get("url") or "") if isinstance(a, dict) else a
     if not isinstance(src, str) or not src:
         return ""
     if src.startswith(("data:", "http://", "https://")):
         return src
-    return src.removeprefix("/gradio_api/file=")
+    if src.startswith("/gradio_api/file="):
+        return urllib.parse.unquote(src.removeprefix("/gradio_api/file="))
+    return src
 
 
 def _sendable_ref(a) -> str:

--- a/test/test_processing_utils.py
+++ b/test/test_processing_utils.py
@@ -57,6 +57,27 @@ class TestTempFileManagement:
         assert len([f for f in gradio_temp_dir.glob("**/*") if f.is_file()]) == 2
         assert Path(f).name == "cheetah1-copy.jpg"
 
+    @pytest.mark.asyncio
+    async def test_move_files_to_cache_encodes_file_urls(self, tmp_path):
+        source = tmp_path / "report%20#final.txt"
+        source.write_text("ok")
+        data = data_classes.FileData(path=str(source)).model_dump()
+
+        sync_result = processing_utils.move_files_to_cache(
+            data, gr.File(), postprocess=True
+        )
+        async_result = await processing_utils.async_move_files_to_cache(
+            data, gr.File(), postprocess=True
+        )
+        proxy_component = gr.File()
+        proxy_component.proxy_url = "https://example.com"
+        proxy_result = processing_utils.move_files_to_cache(
+            data, proxy_component, postprocess=True
+        )
+
+        for result in (sync_result, async_result, proxy_result):
+            assert result["url"].endswith("/report%2520%23final.txt")
+
     def test_save_b64_to_cache(self, gradio_temp_dir, media_data):
         base64_file_1 = media_data.BASE64_IMAGE
         base64_file_2 = media_data.BASE64_AUDIO["data"]

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -14,8 +14,10 @@ from pathlib import Path
 from threading import Thread
 from types import SimpleNamespace
 from unittest.mock import patch
+from urllib.parse import unquote
 
 import gradio_client as grc
+import gradio_client.utils as client_utils
 import httpx
 import numpy as np
 import pandas as pd
@@ -749,6 +751,39 @@ class TestRoutes:
         app.build_proxy_request(
             "https://gradio-tests-test-loading-examples-private.hf.space/file=Bunny.obj"
         )
+
+    @pytest.mark.parametrize(
+        "cached_path",
+        [
+            "/tmp/gradio/abc/computer%20vision#Huggy.png",
+            "/tmp/gradio/abc/my report.png",
+            "/tmp/gradio/abc/100%.png",
+            "/tmp/gradio/abc/q?mark&a=b.png",
+            "/tmp/gradio/abc/plain.png",
+        ],
+    )
+    def test_proxy_request_preserves_encoded_paths(self, cached_path):
+        """The ASGI server percent-decodes the request path once before routing,
+        so the proxy has to re-encode it. Otherwise the upstream server decodes a
+        level too far, and a "#" is dropped as a URL fragment."""
+        space = "https://gradio-tests-test-loading-examples-private.hf.space"
+        app = routes.App()
+        interface = gr.Interface(lambda x: x, "text", "text")
+        interface.proxy_urls = {space}
+        app.configure_app(interface)
+
+        emitted = (
+            f"{API_PREFIX}/proxy={space}{API_PREFIX}/file="
+            f"{client_utils.encode_file_path(cached_path)}"
+        )
+        url_path = unquote(emitted).split(f"{API_PREFIX}/proxy=", 1)[1]
+
+        url, _ = app.build_proxy_request(url_path)
+
+        # `url.path` is decoded exactly once, so it is what the upstream server
+        # will see as its own request path.
+        assert url.path.split("file=", 1)[1] == cached_path
+        assert not url.query and not url.fragment
 
     def test_proxy_does_not_leak_hf_token_externally(self):
         gr.context.Context.token = "abcdef"  # type: ignore

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -112,6 +112,17 @@ class TestRoutes:
         with open(file, "rb") as saved_file:
             assert saved_file.read() == b"abcdefghijklmnopqrstuvwxyz"
 
+    def test_upload_path_with_empty_sanitized_filename(self, test_client):
+        response = test_client.post(
+            f"{API_PREFIX}/upload",
+            files={"files": ("!!!", b"content", "text/plain")},
+        )
+
+        assert response.status_code == 200
+        uploaded = Path(response.json()[0])
+        assert uploaded.name == "file"
+        assert uploaded.read_bytes() == b"content"
+
     def test_custom_upload_path(self, gradio_temp_dir):
         io = Interface(lambda x: x + x, "text", "text")
         app, _, _ = io.launch(prevent_thread_lock=True)

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from gradio_client import utils as client_utils
 
 import gradio as gr
 import gradio.workflow as workflow_module
@@ -945,6 +946,27 @@ class TestCallSpaceFileArgs:
             call_space(["o/r", "/run", json.dumps([{"url": saved["url"]}])])
 
         assert client.predict.call_args.args[0]["path"] == saved["path"]
+
+    def test_sends_a_canvas_url_whose_filename_needed_encoding(
+        self, tmp_path, monkeypatch
+    ):
+        # A Space node can hand a file back under its uploaded name, so the URL
+        # the canvas chains is percent-encoded. The prefix strip has to decode
+        # it, or the path that reaches the next node does not exist on disk.
+        monkeypatch.setenv("GRADIO_TEMP_DIR", str(tmp_path / "cache"))
+        upload_folder = get_upload_folder()
+        os.makedirs(upload_folder, exist_ok=True)
+        owned = os.path.join(upload_folder, "computer vision #1 100%.png")
+        with open(owned, "wb") as f:
+            f.write(b"operator-output")
+        url = f"/gradio_api/file={client_utils.encode_file_path(owned)}"
+        client = MagicMock()
+        client.predict.return_value = "ok"
+
+        with patch("gradio.workflow.Client", return_value=client):
+            call_space(["o/r", "/run", json.dumps([{"url": url}])])
+
+        assert client.predict.call_args.args[0]["path"] == owned
 
 
 class TestSendableRef:


### PR DESCRIPTION
## Description

Fix uploaded and generated file references whose filenames contain URL-significant characters, and ensure upload sanitization always produces a usable cross-platform filename.

The original PNG failure was not image-format-specific: its literal filename contained `%20`. Gradio inserted the returned cache path directly into a browser-facing `/file=` URL, so the browser decoded `%20` to a space and requested a different path, which correctly received 403.

This is a recent regression exposed by [#13204](https://github.com/gradio-app/gradio/pull/13204), which intentionally began preserving valid special characters in uploaded filenames. The older file-URL construction assumed server paths were already URL-safe.

This PR now covers all production `/file=` URL constructors found in the repository:

- encode uploaded paths in the JS client while preserving path separators;
- share the same encoding behavior across sync/async backend outputs, proxy URLs, Python-client downloads, workflows, and MCP-generated URLs;
- retain literal `%`, `#`, and other URL-significant filename characters through a browser request;
- fall back to `file` when sanitization would produce an empty or dot-only name;
- remove Windows-invalid trailing spaces and dots; and
- enforce the byte limit even when the extension alone exceeds it.

Closes: #13778

## AI Disclosure

- [x] I used AI to reproduce and diagnose the bug, inspect related filename paths, implement and self-review the fix, write the regression tests, run verification, and draft this PR description.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Issue #13778 was created after checking for overlapping open issues and PRs. The other open filename-related PRs have different scopes.

## Testing and Formatting Your Code

The changes were developed red-green: each regression test was added and observed failing before its corresponding implementation.

- JS client tests: 157 passed, 17 skipped
- JS client build: passed
- Python filename/client tests: 119 passed
- Focused backend URL/upload tests: passed
- Upload-route subset: 4 passed
- Processing-utils suite: 57 passed; 3 unrelated `nip.io` DNS expectation failures in this local environment
- Ruff on every changed Python file: passed
- `bash scripts/format_backend.sh`: changed files formatted; final repository-wide checks report pre-existing lint/type-environment failures
- `bash scripts/format_frontend.sh`: changed files formatted; final repository-wide `svelte-check` reports 16 unrelated baseline errors

Before/after Spaces:

- Before: https://huggingface.co/spaces/abidlabs/gradio-13778-before
- After: https://huggingface.co/spaces/abidlabs/gradio-13778-after
