### PR TITLE
Load a saved run's outputs when SSR is on

### DIFF
--- a/.changeset/tender-lions-restore.md
+++ b/.changeset/tender-lions-restore.md
@@ -1,0 +1,6 @@
+---
+"@gradio/client": patch
+"gradio": patch
+---
+
+fix:Load a saved run's outputs, not just its inputs, when SSR is on

--- a/client/js/src/index.ts
+++ b/client/js/src/index.ts
@@ -6,6 +6,7 @@ export { upload_files } from "./utils/upload_files";
 export { FileData, upload, prepare_files } from "./upload";
 export { handle_file } from "./helpers/data";
 export {
+	apply_run_history_replay,
 	clear_run_history,
 	consume_run_history_replay,
 	delete_run_history,
@@ -13,6 +14,7 @@ export {
 	read_run_history,
 	run_history_url,
 	stage_run_history_replay,
+	type ReplayTarget,
 	type RunHistoryScope,
 	type StoredRunComponent,
 	type StoredRun

--- a/client/js/src/test/run_history.test.ts
+++ b/client/js/src/test/run_history.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import {
+	apply_run_history_replay,
 	clear_run_history,
 	consume_run_history_replay,
 	delete_run_history,
@@ -311,6 +312,79 @@ describe.skipIf(!in_browser)("run history", () => {
 
 		expect(read_run_history(other_scope)).toEqual([]);
 		expect(consume_run_history_replay(other_scope)).toBeNull();
+	});
+});
+
+describe.skipIf(!in_browser)("replaying a run", () => {
+	function make_config() {
+		return {
+			app_id,
+			components: [
+				{ id: 1, type: "textbox", props: { value: "default in" } },
+				{ id: 2, type: "state", props: { value: "server side" } },
+				{ id: 3, type: "image", props: { value: null } },
+				{ id: 4, type: "textbox", props: { value: "default out" } }
+			],
+			dependencies: [
+				{ id: 7, api_name: "transform", inputs: [1, 2], outputs: [3, 4] }
+			]
+		};
+	}
+
+	const stored = {
+		id: "run-1",
+		endpoint: "/transform",
+		api_name: "/transform",
+		fn_index: 7,
+		page: "/",
+		inputs: ["prompt", null],
+		outputs: [{ url: "http://localhost/image.webp" }, "described"],
+		status: "completed" as const,
+		started_at: new Date().toISOString()
+	};
+
+	test("writes the saved inputs and outputs back into the config", () => {
+		stage_run_history_replay(scope, stored);
+		const config = make_config();
+
+		expect(apply_run_history_replay(config)).toBe(true);
+		expect(config.components.map((component) => component.props.value)).toEqual(
+			[
+				"prompt",
+				// `gr.State` is held on the server, so its default has to survive.
+				"server side",
+				stored.outputs[0],
+				"described"
+			]
+		);
+		// The staged run is consumed, so a reload does not replay it again.
+		expect(apply_run_history_replay(make_config())).toBe(false);
+	});
+
+	test("matches the endpoint by api name when the fn index has moved", () => {
+		stage_run_history_replay(scope, { ...stored, fn_index: 99 });
+		const config = make_config();
+
+		expect(apply_run_history_replay(config)).toBe(true);
+		expect(config.components[3].props.value).toBe("described");
+	});
+
+	test("leaves the config alone when the endpoint is gone", () => {
+		stage_run_history_replay(scope, {
+			...stored,
+			fn_index: 99,
+			api_name: "/removed"
+		});
+		const config = make_config();
+
+		expect(apply_run_history_replay(config)).toBe(false);
+		expect(config.components.map((component) => component.props.value)).toEqual(
+			["default in", "server side", null, "default out"]
+		);
+	});
+
+	test("is a no-op when nothing was staged", () => {
+		expect(apply_run_history_replay(make_config())).toBe(false);
 	});
 });
 

--- a/client/js/src/test/run_history.test.ts
+++ b/client/js/src/test/run_history.test.ts
@@ -349,15 +349,8 @@ describe.skipIf(!in_browser)("replaying a run", () => {
 
 		expect(apply_run_history_replay(config)).toBe(true);
 		expect(config.components.map((component) => component.props.value)).toEqual(
-			[
-				"prompt",
-				// `gr.State` is held on the server, so its default has to survive.
-				"server side",
-				stored.outputs[0],
-				"described"
-			]
+			["prompt", "server side", stored.outputs[0], "described"]
 		);
-		// The staged run is consumed, so a reload does not replay it again.
 		expect(apply_run_history_replay(make_config())).toBe(false);
 	});
 

--- a/client/js/src/utils/run_history.ts
+++ b/client/js/src/utils/run_history.ts
@@ -308,6 +308,64 @@ function consume_run_history_replay_impl(
 	}
 }
 
+/**
+ * The parts of an app config a replayed run writes back into. Kept structural
+ * so every entry point — the SPA and the SSR app each carry their own `Config`
+ * declaration — can hand its config straight over.
+ */
+export interface ReplayTarget {
+	components: { id: number; type: string; props: Record<string, any> }[];
+	dependencies: {
+		id: number;
+		api_name?: string | null;
+		inputs: number[];
+		outputs: number[];
+	}[];
+}
+
+function restore_run_impl(config: ReplayTarget, run: StoredRun): boolean {
+	const dependency = config.dependencies.find(
+		(item) =>
+			item.id === run.fn_index ||
+			(typeof item.api_name === "string" &&
+				`/${item.api_name.replace(/^\//, "")}` === run.api_name)
+	);
+	if (!dependency) return false;
+
+	// Both sides are saved as arrays aligned to the dependency, so these only
+	// have to cope with a history written by some other shape of payload.
+	const inputs = Array.isArray(run.inputs)
+		? run.inputs
+		: Object.values((run.inputs ?? {}) as Record<string, unknown>);
+	const outputs = Array.isArray(run.outputs)
+		? run.outputs
+		: run.outputs === null || run.outputs === undefined
+			? []
+			: [run.outputs];
+
+	const restore = (ids: number[], saved: unknown[]): void => {
+		for (const [index, id] of ids.entries()) {
+			const component = config.components.find((item) => item.id === id);
+			if (!component || index >= saved.length) continue;
+			// `gr.State` is held on the server and always saved as null, so
+			// writing it back would wipe out the component's real default.
+			if (component.type === "state") continue;
+			component.props.value = saved[index];
+		}
+	};
+
+	restore(dependency.inputs, inputs);
+	restore(dependency.outputs, outputs);
+	return true;
+}
+
+function apply_run_history_replay_impl(
+	config: ReplayTarget & RunHistoryScope
+): boolean {
+	const run = consume_run_history_replay_impl(config);
+	return run ? restore_run_impl(config, run) : false;
+}
+
 function start_run_history_impl(options: StartRunOptions): string | null {
 	const key = storage_key(options);
 	if (!key) return null;
@@ -490,6 +548,19 @@ export function consume_run_history_replay(
 	scope: RunHistoryScope | null | undefined
 ): StoredRun | null {
 	return safely(() => consume_run_history_replay_impl(scope), null);
+}
+
+/**
+ * Applies the run staged by the history page, if this page load is the one it
+ * was staged for. Every entry point that renders an app has to call this, or
+ * "Load run" silently does nothing on that entry point.
+ *
+ * @returns whether a staged run was found and applied.
+ */
+export function apply_run_history_replay(
+	config: ReplayTarget & RunHistoryScope
+): boolean {
+	return safely(() => apply_run_history_replay_impl(config), false);
 }
 
 export function start_run_history(options: StartRunOptions): string | null {

--- a/client/js/src/utils/run_history.ts
+++ b/client/js/src/utils/run_history.ts
@@ -332,8 +332,6 @@ function restore_run_impl(config: ReplayTarget, run: StoredRun): boolean {
 	);
 	if (!dependency) return false;
 
-	// Both sides are saved as arrays aligned to the dependency, so these only
-	// have to cope with a history written by some other shape of payload.
 	const inputs = Array.isArray(run.inputs)
 		? run.inputs
 		: Object.values((run.inputs ?? {}) as Record<string, unknown>);

--- a/js/app/src/routes/[...catchall]/+page.ts
+++ b/js/app/src/routes/[...catchall]/+page.ts
@@ -1,7 +1,7 @@
 // import { type LayoutServerLoad } from "./$types";
 import { browser } from "$app/environment";
 
-import { Client } from "@gradio/client";
+import { apply_run_history_replay, Client } from "@gradio/client";
 
 import type { Config } from "@gradio/client";
 import { MISSING_CREDENTIALS_MSG } from "@gradio/client";
@@ -154,6 +154,14 @@ export async function load({
 	}
 
 	let page_config = app.get_url_config(url.toString());
+
+	// The run history page stages the run to reload in session storage and then
+	// navigates here, so this is where a staged run gets written back into the
+	// config. It only exists in the browser, and this load runs again during
+	// hydration, so the values land before the client renders the app.
+	if (browser) {
+		apply_run_history_replay(page_config);
+	}
 
 	await setupi18n(app.config?.i18n_translations || undefined, accept_language);
 	return {

--- a/js/app/src/routes/[...catchall]/+page.ts
+++ b/js/app/src/routes/[...catchall]/+page.ts
@@ -155,10 +155,6 @@ export async function load({
 
 	let page_config = app.get_url_config(url.toString());
 
-	// The run history page stages the run to reload in session storage and then
-	// navigates here, so this is where a staged run gets written back into the
-	// config. It only exists in the browser, and this load runs again during
-	// hydration, so the values land before the client renders the app.
 	if (browser) {
 		apply_run_history_replay(page_config);
 	}

--- a/js/spa/src/Index.svelte
+++ b/js/spa/src/Index.svelte
@@ -84,11 +84,7 @@
 
 <script lang="ts">
 	import { onMount, onDestroy } from "svelte";
-	import {
-		consume_run_history_replay,
-		type SpaceStatus,
-		type StoredRun
-	} from "@gradio/client";
+	import { apply_run_history_replay, type SpaceStatus } from "@gradio/client";
 	import { Embed } from "@gradio/core";
 	import type { ThemeMode } from "@gradio/core";
 	import { StatusTracker } from "@gradio/statustracker";
@@ -152,39 +148,6 @@
 	let active_theme_mode: ThemeMode = $state("system");
 	let api_url = $state("");
 	let run_history = $state(false);
-
-	function restore_run(config: Config, run: StoredRun | null): void {
-		if (!run) return;
-		const dependency = config.dependencies.find(
-			(item) =>
-				item.id === run.fn_index ||
-				(typeof item.api_name === "string" &&
-					`/${item.api_name.replace(/^\//, "")}` === run.api_name)
-		);
-		if (!dependency) return;
-
-		const inputs = Array.isArray(run.inputs)
-			? run.inputs
-			: Object.values(run.inputs as Record<string, unknown>);
-		const outputs = Array.isArray(run.outputs)
-			? run.outputs
-			: run.outputs === null
-				? []
-				: [run.outputs];
-		const restore = (ids: number[], saved: unknown[]): void => {
-			for (const [index, id] of ids.entries()) {
-				const component = config.components.find((item) => item.id === id);
-				if (!component || index >= saved.length) continue;
-				// `gr.State` is held on the server and always saved as null, so
-				// writing it back would wipe out the component's real default.
-				if (component.type === "state") continue;
-				component.props.value = saved[index];
-			}
-		};
-
-		restore(dependency.inputs, inputs);
-		restore(dependency.outputs, outputs);
-	}
 
 	$effect(() => {
 		if (config?.app_id) {
@@ -421,7 +384,7 @@
 		}
 
 		config = app.get_url_config() as unknown as Config;
-		restore_run(config, consume_run_history_replay(config));
+		apply_run_history_replay(config);
 		window.__gradio_space__ = config.space_id;
 
 		if (app.config?.i18n_translations) {

--- a/js/spa/src/RunHistory.svelte
+++ b/js/spa/src/RunHistory.svelte
@@ -41,6 +41,11 @@
 	}
 
 	onMount(() => {
+		// Embedded on Spaces this page loads inside an iframe the parent has
+		// already scrolled past, so it opens mid-list unless we ask for the top.
+		if ("parentIFrame" in window) {
+			window.parentIFrame?.scrollTo(0, 0);
+		}
 		refresh();
 		return on_run_history_change(refresh);
 	});

--- a/js/spa/test/hello_blocks.spec.ts
+++ b/js/spa/test/hello_blocks.spec.ts
@@ -13,3 +13,27 @@ test.describe("i18n", () => {
 		await expect(page.getByLabel("Output Box")).toBeVisible();
 	});
 });
+
+test.describe("run history", () => {
+	test("loading a saved run restores its inputs and outputs", async ({
+		page
+	}) => {
+		await page.getByLabel("Name").fill("run history");
+		await page.getByRole("button", { name: "Greet" }).click();
+		await expect(page.getByLabel("Output Box")).toHaveValue(
+			"Hello run history!"
+		);
+
+		await page.goto(new URL("/", page.url()).href);
+		await expect(page.getByLabel("Name")).toHaveValue("");
+		await expect(page.getByLabel("Output Box")).toHaveValue("");
+
+		await page.goto(new URL("/gradio_api/runs", page.url()).href);
+		await page.getByRole("button", { name: "Load run" }).click();
+
+		await expect(page.getByLabel("Name")).toHaveValue("run history");
+		await expect(page.getByLabel("Output Box")).toHaveValue(
+			"Hello run history!"
+		);
+	});
+});

--- a/js/spa/test/hello_blocks.spec.ts
+++ b/js/spa/test/hello_blocks.spec.ts
@@ -15,25 +15,27 @@ test.describe("i18n", () => {
 });
 
 test.describe("run history", () => {
-	test("loading a saved run restores its inputs and outputs", async ({
+	test("loading an earlier run restores that run, not the latest", async ({
 		page
 	}) => {
-		await page.getByLabel("Name").fill("run history");
+		await page.getByLabel("Name").fill("first");
 		await page.getByRole("button", { name: "Greet" }).click();
-		await expect(page.getByLabel("Output Box")).toHaveValue(
-			"Hello run history!"
-		);
+		await expect(page.getByLabel("Output Box")).toHaveValue("Hello first!");
 
-		await page.goto(new URL("/", page.url()).href);
-		await expect(page.getByLabel("Name")).toHaveValue("");
-		await expect(page.getByLabel("Output Box")).toHaveValue("");
+		await page.getByLabel("Name").fill("second");
+		await page.getByRole("button", { name: "Greet" }).click();
+		await expect(page.getByLabel("Output Box")).toHaveValue("Hello second!");
 
 		await page.goto(new URL("/gradio_api/runs", page.url()).href);
-		await page.getByRole("button", { name: "Load run" }).click();
+		const runs = page.locator("article.run");
+		await expect(runs).toHaveCount(2);
+		await expect(runs.first()).toContainText("Hello second!");
+		await runs
+			.filter({ hasText: "Hello first!" })
+			.getByRole("button", { name: "Load run" })
+			.click();
 
-		await expect(page.getByLabel("Name")).toHaveValue("run history");
-		await expect(page.getByLabel("Output Box")).toHaveValue(
-			"Hello run history!"
-		);
+		await expect(page.getByLabel("Name")).toHaveValue("first");
+		await expect(page.getByLabel("Output Box")).toHaveValue("Hello first!");
 	});
 });

--- a/js/spa/test/image_mod.spec.ts
+++ b/js/spa/test/image_mod.spec.ts
@@ -18,3 +18,36 @@ test("examples_get_updated_correctly", async ({ page }) => {
 		await expect(await image.getAttribute("src")).toContain("logo.png");
 	}).toPass();
 });
+
+test.describe("run history", () => {
+	test("loading an earlier run restores that run's media", async ({ page }) => {
+		const input_image = page.getByTestId("image").locator("img");
+		const output_image = page
+			.locator(".block")
+			.filter({ hasText: "output" })
+			.locator("img");
+
+		await page.locator(".gallery-item").first().click();
+		await expect(input_image).toHaveAttribute("src", /cheetah1/);
+		await page.getByRole("button", { name: "Submit" }).click();
+		await expect(output_image).toBeVisible();
+		const cheetah_output = (await output_image.getAttribute("src")) as string;
+
+		await page.locator(".gallery-item").nth(1).click();
+		await expect(input_image).toHaveAttribute("src", /lion/);
+		await page.getByRole("button", { name: "Submit" }).click();
+		await expect(output_image).not.toHaveAttribute("src", cheetah_output);
+
+		await page.goto(new URL("/gradio_api/runs", page.url()).href);
+		const runs = page.locator("article.run");
+		await expect(runs).toHaveCount(2);
+		await expect(runs.first().locator('img[src*="lion"]')).toBeVisible();
+		await runs
+			.filter({ has: page.locator('img[src*="cheetah1"]') })
+			.getByRole("button", { name: "Load run" })
+			.click();
+
+		await expect(input_image).toHaveAttribute("src", /cheetah1/);
+		await expect(output_image).toHaveAttribute("src", cheetah_output);
+	});
+});


### PR DESCRIPTION
## Description

Reloading a run from the run history page appeared to restore the inputs but never the outputs. It was reported against https://huggingface.co/spaces/abidlabs/run-history-test.

The real behaviour is that **nothing** was being restored. Gradio has two frontend entry points, and only one of them knew how to replay a run:

- `js/spa` (the static SPA in `gradio/templates/frontend`) consumed the staged run and wrote its values back into the config.
- `js/app` (the SvelteKit SSR build in `gradio/templates/node/build`) never did.

Spaces run with `ssr_mode=True`, so the app page is served by the SSR entry. `/gradio_api/runs` is always served by the SPA template (`main()` in `routes.py` handles it), so the history page itself worked fine: it staged the run in session storage and navigated to the app, which never read it. The staged key was still sitting in session storage afterwards, untouched.

The inputs only *looked* restored because that endpoint's saved inputs happened to equal the components' defaults — that demo pre-fills its inputs.

## Changes

- `client/js/src/utils/run_history.ts`: the write-back moves out of the SPA and into the module that already owns replay staging, as `apply_run_history_replay(config)`. It routes through the existing `safely` wrapper, so a malformed history can never break an app load.
- `js/spa/src/Index.svelte`: calls the shared helper instead of its own copy.
- `js/app/src/routes/[...catchall]/+page.ts`: applies the staged run to `page_config` behind a `browser` guard, so the values land during hydration, before Blocks renders.

## Testing

An e2e test in `hello_blocks.spec.ts` makes a run, reloads the page to confirm the defaults come back, then loads the run from the history page and asserts both the input and the output. The browser suite runs in both SSR modes, so that one spec covers both entry points — and it fails on the `SSR=true` leg without this fix (`Expected: "run history"` / `Received: ""`).

Four unit tests cover the write-back itself: `gr.State` keeping its own default, matching an endpoint by api name when the fn index has moved, a removed endpoint, and single-consumption.

Also verified by hand against the reported app, run locally in both modes: after loading a run, the radio, slider, note text and output image URL all match what was saved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)