### PR TITLE
workflow: move delete button

### DIFF
--- a/.changeset/loose-flowers-arrive.md
+++ b/.changeset/loose-flowers-arrive.md
@@ -1,0 +1,6 @@
+---
+"@gradio/workflowcanvas": minor
+"gradio": minor
+---
+
+feat:workflow move delete button

--- a/.changeset/loose-flowers-arrive.md
+++ b/.changeset/loose-flowers-arrive.md
@@ -3,4 +3,4 @@
 "gradio": minor
 ---
 
-feat:workflow move delete button
+feat:workflow: move delete button

--- a/js/workflowcanvas/workflow/WorkflowNodeSF.svelte
+++ b/js/workflowcanvas/workflow/WorkflowNodeSF.svelte
@@ -1049,7 +1049,8 @@
 	}
 
 	.node-delete {
-		display: none;
+		display: flex;
+		visibility: hidden;
 		width: 20px;
 		height: 20px;
 		border: none;
@@ -1059,7 +1060,6 @@
 		font-size: 12px;
 		cursor: pointer;
 		flex-shrink: 0;
-		margin-left: auto;
 		align-items: center;
 		justify-content: center;
 		padding: 0;
@@ -1067,7 +1067,7 @@
 	}
 
 	.wf-node:hover .node-delete {
-		display: flex;
+		visibility: visible;
 	}
 
 	.node-delete:hover {


### PR DESCRIPTION
## Description

i kept accidentally deleting a node due to the delete button appearing on the run button on hover: 

<img width="200" alt="Kapture 2026-08-24 at 19 49 02" src="https://github.com/user-attachments/assets/7ca61502-6c4e-4f6f-b9cb-59201fd4f77b" />

 this moves the delete button to the left, still only visible on hover
