### PR TITLE
Fix untouched ImageEditor round trips

### DIFF
--- a/.changeset/tame-ads-remain.md
+++ b/.changeset/tame-ads-remain.md
@@ -1,0 +1,6 @@
+---
+"@gradio/imageeditor": patch
+"gradio": patch
+---
+
+fix:Fix untouched ImageEditor round trips

--- a/js/imageeditor/ImageEditor.test.ts
+++ b/js/imageeditor/ImageEditor.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render, TEST_PNG, waitFor } from "@self/tootils/render";
+import { run_shared_prop_tests } from "@self/tootils/shared-prop-tests";
+
+import ImageEditor from "./Index.svelte";
+
+const default_props = {
+	sources: ["upload"] as const,
+	interactive: true,
+	label: "Image Editor",
+	show_label: true,
+	value: null,
+	canvas_size: [800, 600] as [number, number],
+	transforms: [] as const,
+	layers: { allow_additional_layers: true, layers: ["Layer 1"] },
+	brush: {
+		default_size: "auto" as const,
+		colors: ["#000000"],
+		default_color: "#000000",
+		color_mode: "defaults" as const
+	},
+	eraser: { default_size: "auto" as const },
+	webcam_options: { mirror: true, constraints: {} },
+	buttons: []
+};
+
+run_shared_prop_tests({
+	component: ImageEditor,
+	name: "ImageEditor",
+	base_props: { ...default_props, interactive: false },
+	has_label: false,
+	has_validation_error: true
+});
+
+describe("get_data / set_data", () => {
+	afterEach(() => cleanup());
+
+	test("an untouched editor returns the original image files", async () => {
+		const background = { ...TEST_PNG, alt_text: "Background" };
+		const layer = { ...TEST_PNG, orig_name: "layer.png" };
+		const composite = { ...TEST_PNG, orig_name: "composite.png" };
+		const value = { background, layers: [layer], composite };
+		const { getByRole, get_data } = await render(ImageEditor, {
+			...default_props,
+			value
+		});
+		await waitFor(() => {
+			expect(getByRole("button", { name: "Pan" })).toBeVisible();
+		});
+
+		expect((await get_data()).value).toEqual(value);
+	});
+});

--- a/js/imageeditor/InteractiveImageEditor.svelte
+++ b/js/imageeditor/InteractiveImageEditor.svelte
@@ -120,6 +120,10 @@
 	});
 
 	export async function get_data(): Promise<ImageBlobs> {
+		if (!can_undo) {
+			return { background, layers, composite };
+		}
+
 		let blobs;
 		try {
 			blobs = await editor.get_blobs();
@@ -127,38 +131,43 @@
 			return { background: null, layers: [], composite: null };
 		}
 
-		const bg = blobs.background
+		const background_upload = blobs.background
 			? upload(
 					await prepare_files([new File([blobs.background], "background.png")]),
 					root
 				)
 			: Promise.resolve(null);
 
-		const layers = blobs.layers
+		const layer_uploads = blobs.layers
 			.filter(is_not_null)
 			.map(async (blob, i) =>
 				upload(await prepare_files([new File([blob], `layer_${i}.png`)]), root)
 			);
 
-		const composite = blobs.composite
+		const composite_upload = blobs.composite
 			? upload(
 					await prepare_files([new File([blobs.composite], "composite.png")]),
 					root
 				)
 			: Promise.resolve(null);
 
-		const [background, composite_, ...layers_] = await Promise.all([
-			bg,
-			composite,
-			...layers
-		]);
+		const [uploaded_background, uploaded_composite, ...uploaded_layers] =
+			await Promise.all([
+				background_upload,
+				composite_upload,
+				...layer_uploads
+			]);
 
 		return {
-			background: Array.isArray(background) ? background[0] : background,
-			layers: layers_
+			background: Array.isArray(uploaded_background)
+				? uploaded_background[0]
+				: uploaded_background,
+			layers: uploaded_layers
 				.flatMap((layer) => (Array.isArray(layer) ? layer : [layer]))
 				.filter(is_file_data),
-			composite: Array.isArray(composite_) ? composite_[0] : composite_
+			composite: Array.isArray(uploaded_composite)
+				? uploaded_composite[0]
+				: uploaded_composite
 		};
 	}
 


### PR DESCRIPTION
## Description

This draft preserves the original ImageEditor payload when the user has not made an undoable edit, avoiding an unnecessary canvas encode/upload round trip that changes background and layer pixels. It also adds a frontend regression test for untouched editor data.

This is a work-in-progress checkpoint while final browser verification and CI follow-up continue.

Closes: #11053

## AI Disclosure

- [x] I used AI to reproduce the issue, draft the implementation and tests, and prepare this PR description. All changes are being self-reviewed and verified by the submitting human.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets #11053. No overlapping open PR was found before opening this draft.

## Testing and Formatting Your Code

- Focused ImageEditor Vitest suite: 7 tests passed
- ImageEditor frontend build passed
- `bash scripts/format_frontend.sh` was run; its repository-wide `svelte-check` phase currently reports unrelated pre-existing errors elsewhere in the tree

