### PR TITLE
Support alt text on Image output

### DIFF
--- a/.changeset/crazy-results-cough.md
+++ b/.changeset/crazy-results-cough.md
@@ -1,0 +1,6 @@
+---
+"@gradio/image": patch
+"gradio": patch
+---
+
+fix:Support alt text on Image output

--- a/gradio/components/image.py
+++ b/gradio/components/image.py
@@ -91,6 +91,7 @@ class Image(StreamingInput, Component):
         webcam_options: WebcamOptions | None = None,
         placeholder: str | None = None,
         watermark: WatermarkOptions | None = None,
+        alt_text: str | None = None,
     ):
         """
         Parameters:
@@ -119,6 +120,7 @@ class Image(StreamingInput, Component):
             preserved_by_key: A list of parameters from this component's constructor. Inside a gr.render() function, if a component is re-rendered with the same key, these (and only these) parameters will be preserved in the UI (if they have been changed by the user or an event listener) instead of re-rendered based on the values provided during constructor.
             placeholder: Custom text for the upload area. Overrides default upload messages when provided. Accepts new lines and `#` to designate a heading.
             watermark: If provided and this component is used to display a `value` image, the `watermark` image will be displayed on the bottom right of the `value` image, 10 pixels from the bottom and 10 pixels from the right. The watermark image will not be resized. Supports `PIL.Image`, `numpy.array`, `pathlib.Path`, and `str` filepaths. SVGs and GIFs are not supported as `watermark` images nor can they be watermarked.
+            alt_text: Alternative text for the image, used by screen readers. If not provided, the image is treated as decorative.
         """
         self.format = format
 
@@ -129,6 +131,7 @@ class Image(StreamingInput, Component):
         self.watermark = (
             watermark if isinstance(watermark, WatermarkOptions) else WatermarkOptions()
         )
+        self.alt_text = alt_text
 
         if isinstance(watermark, (str, Path, PIL.Image.Image, np.ndarray)):
             self.watermark.watermark = watermark
@@ -222,6 +225,7 @@ class Image(StreamingInput, Component):
             watermark=self.watermark,
             cache_dir=self.GRADIO_CACHE,
             format=self.format,
+            alt_text=self.alt_text,
         )
 
     def api_info_as_output(self) -> dict[str, Any]:

--- a/gradio/data_classes.py
+++ b/gradio/data_classes.py
@@ -440,6 +440,9 @@ class ImageData(GradioModel):
     orig_name: str | None = Field(default=None, description="Original filename")
     mime_type: str | None = Field(default=None, description="mime type of image")
     is_stream: bool = Field(default=False, description="Can always be set to False")
+    alt_text: str | None = Field(
+        default=None, description="Alternative text for the image"
+    )
     meta: dict = {"_type": "gradio.FileData"}
 
     model_config = ConfigDict(

--- a/gradio/image_utils.py
+++ b/gradio/image_utils.py
@@ -330,11 +330,13 @@ def postprocess_image(
     cache_dir: str,
     format: str,
     watermark: WatermarkOptions | None = None,
+    alt_text: str | None = None,
 ) -> ImageData | None:
     """
     Parameters:
         value: Expects a `numpy.array`, `PIL.Image`, or `str` or `pathlib.Path` filepath to an image which is displayed.
         watermark: An optional `WatermarkOptions` instance to apply a watermark to the image.
+        alt_text: Alternative text for the image.
     Returns:
         Returns the image as a `FileData` object.
     """
@@ -351,9 +353,10 @@ def postprocess_image(
         return ImageData(
             orig_name=Path(value).name,
             url=f"data:image/svg+xml,{quote(svg_content)}",
+            alt_text=alt_text,
         )
     if watermark and watermark.watermark is not None:
         value = add_watermark(value, watermark)
     saved = save_image(value, cache_dir=cache_dir, format=format)
     orig_name = Path(saved).name if Path(saved).exists() else None
-    return ImageData(path=saved, orig_name=orig_name)
+    return ImageData(path=saved, orig_name=orig_name, alt_text=alt_text)

--- a/js/image/Image.test.ts
+++ b/js/image/Image.test.ts
@@ -80,6 +80,28 @@ describe("Image", () => {
 		expect(img).toBeTruthy();
 		expect(img?.getAttribute("src")).toBe("https://example.com/test.png");
 	});
+
+	test("uses the provided alternative text for static images", async () => {
+		const { getByRole } = await render(Image, {
+			...default_props,
+			interactive: false,
+			value: { ...fake_value, alt_text: "Three vertical color bands" }
+		});
+
+		expect(
+			getByRole("img", { name: "Three vertical color bands" })
+		).toBeVisible();
+	});
+
+	test("treats static images without alternative text as decorative", async () => {
+		const { getByRole } = await render(Image, {
+			...default_props,
+			interactive: false,
+			value: fake_value
+		});
+
+		expect(getByRole("presentation")).toBeVisible();
+	});
 });
 
 describe("Props: label", () => {

--- a/js/image/shared/ImagePreview.svelte
+++ b/js/image/shared/ImagePreview.svelte
@@ -109,7 +109,7 @@
 			<div class:selectable class="image-frame">
 				<Image
 					src={value.url}
-					restProps={{ loading: "lazy", alt: "" }}
+					restProps={{ loading: "lazy", alt: value.alt_text ?? "" }}
 					{onload}
 				/>
 			</div>

--- a/test/components/test_image.py
+++ b/test/components/test_image.py
@@ -57,6 +57,7 @@ class TestImage:
             "type": "pil",
             "placeholder": None,
             "watermark": {"position": "bottom-right", "watermark": None},
+            "alt_text": None,
         }
         assert image_input.preprocess(None) is None
         image_input = gr.Image()
@@ -107,6 +108,22 @@ class TestImage:
         assert base64 == media_data.BASE64_IMAGE
         component = gr.Image(None)
         assert component.get_config().get("value") is None
+
+    def test_alt_text_is_included_in_postprocessed_image(self):
+        component = gr.Image(alt_text="A city bus")
+
+        image = component.postprocess("test/test_files/bus.png")
+
+        assert image is not None
+        assert image.alt_text == "A city bus"
+
+    def test_alt_text_is_included_for_svg_images(self):
+        component = gr.Image(alt_text="Gradio logo")
+
+        image = component.postprocess("test/test_files/file_icon.svg")
+
+        assert image is not None
+        assert image.alt_text == "Gradio logo"
 
     def test_images_upright_after_preprocess(self):
         component = gr.Image(type="pil")


### PR DESCRIPTION
## Description

This draft adds an `alt_text` parameter to `gr.Image`, carries it through `ImageData`, and renders it on the frontend image element. Images without alt text retain presentation semantics, while authored descriptions become accessible names. Backend and frontend regression coverage is included.

This is a work-in-progress checkpoint while final browser verification and CI follow-up continue.

Closes: #13731

## AI Disclosure

- [x] I used AI to reproduce the issue, draft the implementation and tests, and prepare this PR description. All changes are being self-reviewed and verified by the submitting human.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets #13731. No overlapping open PR was found before opening this draft.

## Testing and Formatting Your Code

- Focused Image Vitest suite: 54 tests passed
- Focused backend Image tests: 7 tests passed
- Image frontend build passed
- Backend and frontend formatting scripts were run; the frontend script's repository-wide `svelte-check` phase currently reports unrelated pre-existing errors elsewhere in the tree

