### PR TITLE
Handle a paste in `gr.MultimodalTextbox` as text or as an image, not both

### DIFF
--- a/.changeset/quick-donkeys-lie.md
+++ b/.changeset/quick-donkeys-lie.md
@@ -1,0 +1,6 @@
+---
+"@gradio/multimodaltextbox": patch
+"gradio": patch
+---
+
+fix:Handle a paste in `gr.MultimodalTextbox` as text or as an image, not both

--- a/js/multimodaltextbox/MultimodalTextbox.test.ts
+++ b/js/multimodaltextbox/MultimodalTextbox.test.ts
@@ -126,8 +126,8 @@ describe("MultimodalTextbox", () => {
 
 		const excel_paste = paste_event("1\t2\n3\t4", "cells.png");
 		textbox.dispatchEvent(excel_paste);
-		// an image alone is still attached, and waiting for it gives the paste
-		// above time to have uploaded anything
+		// an image alone is still attached. Waiting for that upload also bounds
+		// the assertion that the paste above uploaded nothing.
 		const image_paste = paste_event(null, "screenshot.png");
 		textbox.dispatchEvent(image_paste);
 
@@ -141,5 +141,49 @@ describe("MultimodalTextbox", () => {
 		);
 		assert.isFalse(excel_paste.defaultPrevented);
 		assert.isTrue(image_paste.defaultPrevented);
+	});
+	test("with nowhere to upload, only a text paste falls back to the browser", async () => {
+		const { getByTestId, listen } = await render(MultimodalTextbox, {
+			show_label: true,
+			max_lines: 1,
+			loading_status,
+			lines: 1,
+			// file_count "single" with a file already attached unmounts Upload
+			file_count: "single",
+			value: {
+				text: "",
+				files: [
+					{
+						path: "cats.jpg",
+						orig_name: "cats.jpg",
+						mime_type: "image/jpeg",
+						meta: { _type: "gradio.FileData" }
+					}
+				]
+			},
+			label: "MultimodalTextbox",
+			interactive: true,
+			root: "http://localhost:7860",
+			max_plain_text_length: 1000,
+			sources: ["upload"],
+			client: mock_client()
+		});
+
+		const upload = listen("upload");
+		const textbox = getByTestId("textbox");
+
+		const image_paste = paste_event(null, "screenshot.png");
+		textbox.dispatchEvent(image_paste);
+		const long_paste = paste_event("x".repeat(2000));
+		textbox.dispatchEvent(long_paste);
+
+		await tick();
+		await tick();
+
+		expect(upload).not.toHaveBeenCalled();
+		// the browser would paste the image's file name, which is worth nothing
+		assert.isTrue(image_paste.defaultPrevented);
+		// the text is its own fallback, so it must not be swallowed
+		assert.isFalse(long_paste.defaultPrevented);
 	});
 });

--- a/js/multimodaltextbox/MultimodalTextbox.test.ts
+++ b/js/multimodaltextbox/MultimodalTextbox.test.ts
@@ -1,6 +1,7 @@
-import { test, describe, assert, afterEach } from "vitest";
-import { cleanup, render } from "@self/tootils/render";
+import { test, describe, assert, afterEach, expect, vi } from "vitest";
+import { cleanup, render, mock_client } from "@self/tootils/render";
 import event from "@testing-library/user-event";
+import { tick } from "svelte";
 
 import MultimodalTextbox from "./Index.svelte";
 import type { ILoadingStatus as LoadingStatus } from "@gradio/statustracker";
@@ -82,5 +83,63 @@ describe("MultimodalTextbox", () => {
 		const submitButton = getByTestId("submit-button");
 		await event.click(submitButton);
 		assert.equal(mock.callCount, 1);
+	});
+
+	function paste_event(
+		text: string | null,
+		image_name?: string
+	): ClipboardEvent {
+		const data = new DataTransfer();
+		if (text) {
+			data.setData("text/plain", text);
+		}
+		if (image_name) {
+			data.items.add(
+				new File([new Uint8Array([1, 2, 3])], image_name, {
+					type: "image/png"
+				})
+			);
+		}
+		return new ClipboardEvent("paste", {
+			clipboardData: data,
+			bubbles: true,
+			cancelable: true
+		});
+	}
+
+	test("a paste is handled as text or as an image, never both", async () => {
+		const { getByTestId, listen } = await render(MultimodalTextbox, {
+			show_label: true,
+			max_lines: 1,
+			loading_status,
+			lines: 1,
+			value: { text: "", files: [] },
+			label: "MultimodalTextbox",
+			interactive: true,
+			root: "http://localhost:7860",
+			sources: ["upload"],
+			client: mock_client()
+		});
+
+		const upload = listen("upload");
+		const textbox = getByTestId("textbox");
+
+		const excel_paste = paste_event("1\t2\n3\t4", "cells.png");
+		textbox.dispatchEvent(excel_paste);
+		// an image alone is still attached, and waiting for it gives the paste
+		// above time to have uploaded anything
+		const image_paste = paste_event(null, "screenshot.png");
+		textbox.dispatchEvent(image_paste);
+
+		await vi.waitFor(() => expect(upload).toHaveBeenCalled());
+		await tick();
+
+		const uploaded = upload.mock.calls.flat(2);
+		assert.deepEqual(
+			uploaded.map((file) => file.orig_name),
+			["screenshot.png"]
+		);
+		assert.isFalse(excel_paste.defaultPrevented);
+		assert.isTrue(image_paste.defaultPrevented);
 	});
 });

--- a/js/multimodaltextbox/MultimodalTextbox.test.ts
+++ b/js/multimodaltextbox/MultimodalTextbox.test.ts
@@ -87,11 +87,15 @@ describe("MultimodalTextbox", () => {
 
 	function paste_event(
 		text: string | null,
-		image_name?: string
+		image_name?: string,
+		with_html = true
 	): ClipboardEvent {
 		const data = new DataTransfer();
 		if (text) {
 			data.setData("text/plain", text);
+			if (with_html) {
+				data.setData("text/html", `<table><tr><td>${text}</td></tr></table>`);
+			}
 		}
 		if (image_name) {
 			data.items.add(
@@ -131,14 +135,15 @@ describe("MultimodalTextbox", () => {
 		const image_paste = paste_event(null, "screenshot.png");
 		textbox.dispatchEvent(image_paste);
 
-		await vi.waitFor(() => expect(upload).toHaveBeenCalled());
+		const uploaded = (): string[] =>
+			upload.mock.calls.flat(2).map((file) => file.orig_name);
+
+		// wait for the screenshot itself, so a regression that uploads
+		// cells.png first cannot satisfy the wait and slip past
+		await vi.waitFor(() => expect(uploaded()).toContain("screenshot.png"));
 		await tick();
 
-		const uploaded = upload.mock.calls.flat(2);
-		assert.deepEqual(
-			uploaded.map((file) => file.orig_name),
-			["screenshot.png"]
-		);
+		assert.deepEqual(uploaded(), ["screenshot.png"]);
 		assert.isFalse(excel_paste.defaultPrevented);
 		assert.isTrue(image_paste.defaultPrevented);
 	});
@@ -185,5 +190,33 @@ describe("MultimodalTextbox", () => {
 		assert.isTrue(image_paste.defaultPrevented);
 		// the text is its own fallback, so it must not be swallowed
 		assert.isFalse(long_paste.defaultPrevented);
+	});
+	test("text with no HTML flavor leaves the image alone", async () => {
+		const { getByTestId, listen } = await render(MultimodalTextbox, {
+			show_label: true,
+			max_lines: 1,
+			loading_status,
+			lines: 1,
+			value: { text: "", files: [] },
+			label: "MultimodalTextbox",
+			interactive: true,
+			root: "http://localhost:7860",
+			sources: ["upload"],
+			client: mock_client()
+		});
+
+		const upload = listen("upload");
+		// a file manager copying an image can put its path in text/plain with
+		// no text/html, and there the image is the point of the paste
+		getByTestId("textbox").dispatchEvent(
+			paste_event("file:///cats.jpg", "cats.jpg", false)
+		);
+
+		await vi.waitFor(() => expect(upload).toHaveBeenCalled());
+
+		assert.deepEqual(
+			upload.mock.calls.flat(2).map((file) => file.orig_name),
+			["cats.jpg"]
+		);
 	});
 });

--- a/js/multimodaltextbox/MultimodalTextbox.test.ts
+++ b/js/multimodaltextbox/MultimodalTextbox.test.ts
@@ -147,6 +147,7 @@ describe("MultimodalTextbox", () => {
 		assert.isFalse(excel_paste.defaultPrevented);
 		assert.isTrue(image_paste.defaultPrevented);
 	});
+
 	test("with nowhere to upload, only a text paste falls back to the browser", async () => {
 		const { getByTestId, listen } = await render(MultimodalTextbox, {
 			show_label: true,
@@ -181,6 +182,8 @@ describe("MultimodalTextbox", () => {
 		textbox.dispatchEvent(image_paste);
 		const long_paste = paste_event("x".repeat(2000));
 		textbox.dispatchEvent(long_paste);
+		const path_paste = paste_event("file:///cats.jpg", "cats.jpg", false);
+		textbox.dispatchEvent(path_paste);
 
 		await tick();
 		await tick();
@@ -188,9 +191,11 @@ describe("MultimodalTextbox", () => {
 		expect(upload).not.toHaveBeenCalled();
 		// the browser would paste the image's file name, which is worth nothing
 		assert.isTrue(image_paste.defaultPrevented);
-		// the text is its own fallback, so it must not be swallowed
+		// text is its own fallback, so it must not be swallowed either way
 		assert.isFalse(long_paste.defaultPrevented);
+		assert.isFalse(path_paste.defaultPrevented);
 	});
+
 	test("text with no HTML flavor leaves the image alone", async () => {
 		const { getByTestId, listen } = await render(MultimodalTextbox, {
 			show_label: true,

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -324,11 +324,18 @@
 			return;
 		}
 
+		// the image is a rendering of the pasted text, not an attachment (#10910)
+		if (text) return;
+
 		for (let index in items) {
 			const item = items[index];
 			if (item.kind === "file" && item.type.includes("image")) {
 				const blob = item.getAsFile();
-				if (blob) upload_component.load_files([blob]);
+				if (blob && upload_component) {
+					// browsers otherwise paste the file name as text next to it
+					event.preventDefault();
+					upload_component.load_files([blob]);
+				}
 			}
 		}
 	}

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -322,8 +322,9 @@
 			return;
 		}
 
-		// text plus HTML means the image is a rendering of that content; text
-		// alone can be a file path sitting next to its own file (#10910)
+		// text plus HTML means the image is a rendering of that content. Text
+		// alone may be an image's own file path on platforms we have not
+		// measured, so leave those pastes to the image branch (#10910)
 		if (text && event.clipboardData.types.includes("text/html")) return;
 
 		for (let index in items) {
@@ -331,8 +332,9 @@
 			if (item.kind === "file" && item.type.includes("image")) {
 				const blob = item.getAsFile();
 				if (blob) {
-					// browsers otherwise paste the file name as text next to it
-					event.preventDefault();
+					// claim the paste so the browser cannot insert the file name,
+					// unless that would leave text with nothing to replace it
+					if (upload_component || !text) event.preventDefault();
 					upload_component?.load_files([blob]);
 				}
 			}

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -312,15 +312,13 @@
 		const items = event.clipboardData.items;
 		const text = event.clipboardData.getData("text");
 
-		if (text && text.length > max_plain_text_length) {
+		if (text && text.length > max_plain_text_length && upload_component) {
 			event.preventDefault();
 			const file = new window.File([text], "pasted_text.txt", {
 				type: "text/plain",
 				lastModified: Date.now()
 			});
-			if (upload_component) {
-				upload_component.load_files([file]);
-			}
+			upload_component.load_files([file]);
 			return;
 		}
 

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -331,10 +331,10 @@
 			const item = items[index];
 			if (item.kind === "file" && item.type.includes("image")) {
 				const blob = item.getAsFile();
-				if (blob && upload_component) {
+				if (blob) {
 					// browsers otherwise paste the file name as text next to it
 					event.preventDefault();
-					upload_component.load_files([blob]);
+					upload_component?.load_files([blob]);
 				}
 			}
 		}

--- a/js/multimodaltextbox/shared/MultimodalTextbox.svelte
+++ b/js/multimodaltextbox/shared/MultimodalTextbox.svelte
@@ -322,8 +322,9 @@
 			return;
 		}
 
-		// the image is a rendering of the pasted text, not an attachment (#10910)
-		if (text) return;
+		// text plus HTML means the image is a rendering of that content; text
+		// alone can be a file path sitting next to its own file (#10910)
+		if (text && event.clipboardData.types.includes("text/html")) return;
 
 		for (let index in items) {
 			const item = items[index];
@@ -381,10 +382,10 @@
 				}
 
 				if (valid_files.length > 0) {
-					upload_component.load_files(valid_files);
+					upload_component?.load_files(valid_files);
 				}
 			} else {
-				upload_component.load_files(files);
+				upload_component?.load_files(files);
 			}
 		}
 	}


### PR DESCRIPTION

## Description

Copying cells in desktop Excel puts three flavors on the clipboard at once: `text/plain` with the tab-separated cells, `text/html` with a `<table>`, and `image/png` with a bitmap of the copied range. Pasting that into `gr.MultimodalTextbox` inserted the text and *also* attached the PNG, so users got a redundant image on every such paste. The reporter saw the same thing from PowerPoint. Not every spreadsheet behaves this way -- Google Sheets puts no image on the clipboard, so it never triggered this.

`handle_paste` attached any `image/*` item on the clipboard without checking whether the same paste carried text. It now skips the image when the clipboard has both `text/plain` and `text/html`, which is what an office application writes: the text is what the browser inserts, and the image is a rendering of that same content. Pasting a screenshot or an image copied from a web page is unaffected either way, since those clipboards carry no `text/plain` at all.

The `text/html` half of the condition is a precaution rather than something I measured. macOS Finder puts no `text/plain` on the clipboard when copying a file, per the table below, but a file manager elsewhere putting the file's own path there is plausible, and keying on `text/plain` alone would then throw away the image a user meant to attach. Requiring `text/html` too costs nothing for the reported cases, since every office suite writes it. A hypothetical application that writes `text/plain` plus a bitmap and no HTML would keep the old behaviour.

That condition rests on what each kind of paste actually carries, measured in Chrome on macOS:

| copied | `clipboardData.types` | image item | result |
|---|---|---|---|
| cells in Numbers | `text/plain, text/html, Files` | yes | text only (was text + image) |
| cells in Google Sheets | `text/plain, text/html, ...` | none | unaffected, never had the bug |
| a screenshot | `Files` | yes | image attached |
| "Copy image" on a web page | `text/html, Files` | yes | image attached |
| an image file in Finder | `Files` | yes | image attached, file name no longer inserted |

Selecting a mix of text and an image on a page and copying that puts no image on the clipboard at all, so there is nothing to arbitrate there.

This also makes short and long pastes consistent. The `max_plain_text_length` branch added in #10135 already returns before the image loop, so a paste over 1000 characters never attached the bitmap. Only shorter pastes did, which is why the report describes the behaviour as intermittent; its screenshots show about 460 characters, well under the default 1000. Apps that raise the limit (the reporter's own workaround sets it to 100000) hit it at any size, and the fix covers both since it does not look at the length.

The same handler had the mirror problem, which showed up while checking the above, so it is fixed here too: pasting an image *file* (one copied in a file manager) attached the image and *also* left its name in the textarea, e.g. `{"text": "cats.jpg", "files": ["/tmp/gradio/.../cats.jpg"]}`. That text comes from the browser's default paste action, which inserts the file name; the web-visible `DataTransfer` hides it, so the clipboard looks like `types: [Files]` with no `text/plain`. An app suppresses it by claiming the paste, which `handle_paste` never did. It now calls `event.preventDefault()` when it takes a clipboard image, so the file name never lands in the box. A plain `gr.Textbox`, which has no paste handler at all, gets the same file name inserted, which is what pinned that half on the browser rather than on this component.

Both halves are the same root cause: the handler did not decide between the text and the image, so each paste got a bit of both. It now decides, and this is the whole rule:

| clipboard | what the paste becomes |
|---|---|
| text + HTML + image | the text; the image is dropped |
| text + image, no HTML | the image; the text is dropped |
| image only | the image |
| text only | the text, as before |

The middle row is the one worth noticing, because it goes the other way from the first.

`handle_drop` in the same component dereferenced `upload_component` the same way, so dropping a second file under `file_count="single"` threw as well; it now carries the same guard.

Both branches also mishandled a missing upload target. With the default `file_count="single"`, `show_upload` goes false once a file is attached, so the `Upload` component unmounts; the same is true whenever `sources` excludes `"upload"`. Pasting an image then threw `TypeError: Cannot read properties of null (reading 'load_files')` (present since #7872), and pasting text over `max_plain_text_length` called `event.preventDefault()` before finding it had nowhere to put the file, so the pasted text vanished with nothing to show for it.

They are fixed differently on purpose. An image paste is claimed either way, because the only thing the browser would leave behind is the file name, which is worth nothing. A long text paste is claimed only when the file can actually be created, because otherwise the browser inserting the text is exactly the right fallback.

Closes: #10910

## Before / after Spaces

- [Before fix](https://huggingface.co/spaces/hysts-debug/gradio-10910-before)
- [After fix](https://huggingface.co/spaces/hysts-debug/gradio-10910-after)

Same app on both, differing only in which gradio they install: the released `6.26.0` and the preview wheel from this PR. The copy buttons put a spreadsheet-shaped payload on the clipboard, so you can see the difference without a spreadsheet app.

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`

