### PR TITLE
Fix custom component template generation

### DIFF
--- a/.changeset/breezy-berries-sort.md
+++ b/.changeset/breezy-berries-sort.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Fix custom component template generation

--- a/gradio/cli/commands/components/_create_utils.py
+++ b/gradio/cli/commands/components/_create_utils.py
@@ -266,7 +266,7 @@ def _get_js_dependency_version(name: str, local_js_dir: Path) -> str:
 
 def copy_svelte_to_deps(package_json: dict):
     svelte_version = package_json.get("peerDependencies", {}).get("svelte", "latest")
-    package_json["dependencies"]["svelte"] = svelte_version
+    package_json.setdefault("dependencies", {})["svelte"] = svelte_version
     return package_json
 
 

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -812,6 +812,7 @@ def get_all_components() -> "list[type[Component] | type[BlockContext]]":
             "Interface",
             "Blocks",
             "TabbedInterface",
+            "Workflow",
             "NativePlot",
             "SketchBox",
         ]

--- a/test/test_gradio_component_cli.py
+++ b/test/test_gradio_component_cli.py
@@ -22,6 +22,21 @@ core = [
 ]
 
 
+def test_copy_svelte_to_deps_creates_missing_dependencies():
+    package_json = {
+        "peerDependencies": {"svelte": "^5.0.0"},
+    }
+
+    assert _create_utils.copy_svelte_to_deps(package_json) == {
+        "dependencies": {"svelte": "^5.0.0"},
+        "peerDependencies": {"svelte": "^5.0.0"},
+    }
+
+
+def test_custom_component_templates_exclude_workflow():
+    assert "Workflow" not in core
+
+
 def test_component_root_downloads_missing_version_to_snapshot_cache(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
Fix custom component creation for layout templates whose package manifests omit a dependencies table. The CLI now creates that table before adding Svelte. Also excludes `Workflow`  from the custom-component template inventory.

Closes: #13780