### PR TITLE
Fix flaky backend tests that build a bare `TestClient`

### DIFF
--- a/test/test_history.py
+++ b/test/test_history.py
@@ -409,8 +409,9 @@ def recording_app(monkeypatch):
     with (
         patch("gradio.history.resolve_token", return_value="tok"),
         patch("gradio.history.HfApi", return_value=hub),
+        TestClient(app) as client,
     ):
-        yield TestClient(app), hub, io
+        yield client, hub, io
     io.close()
     close_all()
 
@@ -537,8 +538,9 @@ def workflow_app(tmp_path, monkeypatch):
     with (
         patch("gradio.history.resolve_token", return_value="tok"),
         patch("gradio.history.HfApi", return_value=hub),
+        TestClient(app) as client,
     ):
-        yield TestClient(app), hub, wf, canvas._id
+        yield client, hub, wf, canvas._id
     wf.close()
     close_all()
 
@@ -636,8 +638,8 @@ class TestWorkflowRecording:
         with (
             patch("gradio.history.resolve_token", return_value="tok"),
             patch("gradio.history.HfApi", return_value=hub),
+            TestClient(app) as client,
         ):
-            client = TestClient(app)
             headers = {"X-Gradio-History-Bucket": "alice/hist"}
             r = client.post(
                 f"/gradio_api/run/{internal._id}",

--- a/test/test_queueing.py
+++ b/test/test_queueing.py
@@ -198,8 +198,10 @@ def test_heartbeat_task_cancelled_after_stream_completes():
         heartbeat_tasks.append(task)
         return task
 
-    with patch("gradio.routes.asyncio.create_task", side_effect=tracking_create_task):
-        test_client = TestClient(app)
+    with (
+        patch("gradio.routes.asyncio.create_task", side_effect=tracking_create_task),
+        TestClient(app) as test_client,
+    ):
         r = test_client.post(
             f"{API_PREFIX}/queue/join",
             json={

--- a/test/test_queueing.py
+++ b/test/test_queueing.py
@@ -188,7 +188,7 @@ def test_heartbeat_task_cancelled_after_stream_completes():
 
         name.submit(greet, name, output)
 
-    app, local_url, _ = demo.launch(prevent_thread_lock=True)
+    app, _, _ = demo.launch(prevent_thread_lock=True)
 
     heartbeat_tasks = []
     original_create_task = asyncio.create_task
@@ -198,38 +198,38 @@ def test_heartbeat_task_cancelled_after_stream_completes():
         heartbeat_tasks.append(task)
         return task
 
-    with (
-        patch("gradio.routes.asyncio.create_task", side_effect=tracking_create_task),
-        TestClient(app) as test_client,
-    ):
-        r = test_client.post(
-            f"{API_PREFIX}/queue/join",
-            json={
-                "data": ["hello"],
-                "fn_index": 0,
-                "event_data": None,
-                "session_hash": "test_heartbeat",
-                "trigger_id": None,
-            },
-        )
-        assert r.status_code == 200
+    with TestClient(app) as test_client:
+        with patch(
+            "gradio.routes.asyncio.create_task", side_effect=tracking_create_task
+        ):
+            r = test_client.post(
+                f"{API_PREFIX}/queue/join",
+                json={
+                    "data": ["hello"],
+                    "fn_index": 0,
+                    "event_data": None,
+                    "session_hash": "test_heartbeat",
+                    "trigger_id": None,
+                },
+            )
+            assert r.status_code == 200
 
-        r = test_client.get(f"{API_PREFIX}/queue/data?session_hash=test_heartbeat")
+            r = test_client.get(f"{API_PREFIX}/queue/data?session_hash=test_heartbeat")
 
-        # Verify we got a process_completed message
-        got_completed = False
-        for line in r.iter_lines():
-            if "data" in line:
-                data = json.loads(line[5:])
-                if data["msg"] == "process_completed":
-                    got_completed = True
-        assert got_completed
+            # Verify we got a process_completed message
+            got_completed = False
+            for line in r.iter_lines():
+                if "data" in line:
+                    data = json.loads(line[5:])
+                    if data["msg"] == "process_completed":
+                        got_completed = True
+            assert got_completed
 
-    assert len(heartbeat_tasks) > 0, "No heartbeat tasks were created"
-    for task in heartbeat_tasks:
-        assert task.cancelled() or task.done(), (
-            "Heartbeat task was not cancelled after stream completed"
-        )
+        assert len(heartbeat_tasks) > 0, "No heartbeat tasks were created"
+        for task in heartbeat_tasks:
+            assert task.cancelled() or task.done(), (
+                "Heartbeat task was not cancelled after stream completed"
+            )
     demo.close()
 
 


### PR DESCRIPTION
## Description

`test/test_history.py`'s two recording tests and `test/test_queueing.py::test_heartbeat_task_cancelled_after_stream_completes` fail intermittently. All three drive the app through a bare `TestClient(app)`, and starlette only keeps a single event loop across requests when the client is entered as a context manager. Without the `with` block each request gets its own blocking portal, and that loop closes as soon as the response is complete.

`schedule_record_run` files the record with `asyncio.get_running_loop().create_task(...)` and `record_run` then awaits `anyio.to_thread.run_sync(...)`, so when the offload has not come back in time the task is left pending on a loop that will never run again and the record is never written. The tests then sit out the full 30 second `_wait_for` and report "no record was written". The heartbeat task in the queueing test is stranded the same way, which is why it ends up neither `cancelled()` nor `done()`. Under uvicorn the loop outlives the request, so this only ever affected the tests.

The fix is to enter the clients as context managers so one portal spans the whole test. Four places, nine lines, no library change.

Measured locally with CI's own command, `pytest -n auto -m "not flaky and not serial"`:

| | before | after |
|---|---|---|
| `test/test_history.py` alone | 4 of 5 runs failed | 8 of 8 clean |
| whole backend suite | 4 of 5 runs failed | 3 of 3 clean |

The timing is the part worth keeping. Every failing run took 37 to 43 seconds, because it waited out the 30 second poll, and every run after the change took 7 to 17 seconds without entering the wait at all. That is what says the race is gone rather than just less frequent.

One caveat on evidence, since the three tests are not equally covered by the above. The two `test_history.py` tests reproduce locally and the numbers are theirs. `test_heartbeat_task_cancelled_after_stream_completes` does not reproduce locally, since it passes in isolation with or without the change; it is included because it was observed failing on CI and builds its client the same way. The change to it is safe either way, but it rests on that rather than on a measurement.

Closes: #13823

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to... I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
