### PR TITLE
Let the backend test job fail the run

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -100,7 +100,10 @@ jobs:
           - os: ${{ github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'windows-tests') && 'dummy' || 'windows-latest' }}
           - test-type: ${{ github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'flaky-tests') && 'dummy' || 'flaky' }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
+    # The flaky suite and windows are expected to be unreliable and should not
+    # fail the run. ubuntu + not-flaky should, so that a red job shows up as a
+    # red run rather than only inside the job.
+    continue-on-error: ${{ matrix.test-type == 'flaky' || matrix.os == 'windows-latest' }}
     steps:
       - uses: actions/checkout@v4
       - name: Download gradio wheel


### PR DESCRIPTION
## Description

`continue-on-error: true` sat at the job level on the `test` matrix, so it covered all four combinations, including `ubuntu-latest` + `not flaky`. When that job failed, its own check run was recorded as `failure`, but the check suite and the workflow run both rolled up to `success`. The roll-up is what the commit list and `gh run list` show, so a red job appeared as a green tick.

This does not weaken the PR gate, and the change does not tighten it either: required status checks match on the check run name, and `test-ubuntu-latest-not-flaky` was already `failure` there. What was hidden is pushes to `main`, where there is no PR to gate. `19cb8f7bc` is on `main` right now with a failing backend job and a green tick, and four `test_load_assets` failures reached `main` the same way until a release PR made them look like release breakage (#13697).

The matrix also covers `test-type: flaky` and `windows-latest`, both of which run only under a label and are expected to be unreliable, which is presumably what the setting was for. Scoping it to those keeps that intent and lets the combination everyone actually reads tell the truth.

Two checks behind the change, both done before proposing it:

- Nothing downstream keys off this workflow's conclusion. Seven workflows gate on `github.event.workflow_run.conclusion == 'success'` and every one listens to a different workflow. The only one listening to `python` is `update-checks.yml`, which fires on `completed` regardless of conclusion and whose single job runs only when the python workflow did *not* run.
- It will not turn `main` red for unrelated reasons. Job-level conclusions for the 17 most recent `python` runs on `main` (2026-08-24 to 2026-09-04): 11 green, 1 red, 5 that skipped the python tests entirely. The one red is the flakiness fixed by #13824.

Best merged after #13824, so the first honest run is a green one.

Closes: #13826

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to... I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
