### PR TITLE
Drain run-history writes on shutdown

### DIFF
--- a/.changeset/mean-tips-dig.md
+++ b/.changeset/mean-tips-dig.md
@@ -1,0 +1,5 @@
+---
+"gradio": patch
+---
+
+fix:Drain run-history writes on shutdown

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -1157,6 +1157,32 @@ async def _delete_state_handler(app: App):
         await _cancel_background_task(task)
 
 
+HISTORY_DRAIN_TIMEOUT = 5.0
+
+
+@asynccontextmanager
+async def _drain_history_tasks(app: App, timeout: float = HISTORY_DRAIN_TIMEOUT):
+    """On shutdown, give in-flight run-history writes a bounded chance to finish.
+
+    A record is filed as a detached task so a prediction never waits on the Hub,
+    and nothing else ever awaits those tasks. Without this, a shutdown cancels
+    whatever is still in `record_run`, and a record that has not yet reached the
+    Hub call is lost outright.
+    """
+    try:
+        yield
+    finally:
+        tasks = {
+            task
+            for task in getattr(app.state, "history_tasks", None) or ()
+            if not task.done()
+        }
+        if tasks:
+            _, pending = await asyncio.wait(tasks, timeout=timeout)
+            for task in pending:
+                task.cancel()
+
+
 def create_lifespan_handler(
     user_lifespan: Callable[[App], AbstractAsyncContextManager] | None,
     frequency: int | None = 1,
@@ -1173,6 +1199,9 @@ def create_lifespan_handler(
                 await stack.enter_async_context(_lifespan_handler(app, frequency, age))
             if user_lifespan is not None:
                 state = await stack.enter_async_context(user_lifespan(app))
+            # Entered last so it unwinds first: the records are drained while
+            # the rest of the app is still up.
+            await stack.enter_async_context(_drain_history_tasks(app))
             yield state
 
     return _handler

--- a/gradio/route_utils.py
+++ b/gradio/route_utils.py
@@ -1172,9 +1172,11 @@ async def _drain_history_tasks(app: App, timeout: float = HISTORY_DRAIN_TIMEOUT)
     try:
         yield
     finally:
+        # `state` itself is absent on the stand-in apps the lifespan tests use.
+        state = getattr(app, "state", None)
         tasks = {
             task
-            for task in getattr(app.state, "history_tasks", None) or ()
+            for task in getattr(state, "history_tasks", None) or ()
             if not task.done()
         }
         if tasks:

--- a/test/test_history.py
+++ b/test/test_history.py
@@ -458,6 +458,43 @@ class TestServerSideRecording:
         assert r.json()["data"] == ["hello world"]
 
 
+def test_a_record_still_in_flight_survives_shutdown(monkeypatch):
+    """Records are filed as detached tasks, so a shutdown that does not wait for
+    them loses whatever has not reached the Hub yet. The delay goes in the
+    prelude rather than in the Hub call on purpose: `anyio.to_thread.run_sync`
+    cannot interrupt its worker thread, so a write that has already started
+    finishes either way and would not tell the two behaviours apart."""
+    monkeypatch.delenv("GRADIO_HISTORY_BUCKET", raising=False)
+    hub = FakeHub()
+    original = history_mod.externalize_assets
+
+    async def slow_externalize(*args, **kwargs):
+        await asyncio.sleep(0.3)
+        return await original(*args, **kwargs)
+
+    def greet(name):
+        return f"hello {name}"
+
+    io = gr.Interface(greet, "text", "text", api_name="greet")
+    app, _, _ = io.launch(prevent_thread_lock=True)
+    with (
+        patch("gradio.history.resolve_token", return_value="tok"),
+        patch("gradio.history.HfApi", return_value=hub),
+        patch("gradio.history.externalize_assets", slow_externalize),
+        TestClient(app) as client,
+    ):
+        r = client.post(
+            "/gradio_api/run/greet",
+            json={"data": ["world"]},
+            headers={"X-Gradio-History-Bucket": "alice/hist"},
+        )
+        assert r.status_code == 200, r.text
+    # Leaving the block runs the lifespan shutdown, which is where the drain is.
+    assert len(hub.files) == 1, "the record was dropped by the shutdown"
+    io.close()
+    close_all()
+
+
 # ------------------------------------------------- end-to-end: workflow canvas
 
 


### PR DESCRIPTION
## Description

A run-history record is filed as a detached task, so a prediction never waits on the Hub. `app.state.history_tasks` collects those tasks, but nothing ever awaits them, so a shutdown cancels whatever is still in flight and the record is gone.

`record_run` awaits `externalize_assets` twice and then the write limiter before it reaches the Hub, and where the cancellation lands decides the outcome:

| record pinned at | task after shutdown | record |
|---|---|---|
| the Hub write | `cancelled=True` | written |
| the async prelude, before any Hub call | `cancelled=True` | **lost** |

`close()` returned in 0.20 s in both cases. The first row survives only because `anyio.to_thread.run_sync` cannot interrupt its worker thread, so the thread runs to completion and its result is discarded; that also means it would not survive the process exit that normally follows a shutdown. The prelude is the larger window in practice, since asset externalisation fetches remote media and the limiter can hold a task while other writes drain.

The fix adds a drain to the lifespan stack, entered last so it unwinds first and the records are flushed while the rest of the app is still up. It is bounded at five seconds so a shutdown cannot hang on an unreachable Hub, and anything still pending after that is cancelled as before.

Closes: #13825

## Testing

Worth one note, because the obvious version of this test does not work. The regression test puts its delay in `record_run`'s prelude rather than in the Hub call. A write that has already started finishes either way, for the `anyio` reason above, so slowing the Hub call gives a test that passes with or without the fix. Verified in both directions: it fails with `AssertionError: the record was dropped by the shutdown` against `main`'s `route_utils.py`, and passes with the change.

`test/test_history.py::TestServerSideRecording::test_a_normal_prediction_is_recorded` can flake on this branch, which is cut from `main`. That is #13823, fixed by #13824, and unrelated to this change.

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to... I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`
