### PR TITLE
Fix Dropdown labels for None-valued choices

### DIFF
--- a/.changeset/late-dancers-invite.md
+++ b/.changeset/late-dancers-invite.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dropdown": patch
+"gradio": patch
+---
+
+fix:Fix Dropdown labels for None-valued choices

--- a/js/dropdown/dropdown.test.ts
+++ b/js/dropdown/dropdown.test.ts
@@ -98,6 +98,20 @@ describe("Single-select: Rendering", () => {
 		expect(input.value).toBe("Banana Display");
 	});
 
+	test("renders the display name when null is a choice value", async () => {
+		const { getByLabelText } = await render(Dropdown, {
+			...single_select_props,
+			choices: [
+				["Default", null],
+				["Option A", "a"]
+			],
+			value: null
+		});
+
+		const input = getByLabelText("Dropdown") as HTMLInputElement;
+		expect(input).toHaveValue("Default");
+	});
+
 	test("renders empty input when value is null", async () => {
 		const { getByLabelText } = await render(Dropdown, {
 			...single_select_props,
@@ -564,6 +578,27 @@ describe("Single-select: Selection", () => {
 		expect(input.value).toBe("Banana Display");
 		const data = await get_data();
 		expect(data.value).toBe("banana_val");
+	});
+
+	test("clicking an option with a null value keeps its display name", async () => {
+		const { getByLabelText, getAllByTestId, get_data } = await render(
+			Dropdown,
+			{
+				...single_select_props,
+				choices: [
+					["Default", null],
+					["Option A", "a"]
+				],
+				value: "a"
+			}
+		);
+
+		const input = getByLabelText("Dropdown") as HTMLInputElement;
+		await input.focus();
+		await event.click(getAllByTestId("dropdown-option")[0]);
+
+		expect(input).toHaveValue("Default");
+		expect((await get_data()).value).toBeNull();
 	});
 
 	test("arrow down then Enter selects first option", async () => {

--- a/js/dropdown/shared/Dropdown.svelte
+++ b/js/dropdown/shared/Dropdown.svelte
@@ -78,7 +78,6 @@
 		}
 		if (
 			current_value === undefined ||
-			current_value === null ||
 			(Array.isArray(current_value) && current_value.length === 0)
 		) {
 			input_text = "";
@@ -86,6 +85,9 @@
 		} else if (values.includes(current_value as string | number)) {
 			input_text = names[values.indexOf(current_value as string | number)];
 			selected_index = values.indexOf(current_value as string | number);
+		} else if (current_value === null) {
+			input_text = "";
+			selected_index = null;
 		} else if (allow_custom_value) {
 			input_text = current_value as string;
 			selected_index = null;


### PR DESCRIPTION
## Description

Fixes single-select Dropdowns whose choices include a display label mapped to `None`. The component now checks for a matching choice before treating a `None` value as an empty selection, so the label is shown while the submitted value remains `None`.

Closes: #13832

## Before / after Spaces
<!-- gradio-before-after-spaces -->

Both Spaces run the same reproduction from the issue:

- [Before fix — released Gradio 6.26.0](https://huggingface.co/spaces/dawood/gradio-13832-dropdown-none-before)
- [After fix — wheel built from `0edbbc905`](https://huggingface.co/spaces/dawood/gradio-13832-dropdown-none-after)

On load, compare the **Choose an option** field: the before Space leaves it blank, while the after Space shows **Default**. Then select **Option A** followed by **Default**; the after Space keeps **Default** visible and the result confirms that its submitted value is still `None`.

The temporary demo and wheel are hosted in the Spaces and are not committed to this branch.

## AI Disclosure

- [x] I used AI to investigate the regression, draft and self-review the implementation and tests, create the comparison Spaces, and prepare this PR description.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets #13832. I checked for overlapping open PRs before starting and found none.

## Testing and Formatting Your Code

- Added focused Vitest component coverage for initial rendering and selecting a `None`-valued choice. No Playwright tests were added.
- `CI=1 pnpm exec vitest run --config .config/vitest.config.ts js/dropdown/dropdown.test.ts` — 140 passed, 4 todo.
- Targeted Prettier and ESLint checks passed for the changed frontend source; the test file is excluded by the repository ESLint configuration.
- `bash scripts/format_frontend.sh` formatted the changes successfully. Its repository-wide type-check reports 16 existing errors in unrelated files.
- No changeset was added manually; the repository's PR automation generated `.changeset/late-dancers-invite.md` from the PR title after the branch was pushed.
