### PR TITLE
Speed up multipage app navigation

### DIFF
--- a/.changeset/short-walls-marry.md
+++ b/.changeset/short-walls-marry.md
@@ -1,0 +1,7 @@
+---
+"@gradio/client": minor
+"@self/app": minor
+"gradio": minor
+---
+
+feat:Speed up multipage app navigation

--- a/client/js/src/client.ts
+++ b/client/js/src/client.ts
@@ -48,6 +48,7 @@ export class Client {
 	app_reference: string;
 	options: ClientOptions;
 	deep_link: string | null = null;
+	page: string | null = null;
 
 	config: Config | undefined;
 	api_prefix = "";
@@ -199,6 +200,7 @@ export class Client {
 	) {
 		this.app_reference = app_reference;
 		this.deep_link = options.query_params?.deep_link || null;
+		this.page = options.query_params?.page ?? null;
 		if (!options.events) {
 			options.events = ["data"];
 		}

--- a/client/js/src/helpers/init_helpers.ts
+++ b/client/js/src/helpers/init_helpers.ts
@@ -129,12 +129,10 @@ export async function resolve_config(
 			window.gradio_config.dev_mode ||
 			(typeof window !== "undefined" && window?.BUILD_MODE === "dev")
 		) {
-			let config_url = join_urls(
-				endpoint,
-				this.deep_link
-					? CONFIG_URL + "?deep_link=" + this.deep_link
-					: CONFIG_URL
-			);
+			let config_url = new URL(join_urls(endpoint, CONFIG_URL));
+			if (this.deep_link)
+				config_url.searchParams.set("deep_link", this.deep_link);
+			if (this.page !== null) config_url.searchParams.set("page", this.page);
 			const response = await this.fetch(config_url, {
 				headers,
 				credentials: this.options.credentials ?? "same-origin"
@@ -160,10 +158,10 @@ export async function resolve_config(
 		);
 		return config;
 	} else if (endpoint) {
-		let config_url = join_urls(
-			endpoint,
-			this.deep_link ? CONFIG_URL + "?deep_link=" + this.deep_link : CONFIG_URL
-		);
+		let config_url = new URL(join_urls(endpoint, CONFIG_URL));
+		if (this.deep_link)
+			config_url.searchParams.set("deep_link", this.deep_link);
+		if (this.page !== null) config_url.searchParams.set("page", this.page);
 
 		const response = await this.fetch(config_url, {
 			headers,

--- a/client/js/src/test/init.test.ts
+++ b/client/js/src/test/init.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./test_data";
 import { initialise_server } from "./server";
 import { SPACE_NOT_FOUND_MSG } from "../constants";
+import { HttpResponse, http } from "msw";
 
 const app_reference = "hmb/hello_world";
 const broken_app_reference = "hmb/bye_world";
@@ -63,6 +64,29 @@ describe("Client class", () => {
 		test("connecting to a running app with a direct app URL", async () => {
 			const app = await Client.connect(direct_app_reference);
 			expect(app.config).toEqual(config_response);
+		});
+
+		test("forwards a page query when resolving config and API info", async () => {
+			const requested_urls: string[] = [];
+			server.resetHandlers(
+				http.get(`${direct_app_reference}/config`, ({ request }) => {
+					requested_urls.push(request.url);
+					return HttpResponse.json(config_response);
+				}),
+				http.get(`${direct_app_reference}/info`, ({ request }) => {
+					requested_urls.push(request.url);
+					return HttpResponse.json(response_api_info);
+				})
+			);
+
+			await Client.connect(direct_app_reference, {
+				query_params: { page: "details" }
+			});
+
+			expect(requested_urls).toEqual([
+				`${direct_app_reference}/config?page=details`,
+				`${direct_app_reference}/info?page=details`
+			]);
 		});
 
 		test("connecting successfully to a private running app with a space reference", async () => {

--- a/client/js/src/test/init.test.ts
+++ b/client/js/src/test/init.test.ts
@@ -68,7 +68,7 @@ describe("Client class", () => {
 
 		test("forwards a page query when resolving config and API info", async () => {
 			const requested_urls: string[] = [];
-			server.resetHandlers(
+			server.use(
 				http.get(`${direct_app_reference}/config`, ({ request }) => {
 					requested_urls.push(request.url);
 					return HttpResponse.json(config_response);

--- a/client/js/src/test/server.ts
+++ b/client/js/src/test/server.ts
@@ -8,6 +8,7 @@ const IS_NODE =
 interface MockServer {
 	start: (opts: StartOptions) => void | ReturnType<SetupWorker["start"]>;
 	stop: () => void | Promise<void>;
+	use: (...handlers: any[]) => void;
 	resetHandlers: (...handlers: any[]) => void;
 }
 
@@ -18,6 +19,7 @@ export async function initialise_server(): Promise<MockServer> {
 		return {
 			start: (opts: StartOptions) => server.listen(opts),
 			stop: () => server.close(),
+			use: (...h) => server.use(...h),
 			resetHandlers: (...h) => server.resetHandlers(...h)
 		};
 	}
@@ -26,6 +28,7 @@ export async function initialise_server(): Promise<MockServer> {
 	return {
 		start: (opts: StartOptions) => worker.start(opts),
 		stop: () => worker.stop(),
+		use: (...h) => worker.use(...h),
 		resetHandlers: (...h) => worker.resetHandlers(...h)
 	};
 }

--- a/client/js/src/utils/view_api.ts
+++ b/client/js/src/utils/view_api.ts
@@ -28,7 +28,10 @@ export async function view_api(this: Client): Promise<any> {
 		if (typeof window !== "undefined" && window.gradio_api_info) {
 			api_info = window.gradio_api_info;
 		} else {
-			const url = join_urls(config.root, this.api_prefix, API_INFO_URL);
+			const url = new URL(
+				join_urls(config.root, this.api_prefix, API_INFO_URL)
+			);
+			if (this.page !== null) url.searchParams.set("page", this.page);
 			response = await this.fetch(url, {
 				headers,
 				credentials: this.options.credentials ?? "same-origin"

--- a/gradio/blocks.py
+++ b/gradio/blocks.py
@@ -3645,16 +3645,21 @@ Received inputs:
         for startup_event in self.extra_startup_events:
             await startup_event()
 
-    def get_api_info(self, all_endpoints: bool = False) -> APIInfo:
+    def get_api_info(
+        self, all_endpoints: bool = False, page: str | None = None
+    ) -> APIInfo:
         """
         Gets the information needed to generate the API docs from a Blocks.
         Parameters:
             all_endpoints: If True, returns information about all endpoints, including those with api_visibility="undocumented".
+            page: If provided, returns information only for endpoints on this page.
         """
         config = self.config
         api_info: APIInfo = {"named_endpoints": {}, "unnamed_endpoints": {}}
 
         for fn in self.fns.values():
+            if page is not None and fn.page != page:
+                continue
             if not fn.fn or fn.api_visibility == "private":
                 continue
             if not all_endpoints and fn.api_visibility != "public":

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -77,6 +77,8 @@ from gradio import (
 from gradio.brotli_middleware import BrotliMiddleware
 from gradio.context import Context
 from gradio.data_classes import (
+    APIInfo,
+    BlocksConfigDict,
     CancelBody,
     ComponentServerBlobBody,
     ComponentServerJSONBody,
@@ -595,8 +597,8 @@ class App(FastAPI):
                 attach_page(page)
 
         def load_deep_link(
-            deep_link: str, config: dict[str, Any], page: str | None = None
-        ):
+            deep_link: str, config: BlocksConfigDict, page: str | None = None
+        ) -> tuple[list[dict[str, Any]], Literal["valid", "invalid"]]:
             components = config["components"]
             try:
                 user_path = Path("deep_links") / deep_link / "state.json"
@@ -623,10 +625,10 @@ class App(FastAPI):
             return components, deep_link_state
 
         def get_page_config(
-            config: dict[str, Any],
+            config: BlocksConfigDict,
             page: str,
             components: list[dict[str, Any]] | None = None,
-        ) -> dict[str, Any]:
+        ) -> BlocksConfigDict:
             """Copy only the component and dependency data needed by one page."""
             page_config = config["page"][page]
             component_ids = set(page_config["components"])
@@ -640,12 +642,15 @@ class App(FastAPI):
                     if component["id"] in component_ids
                 ]
             )
-            filtered_config = utils.safe_deepcopy(
-                {
-                    key: value
-                    for key, value in config.items()
-                    if key not in {"components", "dependencies", "layout"}
-                }
+            filtered_config = cast(
+                BlocksConfigDict,
+                utils.safe_deepcopy(
+                    {
+                        key: value
+                        for key, value in config.items()
+                        if key not in {"components", "dependencies", "layout"}
+                    }
+                ),
             )
             filtered_config["components"] = utils.safe_deepcopy(page_components)
             filtered_config["dependencies"] = utils.safe_deepcopy(
@@ -862,22 +867,22 @@ class App(FastAPI):
                 )
             return app.api_info
 
-        def prepare_api_info(
-            request: fastapi.Request, info: dict[str, Any]
-        ) -> dict[str, Any]:
-            info = cast(dict[str, Any], utils.safe_deepcopy(info))
-            info = route_utils.update_example_values_to_use_public_url(info)
+        def prepare_api_info(request: fastapi.Request, info: APIInfo) -> dict[str, Any]:
+            prepared_info = cast(dict[str, Any], utils.safe_deepcopy(info))
+            prepared_info = route_utils.update_example_values_to_use_public_url(
+                prepared_info
+            )
             root = route_utils.get_root_url(
                 request=request,
                 route_path=f"{API_PREFIX}/info",
                 root_path=app.root_path,
             )
             space_id = app.get_blocks().space_id
-            cli_snippets = generate_cli_snippet(info["named_endpoints"])
+            cli_snippets = generate_cli_snippet(prepared_info["named_endpoints"])
             for k, v in cli_snippets.items():
                 cli_snippets[k] = v.replace("{space_id}", space_id or str(root))
             api_prefix = API_PREFIX + "/"
-            for ep_name, ep_info in info.get("named_endpoints", {}).items():
+            for ep_name, ep_info in prepared_info.get("named_endpoints", {}).items():
                 ep_info["code_snippets"] = generate_code_snippets(
                     ep_name,
                     ep_info,
@@ -886,7 +891,7 @@ class App(FastAPI):
                     api_prefix=api_prefix,
                 )
                 ep_info["code_snippets"]["cli"] = cli_snippets[ep_name]
-            return info
+            return prepared_info
 
         @router.get("/openapi.json", dependencies=[Depends(login_check)])
         def openapi_schema(request: fastapi.Request):
@@ -1101,12 +1106,12 @@ class App(FastAPI):
             deep_link: str = "",
             page: str | None = None,
         ):
-            source_config = app.get_blocks().config
+            source_config = cast(BlocksConfigDict, app.get_blocks().config)
             selected_page = (
                 page if page is not None and page in source_config["page"] else None
             )
             components = None
-            deep_link_state = None
+            deep_link_state: Literal["valid", "invalid"] = "invalid"
             if deep_link:
                 components, deep_link_state = load_deep_link(
                     deep_link,

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -614,13 +614,50 @@ class App(FastAPI):
             except (FileNotFoundError, OSError, orjson.JSONDecodeError):
                 deep_link_state = "invalid"
                 components = []
-            if page:
+            if page is not None:
                 components = [
                     component
                     for component in components
                     if component["id"] in config["page"][page]["components"]
                 ]
             return components, deep_link_state
+
+        def get_page_config(
+            config: dict[str, Any],
+            page: str,
+            components: list[dict[str, Any]] | None = None,
+        ) -> dict[str, Any]:
+            """Copy only the component and dependency data needed by one page."""
+            page_config = config["page"][page]
+            component_ids = set(page_config["components"])
+            dependency_ids = set(page_config["dependencies"])
+            page_components = (
+                components
+                if components is not None
+                else [
+                    component
+                    for component in config["components"]
+                    if component["id"] in component_ids
+                ]
+            )
+            filtered_config = utils.safe_deepcopy(
+                {
+                    key: value
+                    for key, value in config.items()
+                    if key not in {"components", "dependencies", "layout"}
+                }
+            )
+            filtered_config["components"] = utils.safe_deepcopy(page_components)
+            filtered_config["dependencies"] = utils.safe_deepcopy(
+                [
+                    dependency
+                    for dependency in config.get("dependencies", [])
+                    if dependency["id"] in dependency_ids
+                ]
+            )
+            filtered_config["layout"] = utils.safe_deepcopy(page_config["layout"])
+            filtered_config["current_page"] = page
+            return filtered_config
 
         @app.head("/", response_class=HTMLResponse)
         @app.get("/", response_class=HTMLResponse)
@@ -641,29 +678,18 @@ class App(FastAPI):
                 or blocks.custom_mount_path,
             )
             if (app.auth is None and app.auth_dependency is None) or user is not None:
-                config = utils.safe_deepcopy(blocks.config)
+                source_config = blocks.config
                 deep_link_state = "none"
-                components = [
-                    component
-                    for component in config["components"]
-                    if component["id"] in config["page"][page]["components"]
-                ]
+                components = None
                 if deep_link:
                     components, deep_link_state = load_deep_link(
                         deep_link,
-                        config,  # type: ignore
+                        source_config,  # type: ignore
                         page,
                     )
+                config = get_page_config(source_config, page, components)  # type: ignore
                 config["username"] = user
                 config["deep_link_state"] = deep_link_state
-                config["components"] = components  # type: ignore
-                config["dependencies"] = [
-                    dependency
-                    for dependency in config.get("dependencies", [])
-                    if dependency["id"] in config["page"][page]["dependencies"]
-                ]
-                config["layout"] = config["page"][page]["layout"]
-                config["current_page"] = page
                 # Update root after loading the deep link state (if applicable)
                 # so that static files are served from the correct root
                 config = route_utils.update_root_in_config(config, root)
@@ -692,7 +718,7 @@ class App(FastAPI):
                 template = (
                     "frontend/share.html" if blocks.share else "frontend/index.html"
                 )
-                gradio_api_info = api_info(request)
+                gradio_api_info = api_info(request, page=page)
                 resp = templates.TemplateResponse(
                     request=request,
                     name=template,
@@ -819,37 +845,48 @@ class App(FastAPI):
 
         @router.get("/info/", dependencies=[Depends(login_check)])
         @router.get("/info", dependencies=[Depends(login_check)])
-        def api_info(request: fastapi.Request):
+        def api_info(request: fastapi.Request, page: str | None = None):
             all_endpoints = request.query_params.get("all_endpoints", False)
+            if page is not None and page in app.get_blocks().config["page"]:
+                info = app.get_blocks().get_api_info(
+                    all_endpoints=bool(all_endpoints), page=page
+                )
+                return prepare_api_info(request, info)
             if all_endpoints:
                 if not app.all_app_info:
                     app.all_app_info = app.get_blocks().get_api_info(all_endpoints=True)
                 return app.all_app_info
             if not app.api_info:
-                api_info = utils.safe_deepcopy(app.get_blocks().get_api_info())
-                api_info = cast(dict[str, Any], api_info)
-                api_info = route_utils.update_example_values_to_use_public_url(api_info)
-                root = route_utils.get_root_url(
-                    request=request,
-                    route_path=f"{API_PREFIX}/info",
-                    root_path=app.root_path,
+                app.api_info = prepare_api_info(
+                    request, app.get_blocks().get_api_info()
                 )
-                space_id = app.get_blocks().space_id
-                cli_snippets = generate_cli_snippet(api_info["named_endpoints"])
-                for k, v in cli_snippets.items():
-                    cli_snippets[k] = v.replace("{space_id}", space_id or str(root))
-                api_prefix = API_PREFIX + "/"
-                for ep_name, ep_info in api_info.get("named_endpoints", {}).items():
-                    ep_info["code_snippets"] = generate_code_snippets(
-                        ep_name,
-                        ep_info,
-                        str(root),
-                        space_id=space_id,
-                        api_prefix=api_prefix,
-                    )
-                    ep_info["code_snippets"]["cli"] = cli_snippets[ep_name]
-                app.api_info = api_info
             return app.api_info
+
+        def prepare_api_info(
+            request: fastapi.Request, info: dict[str, Any]
+        ) -> dict[str, Any]:
+            info = cast(dict[str, Any], utils.safe_deepcopy(info))
+            info = route_utils.update_example_values_to_use_public_url(info)
+            root = route_utils.get_root_url(
+                request=request,
+                route_path=f"{API_PREFIX}/info",
+                root_path=app.root_path,
+            )
+            space_id = app.get_blocks().space_id
+            cli_snippets = generate_cli_snippet(info["named_endpoints"])
+            for k, v in cli_snippets.items():
+                cli_snippets[k] = v.replace("{space_id}", space_id or str(root))
+            api_prefix = API_PREFIX + "/"
+            for ep_name, ep_info in info.get("named_endpoints", {}).items():
+                ep_info["code_snippets"] = generate_code_snippets(
+                    ep_name,
+                    ep_info,
+                    str(root),
+                    space_id=space_id,
+                    api_prefix=api_prefix,
+                )
+                ep_info["code_snippets"]["cli"] = cli_snippets[ep_name]
+            return info
 
         @router.get("/openapi.json", dependencies=[Depends(login_check)])
         def openapi_schema(request: fastapi.Request):
@@ -1062,8 +1099,24 @@ class App(FastAPI):
             request: fastapi.Request,
             user: str = Depends(get_current_user),
             deep_link: str = "",
+            page: str | None = None,
         ):
-            config = utils.safe_deepcopy(app.get_blocks().config)
+            source_config = app.get_blocks().config
+            selected_page = (
+                page if page is not None and page in source_config["page"] else None
+            )
+            components = None
+            deep_link_state = None
+            if deep_link:
+                components, deep_link_state = load_deep_link(
+                    deep_link,
+                    source_config,
+                    selected_page if selected_page is not None else "",
+                )
+            if selected_page is not None:
+                config = get_page_config(source_config, selected_page, components)
+            else:
+                config = utils.safe_deepcopy(source_config)
             root = route_utils.get_root_url(
                 request=request,
                 route_path="/config",
@@ -1073,7 +1126,6 @@ class App(FastAPI):
             )
             config["username"] = user
             if deep_link:
-                components, deep_link_state = load_deep_link(deep_link, config, page="")  # type: ignore
                 config["components"] = components  # type: ignore
                 config["deep_link_state"] = deep_link_state
             if hasattr(blocks, "i18n_instance") and blocks.i18n_instance:

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1116,7 +1116,7 @@ class App(FastAPI):
                 components, deep_link_state = load_deep_link(
                     deep_link,
                     source_config,
-                    selected_page if selected_page is not None else "",
+                    selected_page,
                 )
             if selected_page is not None:
                 config = get_page_config(source_config, selected_page, components)

--- a/gradio/routes.py
+++ b/gradio/routes.py
@@ -1517,7 +1517,11 @@ class App(FastAPI):
             request: fastapi.Request,
             username: str = Depends(get_current_user),
         ):
-            endpoint_info = app.api_info["named_endpoints"]["/" + api_name]  # type: ignore
+            # A page-scoped HTML or /info request deliberately does not populate
+            # the full API-info cache. Build it lazily for this endpoint instead
+            # of relying on the app's home page having been requested first.
+            full_api_info = app.api_info or api_info(request)
+            endpoint_info = full_api_info["named_endpoints"]["/" + api_name]
             parameters_info = endpoint_info["parameters"]
             body = dict(body)
             oauth_token = None

--- a/js/app/proxy_routes.test.js
+++ b/js/app/proxy_routes.test.js
@@ -16,6 +16,29 @@ import {
 	PYTHON_ROUTE_PREFIXES,
 	STATIC_ROUTE_PREFIXES
 } from "./proxy_routes.js";
+import { get_current_page } from "./src/lib/page_utils.js";
+
+describe("get_current_page", () => {
+	it("returns a subpage for an app mounted at the origin root", () => {
+		assert.equal(
+			get_current_page("/audio_debugger", "https://example.com"),
+			"audio_debugger"
+		);
+	});
+
+	it("returns a subpage relative to a mounted root", () => {
+		assert.equal(
+			get_current_page("/gradio/audio_debugger", "https://example.com/gradio"),
+			"audio_debugger"
+		);
+	});
+
+	it("returns the home page for the app root or an unrelated path", () => {
+		assert.equal(get_current_page("/", "https://example.com"), "");
+		assert.equal(get_current_page("/gradio", "https://example.com/gradio"), "");
+		assert.equal(get_current_page("/other", "https://example.com/gradio"), "");
+	});
+});
 
 describe("classifyRoute", () => {
 	describe("python routes", () => {

--- a/js/app/src/lib/page_utils.js
+++ b/js/app/src/lib/page_utils.js
@@ -1,0 +1,17 @@
+/**
+ * Return the Gradio page path represented by a request URL.
+ *
+ * @param {string} pathname
+ * @param {string} root_url
+ * @returns {string}
+ */
+export function get_current_page(pathname, root_url) {
+	const strip_slashes = (path) => path.replace(/^\/+|\/+$/g, "");
+	const root_path = strip_slashes(new URL(root_url).pathname);
+	const url_path = strip_slashes(pathname);
+
+	if (!root_path) return url_path;
+	if (url_path === root_path) return "";
+	if (!url_path.startsWith(`${root_path}/`)) return "";
+	return url_path.slice(root_path.length + 1);
+}

--- a/js/app/src/routes/[...catchall]/+page.server.ts
+++ b/js/app/src/routes/[...catchall]/+page.server.ts
@@ -1,6 +1,12 @@
 import { dev } from "$app/environment";
 
-export async function load({ request }: { request: Request }): Promise<{
+export async function load({
+	request,
+	url
+}: {
+	request: Request;
+	url: URL;
+}): Promise<{
 	server: string;
 	port: string;
 	local_dev_mode: string | undefined;
@@ -21,12 +27,22 @@ export async function load({ request }: { request: Request }): Promise<{
 		request.headers.get("x-gradio-original-url") || server
 	).origin;
 	const cookie = request.headers.get("cookie");
+	const strip_slashes = (path: string): string =>
+		path.replace(/^\/+|\/+$/g, "");
+	const root_path = strip_slashes(new URL(mount_path, real_url).pathname);
+	const url_path = strip_slashes(url.pathname);
+	const current_page =
+		url_path === root_path || !url_path.startsWith(root_path + "/")
+			? ""
+			: url_path.slice(root_path.length + 1);
 
 	// Check if auth is required by making a request to /config
 	// This runs only on the server, so it's safe to make this request
 	let auth_required = false;
 	try {
-		const configResponse = await fetch(`${server}/config`, {
+		const config_url = new URL(`${server}/config`);
+		config_url.searchParams.set("page", current_page);
+		const configResponse = await fetch(config_url, {
 			headers: {
 				...(cookie ? { Cookie: cookie } : {})
 			}

--- a/js/app/src/routes/[...catchall]/+page.server.ts
+++ b/js/app/src/routes/[...catchall]/+page.server.ts
@@ -1,4 +1,5 @@
 import { dev } from "$app/environment";
+import { get_current_page } from "$lib/page_utils.js";
 
 export async function load({
 	request,
@@ -27,14 +28,10 @@ export async function load({
 		request.headers.get("x-gradio-original-url") || server
 	).origin;
 	const cookie = request.headers.get("cookie");
-	const strip_slashes = (path: string): string =>
-		path.replace(/^\/+|\/+$/g, "");
-	const root_path = strip_slashes(new URL(mount_path, real_url).pathname);
-	const url_path = strip_slashes(url.pathname);
-	const current_page =
-		url_path === root_path || !url_path.startsWith(root_path + "/")
-			? ""
-			: url_path.slice(root_path.length + 1);
+	const current_page = get_current_page(
+		url.pathname,
+		new URL(mount_path, real_url).href
+	);
 
 	// Check if auth is required by making a request to /config
 	// This runs only on the server, so it's safe to make this request

--- a/js/app/src/routes/[...catchall]/+page.ts
+++ b/js/app/src/routes/[...catchall]/+page.ts
@@ -6,18 +6,9 @@ import { apply_run_history_replay, Client } from "@gradio/client";
 import type { Config } from "@gradio/client";
 import { MISSING_CREDENTIALS_MSG } from "@gradio/client";
 import { setupi18n } from "@gradio/core";
+import { get_current_page } from "$lib/page_utils.js";
 
 export let ssr = true;
-
-function get_current_page(url: URL, root_url: string): string {
-	const strip_slashes = (path: string): string =>
-		path.replace(/^\/+|\/+$/g, "");
-	const root_path = strip_slashes(new URL(root_url).pathname);
-	const url_path = strip_slashes(url.pathname);
-	if (url_path === root_path) return "";
-	if (!url_path.startsWith(root_path + "/")) return "";
-	return url_path.slice(root_path.length + 1);
-}
 
 export async function load({
 	url,
@@ -44,7 +35,7 @@ export async function load({
 			? new URL(mount_path || "/", root_url).href
 			: server;
 	const deepLink = url.searchParams.get("deep_link");
-	const currentPage = get_current_page(url, root_url);
+	const currentPage = get_current_page(url.pathname, root_url);
 	const headers = new Headers();
 	if (!browser) {
 		headers.append("x-gradio-server", root_url);

--- a/js/app/src/routes/[...catchall]/+page.ts
+++ b/js/app/src/routes/[...catchall]/+page.ts
@@ -9,6 +9,16 @@ import { setupi18n } from "@gradio/core";
 
 export let ssr = true;
 
+function get_current_page(url: URL, root_url: string): string {
+	const strip_slashes = (path: string): string =>
+		path.replace(/^\/+|\/+$/g, "");
+	const root_path = strip_slashes(new URL(root_url).pathname);
+	const url_path = strip_slashes(url.pathname);
+	if (url_path === root_path) return "";
+	if (!url_path.startsWith(root_path + "/")) return "";
+	return url_path.slice(root_path.length + 1);
+}
+
 export async function load({
 	url,
 	data: {
@@ -34,6 +44,7 @@ export async function load({
 			? new URL(mount_path || "/", root_url).href
 			: server;
 	const deepLink = url.searchParams.get("deep_link");
+	const currentPage = get_current_page(url, root_url);
 	const headers = new Headers();
 	if (!browser) {
 		headers.append("x-gradio-server", root_url);
@@ -96,7 +107,10 @@ export async function load({
 		app = await Client.connect(api_url, {
 			with_null_state: true,
 			events: ["data", "log", "status", "render"],
-			query_params: deepLink ? { deep_link: deepLink } : undefined,
+			query_params: {
+				...(deepLink ? { deep_link: deepLink } : {}),
+				page: currentPage
+			},
 			headers,
 			cookies: cookie || undefined
 		});

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -164,6 +164,15 @@ class TestRoutes:
             )
             home_info = client.get(f"{API_PREFIX}/info?page=").json()
             assert set(home_info["named_endpoints"]) == {"/home_endpoint"}
+
+            # Page-scoped requests leave the full API-info cache empty. The cURL
+            # endpoint must initialize it lazily instead of returning a 500.
+            assert app.api_info is None
+            curl_response = client.post(
+                f"{API_PREFIX}/call/v2/home_endpoint", json={"value": "hello"}
+            )
+            assert curl_response.status_code == 200
+            assert app.api_info is not None
         finally:
             demo.close()
 

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -117,7 +117,7 @@ class TestRoutes:
         response = test_client.get("/config/")
         assert response.status_code == 200
 
-    def test_multipage_config_and_info_can_be_scoped_to_page(self):
+    def test_multipage_config_and_info_can_be_scoped_to_page(self, gradio_temp_dir):
         with Blocks() as demo:
             home_input = Textbox()
             home_output = Textbox()
@@ -173,6 +173,26 @@ class TestRoutes:
             )
             assert curl_response.status_code == 200
             assert app.api_info is not None
+
+            deep_link_dir = gradio_temp_dir / "deep_links" / "multipage"
+            deep_link_dir.mkdir(parents=True)
+            (deep_link_dir / "state.json").write_text(
+                json.dumps(full_config["components"])
+            )
+            legacy_deep_link_config = client.get("/config?deep_link=multipage").json()
+            assert {
+                component["id"] for component in legacy_deep_link_config["components"]
+            } == {component["id"] for component in full_config["components"]}
+            assert details_input._id in {
+                component["id"] for component in legacy_deep_link_config["components"]
+            }
+
+            home_deep_link_config = client.get(
+                "/config?deep_link=multipage&page="
+            ).json()
+            assert {
+                component["id"] for component in home_deep_link_config["components"]
+            } == set(home_deep_link_config["page"][""]["components"])
         finally:
             demo.close()
 

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -117,6 +117,56 @@ class TestRoutes:
         response = test_client.get("/config/")
         assert response.status_code == 200
 
+    def test_multipage_config_and_info_can_be_scoped_to_page(self):
+        with Blocks() as demo:
+            home_input = Textbox()
+            home_output = Textbox()
+            home_input.change(
+                lambda value: value,
+                home_input,
+                home_output,
+                api_name="home_endpoint",
+            )
+        with demo.route("Details", path="details"):
+            details_input = Textbox()
+            details_output = Textbox()
+            details_input.change(
+                lambda value: value,
+                details_input,
+                details_output,
+                api_name="details_endpoint",
+            )
+
+        app, _, _ = demo.launch(prevent_thread_lock=True)
+        try:
+            client = TestClient(app)
+            full_config = client.get("/config").json()
+            page_config = client.get("/config?page=details").json()
+
+            assert page_config["current_page"] == "details"
+            assert page_config["pages"] == full_config["pages"]
+            assert {component["id"] for component in page_config["components"]} == set(
+                page_config["page"]["details"]["components"]
+            )
+            assert {
+                dependency["id"] for dependency in page_config["dependencies"]
+            } == set(page_config["page"]["details"]["dependencies"])
+            assert len(page_config["components"]) < len(full_config["components"])
+            assert len(page_config["dependencies"]) < len(full_config["dependencies"])
+
+            page_info = client.get(f"{API_PREFIX}/info?page=details").json()
+            assert set(page_info["named_endpoints"]) == {"/details_endpoint"}
+
+            home_config = client.get("/config?page=").json()
+            assert home_config["current_page"] == ""
+            assert {component["id"] for component in home_config["components"]} == set(
+                home_config["page"][""]["components"]
+            )
+            home_info = client.get(f"{API_PREFIX}/info?page=").json()
+            assert set(home_info["named_endpoints"]) == {"/home_endpoint"}
+        finally:
+            demo.close()
+
     def test_audio_stream_playlist_uses_stable_target_duration(self):
         with Blocks() as demo:
             audio = gr.Audio()


### PR DESCRIPTION
This was really bugging mewhenever I'd take a look at the deployed Spaces. 

Multipage navigation currently serializes, transfers, and processes data for the entire app on every page load. This is especially costly in SSR mode because the SvelteKit server and the browser client each resolve the config and API metadata. The supplied 39-page demo sends about 2.28 MB of config plus 7.45 MB of API metadata before an individual page can render.

This PR adds an optional `page` query to `/config` and `/gradio_api/info`, forwards the current route from the SvelteKit app through `@gradio/client`, and filters components, dependencies, layout, and endpoints before copying or serializing them. Requests without `page` retain the existing full-app responses for backwards compatibility.

For `audio_debugger` in the supplied demo, the combined uncompressed config and API-info JSON is reduced from about 9.73 MB to 111 KB (roughly 87x smaller / 98.9% less data).

To see the benefits of this, try visiting the deployed Space from this PR: https://huggingface.co/spaces/gradio-pr-deploys/pr-13843-all-demos

versus one of the other deployed Spaces from any other PR, e.g. https://huggingface.co/spaces/gradio-pr-deploys/pr-13842-all-demos 