### PR TITLE
Import CSV and TSV files dropped on `gr.Dataframe`

### DIFF
--- a/.changeset/clear-readers-dress.md
+++ b/.changeset/clear-readers-dress.md
@@ -1,5 +1,6 @@
 ---
 "@gradio/dataframe": patch
+"@gradio/upload": patch
 "gradio": patch
 ---
 

--- a/.changeset/clear-readers-dress.md
+++ b/.changeset/clear-readers-dress.md
@@ -1,0 +1,6 @@
+---
+"@gradio/dataframe": patch
+"gradio": patch
+---
+
+fix:Import CSV and TSV files dropped on `gr.Dataframe`

--- a/js/dataframe/Dataframe.test.ts
+++ b/js/dataframe/Dataframe.test.ts
@@ -1744,6 +1744,39 @@ describe("Dataframe CSV drop", () => {
 		]);
 	});
 
+	// the narrower and shorter cases above are caught by the bounds guard in
+	// handle_blur. this one is not: the edited cell is still in range after the
+	// import, so the teardown commit lands on a row that exists
+	test("drops an in-flight cell edit when the imported table is the same shape", async () => {
+		const { container, listen } = await render(Dataframe, dynamic_3x3_props);
+		await wait();
+		const change = listen("change");
+		const edit = listen("edit");
+
+		const cell = get_cell(container, 0, 0)!;
+		await fireEvent.mouseDown(cell);
+		await fireEvent.dblClick(cell);
+		await wait();
+
+		const textarea = container.querySelector(
+			"textarea[aria-label='Edit cell']"
+		) as HTMLTextAreaElement;
+		textarea.value = "typed";
+		await fireEvent.input(textarea);
+		await wait();
+
+		drop_csv(container, "x,y,z\n1,2,3\n4,5,6\n7,8,9\n");
+		await wait();
+
+		expect(edit).not.toHaveBeenCalled();
+		expect(get_cell(container, 0, 0)?.textContent).toContain("1");
+		expect(change.mock.calls.at(-1)?.[0].data).toEqual([
+			["1", "2", "3"],
+			["4", "5", "6"],
+			["7", "8", "9"]
+		]);
+	});
+
 	// a coordinate kept from the old table reaches handle_copy, which reads it
 	// out of the new one. asserted against an import of the same shape, so the
 	// cell is still in the DOM and its class means something

--- a/js/dataframe/Dataframe.test.ts
+++ b/js/dataframe/Dataframe.test.ts
@@ -1615,6 +1615,35 @@ describe("Dataframe CSV drop", () => {
 		"VISUAL: the file drag outline is drawn inside the table's border and follows its corner radius, needs Playwright visual regression screenshot comparison"
 	);
 
+	// #13729 moved this component off hidden sr-only text and onto ARIA attributes
+	// on the grid, so the drop hint goes there too rather than into <Upload>, which
+	// discards a label on its div branch
+	test("announces the drop target on an editable table", async () => {
+		const { container } = await render(Dataframe, drop_props);
+		await wait();
+
+		const described_by =
+			get_table_wrap(container).getAttribute("aria-describedby");
+		expect(described_by).toBeTruthy();
+		// tootils stubs i18n as a passthrough, so the key stands in for the string
+		// it resolves to (en.json: "Drop CSV or TSV files here to import data into
+		// dataframe")
+		expect(document.getElementById(described_by!)?.textContent).toBe(
+			"dataframe.drop_to_upload"
+		);
+	});
+
+	test("does not announce a drop target on a read-only table", async () => {
+		const { container } = await render(Dataframe, {
+			...drop_props,
+			interactive: false
+		});
+		await wait();
+
+		expect(get_table_wrap(container)).not.toHaveAttribute("aria-describedby");
+		expect(container.querySelector(".drop-hint")).toBeNull();
+	});
+
 	test("does not highlight the table when it is not interactive", async () => {
 		const { container } = await render(Dataframe, {
 			...drop_props,

--- a/js/dataframe/Dataframe.test.ts
+++ b/js/dataframe/Dataframe.test.ts
@@ -1473,3 +1473,129 @@ describe("Boolean column select-all header checkbox", () => {
 		expect(admin.indeterminate).toBe(false);
 	});
 });
+
+describe("Dataframe CSV drop", () => {
+	afterEach(() => cleanup());
+
+	const drop_props = {
+		...default_props,
+		value: {
+			data: [["", ""]],
+			headers: ["a", "b"],
+			metadata: null
+		},
+		col_count: [2, "dynamic"] as [number, "dynamic"],
+		row_count: [1, "dynamic"] as [number, "dynamic"]
+	};
+
+	// dispatched natively rather than through fireEvent: testing-library builds
+	// its own DataTransfer and copies only own properties across, which leaves
+	// the file list empty
+	function drop_csv(
+		container: HTMLElement,
+		text: string,
+		name = "data.csv"
+	): void {
+		const data_transfer = new DataTransfer();
+		data_transfer.items.add(new File([text], name, { type: "text/csv" }));
+		const upload_container = container.querySelector(
+			".upload-container"
+		) as HTMLElement;
+		upload_container.dispatchEvent(
+			new DragEvent("drop", {
+				bubbles: true,
+				cancelable: true,
+				dataTransfer: data_transfer
+			})
+		);
+	}
+
+	function header_texts(container: HTMLElement): string[] {
+		return Array.from(
+			container.querySelectorAll("th.header-cell .header-content")
+		).map((h) => h.textContent?.trim() ?? "");
+	}
+
+	test("imports a dropped CSV as headers and values", async () => {
+		const { container, listen } = await render(Dataframe, drop_props);
+		await wait();
+		const change = listen("change");
+
+		drop_csv(container, "name,age\nAlice,30\nBob,25\n");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["name", "age"]);
+		expect(get_cell(container, 0, 0)?.textContent).toContain("Alice");
+		expect(get_cell(container, 1, 1)?.textContent).toContain("25");
+		expect(change.mock.calls.at(-1)?.[0].data).toEqual([
+			["Alice", "30"],
+			["Bob", "25"]
+		]);
+	});
+
+	test("imports a dropped single-column CSV", async () => {
+		const { container } = await render(Dataframe, drop_props);
+		await wait();
+
+		drop_csv(container, "name\nAlice\nBob\n");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["name"]);
+		expect(get_cell(container, 0, 0)?.textContent).toContain("Alice");
+		expect(get_cell(container, 1, 0)?.textContent).toContain("Bob");
+	});
+
+	function drag_file(
+		container: HTMLElement,
+		type: "dragenter" | "dragleave"
+	): void {
+		const upload_container = container.querySelector(
+			".upload-container"
+		) as HTMLElement;
+		upload_container.dispatchEvent(
+			new DragEvent(type, { bubbles: true, cancelable: true })
+		);
+	}
+
+	test("highlights the table while a file is dragged over it", async () => {
+		const { container } = await render(Dataframe, drop_props);
+		await wait();
+		const table_wrap = get_table_wrap(container);
+
+		drag_file(container, "dragenter");
+		await wait();
+		expect(table_wrap).toHaveClass("file-dragging");
+
+		drag_file(container, "dragleave");
+		await wait();
+		expect(table_wrap).not.toHaveClass("file-dragging");
+	});
+
+	test("does not highlight the table when it is not interactive", async () => {
+		const { container } = await render(Dataframe, {
+			...drop_props,
+			interactive: false
+		});
+		await wait();
+
+		drag_file(container, "dragenter");
+		await wait();
+
+		expect(get_table_wrap(container)).not.toHaveClass("file-dragging");
+	});
+
+	test("ignores a dropped CSV when the dataframe is not interactive", async () => {
+		const { container, listen } = await render(Dataframe, {
+			...drop_props,
+			interactive: false
+		});
+		await wait();
+		const change = listen("change");
+
+		drop_csv(container, "name,age\nAlice,30\nBob,25\n");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["a", "b"]);
+		expect(change).not.toHaveBeenCalled();
+	});
+});

--- a/js/dataframe/Dataframe.test.ts
+++ b/js/dataframe/Dataframe.test.ts
@@ -1559,16 +1559,18 @@ describe("Dataframe CSV drop", () => {
 		expect(get_cell(container, 0, 1)?.textContent).toContain("hello\tworld");
 	});
 
-	test("ignores a dropped file that is neither CSV nor TSV", async () => {
+	test("reports a dropped file that is neither CSV nor TSV", async () => {
 		const { container, listen } = await render(Dataframe, drop_props);
 		await wait();
 		const change = listen("change");
+		const error = listen("error");
 
 		drop_csv(container, "name,age\nAlice,30\n", "data.png");
 		await wait();
 
 		expect(header_texts(container)).toEqual(["a", "b"]);
 		expect(change).not.toHaveBeenCalled();
+		expect(error).toHaveBeenCalled();
 	});
 
 	test("imports a dropped single-column CSV", async () => {
@@ -1641,5 +1643,200 @@ describe("Dataframe CSV drop", () => {
 		expect(header_texts(container)).toEqual(["a", "b"]);
 		expect(change).not.toHaveBeenCalled();
 		expect(input).not.toHaveBeenCalled();
+	});
+
+	const dynamic_3x3_props = {
+		...drop_props,
+		value: {
+			data: [
+				["a1", "b1", "c1"],
+				["a2", "b2", "c2"],
+				["a3", "b3", "c3"]
+			],
+			headers: ["A", "B", "C"],
+			metadata: null
+		},
+		col_count: [3, "dynamic"] as [number, "dynamic"],
+		row_count: [3, "dynamic"] as [number, "dynamic"]
+	};
+
+	const fixed_props = {
+		...drop_props,
+		value: {
+			data: [
+				["", ""],
+				["", ""]
+			],
+			headers: ["a", "b"],
+			metadata: null
+		},
+		col_count: [2, "fixed"] as [number, "fixed"],
+		row_count: [2, "fixed"] as [number, "fixed"]
+	};
+
+	function drag_over(target: Element, type: "dragenter" | "dragleave"): void {
+		target.dispatchEvent(
+			new DragEvent(type, { bubbles: true, cancelable: true })
+		);
+	}
+
+	// both delimiters split every line into the same number of fields, so
+	// guess_delimiter returns both and the extension breaks the tie
+	test("imports a dropped TSV whose fields contain commas", async () => {
+		const { container } = await render(Dataframe, drop_props);
+		await wait();
+
+		drop_csv(container, "first,last\tage\nAlice,Smith\t30\n", "data.tsv");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["first,last", "age"]);
+		expect(get_cell(container, 0, 0)?.textContent).toContain("Alice,Smith");
+		expect(get_cell(container, 0, 1)?.textContent).toContain("30");
+	});
+
+	test("reports an error and keeps the table when the file is blank", async () => {
+		const { container, listen } = await render(Dataframe, drop_props);
+		await wait();
+		const change = listen("change");
+		const error = listen("error");
+
+		drop_csv(container, "   \n");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["a", "b"]);
+		expect(change).not.toHaveBeenCalled();
+		expect(error).toHaveBeenCalled();
+	});
+
+	// the cell unmounts while still in edit mode, and EditableCell commits on
+	// teardown, so the stale coordinates land in the table that replaced it
+	test("drops an in-flight cell edit when the imported table is narrower", async () => {
+		const { container, listen } = await render(Dataframe, dynamic_3x3_props);
+		await wait();
+		const change = listen("change");
+		const edit = listen("edit");
+
+		await fireEvent.dblClick(get_cell(container, 0, 2)!);
+		await wait();
+
+		drop_csv(container, "name,age\nAlice,30\n");
+		await wait();
+
+		expect(edit).not.toHaveBeenCalled();
+		expect(change.mock.calls.at(-1)?.[0].data).toEqual([["Alice", "30"]]);
+	});
+
+	test("drops an in-flight cell edit when the imported table is shorter", async () => {
+		const { container, listen } = await render(Dataframe, dynamic_3x3_props);
+		await wait();
+		const change = listen("change");
+		const edit = listen("edit");
+
+		await fireEvent.dblClick(get_cell(container, 2, 0)!);
+		await wait();
+
+		drop_csv(container, "name,age,role\nAlice,30,Engineer\n");
+		await wait();
+
+		expect(edit).not.toHaveBeenCalled();
+		expect(change.mock.calls.at(-1)?.[0].data).toEqual([
+			["Alice", "30", "Engineer"]
+		]);
+	});
+
+	// a coordinate kept from the old table reaches handle_copy, which reads it
+	// out of the new one. asserted against an import of the same shape, so the
+	// cell is still in the DOM and its class means something
+	test("clears the cell selection when a file is imported", async () => {
+		const { container } = await render(Dataframe, dynamic_3x3_props);
+		await wait();
+
+		await fireEvent.mouseDown(get_cell(container, 2, 2)!);
+		await wait();
+		expect(get_cell(container, 2, 2)?.className).toContain("cell-selected");
+
+		drop_csv(container, "x,y,z\n1,2,3\n4,5,6\n7,8,9\n");
+		await wait();
+
+		expect(get_cell(container, 2, 2)?.className).not.toContain("cell-selected");
+	});
+
+	// dragenter on the cell being entered arrives before dragleave on the one
+	// being left, and both bubble to the drop target
+	test("keeps the highlight while the file moves between cells", async () => {
+		const { container } = await render(Dataframe, dynamic_3x3_props);
+		await wait();
+		const table_wrap = get_table_wrap(container);
+		const first = get_cell(container, 0, 0)!;
+		const second = get_cell(container, 0, 1)!;
+
+		drag_over(first, "dragenter");
+		await wait();
+		expect(table_wrap).toHaveClass("file-dragging");
+
+		drag_over(second, "dragenter");
+		drag_over(first, "dragleave");
+		await wait();
+		expect(table_wrap).toHaveClass("file-dragging");
+
+		drag_over(second, "dragleave");
+		await wait();
+		expect(table_wrap).not.toHaveClass("file-dragging");
+	});
+
+	test("imports into a fixed-shape dataframe when the file matches", async () => {
+		const { container } = await render(Dataframe, fixed_props);
+		await wait();
+
+		drop_csv(container, "name,age\nAlice,30\nBob,25\n");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["name", "age"]);
+		expect(get_cell(container, 1, 0)?.textContent).toContain("Bob");
+	});
+
+	test("rejects a dropped file that does not fit a fixed column count", async () => {
+		const { container, listen } = await render(Dataframe, fixed_props);
+		await wait();
+		const change = listen("change");
+		const error = listen("error");
+
+		drop_csv(container, "name,age,role\nAlice,30,Engineer\nBob,25,Designer\n");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["a", "b"]);
+		expect(change).not.toHaveBeenCalled();
+		expect(error).toHaveBeenCalled();
+	});
+
+	test("rejects a dropped file that does not fit a fixed row count", async () => {
+		const { container, listen } = await render(Dataframe, fixed_props);
+		await wait();
+		const change = listen("change");
+		const error = listen("error");
+
+		drop_csv(container, "name,age\nAlice,30\n");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["a", "b"]);
+		expect(change).not.toHaveBeenCalled();
+		expect(error).toHaveBeenCalled();
+	});
+
+	test("rejects a dropped file when a column is read-only", async () => {
+		const { container, listen } = await render(Dataframe, {
+			...drop_props,
+			static_columns: [0]
+		});
+		await wait();
+		const change = listen("change");
+		const error = listen("error");
+
+		drop_csv(container, "name,age\nAlice,30\n");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["a", "b"]);
+		expect(change).not.toHaveBeenCalled();
+		expect(error).toHaveBeenCalled();
 	});
 });

--- a/js/dataframe/Dataframe.test.ts
+++ b/js/dataframe/Dataframe.test.ts
@@ -1545,8 +1545,8 @@ describe("Dataframe CSV drop", () => {
 		expect(get_cell(container, 1, 1)?.textContent).toContain("25");
 	});
 
-	// guess_delimiter counts raw tabs, so the quoted one makes the tab counts
-	// disagree between the two lines and it detects nothing
+	// counting raw tabs misses this: the quoted one makes the counts disagree
+	// between the two lines, so nothing looks consistent
 	test("imports a dropped TSV whose field contains a quoted tab", async () => {
 		const { container } = await render(Dataframe, drop_props);
 		await wait();
@@ -1585,16 +1585,14 @@ describe("Dataframe CSV drop", () => {
 		expect(get_cell(container, 1, 0)?.textContent).toContain("Bob");
 	});
 
-	function drag_file(
-		container: HTMLElement,
-		type: "dragenter" | "dragleave"
-	): void {
-		const upload_container = container.querySelector(
-			".upload-container"
-		) as HTMLElement;
-		upload_container.dispatchEvent(
+	function drag_over(target: Element, type: "dragenter" | "dragleave"): void {
+		target.dispatchEvent(
 			new DragEvent(type, { bubbles: true, cancelable: true })
 		);
+	}
+
+	function drop_target(container: HTMLElement): Element {
+		return container.querySelector(".upload-container")!;
 	}
 
 	test("highlights the table while a file is dragged over it", async () => {
@@ -1602,11 +1600,11 @@ describe("Dataframe CSV drop", () => {
 		await wait();
 		const table_wrap = get_table_wrap(container);
 
-		drag_file(container, "dragenter");
+		drag_over(drop_target(container), "dragenter");
 		await wait();
 		expect(table_wrap).toHaveClass("file-dragging");
 
-		drag_file(container, "dragleave");
+		drag_over(drop_target(container), "dragleave");
 		await wait();
 		expect(table_wrap).not.toHaveClass("file-dragging");
 	});
@@ -1651,7 +1649,7 @@ describe("Dataframe CSV drop", () => {
 		});
 		await wait();
 
-		drag_file(container, "dragenter");
+		drag_over(drop_target(container), "dragenter");
 		await wait();
 
 		expect(get_table_wrap(container)).not.toHaveClass("file-dragging");
@@ -1703,14 +1701,8 @@ describe("Dataframe CSV drop", () => {
 		row_count: [2, "fixed"] as [number, "fixed"]
 	};
 
-	function drag_over(target: Element, type: "dragenter" | "dragleave"): void {
-		target.dispatchEvent(
-			new DragEvent(type, { bubbles: true, cancelable: true })
-		);
-	}
-
-	// both delimiters split every line into the same number of fields, so
-	// guess_delimiter returns both and the extension breaks the tie
+	// both delimiters split every line into the same number of fields, so the
+	// extension breaks the tie
 	test("imports a dropped TSV whose fields contain commas", async () => {
 		const { container } = await render(Dataframe, drop_props);
 		await wait();
@@ -1772,6 +1764,98 @@ describe("Dataframe CSV drop", () => {
 		expect(error).toHaveBeenCalled();
 	});
 
+	// separators alone parse into a header of blank names, which would replace
+	// the table with unnamed columns instead of reporting anything
+	test("reports an error and keeps the table when the file has no column names", async () => {
+		const { container, listen } = await render(Dataframe, drop_props);
+		await wait();
+		const change = listen("change");
+		const error = listen("error");
+
+		drop_csv(container, ",\n");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["a", "b"]);
+		expect(change).not.toHaveBeenCalled();
+		expect(error).toHaveBeenCalled();
+	});
+
+	test("imports a dropped CSV that ends with a blank line", async () => {
+		const { container, listen } = await render(Dataframe, drop_props);
+		await wait();
+		const change = listen("change");
+		const error = listen("error");
+
+		drop_csv(container, "name,age\nAlice,30\n\n");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["name", "age"]);
+		expect(error).not.toHaveBeenCalled();
+		expect(change.mock.calls.at(-1)?.[0].data).toEqual([["Alice", "30"]]);
+	});
+
+	// the name says comma and the header does split on one, but only the tab
+	// splits every line, so the name loses to the file's own shape
+	test("imports a mislabeled CSV whose header holds a tab", async () => {
+		const { container, listen } = await render(Dataframe, drop_props);
+		await wait();
+		const error = listen("error");
+
+		drop_csv(container, "first,last\tage\nAlice\t30\n");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["first,last", "age"]);
+		expect(get_cell(container, 0, 0)?.textContent).toContain("Alice");
+		expect(error).not.toHaveBeenCalled();
+	});
+
+	// a dropped file the upload rejects would otherwise report a type error on a
+	// table that ignores dropped files in the first place
+	test("reports nothing for a file dropped on a read-only table", async () => {
+		const { container, listen } = await render(Dataframe, {
+			...drop_props,
+			interactive: false
+		});
+		await wait();
+		const error = listen("error");
+
+		drop_csv(container, "name,age\nAlice,30\n", "data.png");
+		await wait();
+
+		expect(error).not.toHaveBeenCalled();
+	});
+
+	// a value can reach the frontend ragged, and a cell past the end of its own
+	// row still renders and still takes an edit
+	test("keeps an edit to a cell in a row shorter than the header", async () => {
+		const { container, listen } = await render(Dataframe, {
+			...drop_props,
+			value: {
+				data: [["a1"], ["a2", "b2"]],
+				headers: ["A", "B"],
+				metadata: null
+			}
+		});
+		await wait();
+		const edit = listen("edit");
+
+		const cell = get_cell(container, 0, 1)!;
+		await fireEvent.mouseDown(cell);
+		await fireEvent.dblClick(cell);
+		await wait();
+
+		const textarea = container.querySelector(
+			"textarea[aria-label='Edit cell']"
+		) as HTMLTextAreaElement;
+		textarea.value = "typed";
+		await fireEvent.input(textarea);
+		await fireEvent.blur(textarea);
+		await wait();
+
+		expect(edit).toHaveBeenCalled();
+		expect(get_cell(container, 0, 1)?.textContent).toContain("typed");
+	});
+
 	// the cell unmounts while still in edit mode, and EditableCell commits on
 	// teardown, so the stale coordinates land in the table that replaced it
 	test("drops an in-flight cell edit when the imported table is narrower", async () => {
@@ -1808,9 +1892,9 @@ describe("Dataframe CSV drop", () => {
 		]);
 	});
 
-	// the narrower and shorter cases above are caught by the bounds guard in
-	// handle_blur. this one is not: the edited cell is still in range after the
-	// import, so the teardown commit lands on a row that exists
+	// the shorter case above is caught by the row guard in handle_blur. this one
+	// is not: the edited cell is still in range after the import, so the
+	// teardown commit lands on a row that exists
 	test("drops an in-flight cell edit when the imported table is the same shape", async () => {
 		const { container, listen } = await render(Dataframe, dynamic_3x3_props);
 		await wait();

--- a/js/dataframe/Dataframe.test.ts
+++ b/js/dataframe/Dataframe.test.ts
@@ -1533,6 +1533,30 @@ describe("Dataframe CSV drop", () => {
 		]);
 	});
 
+	test("imports a dropped TSV as headers and values", async () => {
+		const { container } = await render(Dataframe, drop_props);
+		await wait();
+
+		drop_csv(container, "name\tage\nAlice\t30\nBob\t25\n", "data.tsv");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["name", "age"]);
+		expect(get_cell(container, 0, 0)?.textContent).toContain("Alice");
+		expect(get_cell(container, 1, 1)?.textContent).toContain("25");
+	});
+
+	test("ignores a dropped file that is neither CSV nor TSV", async () => {
+		const { container, listen } = await render(Dataframe, drop_props);
+		await wait();
+		const change = listen("change");
+
+		drop_csv(container, "name,age\nAlice,30\n", "data.png");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["a", "b"]);
+		expect(change).not.toHaveBeenCalled();
+	});
+
 	test("imports a dropped single-column CSV", async () => {
 		const { container } = await render(Dataframe, drop_props);
 		await wait();
@@ -1591,11 +1615,13 @@ describe("Dataframe CSV drop", () => {
 		});
 		await wait();
 		const change = listen("change");
+		const input = listen("input");
 
 		drop_csv(container, "name,age\nAlice,30\nBob,25\n");
 		await wait();
 
 		expect(header_texts(container)).toEqual(["a", "b"]);
 		expect(change).not.toHaveBeenCalled();
+		expect(input).not.toHaveBeenCalled();
 	});
 });

--- a/js/dataframe/Dataframe.test.ts
+++ b/js/dataframe/Dataframe.test.ts
@@ -1609,6 +1609,10 @@ describe("Dataframe CSV drop", () => {
 		expect(table_wrap).not.toHaveClass("file-dragging");
 	});
 
+	test.todo(
+		"VISUAL: the file drag outline is drawn inside the table's border and follows its corner radius, needs Playwright visual regression screenshot comparison"
+	);
+
 	test("does not highlight the table when it is not interactive", async () => {
 		const { container } = await render(Dataframe, {
 			...drop_props,

--- a/js/dataframe/Dataframe.test.ts
+++ b/js/dataframe/Dataframe.test.ts
@@ -1694,6 +1694,41 @@ describe("Dataframe CSV drop", () => {
 		expect(get_cell(container, 0, 1)?.textContent).toContain("30");
 	});
 
+	// the name says tab, but every tab-split of this file is one field wide, so it
+	// has to be read as the comma-separated file it actually is
+	test("imports a mislabeled TSV whose field holds a quoted comma", async () => {
+		const { container } = await render(Dataframe, drop_props);
+		await wait();
+
+		drop_csv(container, 'name,note\nAlice,"x,y"\n', "data.tsv");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["name", "note"]);
+		expect(get_cell(container, 0, 0)?.textContent).toContain("Alice");
+		expect(get_cell(container, 0, 1)?.textContent).toContain("x,y");
+	});
+
+	test("rejects a dropped file whose rows do not match its header", async () => {
+		const { container, listen } = await render(Dataframe, drop_props);
+		await wait();
+		const change = listen("change");
+		const error = listen("error");
+
+		drop_csv(container, "name,age\nAlice,30,Engineer\n");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["a", "b"]);
+		expect(change).not.toHaveBeenCalled();
+		expect(error).toHaveBeenCalledTimes(1);
+
+		drop_csv(container, "name,age\nAlice\n");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["a", "b"]);
+		expect(change).not.toHaveBeenCalled();
+		expect(error).toHaveBeenCalledTimes(2);
+	});
+
 	test("reports an error and keeps the table when the file is blank", async () => {
 		const { container, listen } = await render(Dataframe, drop_props);
 		await wait();

--- a/js/dataframe/Dataframe.test.ts
+++ b/js/dataframe/Dataframe.test.ts
@@ -1545,6 +1545,20 @@ describe("Dataframe CSV drop", () => {
 		expect(get_cell(container, 1, 1)?.textContent).toContain("25");
 	});
 
+	// guess_delimiter counts raw tabs, so the quoted one makes the tab counts
+	// disagree between the two lines and it detects nothing
+	test("imports a dropped TSV whose field contains a quoted tab", async () => {
+		const { container } = await render(Dataframe, drop_props);
+		await wait();
+
+		drop_csv(container, 'name\tnote\nAlice\t"hello\tworld"\n', "data.tsv");
+		await wait();
+
+		expect(header_texts(container)).toEqual(["name", "note"]);
+		expect(get_cell(container, 0, 0)?.textContent).toContain("Alice");
+		expect(get_cell(container, 0, 1)?.textContent).toContain("hello\tworld");
+	});
+
 	test("ignores a dropped file that is neither CSV nor TSV", async () => {
 		const { container, listen } = await render(Dataframe, drop_props);
 		await wait();

--- a/js/dataframe/Dataframe.test.ts
+++ b/js/dataframe/Dataframe.test.ts
@@ -1858,6 +1858,31 @@ describe("Dataframe CSV drop", () => {
 		expect(get_cell(container, 2, 2)?.className).not.toContain("cell-selected");
 	});
 
+	// tanstack keys sorting and column filters by positional col_N, and a search
+	// left over from the old table hides imported rows, which commit_filter then
+	// drops from the value entirely
+	test("clears the search when a file is imported", async () => {
+		const { container } = await render(Dataframe, {
+			...dynamic_3x3_props,
+			show_search: "search"
+		});
+		await wait();
+
+		const search = container.querySelector(
+			"input.search-input"
+		) as HTMLInputElement;
+		search.value = "a1";
+		await fireEvent.input(search);
+		await wait();
+		expect(get_cell(container, 1, 0)).toBeNull();
+
+		drop_csv(container, "x,y,z\n1,2,3\n4,5,6\n7,8,9\n");
+		await wait();
+
+		expect(get_cell(container, 0, 0)?.textContent).toContain("1");
+		expect(get_cell(container, 2, 0)?.textContent).toContain("7");
+	});
+
 	// dragenter on the cell being entered arrives before dragleave on the one
 	// being left, and both bubble to the drop target
 	test("keeps the highlight while the file moves between cells", async () => {

--- a/js/dataframe/Index.svelte
+++ b/js/dataframe/Index.svelte
@@ -124,5 +124,6 @@
 		oninput={handle_input}
 		onselect={handle_select}
 		onedit={handle_edit}
+		onerror={(message) => gradio.dispatch("error", message)}
 	/>
 </Block>

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -1074,6 +1074,16 @@
 		if (!new_headers.length) {
 			throw new Error("The dropped file is empty.");
 		}
+		// a row the header cannot account for would reach the backend as a ragged
+		// value, and the column checks below only see the header
+		const ragged = new_values.findIndex(
+			(row) => row.length !== new_headers.length
+		);
+		if (ragged !== -1) {
+			throw new Error(
+				`Line ${ragged + 2} of the file has ${new_values[ragged].length} fields, the header has ${new_headers.length}.`
+			);
+		}
 		// the menu paths already refuse to change a fixed shape or write to a
 		// read-only column, so an import must not be the way around them
 		if (static_columns.length > 0) {

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -276,6 +276,7 @@
 	let is_dragging = $state(false);
 	let show_scroll_button = $state(false);
 	let file_dragging = $state(false);
+	let discard_pending_edit = false;
 
 	let parent: HTMLDivElement;
 
@@ -580,13 +581,17 @@
 		blur_event: FocusEvent;
 		coords: [number, number];
 	}): void {
+		// an import replaces the table under an open editor, and EditableCell
+		// commits when it leaves edit mode either way. that half-typed value
+		// belongs to the table that just went away
+		if (discard_pending_edit) return;
+
 		const { coords } = detail;
 		const input_el = detail.blur_event.target as HTMLTextAreaElement;
 		if (!input_el || input_el.value === undefined) return;
 
 		const [row, col] = coords;
-		// EditableCell commits on teardown, so a cell that was being edited when
-		// the table shrank blurs against coordinates that no longer exist
+		// and any other path that shrinks the table leaves coordinates behind
 		if (col >= (values?.[row]?.length ?? 0)) return;
 		const old_value = values[row][col];
 		const new_value = input_el.value;
@@ -1085,10 +1090,12 @@
 			);
 		}
 
+		discard_pending_edit = true;
 		headers = new_headers;
 		values = new_values;
 		reset_interaction_state();
 		push_change(new_values, headers as string[]);
+		tick().then(() => (discard_pending_edit = false));
 	}
 
 	// undefined when every dropped file was filtered out by `filetype`

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -277,6 +277,9 @@
 	let show_scroll_button = $state(false);
 	let file_dragging = $state(false);
 	let discard_pending_edit = false;
+	// document-unique so several dataframes on a page do not describe each
+	// other's grids
+	const drop_hint_id = $props.id();
 
 	let parent: HTMLDivElement;
 
@@ -1221,6 +1224,7 @@
 		aria-rowcount={rows.length + 1}
 		aria-colcount={resolved_headers.length + Number(show_row_numbers)}
 		aria-readonly={!editable}
+		aria-describedby={editable ? drop_hint_id : undefined}
 		tabindex={rows.length === 0 ? 0 : -1}
 		style="--df-max-col-width: {viewport_width}px;"
 	>
@@ -1237,7 +1241,6 @@
 			onload={on_file_upload}
 			{onerror}
 			bind:dragging={file_dragging}
-			aria_label={i18n("dataframe.drop_to_upload")}
 			tab_index={-1}
 			container_element="div"
 		>
@@ -1454,6 +1457,15 @@
 			<button class="scroll-top-button" onclick={scroll_to_top}>&uarr;</button>
 		{/if}
 	</div>
+
+	<!-- outside the grid: #13729 took the label off a span like this one and put it
+	     on the grid as an attribute, and a test pins that there is no sr-only text
+	     inside. a description has no equally well supported attribute form -->
+	{#if editable}
+		<span id={drop_hint_id} class="drop-hint"
+			>{i18n("dataframe.drop_to_upload")}</span
+		>
+	{/if}
 </div>
 
 {#if active_cell_menu || active_header_menu}
@@ -1592,6 +1604,17 @@
 		outline-offset: -2px;
 		/* matches the .upload-container border the outline covers */
 		border-radius: var(--table-radius);
+	}
+
+	/* an aria-describedby target, so it has to stay in the accessibility tree
+	   rather than be hidden with display: none */
+	.drop-hint {
+		position: absolute;
+		clip-path: inset(50%);
+		width: 1px;
+		height: 1px;
+		overflow: hidden;
+		white-space: nowrap;
 	}
 
 	.table-wrap.dragging {

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -35,7 +35,7 @@
 		is_cell_selected,
 		handle_click_outside as handle_click_outside_util
 	} from "./utils/selection_utils";
-	import { copy_table_data, handle_file_upload } from "./utils/table_utils";
+	import { copy_table_data, parse_table_file } from "./utils/table_utils";
 	import { gradio_filter_fn } from "./utils/filter";
 	import { create_column_measurement } from "./column_measurement.svelte.js";
 
@@ -73,7 +73,8 @@
 		onselect,
 		onedit,
 		onsearch,
-		onfullscreen
+		onfullscreen,
+		onerror
 	}: {
 		datatype: Datatype | Datatype[];
 		label?: string | null;
@@ -109,6 +110,7 @@
 		onedit?: (detail: EditData) => void;
 		onsearch?: (detail: string | null) => void;
 		onfullscreen?: () => void;
+		onerror?: (message: string) => void;
 	} = $props();
 
 	type GradioRow = Record<string, CellValue> & { _index: number };
@@ -583,7 +585,10 @@
 		if (!input_el || input_el.value === undefined) return;
 
 		const [row, col] = coords;
-		const old_value = values?.[row]?.[col];
+		// EditableCell commits on teardown, so a cell that was being edited when
+		// the table shrank blurs against coordinates that no longer exist
+		if (col >= (values?.[row]?.length ?? 0)) return;
+		const old_value = values[row][col];
 		const new_value = input_el.value;
 
 		if (String(old_value) !== String(new_value)) {
@@ -813,15 +818,21 @@
 		setTimeout(() => (copy_flash = false), 800);
 	}
 
+	// every one of these holds a row or column index, so they have to go
+	// whenever the table stops being the one they were recorded against
+	function reset_interaction_state(): void {
+		selected_cells = [];
+		selected = false;
+		editing = false;
+		header_edit = false;
+		selected_header = false;
+		active_cell_menu = null;
+		active_header_menu = null;
+	}
+
 	function handle_click_outside(event: Event): void {
 		if (handle_click_outside_util(event, parent)) {
-			selected_cells = [];
-			selected = false;
-			editing = false;
-			header_edit = false;
-			selected_header = false;
-			active_cell_menu = null;
-			active_header_menu = null;
+			reset_interaction_state();
 		}
 	}
 
@@ -1051,23 +1062,47 @@
 		}
 	}
 
+	function apply_imported_table(
+		new_headers: (string | null)[],
+		new_values: CellValue[][]
+	): void {
+		if (!new_headers.length) {
+			throw new Error("The dropped file is empty.");
+		}
+		// the menu paths already refuse to change a fixed shape or write to a
+		// read-only column, so an import must not be the way around them
+		if (static_columns.length > 0) {
+			throw new Error("Cannot import into a table with read-only columns.");
+		}
+		if (col_count[1] === "fixed" && new_headers.length !== col_count[0]) {
+			throw new Error(
+				`This table takes exactly ${col_count[0]} columns, the file has ${new_headers.length}.`
+			);
+		}
+		if (row_count[1] === "fixed" && new_values.length !== row_count[0]) {
+			throw new Error(
+				`This table takes exactly ${row_count[0]} rows, the file has ${new_values.length}.`
+			);
+		}
+
+		headers = new_headers;
+		values = new_values;
+		reset_interaction_state();
+		push_change(new_values, headers as string[]);
+	}
+
 	// undefined when every dropped file was filtered out by `filetype`
 	function on_file_upload(file: File | undefined): void {
 		if (!editable || !file) return;
-		handle_file_upload(
-			file,
-			(head) => {
-				headers = head.map((h: any) => h ?? "");
-				return (headers as string[]).map((h: string, i: number) => ({
-					id: `h_${i}`,
-					value: h
-				}));
-			},
-			(vals) => {
-				values = vals;
-				push_change(vals, headers as string[]);
-			}
-		);
+		parse_table_file(file)
+			.then(({ headers: new_headers, values: new_values }) =>
+				apply_imported_table(new_headers, new_values)
+			)
+			.catch((e) => {
+				const message = e instanceof Error ? e.message : String(e);
+				if (onerror) onerror(message);
+				else console.error(message);
+			});
 	}
 
 	onMount(() => {
@@ -1183,6 +1218,7 @@
 			filetype={[".csv", ".tsv"]}
 			{root}
 			onload={on_file_upload}
+			{onerror}
 			bind:dragging={file_dragging}
 			aria_label={i18n("dataframe.drop_to_upload")}
 			tab_index={-1}
@@ -1509,8 +1545,13 @@
 
 	.table-wrap {
 		position: relative;
-		transition: 150ms;
 		width: 100%;
+		/* the duration used to stand alone, which means every property. that
+		   swept the drag outline in from `currentcolor`, near-white in dark
+		   mode, before it reached the accent. the list is what the fullscreen
+		   rules above actually change */
+		transition-property: flex-grow, flex-shrink, flex-basis, min-height;
+		transition-duration: 150ms;
 	}
 
 	/* Constrain Upload component wrapper */

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -1530,6 +1530,8 @@
 	.table-wrap.file-dragging {
 		outline: 2px solid var(--color-accent);
 		outline-offset: -2px;
+		/* matches the .upload-container border the outline covers */
+		border-radius: var(--table-radius);
 	}
 
 	.table-wrap.dragging {

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -273,7 +273,7 @@
 	let copy_flash = $state(false);
 	let is_dragging = $state(false);
 	let show_scroll_button = $state(false);
-	let dragging = $state(false); // file drag
+	let file_dragging = $state(false);
 
 	let parent: HTMLDivElement;
 
@@ -1051,9 +1051,10 @@
 		}
 	}
 
-	function on_file_upload(file_data: any): void {
+	function on_file_upload(file: Blob): void {
+		if (!editable) return;
 		handle_file_upload(
-			typeof file_data === "string" ? file_data : (file_data?.data ?? ""),
+			file,
 			(head) => {
 				headers = head.map((h: any) => h ?? "");
 				return (headers as string[]).map((h: string, i: number) => ({
@@ -1159,6 +1160,7 @@
 		bind:this={parent}
 		class="table-wrap"
 		class:dragging={is_dragging}
+		class:file-dragging={file_dragging && editable}
 		class:menu-open={active_cell_menu || active_header_menu}
 		onkeydown={handle_keydown}
 		role="grid"
@@ -1176,9 +1178,10 @@
 			center={false}
 			boundedheight={false}
 			disable_click={true}
+			format="blob"
 			{root}
 			onload={on_file_upload}
-			bind:dragging
+			bind:dragging={file_dragging}
 			aria_label={i18n("dataframe.drop_to_upload")}
 			tab_index={-1}
 			container_element="div"
@@ -1519,6 +1522,14 @@
 
 	.table-wrap:focus-within {
 		outline: none;
+	}
+
+	/* after :focus-within, which is equally specific and would otherwise
+	   clear the outline whenever a cell is focused. drawn inside the box so
+	   hovering a file over the table shifts nothing */
+	.table-wrap.file-dragging {
+		outline: 2px solid var(--color-accent);
+		outline-offset: -2px;
 	}
 
 	.table-wrap.dragging {

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -1107,6 +1107,12 @@
 		headers = new_headers;
 		values = new_values;
 		reset_interaction_state();
+		// tanstack keys these by positional col_N, so they would land on whichever
+		// column now sits at that index. a search is worse than misplaced: it hides
+		// imported rows, and commit_filter then drops the hidden ones from the value
+		sorting = [];
+		column_filters = [];
+		global_filter = "";
 		push_change(new_values, headers as string[]);
 		tick().then(() => (discard_pending_edit = false));
 	}

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -1051,8 +1051,9 @@
 		}
 	}
 
-	function on_file_upload(file: Blob): void {
-		if (!editable) return;
+	// undefined when every dropped file was filtered out by `filetype`
+	function on_file_upload(file: Blob | undefined): void {
+		if (!editable || !file) return;
 		handle_file_upload(
 			file,
 			(head) => {
@@ -1179,6 +1180,7 @@
 			boundedheight={false}
 			disable_click={true}
 			format="blob"
+			filetype={[".csv", ".tsv"]}
 			{root}
 			onload={on_file_upload}
 			bind:dragging={file_dragging}

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -594,8 +594,10 @@
 		if (!input_el || input_el.value === undefined) return;
 
 		const [row, col] = coords;
-		// and any other path that shrinks the table leaves coordinates behind
-		if (col >= (values?.[row]?.length ?? 0)) return;
+		// and deleting a row leaves the editor's row behind. a column short of
+		// the header is not the same thing: a value can arrive ragged, and the
+		// cell past the end of its own row still renders and still takes an edit
+		if (!values?.[row]) return;
 		const old_value = values[row][col];
 		const new_value = input_el.value;
 
@@ -1077,6 +1079,11 @@
 		if (!new_headers.length) {
 			throw new Error("The dropped file is empty.");
 		}
+		// a file of separators alone parses into a header of blank names, and
+		// importing it would replace the table with unnamed columns
+		if (new_headers.every((h) => !h?.trim())) {
+			throw new Error("The dropped file has no column names.");
+		}
 		// a row the header cannot account for would reach the backend as a ragged
 		// value, and the column checks below only see the header
 		const ragged = new_values.findIndex(
@@ -1245,7 +1252,7 @@
 			filetype={[".csv", ".tsv"]}
 			{root}
 			onload={on_file_upload}
-			{onerror}
+			onerror={editable ? onerror : undefined}
 			bind:dragging={file_dragging}
 			tab_index={-1}
 			container_element="div"

--- a/js/dataframe/shared/Table.svelte
+++ b/js/dataframe/shared/Table.svelte
@@ -1052,7 +1052,7 @@
 	}
 
 	// undefined when every dropped file was filtered out by `filetype`
-	function on_file_upload(file: Blob | undefined): void {
+	function on_file_upload(file: File | undefined): void {
 		if (!editable || !file) return;
 		handle_file_upload(
 			file,

--- a/js/dataframe/shared/types.ts
+++ b/js/dataframe/shared/types.ts
@@ -3,12 +3,6 @@ export type EditingState = CellCoordinate | false;
 
 export type Headers = (string | null)[];
 
-export interface HeadersWithIDs {
-	id: string;
-	value: string;
-}
-[];
-
 export type CellValue = string | number | boolean;
 
 export interface TableCell {

--- a/js/dataframe/shared/utils/table_utils.ts
+++ b/js/dataframe/shared/utils/table_utils.ts
@@ -47,38 +47,26 @@ export async function copy_table_data(
 	}
 }
 
-export function guess_delimiter(
-	text: string,
-	possibleDelimiters: string[]
-): string[] {
-	return possibleDelimiters.filter(weedOut);
-
-	function weedOut(delimiter: string): boolean {
-		var cache = -1;
-		return text.split("\n").every(checkLength);
-
-		function checkLength(line: string): boolean {
-			if (!line) return true;
-			var length = line.split(delimiter).length;
-			if (cache < 0) cache = length;
-			return cache === length && length > 1;
-		}
-	}
-}
-
 export async function parse_table_file(
 	file: File
 ): Promise<{ headers: Headers; values: CellValue[][] }> {
 	const text = await file.text();
 	if (!text.trim()) return { headers: [], values: [] };
-	// the drop zone only accepts .csv and .tsv, so the extension is the
-	// authoritative separator. guessing still goes first, with the extension's
-	// separator ahead of the other, so a mislabeled file is read by its content:
-	// both separators can look consistent at once (a TSV with a comma in every
-	// row), and neither does for a single column or a quoted separator.
+	// the drop zone only accepts .csv and .tsv, so the extension goes first and
+	// decides on its own for a single-column file, where neither separator splits
+	// anything. a mislabeled file is still read by its content, and the split is
+	// d3's rather than a raw count so a separator inside a quoted field does not
+	// throw the detection off.
 	const by_extension = file.name.toLowerCase().endsWith(".tsv") ? "\t" : ",";
 	const candidates = by_extension === "\t" ? ["\t", ","] : [",", "\t"];
-	const [delimiter = by_extension] = guess_delimiter(text, candidates);
-	const [head = [], ...rest] = dsvFormat(delimiter).parseRows(text);
+	let rows: string[][] | undefined;
+	for (const delimiter of candidates) {
+		const parsed = dsvFormat(delimiter).parseRows(text);
+		if ((parsed[0]?.length ?? 0) > 1) {
+			rows = parsed;
+			break;
+		}
+	}
+	const [head = [], ...rest] = rows ?? dsvFormat(by_extension).parseRows(text);
 	return { headers: head.map((h) => h ?? ""), values: rest };
 }

--- a/js/dataframe/shared/utils/table_utils.ts
+++ b/js/dataframe/shared/utils/table_utils.ts
@@ -67,14 +67,17 @@ export function guess_delimiter(
 }
 
 export async function handle_file_upload(
-	file: Blob,
+	file: File,
 	update_headers: (headers: Headers) => HeadersWithIDs[],
 	update_values: (values: CellValue[][]) => void
 ): Promise<void> {
 	const text = await file.text();
 	if (!text) return;
-	// a single-column file has no delimiter to find, so fall back to a comma
-	const [delimiter = ","] = guess_delimiter(text, [",", "\t"]);
+	// guess_delimiter counts raw separators, so it finds nothing for a single
+	// column, or when a quoted field contains the separator. The drop zone only
+	// accepts .csv and .tsv, so the extension settles those cases.
+	const by_extension = file.name.toLowerCase().endsWith(".tsv") ? "\t" : ",";
+	const [delimiter = by_extension] = guess_delimiter(text, [",", "\t"]);
 	const [head, ...rest] = dsvFormat(delimiter).parseRows(text);
 	update_headers(head);
 	update_values(rest);

--- a/js/dataframe/shared/utils/table_utils.ts
+++ b/js/dataframe/shared/utils/table_utils.ts
@@ -1,4 +1,4 @@
-import type { CellValue, Headers, HeadersWithIDs, TableData } from "../types";
+import type { CellValue, Headers, TableData } from "../types";
 import { dsvFormat } from "d3-dsv";
 
 export function make_cell_id(row: number, col: number): string {
@@ -66,19 +66,19 @@ export function guess_delimiter(
 	}
 }
 
-export async function handle_file_upload(
-	file: File,
-	update_headers: (headers: Headers) => HeadersWithIDs[],
-	update_values: (values: CellValue[][]) => void
-): Promise<void> {
+export async function parse_table_file(
+	file: File
+): Promise<{ headers: Headers; values: CellValue[][] }> {
 	const text = await file.text();
-	if (!text) return;
-	// guess_delimiter counts raw separators, so it finds nothing for a single
-	// column, or when a quoted field contains the separator. The drop zone only
-	// accepts .csv and .tsv, so the extension settles those cases.
+	if (!text.trim()) return { headers: [], values: [] };
+	// the drop zone only accepts .csv and .tsv, so the extension is the
+	// authoritative separator. guessing still goes first, with the extension's
+	// separator ahead of the other, so a mislabeled file is read by its content:
+	// both separators can look consistent at once (a TSV with a comma in every
+	// row), and neither does for a single column or a quoted separator.
 	const by_extension = file.name.toLowerCase().endsWith(".tsv") ? "\t" : ",";
-	const [delimiter = by_extension] = guess_delimiter(text, [",", "\t"]);
-	const [head, ...rest] = dsvFormat(delimiter).parseRows(text);
-	update_headers(head);
-	update_values(rest);
+	const candidates = by_extension === "\t" ? ["\t", ","] : [",", "\t"];
+	const [delimiter = by_extension] = guess_delimiter(text, candidates);
+	const [head = [], ...rest] = dsvFormat(delimiter).parseRows(text);
+	return { headers: head.map((h) => h ?? ""), values: rest };
 }

--- a/js/dataframe/shared/utils/table_utils.ts
+++ b/js/dataframe/shared/utils/table_utils.ts
@@ -53,20 +53,37 @@ export async function parse_table_file(
 	const text = await file.text();
 	if (!text.trim()) return { headers: [], values: [] };
 	// the drop zone only accepts .csv and .tsv, so the extension goes first and
-	// decides on its own for a single-column file, where neither separator splits
-	// anything. a mislabeled file is still read by its content, and the split is
-	// d3's rather than a raw count so a separator inside a quoted field does not
-	// throw the detection off.
+	// wins any tie, but a mislabeled file is still read by its content: a
+	// separator only takes the file if it splits every line the same way, which
+	// is what tells a real separator from one that sits in a header name. the
+	// split is d3's rather than a raw count, so a separator inside a quoted
+	// field does not throw the detection off.
 	const by_extension = file.name.toLowerCase().endsWith(".tsv") ? "\t" : ",";
 	const candidates = by_extension === "\t" ? ["\t", ","] : [",", "\t"];
-	let rows: string[][] | undefined;
+	let consistent: string[][] | undefined;
+	let ragged: string[][] | undefined;
+	let unsplit: string[][] | undefined;
 	for (const delimiter of candidates) {
-		const parsed = dsvFormat(delimiter).parseRows(text);
-		if ((parsed[0]?.length ?? 0) > 1) {
-			rows = parsed;
+		// a blank line parses to a single empty field, which both the width
+		// checks below and the caller's ragged check would read as a short row
+		const parsed = dsvFormat(delimiter)
+			.parseRows(text)
+			.filter((row) => row.length > 1 || row[0] !== "");
+		const width = parsed[0]?.length ?? 0;
+		// the extension is first in `candidates`, so this keeps its parse for the
+		// single-column case rather than running it again at the end
+		unsplit ??= parsed;
+		if (width < 2) continue;
+		if (parsed.every((row) => row.length === width)) {
+			consistent = parsed;
 			break;
 		}
+		// a separator that splits the header but leaves the rows uneven is
+		// usually the one that just happens to appear in a header name. keep it
+		// only in case the other does not split at all, where a ragged table is
+		// still better to report on than an unsplit one
+		ragged ??= parsed;
 	}
-	const [head = [], ...rest] = rows ?? dsvFormat(by_extension).parseRows(text);
+	const [head = [], ...rest] = consistent ?? ragged ?? unsplit ?? [];
 	return { headers: head.map((h) => h ?? ""), values: rest };
 }

--- a/js/dataframe/shared/utils/table_utils.ts
+++ b/js/dataframe/shared/utils/table_utils.ts
@@ -66,30 +66,16 @@ export function guess_delimiter(
 	}
 }
 
-export function data_uri_to_blob(data_uri: string): Blob {
-	const byte_str = atob(data_uri.split(",")[1]);
-	const mime_str = data_uri.split(",")[0].split(":")[1].split(";")[0];
-	const ab = new ArrayBuffer(byte_str.length);
-	const ia = new Uint8Array(ab);
-	for (let i = 0; i < byte_str.length; i++) {
-		ia[i] = byte_str.charCodeAt(i);
-	}
-	return new Blob([ab], { type: mime_str });
-}
-
-export function handle_file_upload(
-	data_uri: string,
+export async function handle_file_upload(
+	file: Blob,
 	update_headers: (headers: Headers) => HeadersWithIDs[],
 	update_values: (values: CellValue[][]) => void
-): void {
-	const blob = data_uri_to_blob(data_uri);
-	const reader = new FileReader();
-	reader.addEventListener("loadend", (e) => {
-		if (!e?.target?.result || typeof e.target.result !== "string") return;
-		const [delimiter] = guess_delimiter(e.target.result, [",", "\t"]);
-		const [head, ...rest] = dsvFormat(delimiter).parseRows(e.target.result);
-		update_headers(head);
-		update_values(rest);
-	});
-	reader.readAsText(blob);
+): Promise<void> {
+	const text = await file.text();
+	if (!text) return;
+	// a single-column file has no delimiter to find, so fall back to a comma
+	const [delimiter = ","] = guess_delimiter(text, [",", "\t"]);
+	const [head, ...rest] = dsvFormat(delimiter).parseRows(text);
+	update_headers(head);
+	update_values(rest);
 }

--- a/js/dataframe/shared/utils/utils.ts
+++ b/js/dataframe/shared/utils/utils.ts
@@ -15,7 +15,6 @@ export type Datatype =
 export type Metadata = {
 	[key: string]: string[][] | null;
 } | null;
-export type HeadersWithIDs = { value: string; id: string }[];
 export type DataframeValue = {
 	data: Data;
 	headers: Headers;

--- a/js/dataframe/standalone/default_i18n.ts
+++ b/js/dataframe/standalone/default_i18n.ts
@@ -5,6 +5,8 @@ export const default_i18n: Record<string, string> = {
 	"dataframe.add_column_left": "Add column left",
 	"dataframe.add_column_right": "Add column right",
 	"dataframe.delete_column": "Delete column",
+	"dataframe.drop_to_upload":
+		"Drop CSV or TSV files here to import data into dataframe",
 	"dataframe.sort_asc": "Sort ascending",
 	"dataframe.sort_desc": "Sort descending",
 	"dataframe.sort_ascending": "Sort ascending",

--- a/js/dataframe/test/table_utils.test.ts
+++ b/js/dataframe/test/table_utils.test.ts
@@ -117,6 +117,55 @@ describe("parse_table_file", () => {
 		});
 	});
 
+	// the extension says comma and the header does split on one, but only the
+	// tab splits every line, so the name loses to the file's own shape
+	test("reads a mislabeled file whose header holds the other separator", async () => {
+		const file = new File(["first,last\tage\nAlice\t30\n"], "data.csv");
+		expect(await parse_table_file(file)).toEqual({
+			headers: ["first,last", "age"],
+			values: [["Alice", "30"]]
+		});
+	});
+
+	// nothing splits this file consistently, so the separator that at least
+	// splits the header wins and the caller gets to report a useful mismatch
+	test("falls back to the separator that splits the header", async () => {
+		const file = new File(["name,age\nAlice,30,Engineer\n"], "data.tsv");
+		expect(await parse_table_file(file)).toEqual({
+			headers: ["name", "age"],
+			values: [["Alice", "30", "Engineer"]]
+		});
+	});
+
+	test("ignores blank lines", async () => {
+		const file = new File(["a,b\n1,2\n\n3,4\n\n"], "data.csv");
+		expect(await parse_table_file(file)).toEqual({
+			headers: ["a", "b"],
+			values: [
+				["1", "2"],
+				["3", "4"]
+			]
+		});
+	});
+
+	test("ignores blank lines in a file with windows line endings", async () => {
+		const file = new File(["a,b\r\n1,2\r\n\r\n"], "data.csv");
+		expect(await parse_table_file(file)).toEqual({
+			headers: ["a", "b"],
+			values: [["1", "2"]]
+		});
+	});
+
+	// excel writes one in front of its csv export. Blob.text() decodes as UTF-8,
+	// which drops it, so this holds as long as the file is read that way
+	test("strips a byte order mark from the first header", async () => {
+		const file = new File(["﻿name,age\nAlice,30\n"], "data.csv");
+		expect(await parse_table_file(file)).toEqual({
+			headers: ["name", "age"],
+			values: [["Alice", "30"]]
+		});
+	});
+
 	test("returns nothing for a file that holds only whitespace", async () => {
 		const file = new File(["   \n"], "data.csv");
 		expect(await parse_table_file(file)).toEqual({ headers: [], values: [] });

--- a/js/dataframe/test/table_utils.test.ts
+++ b/js/dataframe/test/table_utils.test.ts
@@ -2,7 +2,6 @@ import { describe, test, expect } from "vitest";
 import {
 	make_cell_id,
 	make_header_id,
-	guess_delimiter,
 	parse_table_file
 } from "../shared/utils/table_utils";
 import { cast_value_to_type } from "../shared/utils/utils";
@@ -69,30 +68,29 @@ describe("cast_value_to_type", () => {
 	});
 });
 
-describe("guess_delimiter", () => {
-	test("detects comma delimiter", () => {
-		const csv = "a,b,c\n1,2,3\n4,5,6";
-		expect(guess_delimiter(csv, [",", "\t"])).toContain(",");
-	});
-
-	test("detects tab delimiter", () => {
-		const tsv = "a\tb\tc\n1\t2\t3\n4\t5\t6";
-		expect(guess_delimiter(tsv, [",", "\t"])).toContain("\t");
-	});
-
-	test("returns empty array when no consistent delimiter", () => {
-		const text = "abc\ndef\nghi";
-		expect(guess_delimiter(text, [",", "\t"])).toEqual([]);
-	});
-
-	test("handles single-line input", () => {
-		// single line with commas — cache set once, always matches
-		const text = "a,b,c";
-		expect(guess_delimiter(text, [",", "\t"])).toContain(",");
-	});
-});
-
 describe("parse_table_file", () => {
+	test("detects a comma-separated file", async () => {
+		const file = new File(["a,b,c\n1,2,3\n4,5,6"], "data.csv");
+		expect(await parse_table_file(file)).toEqual({
+			headers: ["a", "b", "c"],
+			values: [
+				["1", "2", "3"],
+				["4", "5", "6"]
+			]
+		});
+	});
+
+	test("detects a tab-separated file", async () => {
+		const file = new File(["a\tb\tc\n1\t2\t3\n4\t5\t6"], "data.tsv");
+		expect(await parse_table_file(file)).toEqual({
+			headers: ["a", "b", "c"],
+			values: [
+				["1", "2", "3"],
+				["4", "5", "6"]
+			]
+		});
+	});
+
 	test("picks the extension's delimiter when both look consistent", async () => {
 		const file = new File(["first,last\tage\nAlice,Smith\t30\n"], "data.tsv");
 		expect(await parse_table_file(file)).toEqual({
@@ -106,6 +104,16 @@ describe("parse_table_file", () => {
 		expect(await parse_table_file(file)).toEqual({
 			headers: ["name", "age"],
 			values: [["Alice", "30"]]
+		});
+	});
+
+	// counting raw separators misses this: the quoted comma makes the comma counts
+	// disagree between the two lines, so nothing looks consistent
+	test("reads a mislabeled file whose field holds a quoted comma", async () => {
+		const file = new File(['name,note\nA,"x,y"\n'], "data.tsv");
+		expect(await parse_table_file(file)).toEqual({
+			headers: ["name", "note"],
+			values: [["A", "x,y"]]
 		});
 	});
 

--- a/js/dataframe/test/table_utils.test.ts
+++ b/js/dataframe/test/table_utils.test.ts
@@ -2,7 +2,8 @@ import { describe, test, expect } from "vitest";
 import {
 	make_cell_id,
 	make_header_id,
-	guess_delimiter
+	guess_delimiter,
+	parse_table_file
 } from "../shared/utils/table_utils";
 import { cast_value_to_type } from "../shared/utils/utils";
 
@@ -88,5 +89,28 @@ describe("guess_delimiter", () => {
 		// single line with commas — cache set once, always matches
 		const text = "a,b,c";
 		expect(guess_delimiter(text, [",", "\t"])).toContain(",");
+	});
+});
+
+describe("parse_table_file", () => {
+	test("picks the extension's delimiter when both look consistent", async () => {
+		const file = new File(["first,last\tage\nAlice,Smith\t30\n"], "data.tsv");
+		expect(await parse_table_file(file)).toEqual({
+			headers: ["first,last", "age"],
+			values: [["Alice,Smith", "30"]]
+		});
+	});
+
+	test("reads a mislabeled file by its content", async () => {
+		const file = new File(["name,age\nAlice,30\n"], "data.tsv");
+		expect(await parse_table_file(file)).toEqual({
+			headers: ["name", "age"],
+			values: [["Alice", "30"]]
+		});
+	});
+
+	test("returns nothing for a file that holds only whitespace", async () => {
+		const file = new File(["   \n"], "data.csv");
+		expect(await parse_table_file(file)).toEqual({ headers: [], values: [] });
 	});
 });

--- a/js/dataframe/test/table_utils.test.ts
+++ b/js/dataframe/test/table_utils.test.ts
@@ -2,8 +2,7 @@ import { describe, test, expect } from "vitest";
 import {
 	make_cell_id,
 	make_header_id,
-	guess_delimiter,
-	data_uri_to_blob
+	guess_delimiter
 } from "../shared/utils/table_utils";
 import { cast_value_to_type } from "../shared/utils/utils";
 
@@ -89,21 +88,5 @@ describe("guess_delimiter", () => {
 		// single line with commas — cache set once, always matches
 		const text = "a,b,c";
 		expect(guess_delimiter(text, [",", "\t"])).toContain(",");
-	});
-});
-
-describe("data_uri_to_blob", () => {
-	test("converts data URI to Blob with correct MIME type", () => {
-		const data_uri = "data:text/plain;base64,SGVsbG8=";
-		const blob = data_uri_to_blob(data_uri);
-		expect(blob.type).toBe("text/plain");
-	});
-
-	test("converts data URI to Blob with correct content", async () => {
-		// "Hello" in base64 is "SGVsbG8="
-		const data_uri = "data:text/plain;base64,SGVsbG8=";
-		const blob = data_uri_to_blob(data_uri);
-		const text = await blob.text();
-		expect(text).toBe("Hello");
 	});
 });

--- a/js/dataframe/types.ts
+++ b/js/dataframe/types.ts
@@ -7,6 +7,7 @@ export interface DataframeEvents {
 	input: never;
 	select: SelectData;
 	edit: EditData;
+	error: string;
 	clear_status: LoadingStatus;
 }
 

--- a/js/upload/src/utils.ts
+++ b/js/upload/src/utils.ts
@@ -118,21 +118,29 @@ export function create_drag(): {
 				e.stopPropagation();
 			}
 
+			// dragenter on the element being entered arrives before dragleave on
+			// the one being left, and both bubble here, so a drop zone with
+			// children needs the depth to know when the file has actually left
+			let drag_depth = 0;
+
 			function handle_drag_enter(e: DragEvent): void {
 				e.preventDefault();
 				e.stopPropagation();
-				_options.on_drag_change?.(true);
+				drag_depth++;
+				if (drag_depth === 1) _options.on_drag_change?.(true);
 			}
 
 			function handle_drag_leave(e: DragEvent): void {
 				e.preventDefault();
 				e.stopPropagation();
-				_options.on_drag_change?.(false);
+				drag_depth = Math.max(0, drag_depth - 1);
+				if (drag_depth === 0) _options.on_drag_change?.(false);
 			}
 
 			function handle_drop(e: DragEvent): void {
 				e.preventDefault();
 				e.stopPropagation();
+				drag_depth = 0;
 				_options.on_drag_change?.(false);
 
 				if (!e.dataTransfer?.files) return;


### PR DESCRIPTION
## Description

Dropping a CSV or TSV file on a `gr.Dataframe` uploaded the file, discarded the result, and logged nothing in either the browser console or the server.

`Table.svelte` mounted `<Upload>` with no `format` prop, so it took the default `"file"`: the file went to the server and `onload` came back with a `FileData`. The reader on the other side asked for `file_data.data`, a field `FileData` does not have, fell back to an empty string, and `atob("")` threw inside the `try` that wraps `onload`. `Table.svelte` passes no `onerror`, which is why the failure surfaced nowhere. This is older than the Svelte 5 migration: `data` was last part of Upload's load payload in #5498 and #6307, the v4 rework that replaced client-side data URIs with server-side upload, and the dataframe's reader was never updated to match.

Passing `format="blob"` hands `onload` the dropped `File` itself, so the file is parsed client-side with no server round trip and no upload indicator flashing before nothing happens. `filetype` narrows the drop target to `.csv` and `.tsv`, so dropping an image no longer decodes it as table text.

A drop having been a no-op for three years, several things around it were correct only because nothing ever reached them. They land here because the repair is what makes them live:

- The drop target was never gated on `interactive`. A read-only dataframe would have started accepting dropped files and pushing new values to the backend, while already advertising `aria-readonly` on the same element. `on_file_upload` now returns early when the table is not editable, and the error channel below is withheld along with it, so a table that ignores a dropped CSV does not report on a dropped PNG either. One residual: the drag action still calls `preventDefault`, so a file dragged over a read-only table shows a copy cursor and then does nothing.
- Nothing told the user a drop was possible, which is most of why this went unnoticed. `bind:dragging` fed a variable nothing else read, and the existing `.table-wrap.dragging` highlight belongs to the cell-selection drag, `cursor: crosshair` included. The file drag now has its own class, drawn as an inset outline so nothing shifts, and the variable is renamed `file_dragging` so the two stop looking alike. `<Block>` sets `container={false}` here, which zeroes the border width, so the `border_mode={dragging ? "focus" : "base"}` pattern other components use would have been invisible.
- That highlight then turned out not to work. `create_drag` flipped `dragging` from bare `dragenter` / `dragleave` handlers, and both events bubble. This drop target wraps every cell, so crossing a cell boundary delivers `dragenter` on the cell being entered before `dragleave` on the one being left, leaving the flag false while the file is still over the table: the outline lit for the instant of each crossing and was off the rest of the time. `create_drag` now counts depth. That is in `@gradio/upload` rather than here because every drop zone with children has it, and single-child zones simply never cross an inner boundary.
- What was left of the highlight arrived as a white flash. `.table-wrap` carries a bare `transition: 150ms`, which means every property, so the outline swept in over 150ms from `currentcolor`, and `currentcolor` here is `--body-text-color`, near-white in dark mode. The declaration predates every class now on that element and the fullscreen rules are the only other thing it can still reach, so it is narrowed to the properties those change rather than removed.
- Errors still went nowhere. `<Upload>` calls `onerror` for each file `filetype` turns away, and `Table.svelte` passed no handler, so dropping a PNG would light the table up and then do nothing at all, which is the silence this PR set out to remove. `Table.svelte` takes an `onerror` prop, `Index.svelte` dispatches it as `error`, and the parse promise is caught into the same channel.
- An import could walk past constraints the rest of the component enforces. `add_row` and `add_col` refuse to change a fixed `row_count` or `col_count`, and the cell handlers refuse to write to a `static_columns` entry, but the import assigned `headers` and `values` wholesale. It now turns the file away and says why; an empty file, a file of separators alone (which parses into a header of blank names and would leave the table with unnamed columns), and a file whose rows disagree with its own header all get the same treatment, the last because a check on the header alone lets `a,b` over `1,2,3` through and pushes the ragged row to the backend. `handle_file_upload` became `parse_table_file`, returning the parsed table instead of driving two callbacks, so all of this is settled before anything is assigned.
- The drop target had nothing to say for itself. `dataframe.drop_to_upload` was handed to `<Upload>` as `aria_label`, which that component applies only on its button branch, and the dataframe sets `container_element="div"`, so the string was built and discarded. The key is translated into 33 locales and has no other consumer, and this is the change that turns it from a dead string into a live affordance, so the grid now carries `aria-describedby`. `aria-description` would have been smaller but it is ARIA 1.3: support is partial and it is missing from `svelte/elements`, so it does not type-check. Making the key live also exposed that the standalone build's fallback map carries every other key the shared components use but not this one, which would have put the raw key on screen there.
- Cell state outlived the table it pointed at. `editing` and `selected_cells` hold coordinates and nothing cleared them on import, and a stale selection reached `copy_table_data` on the next copy. `EditableCell` commits its value whenever it leaves edit mode, which cuts three ways: a narrower file left a ragged row, a shorter one threw `TypeError: Cannot set properties of undefined` out of an effect, and a file of the same shape or larger wrote the half-typed value into the table that had just replaced it, with the imported value reported as `previous_value`. The import clears that state and marks the pending edit for discard, and `handle_blur` also ignores a row the table no longer has. It checks the row alone: a value can arrive ragged from the backend, and a cell past the end of a short row still renders and still takes an edit.

The delimiter needs a word of its own. `guess_delimiter` counted raw separators, which is wrong in both directions: it found *both* candidates for a TSV carrying a comma in every row, where the order of its argument list quietly picked the comma, and it found *neither* when a separator sat inside a quoted field, so a comma-separated file named `.tsv` fell through to the extension and came out as a single column. It is gone. `parse_table_file` hands each candidate to `dsvFormat` instead, which is quote-aware for free, and takes the first that splits every line of the file into the same number of fields. Requiring all the lines to agree is what tells a real separator from one that merely sits in a header name, and a candidate that splits only the header is kept as a fallback for the case where the other does not split at all, so a file that is genuinely ragged is still reported against the shape it was meant to have. `filetype` guarantees the extension is `.csv` or `.tsv`, so trying that one first breaks a tie and settles a single-column file, where nothing splits either way. Blank lines are dropped before any of this, since one parses into a row of a single empty field and a trailing newline would otherwise be enough to refuse the whole file.

Repairing the import rather than removing it leaves both drag-and-drop statements in the tabular workflows guide accurate, so that guide is unchanged. `data_uri_to_blob` and its tests go away with the data-URI path, which had no other callers, and `HeadersWithIDs` goes with `handle_file_upload`, its last reference.

Closes: #13835

## Before / after Spaces

- [Before fix](https://huggingface.co/spaces/hysts-debug/gradio-13835-before)
- [After fix](https://huggingface.co/spaces/hysts-debug/gradio-13835-after)

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. You should self-review all PRs, especially if they were generated with AI.

- [x] I used AI to investigate the root cause and implement the fix.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/gradio-app/gradio/issues) for this change. If not, please create an issue before you create this PR, unless the fix is very small. 

Not adhering to this guideline will result in the PR being closed. 

## Testing and Formatting Your Code

1. PRs will only be merged if tests pass on CI. We recommend at least running the backend tests locally, please set up [your Gradio environment locally](https://github.com/gradio-app/gradio/blob/main/CONTRIBUTING.md) and run the backed tests: `bash scripts/run_backend_tests.sh`

2. Please run these bash scripts to automatically format your code: `bash scripts/format_backend.sh`, and (if you made any changes to non-Python files) `bash scripts/format_frontend.sh`


