### PR TITLE
Add configurable tab overflow and alignment

### DIFF
--- a/.changeset/quiet-grapes-allow.md
+++ b/.changeset/quiet-grapes-allow.md
@@ -1,0 +1,6 @@
+---
+"@gradio/tabs": minor
+"gradio": minor
+---
+
+feat:Add configurable overflow behavior to Tabs

--- a/.changeset/quiet-grapes-allow.md
+++ b/.changeset/quiet-grapes-allow.md
@@ -1,6 +1,8 @@
 ---
+"@gradio/core": minor
+"@gradio/tabitem": minor
 "@gradio/tabs": minor
 "gradio": minor
 ---
 
-feat:Add configurable overflow behavior to Tabs
+feat:Add configurable tab overflow and alignment

--- a/gradio/interface.py
+++ b/gradio/interface.py
@@ -971,6 +971,7 @@ class TabbedInterface(Blocks):
         tab_names: list[str] | None = None,
         title: str | None = None,
         analytics_enabled: bool | None = None,
+        tabs_kwargs: dict[str, Any] | None = None,
     ):
         """
         Parameters:
@@ -978,6 +979,7 @@ class TabbedInterface(Blocks):
             tab_names: A list of tab names. If None, the tab names will be "Tab 1", "Tab 2", etc.
             title: The tab title to display when this demo is opened in a browser window.
             analytics_enabled: Whether to allow basic telemetry. If None, will use GRADIO_ANALYTICS_ENABLED environment variable or default to True.
+            tabs_kwargs: Additional keyword arguments to pass to the internal `gr.Tabs` layout.
         Returns:
             a Gradio Tabbed Interface for the given interfaces
         """
@@ -994,7 +996,7 @@ class TabbedInterface(Blocks):
                 Markdown(
                     f"<h1 style='text-align: center; margin-bottom: 1rem'>{title}</h1>"
                 )
-            with Tabs():
+            with Tabs(**(tabs_kwargs or {})):
                 for interface, tab_name in zip(interface_list, tab_names, strict=False):
                     with Tab(
                         label=tab_name,

--- a/gradio/layouts/tabs.py
+++ b/gradio/layouts/tabs.py
@@ -118,6 +118,7 @@ class Tab(BlockContext, metaclass=ComponentMeta):
         interactive: bool = True,
         *,
         id: int | str | None = None,
+        alignment: Literal["left", "right"] = "left",
         elem_id: str | None = None,
         elem_classes: list[str] | str | None = None,
         scale: int | None = None,
@@ -130,6 +131,7 @@ class Tab(BlockContext, metaclass=ComponentMeta):
         Parameters:
             label: The visual label for the tab
             id: An optional identifier for the tab, required if you wish to control the selected tab from a predict function.
+            alignment: The side of the tab bar where the tab is placed. Right-aligned tabs are grouped together while preserving their relative order.
             elem_id: An optional string that is assigned as the id of the <div> containing the contents of the Tab layout. The same string followed by "-button" is attached to the Tab button. Can be used for targeting CSS styles.
             elem_classes: An optional string or list of strings that are assigned as the class of this component in the HTML DOM. Can be used for targeting CSS styles.
             render: If False, this layout will not be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.
@@ -148,6 +150,7 @@ class Tab(BlockContext, metaclass=ComponentMeta):
         )
         self.label = label
         self.id = id
+        self.alignment = alignment
         self.visible = visible
         self.scale = scale
         self.interactive = interactive

--- a/gradio/layouts/tabs.py
+++ b/gradio/layouts/tabs.py
@@ -23,6 +23,7 @@ class Tabs(BlockContext, metaclass=ComponentMeta):
         self,
         *,
         selected: int | str | None = None,
+        overflow_behavior: Literal["menu", "wrap"] = "menu",
         visible: bool | Literal["hidden"] = True,
         elem_id: str | None = None,
         elem_classes: list[str] | str | None = None,
@@ -33,6 +34,7 @@ class Tabs(BlockContext, metaclass=ComponentMeta):
         """
         Parameters:
             selected: The currently selected tab. Must correspond to an id passed to the one of the child TabItems. Defaults to the first TabItem.
+            overflow_behavior: Controls how tabs that exceed the available width are displayed. If "menu", overflowing tabs are hidden in a dropdown menu. If "wrap", tabs wrap onto additional rows.
             visible: If False, Tabs will be hidden.
             elem_id: An optional string that is assigned as the id of this component in the HTML DOM. Can be used for targeting CSS styles.
             elem_classes: An optional string or list of strings that are assigned as the class of this component in the HTML DOM. Can be used for targeting CSS styles.
@@ -50,6 +52,7 @@ class Tabs(BlockContext, metaclass=ComponentMeta):
             preserved_by_key=preserved_by_key,
         )
         self.selected = selected
+        self.overflow_behavior = overflow_behavior
 
     def __exit__(self, exc_type=None, *args):
         super().__exit__(exc_type, *args)

--- a/gradio/layouts/tabs.py
+++ b/gradio/layouts/tabs.py
@@ -42,6 +42,10 @@ class Tabs(BlockContext, metaclass=ComponentMeta):
             key: in a gr.render, Components with the same key across re-renders are treated as the same component, not a new component. Properties set in 'preserved_by_key' are not reset across a re-render.
             preserved_by_key: A list of parameters from this component's constructor. Inside a gr.render() function, if a component is re-rendered with the same key, these (and only these) parameters will be preserved in the UI (if they have been changed by the user or an event listener) instead of re-rendered based on the values provided during constructor.
         """
+        if overflow_behavior not in ("menu", "wrap"):
+            raise ValueError(
+                "The `overflow_behavior` parameter must be either 'menu' or 'wrap'."
+            )
         BlockContext.__init__(
             self,
             visible=visible,
@@ -140,6 +144,10 @@ class Tab(BlockContext, metaclass=ComponentMeta):
             interactive: If False, Tab will not be clickable.
             render_children: If True, the children of this Tab will be rendered on the page (but hidden) when the Tab is visible but inactive. This can be useful if you want to ensure that any components (e.g. videos or audio) within the Tab are pre-loaded before the user clicks on the Tab.
         """
+        if alignment not in ("left", "right"):
+            raise ValueError(
+                "The `alignment` parameter must be either 'left' or 'right'."
+            )
         BlockContext.__init__(
             self,
             elem_id=elem_id,

--- a/js/core/src/init.svelte.ts
+++ b/js/core/src/init.svelte.ts
@@ -32,6 +32,7 @@ type visitor<T> = (node: T) => ProcessedComponentMeta;
 type Tab = {
 	label: string;
 	id: string;
+	alignment: "left" | "right";
 	visible: boolean;
 	interactive: boolean;
 	elem_id: string | undefined;
@@ -655,6 +656,7 @@ export class AppTree {
 		initial_tabs[tab_index] = {
 			label: i18n ? i18n(raw_label) : raw_label,
 			id: node.props.props.id as string,
+			alignment: (node.props.props.alignment as "left" | "right") ?? "left",
 			elem_id: node.props.shared_props.elem_id,
 			visible: visible === "hidden" ? false : visible,
 			interactive: node.props.shared_props.interactive,
@@ -1017,6 +1019,7 @@ function _gather_initial_tabs(
 		initial_tabs[parent_tab_id].push({
 			label: i18n ? i18n(raw_label) : raw_label,
 			id: node.props.props.id as string,
+			alignment: (node.props.props.alignment as "left" | "right") ?? "left",
 			elem_id: node.props.shared_props.elem_id,
 			visible: node.props.shared_props.visible as boolean,
 			interactive: node.props.shared_props.interactive,

--- a/js/tabitem/Index.svelte
+++ b/js/tabitem/Index.svelte
@@ -20,6 +20,7 @@
 	interactive={gradio.shared.interactive}
 	id={gradio.props.id}
 	order={gradio.props.order}
+	alignment={gradio.props.alignment}
 	scale={gradio.shared.scale}
 	component_id={gradio.props.component_id}
 	onselect={(data) => gradio.dispatch("select", data)}

--- a/js/tabitem/TabItem.test.ts
+++ b/js/tabitem/TabItem.test.ts
@@ -87,6 +87,20 @@ describe("TabItem", () => {
 			);
 		});
 	});
+
+	test("registers its alignment with the parent tabs", async () => {
+		const on_register = vi.fn();
+		await render(TabItemHarness, {
+			tab_alignment: "right",
+			on_register
+		});
+
+		await waitFor(() => {
+			expect(on_register).toHaveBeenCalledWith(
+				expect.objectContaining({ alignment: "right" })
+			);
+		});
+	});
 });
 
 describe("Events: select", () => {

--- a/js/tabitem/TabItemHarness.svelte
+++ b/js/tabitem/TabItemHarness.svelte
@@ -29,6 +29,7 @@
 	order={0}
 	visible={cfg.tab_visible ?? true}
 	interactive={true}
+	alignment={cfg.tab_alignment ?? "left"}
 	scale={0}
 	component_id={1}
 	onselect={(data) => cfg.on_tab_select?.(data)}

--- a/js/tabitem/shared/TabItem.svelte
+++ b/js/tabitem/shared/TabItem.svelte
@@ -12,6 +12,7 @@
 		visible,
 		interactive,
 		order,
+		alignment = "left",
 		scale,
 		component_id,
 		onselect,
@@ -24,6 +25,7 @@
 		visible: boolean | "hidden";
 		interactive: boolean;
 		order: number;
+		alignment?: "left" | "right";
 		scale: number;
 		component_id: number;
 		onselect?: (data: SelectData) => void;
@@ -49,6 +51,7 @@
 			elem_id,
 			visible,
 			interactive,
+			alignment,
 			scale,
 			component_id
 		})

--- a/js/tabitem/types.ts
+++ b/js/tabitem/types.ts
@@ -8,6 +8,7 @@ export interface TabItemProps {
 	visible: boolean | "hidden";
 	interactive: boolean;
 	order: number;
+	alignment?: "left" | "right";
 	component_id: number;
 }
 

--- a/js/tabs/Index.svelte
+++ b/js/tabs/Index.svelte
@@ -58,6 +58,7 @@
 		elem_id={gradio.shared.elem_id}
 		elem_classes={gradio.shared.elem_classes}
 		bind:selected={gradio.props.selected}
+		overflow_behavior={gradio.props.overflow_behavior}
 		onchange={() => gradio.dispatch("change")}
 		onselect={(data) => {
 			gradio.dispatch("select", data);

--- a/js/tabs/Tabs.stories.svelte
+++ b/js/tabs/Tabs.stories.svelte
@@ -86,6 +86,44 @@
 			component_id: 5
 		}
 	];
+
+	function makeTab(label, id, component_id, alignment = "left") {
+		return {
+			label,
+			id,
+			elem_id: undefined,
+			visible: true,
+			interactive: true,
+			scale: null,
+			component_id,
+			alignment
+		};
+	}
+
+	const overflowTabs = [
+		makeTab("Overview", "overview", 1),
+		makeTab("Model Settings", "models", 2),
+		makeTab("Generation", "generation", 3),
+		makeTab("Audio Conversion", "audio", 4),
+		makeTab("Outputs", "outputs", 5),
+		makeTab("Extensions", "extensions", 6),
+		makeTab("System Info", "system", 7),
+		makeTab("Installed Packages", "packages", 8),
+		makeTab("Advanced Options", "advanced", 9, "right"),
+		makeTab("About", "about", 10, "right")
+	];
+
+	const wrappedTabs = [
+		makeTab(
+			"A very long tab label that should truncate within the available width",
+			"long",
+			1
+		),
+		...overflowTabs.slice(1).map((tab, index) => ({
+			...tab,
+			component_id: index + 2
+		}))
+	];
 </script>
 
 <Story name="Tabs" args={{ initial_tabs: basicTabs, selected: "tab-1" }}>
@@ -95,6 +133,40 @@
 				<img style="width: 200px;" alt="Cheetah" src={cheetah} />
 			</div>
 		</BaseTabs>
+	{/snippet}
+</Story>
+
+<Story
+	name="MenuOverflowWithRightAlignedTabs"
+	args={{
+		initial_tabs: overflowTabs,
+		selected: "generation",
+		overflow_behavior: "menu"
+	}}
+>
+	{#snippet template(args)}
+		<div style="width: 520px; max-width: 100%;">
+			<BaseTabs {...args}>
+				<div style="padding: 1rem;">Generation tab content</div>
+			</BaseTabs>
+		</div>
+	{/snippet}
+</Story>
+
+<Story
+	name="WrappedTabsWithRightAlignmentAndLongLabel"
+	args={{
+		initial_tabs: wrappedTabs,
+		selected: "long",
+		overflow_behavior: "wrap"
+	}}
+>
+	{#snippet template(args)}
+		<div style="width: 420px; max-width: 100%;">
+			<BaseTabs {...args}>
+				<div style="padding: 1rem;">Selected tab content</div>
+			</BaseTabs>
+		</div>
 	{/snippet}
 </Story>
 

--- a/js/tabs/Tabs.test.ts
+++ b/js/tabs/Tabs.test.ts
@@ -112,6 +112,44 @@ describe("Accessibility", () => {
 	});
 });
 
+describe("Props: overflow_behavior", () => {
+	afterEach(() => cleanup());
+
+	const many_tabs = Array.from({ length: 20 }, (_, index) =>
+		make_tab({
+			label: `Long tab label ${index + 1}`,
+			id: `t${index + 1}`,
+			component_id: index + 1
+		})
+	);
+
+	test("menu hides overflowing tabs behind the overflow button", async () => {
+		const { getByRole, queryByRole } = await render(Tabs, {
+			...default_props,
+			overflow_behavior: "menu",
+			initial_tabs: many_tabs
+		});
+
+		await waitFor(() => {
+			expect(getByRole("button", { name: "More tabs" })).toBeVisible();
+		});
+		expect(queryByRole("tab", { name: "Long tab label 20" })).toBeNull();
+	});
+
+	test("wrap keeps every tab visible and removes the overflow button", async () => {
+		const { getByRole, queryByRole } = await render(Tabs, {
+			...default_props,
+			overflow_behavior: "wrap",
+			initial_tabs: many_tabs
+		});
+
+		await waitFor(() => {
+			expect(getByRole("tab", { name: "Long tab label 20" })).toBeVisible();
+		});
+		expect(queryByRole("button", { name: "More tabs" })).toBeNull();
+	});
+});
+
 describe("Props: interactive", () => {
 	afterEach(() => cleanup());
 

--- a/js/tabs/Tabs.test.ts
+++ b/js/tabs/Tabs.test.ts
@@ -136,6 +136,29 @@ describe("Props: overflow_behavior", () => {
 		expect(queryByRole("tab", { name: "Long tab label 20" })).toBeNull();
 	});
 
+	test("menu keeps right-aligned tabs visible while left tabs overflow", async () => {
+		const aligned_tabs = [
+			...many_tabs,
+			make_tab({
+				label: "Settings",
+				id: "settings",
+				alignment: "right",
+				component_id: 21
+			})
+		];
+		const { getByRole, queryByRole } = await render(Tabs, {
+			...default_props,
+			overflow_behavior: "menu",
+			initial_tabs: aligned_tabs
+		});
+
+		await waitFor(() => {
+			expect(getByRole("button", { name: "More tabs" })).toBeVisible();
+		});
+		expect(getByRole("tab", { name: "Settings" })).toBeVisible();
+		expect(queryByRole("tab", { name: "Long tab label 20" })).toBeNull();
+	});
+
 	test("wrap keeps every tab visible and removes the overflow button", async () => {
 		const { getByRole, queryByRole } = await render(Tabs, {
 			...default_props,
@@ -147,6 +170,42 @@ describe("Props: overflow_behavior", () => {
 			expect(getByRole("tab", { name: "Long tab label 20" })).toBeVisible();
 		});
 		expect(queryByRole("button", { name: "More tabs" })).toBeNull();
+	});
+
+	test("wrap preserves left and right alignment while tabs overflow", async () => {
+		const aligned_tabs = [
+			make_tab({
+				label: "Settings",
+				id: "settings",
+				alignment: "right",
+				component_id: 1
+			}),
+			...many_tabs,
+			make_tab({
+				label: "About",
+				id: "about",
+				alignment: "right",
+				component_id: 22
+			})
+		];
+		const { getAllByRole, getByRole, queryByRole } = await render(Tabs, {
+			...default_props,
+			overflow_behavior: "wrap",
+			initial_tabs: aligned_tabs
+		});
+
+		await waitFor(() => {
+			expect(getByRole("tab", { name: "About" })).toBeVisible();
+		});
+		expect(queryByRole("button", { name: "More tabs" })).toBeNull();
+		expect(getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+			...many_tabs.map((tab) => tab.label),
+			"Settings",
+			"About"
+		]);
+		expect(getByRole("tab", { name: "Settings" }).parentElement).toHaveClass(
+			"right-tab-group"
+		);
 	});
 });
 
@@ -188,6 +247,33 @@ describe("Events: select", () => {
 			index: 1,
 			id: "t2",
 			component_id: 2
+		});
+	});
+
+	test("right alignment does not change the tab's select index", async () => {
+		const { listen, getByRole } = await render(Tabs, {
+			...default_props,
+			selected: "home",
+			overflow_behavior: "wrap",
+			initial_tabs: [
+				make_tab({
+					label: "Settings",
+					id: "settings",
+					alignment: "right",
+					component_id: 1
+				}),
+				make_tab({ label: "Home", id: "home", component_id: 2 })
+			]
+		});
+		const select = listen("select");
+
+		await fireEvent.click(getByRole("tab", { name: "Settings" }));
+
+		expect(select).toHaveBeenCalledWith({
+			value: "Settings",
+			index: 0,
+			id: "settings",
+			component_id: 1
 		});
 	});
 

--- a/js/tabs/Tabs.test.ts
+++ b/js/tabs/Tabs.test.ts
@@ -159,6 +159,89 @@ describe("Props: overflow_behavior", () => {
 		expect(queryByRole("tab", { name: "Long tab label 20" })).toBeNull();
 	});
 
+	test("menu keeps the selected tab visible ahead of right-aligned tabs", async () => {
+		const selected_label = "Train";
+		const first_right_label =
+			"A very long right-aligned utility tab that cannot fit in the available space";
+		const { getByRole, queryByRole } = await render(Tabs, {
+			...default_props,
+			selected: "train",
+			overflow_behavior: "menu",
+			initial_tabs: [
+				make_tab({ label: "Home", id: "home", component_id: 1 }),
+				make_tab({ label: "Data", id: "data", component_id: 2 }),
+				make_tab({ label: selected_label, id: "train", component_id: 3 }),
+				make_tab({
+					label: first_right_label,
+					id: "utility",
+					alignment: "right",
+					component_id: 4
+				}),
+				make_tab({
+					label: "Help",
+					id: "help",
+					alignment: "right",
+					component_id: 5
+				})
+			]
+		});
+		const tablist = getByRole("tablist");
+		tablist.style.width = "420px";
+		window.dispatchEvent(new Event("resize"));
+
+		await waitFor(() => {
+			expect(getByRole("button", { name: "More tabs" })).toBeVisible();
+		});
+		expect(getByRole("tab", { name: selected_label })).toBeVisible();
+		expect(queryByRole("tab", { name: first_right_label })).toBeNull();
+		expect(queryByRole("tab", { name: "Help" })).toBeNull();
+	});
+
+	test("menu keeps an oversized first tab visible", async () => {
+		const first_label =
+			"A first tab label that is much wider than the available tab bar";
+		const { getByRole, queryByRole } = await render(Tabs, {
+			...default_props,
+			selected: "first",
+			overflow_behavior: "menu",
+			initial_tabs: [
+				make_tab({ label: first_label, id: "first", component_id: 1 }),
+				make_tab({ label: "B", id: "b", component_id: 2 }),
+				make_tab({ label: "C", id: "c", component_id: 3 })
+			]
+		});
+		const tablist = getByRole("tablist");
+		tablist.style.width = "260px";
+		window.dispatchEvent(new Event("resize"));
+
+		await waitFor(() => {
+			expect(getByRole("button", { name: "More tabs" })).toBeVisible();
+		});
+		expect(getByRole("tab", { name: first_label })).toBeVisible();
+		expect(queryByRole("tab", { name: "B" })).toBeNull();
+		expect(queryByRole("tab", { name: "C" })).toBeNull();
+	});
+
+	test("menu promotes a newly selected overflow tab into the tab bar", async () => {
+		const { getByRole } = await render(Tabs, {
+			...default_props,
+			overflow_behavior: "menu",
+			initial_tabs: many_tabs
+		});
+
+		await waitFor(() => {
+			expect(getByRole("button", { name: "More tabs" })).toBeVisible();
+		});
+		await fireEvent.click(getByRole("button", { name: "More tabs" }));
+		await fireEvent.click(getByRole("button", { name: "Long tab label 20" }));
+
+		await waitFor(() => {
+			expect(
+				getByRole("tab", { name: "Long tab label 20", selected: true })
+			).toBeVisible();
+		});
+	});
+
 	test("wrap keeps every tab visible and removes the overflow button", async () => {
 		const { getByRole, queryByRole } = await render(Tabs, {
 			...default_props,
@@ -166,6 +249,47 @@ describe("Props: overflow_behavior", () => {
 			initial_tabs: many_tabs
 		});
 
+		await waitFor(() => {
+			expect(getByRole("tab", { name: "Long tab label 20" })).toBeVisible();
+		});
+		expect(queryByRole("button", { name: "More tabs" })).toBeNull();
+	});
+
+	test("wrap prevents a long label from overflowing horizontally", async () => {
+		const long_label =
+			"A tab label that is substantially wider than the available tab bar width";
+		const { getByRole } = await render(Tabs, {
+			...default_props,
+			overflow_behavior: "wrap",
+			initial_tabs: [
+				make_tab({ label: long_label, id: "long", component_id: 1 })
+			]
+		});
+		const tablist = getByRole("tablist");
+		tablist.style.width = "200px";
+		window.dispatchEvent(new Event("resize"));
+
+		await waitFor(() => {
+			expect(tablist.scrollWidth).toBeLessThanOrEqual(tablist.clientWidth);
+		});
+		expect(getByRole("tab", { name: long_label })).toBeVisible();
+	});
+
+	test("switches between menu and wrap without a resize", async () => {
+		const { getByRole, queryByRole, set_data } = await render(Tabs, {
+			...default_props,
+			overflow_behavior: "wrap",
+			initial_tabs: many_tabs
+		});
+
+		expect(getByRole("tab", { name: "Long tab label 20" })).toBeVisible();
+		await set_data({ overflow_behavior: "menu" });
+		await waitFor(() => {
+			expect(getByRole("button", { name: "More tabs" })).toBeVisible();
+		});
+		expect(queryByRole("tab", { name: "Long tab label 20" })).toBeNull();
+
+		await set_data({ overflow_behavior: "wrap" });
 		await waitFor(() => {
 			expect(getByRole("tab", { name: "Long tab label 20" })).toBeVisible();
 		});

--- a/js/tabs/Tabs.test.ts
+++ b/js/tabs/Tabs.test.ts
@@ -136,29 +136,6 @@ describe("Props: overflow_behavior", () => {
 		expect(queryByRole("tab", { name: "Long tab label 20" })).toBeNull();
 	});
 
-	test("menu keeps right-aligned tabs visible while left tabs overflow", async () => {
-		const aligned_tabs = [
-			...many_tabs,
-			make_tab({
-				label: "Settings",
-				id: "settings",
-				alignment: "right",
-				component_id: 21
-			})
-		];
-		const { getByRole, queryByRole } = await render(Tabs, {
-			...default_props,
-			overflow_behavior: "menu",
-			initial_tabs: aligned_tabs
-		});
-
-		await waitFor(() => {
-			expect(getByRole("button", { name: "More tabs" })).toBeVisible();
-		});
-		expect(getByRole("tab", { name: "Settings" })).toBeVisible();
-		expect(queryByRole("tab", { name: "Long tab label 20" })).toBeNull();
-	});
-
 	test("menu keeps the selected tab visible ahead of right-aligned tabs", async () => {
 		const selected_label = "Train";
 		const first_right_label =
@@ -255,26 +232,6 @@ describe("Props: overflow_behavior", () => {
 		expect(queryByRole("button", { name: "More tabs" })).toBeNull();
 	});
 
-	test("wrap prevents a long label from overflowing horizontally", async () => {
-		const long_label =
-			"A tab label that is substantially wider than the available tab bar width";
-		const { getByRole } = await render(Tabs, {
-			...default_props,
-			overflow_behavior: "wrap",
-			initial_tabs: [
-				make_tab({ label: long_label, id: "long", component_id: 1 })
-			]
-		});
-		const tablist = getByRole("tablist");
-		tablist.style.width = "200px";
-		window.dispatchEvent(new Event("resize"));
-
-		await waitFor(() => {
-			expect(tablist.scrollWidth).toBeLessThanOrEqual(tablist.clientWidth);
-		});
-		expect(getByRole("tab", { name: long_label })).toBeVisible();
-	});
-
 	test("switches between menu and wrap without a resize", async () => {
 		const { getByRole, queryByRole, set_data } = await render(Tabs, {
 			...default_props,
@@ -294,42 +251,6 @@ describe("Props: overflow_behavior", () => {
 			expect(getByRole("tab", { name: "Long tab label 20" })).toBeVisible();
 		});
 		expect(queryByRole("button", { name: "More tabs" })).toBeNull();
-	});
-
-	test("wrap preserves left and right alignment while tabs overflow", async () => {
-		const aligned_tabs = [
-			make_tab({
-				label: "Settings",
-				id: "settings",
-				alignment: "right",
-				component_id: 1
-			}),
-			...many_tabs,
-			make_tab({
-				label: "About",
-				id: "about",
-				alignment: "right",
-				component_id: 22
-			})
-		];
-		const { getAllByRole, getByRole, queryByRole } = await render(Tabs, {
-			...default_props,
-			overflow_behavior: "wrap",
-			initial_tabs: aligned_tabs
-		});
-
-		await waitFor(() => {
-			expect(getByRole("tab", { name: "About" })).toBeVisible();
-		});
-		expect(queryByRole("button", { name: "More tabs" })).toBeNull();
-		expect(getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
-			...many_tabs.map((tab) => tab.label),
-			"Settings",
-			"About"
-		]);
-		expect(getByRole("tab", { name: "Settings" }).parentElement).toHaveClass(
-			"right-tab-group"
-		);
 	});
 });
 

--- a/js/tabs/shared/Tabs.svelte
+++ b/js/tabs/shared/Tabs.svelte
@@ -39,6 +39,7 @@
 		elem_id = "",
 		elem_classes = [],
 		selected = $bindable(),
+		overflow_behavior = "menu",
 		initial_tabs,
 		onchange,
 		onselect,
@@ -48,6 +49,7 @@
 		elem_id?: string;
 		elem_classes?: string[];
 		selected: number | string;
+		overflow_behavior?: "menu" | "wrap";
 		initial_tabs: Tab[];
 		onchange?: () => void;
 		onselect?: (data: TabSelectData) => void;
@@ -172,6 +174,13 @@
 
 	async function handle_menu_overflow(): Promise<void> {
 		if (!tab_nav_el) return;
+		if (overflow_behavior === "wrap") {
+			visible_tabs = tabs;
+			overflow_tabs = [];
+			overflow_has_selected_tab = false;
+			is_overflowing = false;
+			return;
+		}
 
 		await tick();
 		await new Promise((r) => requestAnimationFrame(r));
@@ -230,17 +239,24 @@
 	style:flex-grow={tab_scale}
 >
 	{#if has_tabs}
-		<div class="tab-wrapper">
-			<div class="tab-container visually-hidden" aria-hidden="true">
-				{#each tabs as t, i}
-					{#if is_visible_tab(t)}
-						<button tabindex="-1" bind:this={tab_els[t.id]}>
-							{t?.label}
-						</button>
-					{/if}
-				{/each}
-			</div>
-			<div class="tab-container" bind:this={tab_nav_el} role="tablist">
+		<div class="tab-wrapper" class:wrap={overflow_behavior === "wrap"}>
+			{#if overflow_behavior === "menu"}
+				<div class="tab-container visually-hidden" aria-hidden="true">
+					{#each tabs as t, i}
+						{#if is_visible_tab(t)}
+							<button tabindex="-1" bind:this={tab_els[t.id]}>
+								{t?.label}
+							</button>
+						{/if}
+					{/each}
+				</div>
+			{/if}
+			<div
+				class="tab-container"
+				class:wrap={overflow_behavior === "wrap"}
+				bind:this={tab_nav_el}
+				role="tablist"
+			>
 				{#each visible_tabs as t, i}
 					{#if is_visible_tab(t)}
 						<button
@@ -269,43 +285,45 @@
 					{/if}
 				{/each}
 			</div>
-			<span
-				class="overflow-menu"
-				class:hide={!is_overflowing ||
-					!overflow_tabs.some((t) => is_visible_tab(t))}
-				bind:this={overflow_menu}
-			>
-				<button
-					aria-label="More tabs"
-					onclick={(e) => {
-						e.stopPropagation();
-						overflow_menu_open = !overflow_menu_open;
-					}}
-					class:overflow-item-selected={overflow_has_selected_tab}
+			{#if overflow_behavior === "menu"}
+				<span
+					class="overflow-menu"
+					class:hide={!is_overflowing ||
+						!overflow_tabs.some((t) => is_visible_tab(t))}
+					bind:this={overflow_menu}
 				>
-					<OverflowIcon />
-				</button>
-				<div class="overflow-dropdown" class:hide={!overflow_menu_open}>
-					{#each overflow_tabs as t, i}
-						{#if is_visible_tab(t)}
-							<button
-								onclick={() => {
-									change_tab(t?.id);
-									onselect?.({
-										value: t.label,
-										index: i,
-										id: t.id,
-										component_id: t.component_id
-									});
-								}}
-								class:selected={t?.id === $selected_tab}
-							>
-								{t?.label}
-							</button>
-						{/if}
-					{/each}
-				</div>
-			</span>
+					<button
+						aria-label="More tabs"
+						onclick={(e) => {
+							e.stopPropagation();
+							overflow_menu_open = !overflow_menu_open;
+						}}
+						class:overflow-item-selected={overflow_has_selected_tab}
+					>
+						<OverflowIcon />
+					</button>
+					<div class="overflow-dropdown" class:hide={!overflow_menu_open}>
+						{#each overflow_tabs as t, i}
+							{#if is_visible_tab(t)}
+								<button
+									onclick={() => {
+										change_tab(t?.id);
+										onselect?.({
+											value: t.label,
+											index: i,
+											id: t.id,
+											component_id: t.component_id
+										});
+									}}
+									class:selected={t?.id === $selected_tab}
+								>
+									{t?.label}
+								</button>
+							{/if}
+						{/each}
+					</div>
+				</span>
+			{/if}
 		</div>
 	{/if}
 	{@render children?.()}
@@ -335,12 +353,26 @@
 		margin-bottom: var(--layout-gap);
 	}
 
+	.tab-wrapper.wrap {
+		height: auto;
+	}
+
 	.tab-container {
 		display: flex;
 		align-items: center;
 		width: 100%;
 		position: relative;
 		overflow: hidden;
+		height: var(--size-8);
+	}
+
+	.tab-container.wrap {
+		flex-wrap: wrap;
+		overflow: visible;
+		height: auto;
+	}
+
+	.tab-container.wrap button {
 		height: var(--size-8);
 	}
 

--- a/js/tabs/shared/Tabs.svelte
+++ b/js/tabs/shared/Tabs.svelte
@@ -11,6 +11,7 @@
 		interactive: boolean;
 		scale: number | null;
 		component_id: number;
+		alignment?: "left" | "right";
 	}
 
 	export type TabSelectData = Omit<SelectData, "index"> & {
@@ -26,6 +27,13 @@
 	function find_tab_index(tabs: (Tab | null)[], id: string | number): number {
 		const index = tabs.findIndex((t) => t?.id === id);
 		return index === -1 ? 0 : index;
+	}
+
+	function order_tabs_by_alignment(tabs: (Tab | null)[]): (Tab | null)[] {
+		return [
+			...tabs.filter((tab) => tab?.alignment !== "right"),
+			...tabs.filter((tab) => tab?.alignment === "right")
+		];
 	}
 </script>
 
@@ -57,7 +65,9 @@
 	} = $props();
 
 	let tabs = $state<(Tab | null)[]>([...initial_tabs]);
-	let visible_tabs = $state<(Tab | null)[]>([...initial_tabs]);
+	let visible_tabs = $state<(Tab | null)[]>(
+		order_tabs_by_alignment(initial_tabs)
+	);
 	let overflow_tabs = $state<(Tab | null)[]>([]);
 	let overflow_menu_open = $state(false);
 	let overflow_menu: HTMLElement;
@@ -174,8 +184,9 @@
 
 	async function handle_menu_overflow(): Promise<void> {
 		if (!tab_nav_el) return;
+		const ordered_tabs = order_tabs_by_alignment(tabs);
 		if (overflow_behavior === "wrap") {
-			visible_tabs = tabs;
+			visible_tabs = ordered_tabs;
 			overflow_tabs = [];
 			overflow_has_selected_tab = false;
 			is_overflowing = false;
@@ -188,26 +199,55 @@
 		if (!tab_nav_el) return;
 
 		const available = tab_nav_el.clientWidth;
+		const rendered_tabs = ordered_tabs.filter(is_visible_tab);
+		const tab_width = (tab: Tab): number =>
+			tab_els[tab.id]?.getBoundingClientRect().width ?? 0;
+		const total_width = rendered_tabs.reduce(
+			(total, tab) => total + tab_width(tab),
+			0
+		);
 
-		let cumulative = 0;
-		let split_index = tabs.length;
+		if (total_width <= available) {
+			visible_tabs = ordered_tabs;
+			overflow_tabs = [];
+		} else {
+			const left_tabs = rendered_tabs.filter(
+				(tab) => tab.alignment !== "right"
+			);
+			const right_tabs = rendered_tabs.filter(
+				(tab) => tab.alignment === "right"
+			);
+			const limit = Math.max(0, available - OVERFLOW_BTN_RESERVE);
+			const visible_left_tabs: Tab[] = [];
+			const visible_right_tabs: Tab[] = [];
+			let used_width = 0;
 
-		for (let i = 0; i < tabs.length; i++) {
-			const tab = tabs[i];
-			if (!is_visible_tab(tab)) continue;
-			const el = tab_els[tab.id];
-			if (!el) continue;
-			cumulative += el.getBoundingClientRect().width;
-			const has_more = tabs.slice(i + 1).some((t) => is_visible_tab(t));
-			const limit = has_more ? available - OVERFLOW_BTN_RESERVE : available;
-			if (cumulative > limit) {
-				split_index = i;
-				break;
+			const first_left_tab = left_tabs[0];
+			if (first_left_tab && tab_width(first_left_tab) <= limit) {
+				visible_left_tabs.push(first_left_tab);
+				used_width += tab_width(first_left_tab);
 			}
-		}
 
-		visible_tabs = tabs.slice(0, split_index);
-		overflow_tabs = tabs.slice(split_index);
+			for (const tab of right_tabs) {
+				const width = tab_width(tab);
+				if (used_width + width <= limit) {
+					visible_right_tabs.push(tab);
+					used_width += width;
+				}
+			}
+
+			for (const tab of left_tabs.slice(first_left_tab ? 1 : 0)) {
+				const width = tab_width(tab);
+				if (used_width + width > limit) break;
+				visible_left_tabs.push(tab);
+				used_width += width;
+			}
+
+			visible_tabs = [...visible_left_tabs, ...visible_right_tabs];
+			overflow_tabs = rendered_tabs.filter(
+				(tab) => !visible_tabs.some((visible_tab) => visible_tab?.id === tab.id)
+			);
+		}
 
 		overflow_has_selected_tab = handle_overflow_has_selected_tab($selected_tab);
 		is_overflowing = overflow_tabs.filter((t) => is_visible_tab(t)).length > 0;
@@ -257,33 +297,45 @@
 				bind:this={tab_nav_el}
 				role="tablist"
 			>
+				{#snippet tab_button(t: Tab, display_index: number)}
+					<button
+						role="tab"
+						class:selected={t.id === $selected_tab}
+						aria-selected={t.id === $selected_tab}
+						aria-controls={t.elem_id}
+						disabled={!t.interactive}
+						aria-disabled={!t.interactive}
+						id={t.elem_id ? t.elem_id + "-button" : null}
+						data-tab-id={t.id}
+						onclick={() => {
+							if (t.id !== $selected_tab) {
+								change_tab(t.id);
+								onselect?.({
+									value: t.label,
+									index: tabs.findIndex((tab) => tab?.id === t.id),
+									id: t.id,
+									component_id: t.component_id
+								});
+							}
+						}}
+					>
+						{t.label !== undefined ? t.label : "Tab " + (display_index + 1)}
+					</button>
+				{/snippet}
 				{#each visible_tabs as t, i}
-					{#if is_visible_tab(t)}
-						<button
-							role="tab"
-							class:selected={t.id === $selected_tab}
-							aria-selected={t.id === $selected_tab}
-							aria-controls={t.elem_id}
-							disabled={!t.interactive}
-							aria-disabled={!t.interactive}
-							id={t.elem_id ? t.elem_id + "-button" : null}
-							data-tab-id={t.id}
-							onclick={() => {
-								if (t.id !== $selected_tab) {
-									change_tab(t.id);
-									onselect?.({
-										value: t.label,
-										index: i,
-										id: t.id,
-										component_id: t.component_id
-									});
-								}
-							}}
-						>
-							{t?.label !== undefined ? t?.label : "Tab " + (i + 1)}
-						</button>
+					{#if is_visible_tab(t) && t.alignment !== "right"}
+						{@render tab_button(t, i)}
 					{/if}
 				{/each}
+				{#if visible_tabs.some((t) => is_visible_tab(t) && t.alignment === "right")}
+					<div class="right-tab-group" role="presentation">
+						{#each visible_tabs as t, i}
+							{#if is_visible_tab(t) && t.alignment === "right"}
+								{@render tab_button(t, i)}
+							{/if}
+						{/each}
+					</div>
+				{/if}
 			</div>
 			{#if overflow_behavior === "menu"}
 				<span
@@ -310,7 +362,7 @@
 										change_tab(t?.id);
 										onselect?.({
 											value: t.label,
-											index: i,
+											index: tabs.findIndex((tab) => tab?.id === t.id),
 											id: t.id,
 											component_id: t.component_id
 										});
@@ -370,6 +422,15 @@
 		flex-wrap: wrap;
 		overflow: visible;
 		height: auto;
+		background: repeating-linear-gradient(
+			to bottom,
+			transparent 0,
+			transparent calc(var(--size-8) - 1px),
+			color-mix(in srgb, var(--border-color-primary) 45%, transparent)
+				calc(var(--size-8) - 1px),
+			color-mix(in srgb, var(--border-color-primary) 45%, transparent)
+				var(--size-8)
+		);
 	}
 
 	.tab-container.wrap button {
@@ -406,6 +467,21 @@
 		align-items: center;
 		white-space: nowrap;
 		position: relative;
+	}
+
+	.right-tab-group {
+		margin-left: auto;
+		display: flex;
+		align-items: center;
+		flex-shrink: 1;
+		flex-wrap: wrap;
+		justify-content: flex-end;
+		max-width: 100%;
+	}
+
+	.tab-container:not(.wrap) .right-tab-group {
+		flex-wrap: nowrap;
+		height: 100%;
 	}
 
 	button:disabled {

--- a/js/tabs/shared/Tabs.svelte
+++ b/js/tabs/shared/Tabs.svelte
@@ -161,6 +161,12 @@
 	});
 
 	$effect(() => {
+		overflow_behavior;
+		$selected_tab;
+		handle_menu_overflow();
+	});
+
+	$effect(() => {
 		if (!tab_nav_el) return;
 		handle_menu_overflow();
 		const ro = new ResizeObserver(() => {
@@ -218,31 +224,44 @@
 				(tab) => tab.alignment === "right"
 			);
 			const limit = Math.max(0, available - OVERFLOW_BTN_RESERVE);
-			const visible_left_tabs: Tab[] = [];
-			const visible_right_tabs: Tab[] = [];
+			const visible_tab_ids = new Set<string | number>();
 			let used_width = 0;
 
-			const first_left_tab = left_tabs[0];
-			if (first_left_tab && tab_width(first_left_tab) <= limit) {
-				visible_left_tabs.push(first_left_tab);
-				used_width += tab_width(first_left_tab);
+			function reserve_tab(tab: Tab | undefined): void {
+				if (!tab || visible_tab_ids.has(tab.id)) return;
+				visible_tab_ids.add(tab.id);
+				used_width += tab_width(tab);
 			}
+
+			const first_left_tab = left_tabs[0];
+			const selected_rendered_tab = rendered_tabs.find(
+				(tab) => tab.id === $selected_tab
+			);
+			reserve_tab(first_left_tab);
+			reserve_tab(selected_rendered_tab);
 
 			for (const tab of right_tabs) {
-				const width = tab_width(tab);
-				if (used_width + width <= limit) {
-					visible_right_tabs.push(tab);
-					used_width += width;
-				}
-			}
-
-			for (const tab of left_tabs.slice(first_left_tab ? 1 : 0)) {
+				if (visible_tab_ids.has(tab.id)) continue;
 				const width = tab_width(tab);
 				if (used_width + width > limit) break;
-				visible_left_tabs.push(tab);
+				visible_tab_ids.add(tab.id);
 				used_width += width;
 			}
 
+			for (const tab of left_tabs.slice(first_left_tab ? 1 : 0)) {
+				if (visible_tab_ids.has(tab.id)) continue;
+				const width = tab_width(tab);
+				if (used_width + width > limit) break;
+				visible_tab_ids.add(tab.id);
+				used_width += width;
+			}
+
+			const visible_left_tabs = left_tabs.filter((tab) =>
+				visible_tab_ids.has(tab.id)
+			);
+			const visible_right_tabs = right_tabs.filter((tab) =>
+				visible_tab_ids.has(tab.id)
+			);
 			visible_tabs = [...visible_left_tabs, ...visible_right_tabs];
 			overflow_tabs = rendered_tabs.filter(
 				(tab) => !visible_tabs.some((visible_tab) => visible_tab?.id === tab.id)
@@ -431,6 +450,14 @@
 			color-mix(in srgb, var(--border-color-primary) 45%, transparent)
 				var(--size-8)
 		);
+	}
+
+	.tab-container:not(.visually-hidden) > button,
+	.right-tab-group button {
+		max-width: 100%;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	.tab-container.wrap button {

--- a/js/tabs/types.ts
+++ b/js/tabs/types.ts
@@ -6,6 +6,7 @@ export interface TabsProps {
 	elem_id: string;
 	elem_classes: string[];
 	selected: number | string;
+	overflow_behavior: "menu" | "wrap";
 	initial_tabs: Tab[];
 	name: "tabs" | "walkthrough";
 }

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -222,6 +222,20 @@ class TestTabbedInterface:
             tabbed_interface.get_config_file(),  # type: ignore
         )
 
+    def test_tabbed_interface_passes_tabs_kwargs_to_tabs(self):
+        interface = Interface(lambda x: x, "textbox", "textbox")
+
+        tabbed_interface = TabbedInterface(
+            [interface], tabs_kwargs={"overflow_behavior": "wrap"}
+        )
+        tabs_config = next(
+            component
+            for component in tabbed_interface.get_config_file()["components"]
+            if component["type"] == "tabs"
+        )
+
+        assert tabs_config["props"]["overflow_behavior"] == "wrap"
+
 
 @pytest.mark.parametrize(
     "interface_type", ["standard", "input_only", "output_only", "unified"]

--- a/test/test_tabs.py
+++ b/test/test_tabs.py
@@ -1,3 +1,5 @@
+import pytest
+
 import gradio as gr
 
 
@@ -9,3 +11,13 @@ def test_tabs_overflow_behavior_is_in_config():
 def test_tab_alignment_is_in_config():
     assert gr.Tab("Settings").get_config()["alignment"] == "left"
     assert gr.Tab("Settings", alignment="right").get_config()["alignment"] == "right"
+
+
+def test_tabs_rejects_invalid_overflow_behavior():
+    with pytest.raises(ValueError, match="overflow_behavior"):
+        gr.Tabs(overflow_behavior="wrapp")  # type: ignore[arg-type]
+
+
+def test_tab_rejects_invalid_alignment():
+    with pytest.raises(ValueError, match="alignment"):
+        gr.Tab("Settings", alignment="rigth")  # type: ignore[arg-type]

--- a/test/test_tabs.py
+++ b/test/test_tabs.py
@@ -1,0 +1,6 @@
+import gradio as gr
+
+
+def test_tabs_overflow_behavior_is_in_config():
+    assert gr.Tabs().get_config()["overflow_behavior"] == "menu"
+    assert gr.Tabs(overflow_behavior="wrap").get_config()["overflow_behavior"] == "wrap"

--- a/test/test_tabs.py
+++ b/test/test_tabs.py
@@ -4,3 +4,8 @@ import gradio as gr
 def test_tabs_overflow_behavior_is_in_config():
     assert gr.Tabs().get_config()["overflow_behavior"] == "menu"
     assert gr.Tabs(overflow_behavior="wrap").get_config()["overflow_behavior"] == "wrap"
+
+
+def test_tab_alignment_is_in_config():
+    assert gr.Tab("Settings").get_config()["alignment"] == "left"
+    assert gr.Tab("Settings", alignment="right").get_config()["alignment"] == "right"


### PR DESCRIPTION
## Description

Adds complementary controls for tab overflow and per-tab alignment:

- `gr.Tabs(overflow_behavior="menu" | "wrap")` selects the existing overflow menu or a multi-row tab bar. `"menu"` remains the default.
- `gr.Tab(alignment="left" | "right")` places a tab in the main group or a right-aligned utility group. `"left"` remains the default.
- `gr.TabbedInterface(..., tabs_kwargs={...})` passes layout options such as `overflow_behavior="wrap"` to its internal `gr.Tabs`.

The behaviors work together in both modes. Menu mode keeps the first and selected tabs visible before allocating space to right-aligned tabs, preserves utility-tab order, and immediately promotes a newly selected overflow tab. Wrap mode keeps every tab visible, constrains long labels to the available width, and uses subtle separators between rows while retaining the standard bottom baseline.

Both Python constructors now reject invalid `overflow_behavior` and `alignment` values with a `ValueError`. The overflow layout also responds explicitly when `overflow_behavior` changes at runtime.

Closes: #9853
Closes: #9969

## AI Disclosure

- [x] I used AI to implement and test this change. I reviewed every changed line and verified the behavior locally.
- [ ] I did not use AI

## 🎯 PRs Should Target Issues

This PR targets #9853 and #9969.

## Testing and Formatting Your Code

- `CI=1 pnpm test:run Tabs.test.ts` (2,371 tests passed; 4 skipped; 220 todo)
- `pnpm build-storybook --quiet --stats-json` (includes visual regression stories for menu overflow/right alignment and wrapped tabs/right alignment/long-label truncation)
- `python3 -m pytest test/test_tabs.py test/test_interfaces.py::TestTabbedInterface -q` (6 passed)
- `ruff format --check gradio/interface.py gradio/layouts/tabs.py test/test_interfaces.py test/test_tabs.py`
- `ruff check gradio/interface.py gradio/layouts/tabs.py test/test_interfaces.py test/test_tabs.py`
- `pnpm exec eslint --config .config/eslint.config.js js/tabs/shared/Tabs.svelte --no-warn-ignored`
- `bash scripts/build_frontend.sh --no-download-offline-assets`
- `bash scripts/format_frontend.sh` formatted successfully; its repository-wide `svelte-check` reports pre-existing dependency/baseline errors in unrelated files.
- `bash scripts/format_backend.sh` was attempted; its repository-wide type step cannot resolve optional demo/test dependencies in the local environment. Focused Ruff checks pass.
